### PR TITLE
✨ azure: bump datafactory v11 + kusto v2.4.0, sweep systemMetadata provenance & enum docs

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10 v10.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11 v11.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0
@@ -34,7 +34,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/hybridcompute/armhybridcompute/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/v2 v2.0.2
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -94,8 +94,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcos
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0/go.mod h1:s//ycXE53yRslaDdkNrCEANgvrdSOaUuqcBCJg5VEX0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0 h1:rQyNHB/4ntzvm5F9WAiaAl7jWII+jaI4rL6sSWxTNeM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0/go.mod h1:4jtknLqzaPtwIz8Y9NBp2rXxeA7BbSICWBD0FDzG2VM=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10 v10.0.0 h1:mc2mGr+5wY9v7V0F7O7jXkzB4ByKUWiTU0KTiIWOZeM=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10 v10.0.0/go.mod h1:YhXXTpZ5TanA7EoL74rWIoTZJEwN4CzFc3vJn6b6hTs=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11 v11.0.0 h1:wuYlQlKT1Glo4u27svDqNnJvvYcsgCRDfbUzwFB1S8A=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11 v11.0.0/go.mod h1:Fy9UQD1sVZ6KdB+i1bfnauETftG3PlRhUXqrYlXA7jQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/v2 v2.3.0 h1:58Pq8MyJ4hT2rkkSaZ7gS25+Q1YdsNn+3nuAt+Sg0Yc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/desktopvirtualization/armdesktopvirtualization/v2 v2.3.0/go.mod h1:awlKdgQzRV48H2/m3VEhHQrHwqRpLqDEVkz4LvSgTEc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
@@ -114,8 +114,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.3.0 h1
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/iothub/armiothub v1.3.0/go.mod h1:djbLk3ngutFfQ9fSOM29UzywAkcBI1YUsuUnxTQGsqU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/v2 v2.0.2 h1:O2iuZYGa1nIMDk2uAFR0F7hDALVXMvz8Zwarz6itQ3E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault/v2 v2.0.2/go.mod h1:7t88hsh6P4xqFM9uzaMX2qYfVsqDFkgFR4qdIX/OP+U=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0 h1:5kp5bmJwJuF0HTsPUxRWRy44FxEatQAhv03nYdjXJ3s=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0/go.mod h1:ULnv9Hl5nSpzNHHqJ3xX0kIZp5ZyLcLGHdXNQ8RwIk4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.4.0 h1:XGm8oSW5PItQZpVFHKlBHzYB/1z5UDf/IjrPFakQZVg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.4.0/go.mod h1:YWDu9uFNbVdyy0B0+CLFfmRuB9Gu5el0Zfp0TcVT+Vs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0 h1:EMNgS+pCj2/2LL7+nWG8zPf9sp4u8icP5FNwoBhyc8M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0/go.mod h1:TsM36SmGxYC24DiOTR9wPuBj5HYphihMC6xlnX536bE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0 h1:H5ykGRBhX8CJKpB2tiRVut1DPbH7BnYKQ+orFTD7+JY=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -163,6 +163,8 @@ private azure.subscription.webService.function @defaults("name type") {
   kind string
   // Properties for the function
   properties dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure resource group
@@ -393,7 +395,7 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   publicIpAddresses() []azure.subscription.networkService.ipAddress
   // Whether encryption at host is enabled for all VM disks
   encryptionAtHost bool
-  // Security type of the VM ("ConfidentialVM" or "TrustedLaunch")
+  // Security type of the VM ("ConfidentialVM", "TrustedLaunch", or "Standard")
   securityType string
   // Whether UEFI Secure Boot is enabled
   secureBootEnabled bool
@@ -522,7 +524,7 @@ azure.subscription.computeService.hybridMachine @defaults("name location osName 
   tags map[string]string
   // ARM resource type (Microsoft.HybridCompute/machines)
   type string
-  // Connection status of the Arc agent. Possible values: "Connected", "Disconnected", "Error", "Expired"
+  // Connection status of the Arc agent. Possible values: "Connected", "Disconnected", "Error"
   status string
   // Last time the Arc agent reported in
   lastStatusChange time
@@ -912,7 +914,7 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
   securityPostureReference dict
   // Whether encryption at host is enabled for all scale-set VM disks
   encryptionAtHost bool
-  // Security type applied to scale-set VMs ("ConfidentialVM" or "TrustedLaunch")
+  // Security type applied to scale-set VMs ("ConfidentialVM", "TrustedLaunch", or "Standard")
   securityType string
   // Whether UEFI Secure Boot is enabled on scale-set VMs
   secureBootEnabled bool
@@ -1098,6 +1100,8 @@ azure.subscription.computeService.proximityPlacementGroup @defaults("name locati
   virtualMachineScaleSetIds []string
   // ARM IDs of availability sets in this group (references)
   availabilitySetIds []string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure managed image
@@ -1132,6 +1136,8 @@ azure.subscription.computeService.image @defaults("name location hyperVGeneratio
   provisioningState string
   // Hyper-V generation (V1, V2)
   hyperVGeneration string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Compute Gallery
@@ -1169,6 +1175,8 @@ azure.subscription.computeService.gallery @defaults("name location description")
   sharingStatus dict
   // Image definitions in this gallery
   images() []azure.subscription.computeService.gallery.image
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Compute Gallery image definition
@@ -1224,6 +1232,8 @@ azure.subscription.computeService.gallery.image @defaults("name osType osState h
   releaseNoteUri string
   // Image versions in this image definition
   versions() []azure.subscription.computeService.gallery.image.version
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Compute Gallery image version
@@ -1259,6 +1269,8 @@ azure.subscription.computeService.gallery.image.version @defaults("name location
   replicationStatus dict
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Batch
@@ -1620,6 +1632,8 @@ private azure.subscription.networkService.networkManager.networkGroup @defaults(
   memberType string
   // Resource GUID of the group
   resourceGuid string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Network manager security admin configuration
@@ -1646,6 +1660,8 @@ private azure.subscription.networkService.networkManager.securityAdminConfigurat
   applyOnNetworkIntentPolicyBasedServices []string
   // Rule collections in the configuration
   ruleCollections() []azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Network manager admin rule collection
@@ -1743,6 +1759,8 @@ private azure.subscription.networkService.networkManager.connectivityConfigurati
   appliesToGroups() []azure.subscription.networkService.networkManager.networkGroup
   // Hub resources in the topology; each entry carries resourceId and resourceType
   hubs []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure IP group
@@ -3321,7 +3339,7 @@ private azure.subscription.networkService.applicationGateway.listener @defaults(
   id string
   // Listener name
   name string
-  // Listener protocol ("Http" or "Https")
+  // Listener protocol ("Http", "Https", "Tcp", or "Tls")
   protocol string
   // Port the listener binds to (resolved from the referenced frontendPort)
   port int
@@ -4129,6 +4147,8 @@ azure.subscription.networkService.securityPerimeter @defaults("id name location"
   profiles() []azure.subscription.networkService.securityPerimeter.profile
   // Resource associations placing PaaS resources inside the perimeter
   associations() []azure.subscription.networkService.securityPerimeter.association
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Network security perimeter profile
@@ -4857,6 +4877,8 @@ private azure.subscription.storageService.account.queue @defaults("id name") {
   metadata map[string]string
   // Approximate number of messages in the queue (fetched on demand via Get)
   approximateMessageCount() int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage account table
@@ -4867,6 +4889,8 @@ private azure.subscription.storageService.account.table @defaults("id name") {
   name string
   // Stored access policies (SAS) on the table; each entry has id, permission, startTime, expiryTime
   signedIdentifiers []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Local user configured on a storage account for SFTP/SSH access
@@ -4895,6 +4919,8 @@ private azure.subscription.storageService.account.localUser @defaults("id name h
   userId int
   // Numeric POSIX group ID
   groupId int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage account data protection
@@ -4969,6 +4995,8 @@ private azure.subscription.storageService.account.encryptionScope @defaults("nam
   creationTime time
   // When the encryption scope was last modified
   lastModifiedTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage lifecycle management policy
@@ -4983,6 +5011,8 @@ private azure.subscription.storageService.account.managementPolicy @defaults("id
   lastModifiedTime time
   // Lifecycle management rules
   rules []azure.subscription.storageService.account.managementPolicy.rule
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage lifecycle management policy rule
@@ -5141,6 +5171,8 @@ private azure.subscription.storageService.account.container @defaults("id name")
   deletedTime time
   // Number of remaining days in the soft delete retention period
   remainingRetentionDays int
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage file share
@@ -5190,6 +5222,8 @@ private azure.subscription.storageService.account.fileShare @defaults("name enab
   leaseDuration string
   // User-defined metadata
   metadata map[string]string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage private endpoint connection
@@ -5222,6 +5256,8 @@ private azure.subscription.storageService.account.privateEndpointConnection @def
   actionsRequired string
   // Provisioning state of the connection
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage object replication policy
@@ -5250,6 +5286,8 @@ private azure.subscription.storageService.account.objectReplicationPolicy @defau
   rules []dict
   // Whether blob index tags are replicated alongside blob data; false when the policy omits tag replication
   tagsReplicationEnabled bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Network Security Perimeter configuration of an Azure Storage account
@@ -5305,6 +5343,8 @@ private azure.subscription.storageService.account.networkSecurityPerimeterConfig
   // Each entry has keys: name; issueType ("ConfigurationPropagationFailure"
   // or "Unknown"); severity ("Error" or "Warning"); and description.
   provisioningIssues []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Storage blob inventory policy
@@ -5326,6 +5366,8 @@ private azure.subscription.storageService.account.blobInventoryPolicy @defaults(
   lastModifiedTime time
   // Inventory rules. Each entry has {name, enabled, destination, definition: {format, schedule, objectType, schemaFields, filters}}.
   rules []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Defender for Storage configuration for a single storage account
@@ -5631,7 +5673,7 @@ private azure.subscription.webService.appsiteauthsettings @defaults("id name") {
   enabled bool
   // Action taken when an unauthenticated client requests the app
   //
-  // Possible values: AllowAnonymous, RedirectToLoginPage, Show401, Show403.
+  // Possible values: AllowAnonymous, RedirectToLoginPage.
   // Anything other than AllowAnonymous means unauthenticated requests are blocked
   // or redirected to a login provider.
   unauthenticatedClientAction string
@@ -5679,6 +5721,8 @@ private azure.subscription.webService.appsiteconfig @defaults("id name") {
   detailedErrorLoggingEnabled bool
   // Whether auto-heal is enabled (the app is automatically restarted on certain conditions)
   autoHealEnabled bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure AppSite config IP security restriction rule
@@ -5753,6 +5797,8 @@ private azure.subscription.webService.hostingEnvironment @defaults("id name") {
   virtualNetwork azure.subscription.webService.hostingEnvironment.virtualNetwork
   // Custom settings for changing the behavior of the App Service Environment
   clusterSettings []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Virtual network configuration for an App Service Environment
@@ -5799,6 +5845,8 @@ private azure.subscription.webService.appServicePlan @defaults("id name location
   perSiteScaling bool
   // Whether elastic scale is enabled
   elasticScaleEnabled bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure App Service Certificate
@@ -5827,6 +5875,8 @@ private azure.subscription.webService.certificate @defaults("id name") {
   hostNames []string
   // Whether the certificate is valid
   valid bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Static Web App
@@ -5907,6 +5957,8 @@ private azure.subscription.webService.appsite.hostNameBinding @defaults("id name
   thumbprint string
   // Virtual IP address assigned to the hostname
   virtualIP string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure App Service Virtual Network Connection
@@ -5921,6 +5973,8 @@ private azure.subscription.webService.appsite.virtualNetworkConnection @defaults
   isSwift bool
   // Whether a resync is required
   resyncRequired bool
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL
@@ -6175,6 +6229,8 @@ private azure.subscription.sqlService.database.advancedthreatprotection @default
   state string
   // UTC creation time of the policy
   creationTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL Database backup short-term retention policy
@@ -6281,6 +6337,8 @@ private azure.subscription.sqlService.server.securityAlertPolicyConfig @defaults
   retentionDays int
   // UTC creation time of the policy
   creationTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL Database server-scoped Microsoft Defender for SQL advanced threat protection setting
@@ -6291,6 +6349,8 @@ private azure.subscription.sqlService.server.advancedThreatProtectionSetting @de
   state string
   // UTC creation time of the setting
   creationTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL Database server Microsoft Entra (Azure AD) DevOps audit setting
@@ -6305,6 +6365,8 @@ private azure.subscription.sqlService.server.devOpsAuditingSetting @defaults("st
   storageAccountSubscriptionId string
   // Audit log storage account blob endpoint
   storageEndpoint string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL Database server customer-managed (BYOK) encryption key
@@ -6385,7 +6447,7 @@ private azure.subscription.sqlService.server.replicationLink @defaults("name par
   replicationMode string
   // Replication state ("PENDING", "SEEDING", "CATCH_UP", "SUSPENDED")
   replicationState string
-  // Local replication role ("Primary" or "Secondary")
+  // Local replication role ("Primary", "Secondary", "Source", "Copy", or "NonReadableSecondary")
   role string
   // Whether termination of the replication link is allowed
   isTerminationAllowed bool
@@ -6463,6 +6525,8 @@ private azure.subscription.sqlService.database.securityAlertPolicy @defaults("st
   retentionDays int
   // UTC creation time of the policy
   creationTime time
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure SQL Database database-level vulnerability assessment configuration
@@ -7020,6 +7084,8 @@ private azure.subscription.mySqlService.flexibleServer.administrator @defaults("
   sid string
   // Tenant ID of the administrator
   tenantId string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cosmos DB
@@ -7764,9 +7830,9 @@ private azure.subscription.monitorService.applicationInsight @defaults("name loc
   type string
   // Whether IP masking is disabled
   disableIpMasking bool
-  // Public network access for ingestion (Enabled, Disabled)
+  // Public network access for ingestion ("Enabled", "Disabled", or "SecuredByPerimeter")
   publicNetworkAccessForIngestion string
-  // Public network access for query (Enabled, Disabled)
+  // Public network access for query ("Enabled", "Disabled", or "SecuredByPerimeter")
   publicNetworkAccessForQuery string
   // Data retention period in days
   retentionInDays int
@@ -8082,6 +8148,8 @@ private azure.subscription.cloudDefenderService.jitNetworkAccessPolicy @defaults
   provisioningState string
   // Virtual machines governed by the policy
   virtualMachines() []azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Just-in-time network access VM configuration
@@ -8265,6 +8333,8 @@ private azure.subscription.cloudDefenderService.assessment @defaults("displayNam
   description string
   // Detailed sub-findings underlying the assessment (per-CVE, per-misconfiguration)
   subAssessments() []azure.subscription.cloudDefenderService.assessment.subAssessment
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Defender for Cloud sub-assessment
@@ -8339,6 +8409,8 @@ private azure.subscription.cloudDefenderService.alert @defaults("displayName sev
   remediationSteps []string
   // Identifiers of the resources the alert is related to
   resourceIdentifiers []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Defender for Cloud security settings
@@ -8745,6 +8817,8 @@ private azure.subscription.cloudDefenderService.securityContact @defaults("id na
   notificationSources dict
   // Notifications by role settings
   notificationsByRole dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure IAM service
@@ -9177,7 +9251,7 @@ private azure.subscription.aksService.cluster.nodePool @defaults("name mode vmSi
   name string
   // Pool mode ("System" for kube-system pods, "User" for workloads, "Gateway" for static-egress gateway pools)
   mode string
-  // Pool VM type ("VirtualMachineScaleSets" or "AvailabilitySet")
+  // Pool VM type ("VirtualMachineScaleSets", "AvailabilitySet", or "VirtualMachines")
   vmType string
   // Number of nodes currently in the pool
   count int
@@ -9635,6 +9709,8 @@ private azure.subscription.cacheService.redisInstance.firewallRule @defaults("id
   startIpAddress string
   // Highest IP address in the range
   endIpAddress string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cache for Redis patch schedule
@@ -9647,6 +9723,8 @@ private azure.subscription.cacheService.redisInstance.patchSchedule @defaults("n
   location string
   // List of schedule entries (dayOfWeek, startHourUtc, maintenanceWindow)
   entries []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Cache for Redis private endpoint connection
@@ -9667,10 +9745,12 @@ private azure.subscription.cacheService.redisInstance.privateEndpointConnection 
   status string
   // Reason for approval/rejection of the connection
   description string
-  // Provisioning state. Possible values: "Succeeded", "Creating", "Deleting", "Failed", "Updating"
+  // Provisioning state. Possible values: "Succeeded", "Creating", "Deleting", "Failed"
   provisioningState string
   // Private link group IDs the connection targets (for example "redisCache")
   groupIds []string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Factory service
@@ -9748,6 +9828,8 @@ azure.subscription.dataFactoryService.factory @defaults("name location") {
   integrationRuntimes() []azure.subscription.dataFactoryService.factory.integrationRuntime
   // Managed virtual network for the factory, if one exists
   managedVirtualNetwork() azure.subscription.dataFactoryService.factory.managedVirtualNetwork
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Factory linked service
@@ -9779,10 +9861,20 @@ private azure.subscription.dataFactoryService.factory.linkedService @defaults("n
   //
   // True when a nested `{type: "AzureKeyVaultSecret", store: {...}, secretName: ...}` reference exists in typeProperties.
   usesKeyVaultReference bool
+  // Authentication mode declared by the connector
+  //
+  // The auth scheme the linked service uses to reach its external system,
+  // when the connector declares one, for example "Basic",
+  // "ManagedServiceIdentity", "ServicePrincipal", or "Anonymous". Empty
+  // when the connector has no auth-type field or the credential resolves
+  // through Key Vault (see usesKeyVaultReference).
+  authenticationType string
   // Annotations declared on the linked service (free-form list of any)
   annotations []dict
   // Raw type-specific properties returned by the SDK (shape varies by serviceType)
   typeProperties dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Factory integration runtime
@@ -9806,6 +9898,8 @@ private azure.subscription.dataFactoryService.factory.integrationRuntime @defaul
   description string
   // Type-specific properties returned by the SDK (shape varies by runtimeType)
   typeProperties dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Factory managed virtual network
@@ -9827,6 +9921,8 @@ private azure.subscription.dataFactoryService.factory.managedVirtualNetwork @def
   vnetId string
   // Managed private endpoints attached to this managed virtual network
   privateEndpoints() []azure.subscription.dataFactoryService.factory.managedPrivateEndpoint
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Factory managed private endpoint
@@ -9858,6 +9954,8 @@ private azure.subscription.dataFactoryService.factory.managedPrivateEndpoint @de
   reserved bool
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Synapse Analytics service
@@ -10086,6 +10184,8 @@ private azure.subscription.containerRegistryService.registry.webhook @defaults("
   actions []string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Geo-replication for an Azure Container Registry
@@ -10106,6 +10206,8 @@ private azure.subscription.containerRegistryService.registry.replication @defaul
   zoneRedundancy string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Scope map for token-based access in an Azure Container Registry
@@ -10124,6 +10226,8 @@ private azure.subscription.containerRegistryService.registry.scopeMap @defaults(
   creationDate time
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Repository-scoped access token for an Azure Container Registry
@@ -10150,6 +10254,8 @@ private azure.subscription.containerRegistryService.registry.token @defaults("id
   // `expiry`. An absent expiry means the password never expires. Secret
   // values are never returned.
   passwords []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Pull-through cache rule for an Azure Container Registry
@@ -10172,6 +10278,8 @@ private azure.subscription.containerRegistryService.registry.cacheRule @defaults
   creationDate time
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Credential set referenced by cache rules in an Azure Container Registry
@@ -10192,6 +10300,8 @@ private azure.subscription.containerRegistryService.registry.credentialSet @defa
   creationDate time
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Connected (edge/on-prem) registry that mirrors an Azure Container Registry
@@ -10242,6 +10352,8 @@ private azure.subscription.containerRegistryService.registry.connectedRegistry @
   notificationsList []string
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Log Analytics workspace
@@ -10271,9 +10383,9 @@ azure.subscription.monitorService.workspace @defaults("id name location skuName"
   skuCapacityReservationLevel int
   // Data retention period in days
   retentionInDays int
-  // Public network access for ingestion ("Enabled" or "Disabled")
+  // Public network access for ingestion ("Enabled", "Disabled", or "SecuredByPerimeter")
   publicNetworkAccessForIngestion string
-  // Public network access for query ("Enabled" or "Disabled")
+  // Public network access for query ("Enabled", "Disabled", or "SecuredByPerimeter")
   publicNetworkAccessForQuery string
   // Whether customer-managed key is required for query
   forceCmkForQuery bool
@@ -10488,6 +10600,8 @@ private azure.subscription.monitorService.workspace.nspConfiguration @defaults("
   // Each entry has keys: name; issueType ("ConfigurationPropagationFailure"
   // or "Unknown"); severity ("Error" or "Warning"); and description.
   provisioningIssues []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Log Analytics QueryPack
@@ -10593,7 +10707,7 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   privateEndpointStateForBackup string
   // Private endpoint state for site recovery ("None" or "Enabled")
   privateEndpointStateForSiteRecovery string
-  // Secure score ("Healthy" or "Unhealthy")
+  // Secure score ("Adequate", "Maximum", "Minimum", or "None")
   secureScore string
   // Security settings (soft delete, immutability, enhanced security)
   securitySettings() azure.subscription.recoveryServicesService.vault.securitySettings
@@ -10619,13 +10733,13 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
 private azure.subscription.recoveryServicesService.vault.securitySettings @defaults("softDeleteState immutabilityState multiUserAuthorization") {
   // Security settings identifier
   id string
-  // Soft delete state ("Enabled" or "Disabled")
+  // Soft delete state ("Enabled", "Disabled", or "AlwaysON")
   softDeleteState string
   // Soft delete retention period in days
   softDeleteRetentionPeriodInDays int
-  // Enhanced security state ("Enabled" or "Disabled")
+  // Enhanced security state ("Enabled", "Disabled", or "AlwaysON")
   enhancedSecurityState string
-  // Immutability state ("Locked" or "Unlocked")
+  // Immutability state ("Disabled", "Locked", or "Unlocked")
   immutabilityState string
   // Multi-User Authorization state ("Enabled", "Disabled", or "Invalid"); Enabled requires a Resource Guard for destructive ops
   multiUserAuthorization string
@@ -10665,7 +10779,7 @@ private azure.subscription.recoveryServicesService.vault.monitoringSettings @def
 private azure.subscription.recoveryServicesService.vault.redundancySettings @defaults("storageRedundancy crossRegionRestore") {
   // Redundancy settings identifier
   id string
-  // Standard tier storage redundancy ("GeoRedundant" or "LocallyRedundant")
+  // Standard tier storage redundancy ("GeoRedundant", "LocallyRedundant", or "ZoneRedundant")
   storageRedundancy string
   // Cross-region restore setting ("Enabled" or "Disabled")
   crossRegionRestore string
@@ -10914,7 +11028,7 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
 private azure.subscription.serviceBusService.namespace.networkRules @defaults("defaultAction publicNetworkAccess trustedServiceAccessEnabled") {
   // Default action for traffic that does not match any rule ("Allow" or "Deny")
   defaultAction string
-  // Whether traffic is allowed over the public network ("Enabled", "Disabled", or "SecuredByPerimeter")
+  // Whether traffic is allowed over the public network ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Whether Microsoft-owned trusted services can bypass the rule set
   trustedServiceAccessEnabled bool
@@ -13411,6 +13525,8 @@ private azure.subscription.sentinelService.workspace @defaults("name resourceGro
   //
   // Each entry is a kind-specific dict with `name`, `kind`, and `properties` describing the connector configuration. Kinds include `OfficeATP`, `AzureActiveDirectory`, `AzureSecurityCenter`, `MicrosoftDefenderAdvancedThreatProtection`, and many others.
   dataConnectors() []dict
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Microsoft Sentinel analytics rule
@@ -13609,7 +13725,7 @@ azure.subscription.kustoService.cluster @defaults("id name location publicNetwor
   state string
   // Provisioning state
   provisioningState string
-  // Whether the cluster is reachable from the public internet ("Enabled" or "Disabled")
+  // Whether the cluster is reachable from the public internet, one of "Enabled", "Disabled", or "SecuredByPerimeter"
   publicNetworkAccess string
   // Public IP exposure type ("IPv4" or "DualStack")
   publicIpType string
@@ -13635,6 +13751,8 @@ azure.subscription.kustoService.cluster @defaults("id name location publicNetwor
   cmkKeyVaultUri string
   // Version of the customer-managed encryption key; empty means the latest version is used
   cmkKeyVersion string
+  // Client ID of the multi-tenant Microsoft Entra application used for cross-tenant customer-managed key access; empty for same-tenant keys
+  cmkFederatedIdentityClientId string
   // Databases hosted on the cluster
   databases() []azure.subscription.kustoService.cluster.database
   // Microsoft Entra principals granted cluster-wide access
@@ -13690,6 +13808,8 @@ azure.subscription.kustoService.cluster.database @defaults("name kind hotCachePe
   principalAssignments() []azure.subscription.kustoService.cluster.database.principalAssignment
   // Ingestion data connections feeding the database
   dataConnections() []azure.subscription.kustoService.cluster.database.dataConnection
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer cluster principal assignment
@@ -13716,6 +13836,8 @@ private azure.subscription.kustoService.cluster.principalAssignment @defaults("p
   tenantId string
   // Provisioning state of the assignment
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer database principal assignment
@@ -13742,6 +13864,8 @@ private azure.subscription.kustoService.cluster.database.principalAssignment @de
   tenantId string
   // Provisioning state of the assignment
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Data Explorer cluster callout policy
@@ -13835,7 +13959,10 @@ private azure.subscription.kustoService.cluster.database.dataConnection @default
   name string
   // Data connection location
   location string
-  // Source kind, one of "EventHub", "EventGrid", "IotHub", or "CosmosDb"
+  // Source kind
+  //
+  // One of "EventHub", "EventGrid", "IotHub", "CosmosDb",
+  // "EventHubWithManagedIdentity", or "EventGridWithManagedIdentity".
   kind string
   // Target table the connection ingests into
   tableName string
@@ -13853,6 +13980,8 @@ private azure.subscription.kustoService.cluster.database.dataConnection @default
   managedIdentity() azure.subscription.managedIdentity
   // Provisioning state
   provisioningState string
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
 }
 
 // Azure Automation

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2504,6 +2504,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.function.properties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceFunction).GetProperties()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.webService.function.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceFunction).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.resourcegroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionResourcegroup).GetId()).ToDataRes(types.String)
 	},
@@ -3536,6 +3539,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.proximityPlacementGroup.availabilitySetIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).GetAvailabilitySetIds()).ToDataRes(types.Array(types.String))
 	},
+	"azure.subscription.computeService.proximityPlacementGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.computeService.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetId()).ToDataRes(types.String)
 	},
@@ -3568,6 +3574,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.image.hyperVGeneration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetHyperVGeneration()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.image.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceImage).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.computeService.gallery.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGallery).GetId()).ToDataRes(types.String)
@@ -3607,6 +3616,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.gallery.images": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGallery).GetImages()).ToDataRes(types.Array(types.Resource("azure.subscription.computeService.gallery.image")))
+	},
+	"azure.subscription.computeService.gallery.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceGallery).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.computeService.gallery.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImage).GetId()).ToDataRes(types.String)
@@ -3674,6 +3686,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.gallery.image.versions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImage).GetVersions()).ToDataRes(types.Array(types.Resource("azure.subscription.computeService.gallery.image.version")))
 	},
+	"azure.subscription.computeService.gallery.image.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImage).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.computeService.gallery.image.version.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).GetId()).ToDataRes(types.String)
 	},
@@ -3709,6 +3724,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.computeService.gallery.image.version.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.gallery.image.version.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.batchService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionBatchService).GetSubscriptionId()).ToDataRes(types.String)
@@ -4139,6 +4157,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.networkManager.networkGroup.resourceGuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).GetResourceGuid()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.networkManager.networkGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).GetId()).ToDataRes(types.String)
 	},
@@ -4162,6 +4183,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).GetRuleCollections()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection")))
+	},
+	"azure.subscription.networkService.networkManager.securityAdminConfiguration.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationRuleCollection).GetId()).ToDataRes(types.String)
@@ -4264,6 +4288,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.networkService.networkManager.connectivityConfiguration.hubs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).GetHubs()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.networkService.networkManager.connectivityConfiguration.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.networkService.ipGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceIpGroup).GetId()).ToDataRes(types.String)
@@ -6737,6 +6764,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.securityPerimeter.associations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeter).GetAssociations()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.securityPerimeter.association")))
 	},
+	"azure.subscription.networkService.securityPerimeter.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeter).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.networkService.securityPerimeter.profile.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeterProfile).GetId()).ToDataRes(types.String)
 	},
@@ -7547,6 +7577,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.queue.approximateMessageCount": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetApproximateMessageCount()).ToDataRes(types.Int)
 	},
+	"azure.subscription.storageService.account.queue.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountQueue).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.table.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetId()).ToDataRes(types.String)
 	},
@@ -7555,6 +7588,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.table.signedIdentifiers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetSignedIdentifiers()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.storageService.account.table.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountTable).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.storageService.account.localUser.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).GetId()).ToDataRes(types.String)
@@ -7591,6 +7627,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.localUser.groupId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).GetGroupId()).ToDataRes(types.Int)
+	},
+	"azure.subscription.storageService.account.localUser.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.storageService.account.dataProtection.storageAccountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountDataProtection).GetStorageAccountId()).ToDataRes(types.String)
@@ -7667,6 +7706,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.encryptionScope.lastModifiedTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountEncryptionScope).GetLastModifiedTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.storageService.account.encryptionScope.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountEncryptionScope).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.managementPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -7681,6 +7723,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.managementPolicy.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).GetRules()).ToDataRes(types.Array(types.Resource("azure.subscription.storageService.account.managementPolicy.rule")))
+	},
+	"azure.subscription.storageService.account.managementPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.storageService.account.managementPolicy.rule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicyRule).GetId()).ToDataRes(types.String)
@@ -7862,6 +7907,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.container.remainingRetentionDays": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountContainer).GetRemainingRetentionDays()).ToDataRes(types.Int)
 	},
+	"azure.subscription.storageService.account.container.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountContainer).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.fileShare.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).GetId()).ToDataRes(types.String)
 	},
@@ -7922,6 +7970,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.fileShare.metadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).GetMetadata()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"azure.subscription.storageService.account.fileShare.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.privateEndpointConnection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetId()).ToDataRes(types.String)
 	},
@@ -7949,6 +8000,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.privateEndpointConnection.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.storageService.account.privateEndpointConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.objectReplicationPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -7975,6 +8029,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.objectReplicationPolicy.tagsReplicationEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).GetTagsReplicationEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.storageService.account.objectReplicationPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).GetId()).ToDataRes(types.String)
@@ -8021,6 +8078,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.provisioningIssues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).GetProvisioningIssues()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.storageService.account.blobInventoryPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -8038,6 +8098,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.storageService.account.blobInventoryPolicy.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).GetRules()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.storageService.account.blobInventoryPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.storageService.account.defenderForStorageSetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionStorageServiceAccountDefenderForStorageSetting).GetId()).ToDataRes(types.String)
@@ -8453,6 +8516,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsiteconfig.autoHealEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetAutoHealEnabled()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.webService.appsiteconfig.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestriction.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction).GetId()).ToDataRes(types.String)
 	},
@@ -8552,6 +8618,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.hostingEnvironment.clusterSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceHostingEnvironment).GetClusterSettings()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.webService.hostingEnvironment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceHostingEnvironment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webService.hostingEnvironment.virtualNetwork.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork).GetId()).ToDataRes(types.String)
 	},
@@ -8609,6 +8678,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appServicePlan.elasticScaleEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppServicePlan).GetElasticScaleEnabled()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.webService.appServicePlan.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppServicePlan).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webService.certificate.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceCertificate).GetId()).ToDataRes(types.String)
 	},
@@ -8644,6 +8716,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.certificate.valid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceCertificate).GetValid()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.certificate.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceCertificate).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.webService.staticSite.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceStaticSite).GetId()).ToDataRes(types.String)
@@ -8735,6 +8810,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.webService.appsite.hostNameBinding.virtualIP": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).GetVirtualIP()).ToDataRes(types.String)
 	},
+	"azure.subscription.webService.appsite.hostNameBinding.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.webService.appsite.virtualNetworkConnection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).GetId()).ToDataRes(types.String)
 	},
@@ -8749,6 +8827,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.webService.appsite.virtualNetworkConnection.resyncRequired": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).GetResyncRequired()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.webService.appsite.virtualNetworkConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.sqlService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlService).GetSubscriptionId()).ToDataRes(types.String)
@@ -9059,6 +9140,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.database.advancedthreatprotection.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection).GetCreationTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.sqlService.database.advancedthreatprotection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.sqlService.database.backupshorttermretentionpolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseBackupshorttermretentionpolicy).GetId()).ToDataRes(types.String)
 	},
@@ -9182,6 +9266,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sqlService.server.securityAlertPolicyConfig.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig).GetCreationTime()).ToDataRes(types.Time)
 	},
+	"azure.subscription.sqlService.server.securityAlertPolicyConfig.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).GetId()).ToDataRes(types.String)
 	},
@@ -9190,6 +9277,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).GetCreationTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.sqlService.server.devOpsAuditingSetting.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).GetId()).ToDataRes(types.String)
@@ -9205,6 +9295,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.sqlService.server.devOpsAuditingSetting.storageEndpoint": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).GetStorageEndpoint()).ToDataRes(types.String)
+	},
+	"azure.subscription.sqlService.server.devOpsAuditingSetting.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.sqlService.server.key.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceServerKey).GetId()).ToDataRes(types.String)
@@ -9400,6 +9493,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.sqlService.database.securityAlertPolicy.creationTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy).GetCreationTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.sqlService.database.securityAlertPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.sqlService.database.vulnerabilityAssessment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSqlServiceDatabaseVulnerabilityAssessment).GetId()).ToDataRes(types.String)
@@ -10066,6 +10162,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.mySqlService.flexibleServer.administrator.tenantId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.subscription.mySqlService.flexibleServer.administrator.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cosmosDbService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCosmosDbService).GetSubscriptionId()).ToDataRes(types.String)
@@ -11249,6 +11348,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachines": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).GetVirtualMachines()).ToDataRes(types.Array(types.Resource("azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine")))
 	},
+	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine.vm": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicyVirtualMachine).GetVm()).ToDataRes(types.Resource("azure.subscription.computeService.vm"))
 	},
@@ -11435,6 +11537,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cloudDefenderService.assessment.subAssessments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetSubAssessments()).ToDataRes(types.Array(types.Resource("azure.subscription.cloudDefenderService.assessment.subAssessment")))
 	},
+	"azure.subscription.cloudDefenderService.assessment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cloudDefenderService.assessment.subAssessment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment).GetId()).ToDataRes(types.String)
 	},
@@ -11524,6 +11629,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cloudDefenderService.alert.resourceIdentifiers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAlert).GetResourceIdentifiers()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.cloudDefenderService.alert.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceAlert).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cloudDefenderService.settings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSettings).GetId()).ToDataRes(types.String)
@@ -12037,6 +12145,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cloudDefenderService.securityContact.notificationsByRole": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetNotificationsByRole()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.cloudDefenderService.securityContact.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.authorizationService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationService).GetSubscriptionId()).ToDataRes(types.String)
@@ -13103,6 +13214,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cacheService.redisInstance.firewallRule.endIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule).GetEndIpAddress()).ToDataRes(types.String)
 	},
+	"azure.subscription.cacheService.redisInstance.firewallRule.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.cacheService.redisInstance.patchSchedule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).GetId()).ToDataRes(types.String)
 	},
@@ -13114,6 +13228,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cacheService.redisInstance.patchSchedule.entries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).GetEntries()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.cacheService.redisInstance.patchSchedule.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetId()).ToDataRes(types.String)
@@ -13141,6 +13258,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.groupIds": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetGroupIds()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.dataFactoryService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryService).GetSubscriptionId()).ToDataRes(types.String)
@@ -13217,6 +13337,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetManagedVirtualNetwork()).ToDataRes(types.Resource("azure.subscription.dataFactoryService.factory.managedVirtualNetwork"))
 	},
+	"azure.subscription.dataFactoryService.factory.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactory).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.dataFactoryService.factory.linkedService.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetId()).ToDataRes(types.String)
 	},
@@ -13244,11 +13367,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.dataFactoryService.factory.linkedService.usesKeyVaultReference": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetUsesKeyVaultReference()).ToDataRes(types.Bool)
 	},
+	"azure.subscription.dataFactoryService.factory.linkedService.authenticationType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetAuthenticationType()).ToDataRes(types.String)
+	},
 	"azure.subscription.dataFactoryService.factory.linkedService.annotations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetAnnotations()).ToDataRes(types.Array(types.Dict))
 	},
 	"azure.subscription.dataFactoryService.factory.linkedService.typeProperties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetTypeProperties()).ToDataRes(types.Dict)
+	},
+	"azure.subscription.dataFactoryService.factory.linkedService.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.dataFactoryService.factory.integrationRuntime.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).GetId()).ToDataRes(types.String)
@@ -13268,6 +13397,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.dataFactoryService.factory.integrationRuntime.typeProperties": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).GetTypeProperties()).ToDataRes(types.Dict)
 	},
+	"azure.subscription.dataFactoryService.factory.integrationRuntime.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).GetId()).ToDataRes(types.String)
 	},
@@ -13285,6 +13417,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.privateEndpoints": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).GetPrivateEndpoints()).ToDataRes(types.Array(types.Resource("azure.subscription.dataFactoryService.factory.managedPrivateEndpoint")))
+	},
+	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).GetId()).ToDataRes(types.String)
@@ -13318,6 +13453,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.synapseService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSynapseService).GetSubscriptionId()).ToDataRes(types.String)
@@ -13577,6 +13715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerRegistryService.registry.webhook.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerRegistryService.registry.webhook.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerRegistryService.registry.replication.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).GetId()).ToDataRes(types.String)
 	},
@@ -13601,6 +13742,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerRegistryService.registry.replication.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerRegistryService.registry.replication.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerRegistryService.registry.scopeMap.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).GetId()).ToDataRes(types.String)
 	},
@@ -13621,6 +13765,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerRegistryService.registry.scopeMap.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerRegistryService.registry.scopeMap.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerRegistryService.registry.token.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken).GetId()).ToDataRes(types.String)
@@ -13649,6 +13796,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerRegistryService.registry.token.passwords": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken).GetPasswords()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.containerRegistryService.registry.token.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerRegistryService.registry.cacheRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).GetId()).ToDataRes(types.String)
 	},
@@ -13676,6 +13826,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.containerRegistryService.registry.cacheRule.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.containerRegistryService.registry.cacheRule.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.containerRegistryService.registry.credentialSet.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).GetId()).ToDataRes(types.String)
 	},
@@ -13699,6 +13852,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerRegistryService.registry.credentialSet.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerRegistryService.registry.credentialSet.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.containerRegistryService.registry.connectedRegistry.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).GetId()).ToDataRes(types.String)
@@ -13768,6 +13924,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.containerRegistryService.registry.connectedRegistry.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.containerRegistryService.registry.connectedRegistry.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.monitorService.workspace.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspace).GetId()).ToDataRes(types.String)
@@ -14053,6 +14212,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.monitorService.workspace.nspConfiguration.provisioningIssues": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).GetProvisioningIssues()).ToDataRes(types.Array(types.Dict))
+	},
+	"azure.subscription.monitorService.workspace.nspConfiguration.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.monitorService.queryPack.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionMonitorServiceQueryPack).GetId()).ToDataRes(types.String)
@@ -17054,6 +17216,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.sentinelService.workspace.dataConnectors": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSentinelServiceWorkspace).GetDataConnectors()).ToDataRes(types.Array(types.Dict))
 	},
+	"azure.subscription.sentinelService.workspace.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionSentinelServiceWorkspace).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.sentinelService.alertRule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionSentinelServiceAlertRule).GetId()).ToDataRes(types.String)
 	},
@@ -17279,6 +17444,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.kustoService.cluster.cmkKeyVersion": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceCluster).GetCmkKeyVersion()).ToDataRes(types.String)
 	},
+	"azure.subscription.kustoService.cluster.cmkFederatedIdentityClientId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceCluster).GetCmkFederatedIdentityClientId()).ToDataRes(types.String)
+	},
 	"azure.subscription.kustoService.cluster.databases": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceCluster).GetDatabases()).ToDataRes(types.Array(types.Resource("azure.subscription.kustoService.cluster.database")))
 	},
@@ -17342,6 +17510,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.kustoService.cluster.database.dataConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabase).GetDataConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.kustoService.cluster.database.dataConnection")))
 	},
+	"azure.subscription.kustoService.cluster.database.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabase).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.kustoService.cluster.principalAssignment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).GetId()).ToDataRes(types.String)
 	},
@@ -17366,6 +17537,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.kustoService.cluster.principalAssignment.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).GetProvisioningState()).ToDataRes(types.String)
 	},
+	"azure.subscription.kustoService.cluster.principalAssignment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
 	"azure.subscription.kustoService.cluster.database.principalAssignment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).GetId()).ToDataRes(types.String)
 	},
@@ -17389,6 +17563,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.kustoService.cluster.database.principalAssignment.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.kustoService.cluster.database.principalAssignment.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.kustoService.cluster.calloutPolicy.calloutId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterCalloutPolicy).GetCalloutId()).ToDataRes(types.String)
@@ -17485,6 +17662,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.kustoService.cluster.database.dataConnection.provisioningState": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).GetProvisioningState()).ToDataRes(types.String)
+	},
+	"azure.subscription.kustoService.cluster.database.dataConnection.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.automationService.subscriptionId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAutomationService).GetSubscriptionId()).ToDataRes(types.String)
@@ -17945,6 +18125,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.function.properties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceFunction).Properties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.function.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceFunction).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.resourcegroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19395,6 +19579,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).AvailabilitySetIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.proximityPlacementGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceImage).__id, ok = v.Value.(string)
 		return
@@ -19441,6 +19629,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.image.hyperVGeneration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceImage).HyperVGeneration, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.image.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceImage).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.gallery.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19497,6 +19689,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.gallery.images": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceGallery).Images, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.gallery.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceGallery).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.gallery.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19591,6 +19787,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionComputeServiceGalleryImage).Versions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.computeService.gallery.image.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceGalleryImage).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.computeService.gallery.image.version.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).__id, ok = v.Value.(string)
 		return
@@ -19641,6 +19841,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.gallery.image.version.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.gallery.image.version.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.batchService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20247,6 +20451,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).ResourceGuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.networkManager.networkGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).__id, ok = v.Value.(string)
 		return
@@ -20281,6 +20489,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).RuleCollections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.securityAdminConfiguration.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -20429,6 +20641,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.networkService.networkManager.connectivityConfiguration.hubs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).Hubs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.connectivityConfiguration.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.ipGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -24011,6 +24227,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeter).Associations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.securityPerimeter.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeter).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.securityPerimeter.profile.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeterProfile).__id, ok = v.Value.(string)
 		return
@@ -25171,6 +25391,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).ApproximateMessageCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.queue.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountQueue).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.table.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountTable).__id, ok = v.Value.(string)
 		return
@@ -25185,6 +25409,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.table.signedIdentifiers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountTable).SignedIdentifiers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.table.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountTable).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.localUser.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25237,6 +25465,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.localUser.groupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).GroupId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.localUser.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.dataProtection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25363,6 +25595,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountEncryptionScope).LastModifiedTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.encryptionScope.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountEncryptionScope).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.managementPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).__id, ok = v.Value.(string)
 		return
@@ -25385,6 +25621,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.managementPolicy.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.managementPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.managementPolicy.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25659,6 +25899,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountContainer).RemainingRetentionDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.container.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountContainer).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.fileShare.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).__id, ok = v.Value.(string)
 		return
@@ -25743,6 +25987,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).Metadata, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.fileShare.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountFileShare).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.privateEndpointConnection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).__id, ok = v.Value.(string)
 		return
@@ -25783,6 +26031,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.privateEndpointConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.objectReplicationPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).__id, ok = v.Value.(string)
 		return
@@ -25821,6 +26073,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.objectReplicationPolicy.tagsReplicationEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).TagsReplicationEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.objectReplicationPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -25887,6 +26143,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).ProvisioningIssues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.storageService.account.blobInventoryPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).__id, ok = v.Value.(string)
 		return
@@ -25913,6 +26173,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.storageService.account.blobInventoryPolicy.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.storageService.account.blobInventoryPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.storageService.account.defenderForStorageSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26511,6 +26775,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).AutoHealEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsiteconfig.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteconfig).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsiteconfig.ipSecurityRestriction.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction).__id, ok = v.Value.(string)
 		return
@@ -26651,6 +26919,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceHostingEnvironment).ClusterSettings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.hostingEnvironment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceHostingEnvironment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.hostingEnvironment.virtualNetwork.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork).__id, ok = v.Value.(string)
 		return
@@ -26735,6 +27007,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppServicePlan).ElasticScaleEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appServicePlan.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppServicePlan).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.certificate.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceCertificate).__id, ok = v.Value.(string)
 		return
@@ -26785,6 +27061,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.certificate.valid": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceCertificate).Valid, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.certificate.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceCertificate).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.webService.staticSite.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -26915,6 +27195,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).VirtualIP, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.webService.appsite.hostNameBinding.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.webService.appsite.virtualNetworkConnection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).__id, ok = v.Value.(string)
 		return
@@ -26937,6 +27221,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.webService.appsite.virtualNetworkConnection.resyncRequired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).ResyncRequired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.webService.appsite.virtualNetworkConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27375,6 +27663,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sqlService.database.advancedthreatprotection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sqlService.database.backupshorttermretentionpolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceDatabaseBackupshorttermretentionpolicy).__id, ok = v.Value.(string)
 		return
@@ -27563,6 +27855,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sqlService.server.securityAlertPolicyConfig.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).__id, ok = v.Value.(string)
 		return
@@ -27577,6 +27873,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.sqlService.server.advancedThreatProtectionSetting.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.server.devOpsAuditingSetting.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27601,6 +27901,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.sqlService.server.devOpsAuditingSetting.storageEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).StorageEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.sqlService.server.devOpsAuditingSetting.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.server.key.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27889,6 +28193,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.sqlService.database.securityAlertPolicy.creationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy).CreationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.sqlService.database.securityAlertPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.sqlService.database.vulnerabilityAssessment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -28853,6 +29161,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.mySqlService.flexibleServer.administrator.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.mySqlService.flexibleServer.administrator.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cosmosDbService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -30567,6 +30879,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).VirtualMachines, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicyVirtualMachine).__id, ok = v.Value.(string)
 		return
@@ -30839,6 +31155,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).SubAssessments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cloudDefenderService.assessment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cloudDefenderService.assessment.subAssessment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment).__id, ok = v.Value.(string)
 		return
@@ -30965,6 +31285,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.alert.resourceIdentifiers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceAlert).ResourceIdentifiers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.alert.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceAlert).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cloudDefenderService.settings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -31713,6 +32037,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cloudDefenderService.securityContact.notificationsByRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).NotificationsByRole, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cloudDefenderService.securityContact.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.authorizationService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33263,6 +33591,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule).EndIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.cacheService.redisInstance.firewallRule.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.cacheService.redisInstance.patchSchedule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).__id, ok = v.Value.(string)
 		return
@@ -33281,6 +33613,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cacheService.redisInstance.patchSchedule.entries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).Entries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cacheService.redisInstance.patchSchedule.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33321,6 +33657,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.groupIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).GroupIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cacheService.redisInstance.privateEndpointConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dataFactoryService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33431,6 +33771,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).ManagedVirtualNetwork, ok = plugin.RawToTValue[*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.dataFactoryService.factory.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactory).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.dataFactoryService.factory.linkedService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).__id, ok = v.Value.(string)
 		return
@@ -33471,12 +33815,20 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).UsesKeyVaultReference, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.dataFactoryService.factory.linkedService.authenticationType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).AuthenticationType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.dataFactoryService.factory.linkedService.annotations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).Annotations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dataFactoryService.factory.linkedService.typeProperties": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).TypeProperties, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.dataFactoryService.factory.linkedService.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dataFactoryService.factory.integrationRuntime.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33507,6 +33859,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).TypeProperties, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.dataFactoryService.factory.integrationRuntime.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).__id, ok = v.Value.(string)
 		return
@@ -33533,6 +33889,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.privateEndpoints": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).PrivateEndpoints, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.dataFactoryService.factory.managedVirtualNetwork.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33581,6 +33941,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.synapseService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33963,6 +34327,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerRegistryService.registry.webhook.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerRegistryService.registry.replication.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).__id, ok = v.Value.(string)
 		return
@@ -33999,6 +34367,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerRegistryService.registry.replication.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerRegistryService.registry.scopeMap.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).__id, ok = v.Value.(string)
 		return
@@ -34029,6 +34401,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerRegistryService.registry.scopeMap.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.scopeMap.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.registry.token.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34071,6 +34447,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken).Passwords, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerRegistryService.registry.token.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerRegistryService.registry.cacheRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).__id, ok = v.Value.(string)
 		return
@@ -34111,6 +34491,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.containerRegistryService.registry.cacheRule.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.containerRegistryService.registry.credentialSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).__id, ok = v.Value.(string)
 		return
@@ -34145,6 +34529,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerRegistryService.registry.credentialSet.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.credentialSet.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.containerRegistryService.registry.connectedRegistry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34241,6 +34629,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.containerRegistryService.registry.connectedRegistry.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.containerRegistryService.registry.connectedRegistry.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.workspace.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -34657,6 +35049,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.monitorService.workspace.nspConfiguration.provisioningIssues": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).ProvisioningIssues, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.monitorService.workspace.nspConfiguration.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.monitorService.queryPack.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39031,6 +39427,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionSentinelServiceWorkspace).DataConnectors, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.sentinelService.workspace.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionSentinelServiceWorkspace).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.sentinelService.alertRule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionSentinelServiceAlertRule).__id, ok = v.Value.(string)
 		return
@@ -39359,6 +39759,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionKustoServiceCluster).CmkKeyVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.kustoService.cluster.cmkFederatedIdentityClientId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceCluster).CmkFederatedIdentityClientId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.kustoService.cluster.databases": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceCluster).Databases, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -39447,6 +39851,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionKustoServiceClusterDatabase).DataConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.kustoService.cluster.database.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterDatabase).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.kustoService.cluster.principalAssignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).__id, ok = v.Value.(string)
 		return
@@ -39483,6 +39891,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.kustoService.cluster.principalAssignment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.kustoService.cluster.database.principalAssignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).__id, ok = v.Value.(string)
 		return
@@ -39517,6 +39929,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.kustoService.cluster.database.principalAssignment.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.kustoService.cluster.database.principalAssignment.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.kustoService.cluster.calloutPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39661,6 +40077,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.kustoService.cluster.database.dataConnection.provisioningState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).ProvisioningState, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.kustoService.cluster.database.dataConnection.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.automationService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -40903,12 +41323,13 @@ func (c *mqlAzureSubscription) GetDesktopVirtualization() *plugin.TValue[*mqlAzu
 type mqlAzureSubscriptionWebServiceFunction struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceFunctionInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	Type       plugin.TValue[string]
-	Kind       plugin.TValue[string]
-	Properties plugin.TValue[any]
+	mqlAzureSubscriptionWebServiceFunctionInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Type           plugin.TValue[string]
+	Kind           plugin.TValue[string]
+	Properties     plugin.TValue[any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceFunction creates a new instance of this resource
@@ -40966,6 +41387,22 @@ func (c *mqlAzureSubscriptionWebServiceFunction) GetKind() *plugin.TValue[string
 
 func (c *mqlAzureSubscriptionWebServiceFunction) GetProperties() *plugin.TValue[any] {
 	return &c.Properties
+}
+
+func (c *mqlAzureSubscriptionWebServiceFunction) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.function", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionResourcegroup for the azure.subscription.resourcegroup resource
@@ -43892,7 +44329,7 @@ func (c *mqlAzureSubscriptionComputeServiceDedicatedHost) GetSystemMetadata() *p
 type mqlAzureSubscriptionComputeServiceProximityPlacementGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceProximityPlacementGroupInternal it will be used here
+	mqlAzureSubscriptionComputeServiceProximityPlacementGroupInternal
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
 	Location                    plugin.TValue[string]
@@ -43905,6 +44342,7 @@ type mqlAzureSubscriptionComputeServiceProximityPlacementGroup struct {
 	VirtualMachineIds           plugin.TValue[[]any]
 	VirtualMachineScaleSetIds   plugin.TValue[[]any]
 	AvailabilitySetIds          plugin.TValue[[]any]
+	SystemMetadata              plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceProximityPlacementGroup creates a new instance of this resource
@@ -43992,11 +44430,27 @@ func (c *mqlAzureSubscriptionComputeServiceProximityPlacementGroup) GetAvailabil
 	return &c.AvailabilitySetIds
 }
 
+func (c *mqlAzureSubscriptionComputeServiceProximityPlacementGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.proximityPlacementGroup", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceImage for the azure.subscription.computeService.image resource
 type mqlAzureSubscriptionComputeServiceImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceImageInternal it will be used here
+	mqlAzureSubscriptionComputeServiceImageInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Location               plugin.TValue[string]
@@ -44008,6 +44462,7 @@ type mqlAzureSubscriptionComputeServiceImage struct {
 	StorageProfile         plugin.TValue[any]
 	ProvisioningState      plugin.TValue[string]
 	HyperVGeneration       plugin.TValue[string]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceImage creates a new instance of this resource
@@ -44103,11 +44558,27 @@ func (c *mqlAzureSubscriptionComputeServiceImage) GetHyperVGeneration() *plugin.
 	return &c.HyperVGeneration
 }
 
+func (c *mqlAzureSubscriptionComputeServiceImage) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.image", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceGallery for the azure.subscription.computeService.gallery resource
 type mqlAzureSubscriptionComputeServiceGallery struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceGalleryInternal it will be used here
+	mqlAzureSubscriptionComputeServiceGalleryInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -44121,6 +44592,7 @@ type mqlAzureSubscriptionComputeServiceGallery struct {
 	SoftDeletePolicy  plugin.TValue[any]
 	SharingStatus     plugin.TValue[any]
 	Images            plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceGallery creates a new instance of this resource
@@ -44224,11 +44696,27 @@ func (c *mqlAzureSubscriptionComputeServiceGallery) GetImages() *plugin.TValue[[
 	})
 }
 
+func (c *mqlAzureSubscriptionComputeServiceGallery) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.gallery", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceGalleryImage for the azure.subscription.computeService.gallery.image resource
 type mqlAzureSubscriptionComputeServiceGalleryImage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceGalleryImageInternal it will be used here
+	mqlAzureSubscriptionComputeServiceGalleryImageInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	Location            plugin.TValue[string]
@@ -44251,6 +44739,7 @@ type mqlAzureSubscriptionComputeServiceGalleryImage struct {
 	Eula                plugin.TValue[string]
 	ReleaseNoteUri      plugin.TValue[string]
 	Versions            plugin.TValue[[]any]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceGalleryImage creates a new instance of this resource
@@ -44390,11 +44879,27 @@ func (c *mqlAzureSubscriptionComputeServiceGalleryImage) GetVersions() *plugin.T
 	})
 }
 
+func (c *mqlAzureSubscriptionComputeServiceGalleryImage) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.gallery.image", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionComputeServiceGalleryImageVersion for the azure.subscription.computeService.gallery.image.version resource
 type mqlAzureSubscriptionComputeServiceGalleryImageVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionComputeServiceGalleryImageVersionInternal it will be used here
+	mqlAzureSubscriptionComputeServiceGalleryImageVersionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -44407,6 +44912,7 @@ type mqlAzureSubscriptionComputeServiceGalleryImageVersion struct {
 	SecurityProfile   plugin.TValue[any]
 	ReplicationStatus plugin.TValue[any]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionComputeServiceGalleryImageVersion creates a new instance of this resource
@@ -44492,6 +44998,22 @@ func (c *mqlAzureSubscriptionComputeServiceGalleryImageVersion) GetReplicationSt
 
 func (c *mqlAzureSubscriptionComputeServiceGalleryImageVersion) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionComputeServiceGalleryImageVersion) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.computeService.gallery.image.version", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionBatchService for the azure.subscription.batchService resource
@@ -46129,7 +46651,7 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManager) GetConnectivityConfig
 type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -46138,6 +46660,7 @@ type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup struct {
 	Description       plugin.TValue[string]
 	MemberType        plugin.TValue[string]
 	ResourceGuid      plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup creates a new instance of this resource
@@ -46209,11 +46732,27 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetResour
 	return &c.ResourceGuid
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.networkManager.networkGroup", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration for the azure.subscription.networkService.networkManager.securityAdminConfiguration resource
 type mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationInternal
 	Id                                      plugin.TValue[string]
 	Name                                    plugin.TValue[string]
 	Type                                    plugin.TValue[string]
@@ -46222,6 +46761,7 @@ type mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration 
 	Description                             plugin.TValue[string]
 	ApplyOnNetworkIntentPolicyBasedServices plugin.TValue[[]any]
 	RuleCollections                         plugin.TValue[[]any]
+	SystemMetadata                          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration creates a new instance of this resource
@@ -46302,6 +46842,22 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurat
 		}
 
 		return c.ruleCollections()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.networkManager.securityAdminConfiguration", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -46548,6 +47104,7 @@ type mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration s
 	DeleteExistingPeering plugin.TValue[bool]
 	AppliesToGroups       plugin.TValue[[]any]
 	Hubs                  plugin.TValue[[]any]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration creates a new instance of this resource
@@ -46641,6 +47198,22 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfigurati
 
 func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration) GetHubs() *plugin.TValue[[]any] {
 	return &c.Hubs
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.networkManager.connectivityConfiguration", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionNetworkServiceIpGroup for the azure.subscription.networkService.ipGroup resource
@@ -54957,7 +55530,7 @@ func (c *mqlAzureSubscriptionNetworkServiceExpressRouteCircuitAuthorization) Get
 type mqlAzureSubscriptionNetworkServiceSecurityPerimeter struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionNetworkServiceSecurityPerimeterInternal it will be used here
+	mqlAzureSubscriptionNetworkServiceSecurityPerimeterInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -54967,6 +55540,7 @@ type mqlAzureSubscriptionNetworkServiceSecurityPerimeter struct {
 	ProvisioningState plugin.TValue[string]
 	Profiles          plugin.TValue[[]any]
 	Associations      plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionNetworkServiceSecurityPerimeter creates a new instance of this resource
@@ -55063,6 +55637,22 @@ func (c *mqlAzureSubscriptionNetworkServiceSecurityPerimeter) GetAssociations() 
 		}
 
 		return c.associations()
+	})
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceSecurityPerimeter) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.securityPerimeter", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -57689,6 +58279,7 @@ type mqlAzureSubscriptionStorageServiceAccountQueue struct {
 	Name                    plugin.TValue[string]
 	Metadata                plugin.TValue[map[string]any]
 	ApproximateMessageCount plugin.TValue[int64]
+	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountQueue creates a new instance of this resource
@@ -57746,14 +58337,31 @@ func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetApproximateMessageCo
 	})
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountQueue) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.queue", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountTable for the azure.subscription.storageService.account.table resource
 type mqlAzureSubscriptionStorageServiceAccountTable struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountTableInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountTableInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	SignedIdentifiers plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountTable creates a new instance of this resource
@@ -57805,11 +58413,27 @@ func (c *mqlAzureSubscriptionStorageServiceAccountTable) GetSignedIdentifiers() 
 	return &c.SignedIdentifiers
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountTable) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.table", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountLocalUser for the azure.subscription.storageService.account.localUser resource
 type mqlAzureSubscriptionStorageServiceAccountLocalUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountLocalUserInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountLocalUserInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	Type                  plugin.TValue[string]
@@ -57822,6 +58446,7 @@ type mqlAzureSubscriptionStorageServiceAccountLocalUser struct {
 	PermissionScopes      plugin.TValue[[]any]
 	UserId                plugin.TValue[int64]
 	GroupId               plugin.TValue[int64]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountLocalUser creates a new instance of this resource
@@ -57907,6 +58532,22 @@ func (c *mqlAzureSubscriptionStorageServiceAccountLocalUser) GetUserId() *plugin
 
 func (c *mqlAzureSubscriptionStorageServiceAccountLocalUser) GetGroupId() *plugin.TValue[int64] {
 	return &c.GroupId
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountLocalUser) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.localUser", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionStorageServiceAccountDataProtection for the azure.subscription.storageService.account.dataProtection resource
@@ -58183,7 +58824,7 @@ func (c *mqlAzureSubscriptionStorageServiceAccountFilePropertiesProtocolSettings
 type mqlAzureSubscriptionStorageServiceAccountEncryptionScope struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountEncryptionScopeInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountEncryptionScopeInternal
 	Id                              plugin.TValue[string]
 	Name                            plugin.TValue[string]
 	Type                            plugin.TValue[string]
@@ -58195,6 +58836,7 @@ type mqlAzureSubscriptionStorageServiceAccountEncryptionScope struct {
 	LastKeyRotationTimestamp        plugin.TValue[*time.Time]
 	CreationTime                    plugin.TValue[*time.Time]
 	LastModifiedTime                plugin.TValue[*time.Time]
+	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountEncryptionScope creates a new instance of this resource
@@ -58278,16 +58920,33 @@ func (c *mqlAzureSubscriptionStorageServiceAccountEncryptionScope) GetLastModifi
 	return &c.LastModifiedTime
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountEncryptionScope) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.encryptionScope", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountManagementPolicy for the azure.subscription.storageService.account.managementPolicy resource
 type mqlAzureSubscriptionStorageServiceAccountManagementPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountManagementPolicyInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountManagementPolicyInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Type             plugin.TValue[string]
 	LastModifiedTime plugin.TValue[*time.Time]
 	Rules            plugin.TValue[[]any]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountManagementPolicy creates a new instance of this resource
@@ -58345,6 +59004,22 @@ func (c *mqlAzureSubscriptionStorageServiceAccountManagementPolicy) GetLastModif
 
 func (c *mqlAzureSubscriptionStorageServiceAccountManagementPolicy) GetRules() *plugin.TValue[[]any] {
 	return &c.Rules
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountManagementPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.managementPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionStorageServiceAccountManagementPolicyRule for the azure.subscription.storageService.account.managementPolicy.rule resource
@@ -58839,7 +59514,7 @@ func (c *mqlAzureSubscriptionStorageServiceAccountServicePropertiesLogging) GetR
 type mqlAzureSubscriptionStorageServiceAccountContainer struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountContainerInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountContainerInternal
 	Id                                              plugin.TValue[string]
 	Name                                            plugin.TValue[string]
 	Type                                            plugin.TValue[string]
@@ -58863,6 +59538,7 @@ type mqlAzureSubscriptionStorageServiceAccountContainer struct {
 	Deleted                                         plugin.TValue[bool]
 	DeletedTime                                     plugin.TValue[*time.Time]
 	RemainingRetentionDays                          plugin.TValue[int64]
+	SystemMetadata                                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountContainer creates a new instance of this resource
@@ -58994,11 +59670,27 @@ func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetRemainingRetenti
 	return &c.RemainingRetentionDays
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountContainer) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.container", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountFileShare for the azure.subscription.storageService.account.fileShare resource
 type mqlAzureSubscriptionStorageServiceAccountFileShare struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountFileShareInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountFileShareInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
@@ -59019,6 +59711,7 @@ type mqlAzureSubscriptionStorageServiceAccountFileShare struct {
 	LeaseStatus               plugin.TValue[string]
 	LeaseDuration             plugin.TValue[string]
 	Metadata                  plugin.TValue[map[string]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountFileShare creates a new instance of this resource
@@ -59138,11 +59831,27 @@ func (c *mqlAzureSubscriptionStorageServiceAccountFileShare) GetMetadata() *plug
 	return &c.Metadata
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountFileShare) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.fileShare", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection for the azure.subscription.storageService.account.privateEndpointConnection resource
 type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnectionInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnectionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -59152,6 +59861,7 @@ type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection struct {
 	Description       plugin.TValue[string]
 	ActionsRequired   plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountPrivateEndpointConnection creates a new instance of this resource
@@ -59239,11 +59949,27 @@ func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) Get
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.privateEndpointConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy for the azure.subscription.storageService.account.objectReplicationPolicy resource
 type mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicyInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicyInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Type                   plugin.TValue[string]
@@ -59253,6 +59979,7 @@ type mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy struct {
 	EnabledTime            plugin.TValue[*time.Time]
 	Rules                  plugin.TValue[[]any]
 	TagsReplicationEnabled plugin.TValue[bool]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountObjectReplicationPolicy creates a new instance of this resource
@@ -59328,11 +60055,27 @@ func (c *mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy) GetTa
 	return &c.TagsReplicationEnabled
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.objectReplicationPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration for the azure.subscription.storageService.account.networkSecurityPerimeterConfiguration resource
 type mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfigurationInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfigurationInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
@@ -59348,6 +60091,7 @@ type mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfigurat
 	AssociationName           plugin.TValue[string]
 	AssociationAccessMode     plugin.TValue[string]
 	ProvisioningIssues        plugin.TValue[[]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration creates a new instance of this resource
@@ -59447,17 +60191,34 @@ func (c *mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfig
 	return &c.ProvisioningIssues
 }
 
+func (c *mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.networkSecurityPerimeterConfiguration", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy for the azure.subscription.storageService.account.blobInventoryPolicy resource
 type mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicyInternal it will be used here
+	mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicyInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Type             plugin.TValue[string]
 	Enabled          plugin.TValue[bool]
 	LastModifiedTime plugin.TValue[*time.Time]
 	Rules            plugin.TValue[[]any]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionStorageServiceAccountBlobInventoryPolicy creates a new instance of this resource
@@ -59519,6 +60280,22 @@ func (c *mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy) GetLastMo
 
 func (c *mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy) GetRules() *plugin.TValue[[]any] {
 	return &c.Rules
+}
+
+func (c *mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.storageService.account.blobInventoryPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionStorageServiceAccountDefenderForStorageSetting for the azure.subscription.storageService.account.defenderForStorageSetting resource
@@ -60916,7 +61693,7 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteauthsettings) GetUnauthenticatedCl
 type mqlAzureSubscriptionWebServiceAppsiteconfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceAppsiteconfigInternal it will be used here
+	mqlAzureSubscriptionWebServiceAppsiteconfigInternal
 	Id                                  plugin.TValue[string]
 	Name                                plugin.TValue[string]
 	Kind                                plugin.TValue[string]
@@ -60937,6 +61714,7 @@ type mqlAzureSubscriptionWebServiceAppsiteconfig struct {
 	HttpLoggingEnabled                  plugin.TValue[bool]
 	DetailedErrorLoggingEnabled         plugin.TValue[bool]
 	AutoHealEnabled                     plugin.TValue[bool]
+	SystemMetadata                      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppsiteconfig creates a new instance of this resource
@@ -61082,6 +61860,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetAutoHealEnabled() *plug
 	return &c.AutoHealEnabled
 }
 
+func (c *mqlAzureSubscriptionWebServiceAppsiteconfig) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsiteconfig", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction for the azure.subscription.webService.appsiteconfig.ipSecurityRestriction resource
 type mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction struct {
 	MqlRuntime *plugin.Runtime
@@ -61175,7 +61969,7 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteconfigIpSecurityRestriction) GetHe
 type mqlAzureSubscriptionWebServiceHostingEnvironment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceHostingEnvironmentInternal it will be used here
+	mqlAzureSubscriptionWebServiceHostingEnvironmentInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
@@ -61199,6 +61993,7 @@ type mqlAzureSubscriptionWebServiceHostingEnvironment struct {
 	UserWhitelistedIpRanges   plugin.TValue[[]any]
 	VirtualNetwork            plugin.TValue[*mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork]
 	ClusterSettings           plugin.TValue[[]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceHostingEnvironment creates a new instance of this resource
@@ -61325,6 +62120,22 @@ func (c *mqlAzureSubscriptionWebServiceHostingEnvironment) GetClusterSettings() 
 	return &c.ClusterSettings
 }
 
+func (c *mqlAzureSubscriptionWebServiceHostingEnvironment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.hostingEnvironment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork for the azure.subscription.webService.hostingEnvironment.virtualNetwork resource
 type mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork struct {
 	MqlRuntime *plugin.Runtime
@@ -61388,7 +62199,7 @@ func (c *mqlAzureSubscriptionWebServiceHostingEnvironmentVirtualNetwork) GetSubn
 type mqlAzureSubscriptionWebServiceAppServicePlan struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceAppServicePlanInternal it will be used here
+	mqlAzureSubscriptionWebServiceAppServicePlanInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Location               plugin.TValue[string]
@@ -61404,6 +62215,7 @@ type mqlAzureSubscriptionWebServiceAppServicePlan struct {
 	Status                 plugin.TValue[string]
 	PerSiteScaling         plugin.TValue[bool]
 	ElasticScaleEnabled    plugin.TValue[bool]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppServicePlan creates a new instance of this resource
@@ -61503,11 +62315,27 @@ func (c *mqlAzureSubscriptionWebServiceAppServicePlan) GetElasticScaleEnabled() 
 	return &c.ElasticScaleEnabled
 }
 
+func (c *mqlAzureSubscriptionWebServiceAppServicePlan) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appServicePlan", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionWebServiceCertificate for the azure.subscription.webService.certificate resource
 type mqlAzureSubscriptionWebServiceCertificate struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceCertificateInternal it will be used here
+	mqlAzureSubscriptionWebServiceCertificateInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	Location       plugin.TValue[string]
@@ -61520,6 +62348,7 @@ type mqlAzureSubscriptionWebServiceCertificate struct {
 	ExpirationDate plugin.TValue[*time.Time]
 	HostNames      plugin.TValue[[]any]
 	Valid          plugin.TValue[bool]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceCertificate creates a new instance of this resource
@@ -61605,6 +62434,22 @@ func (c *mqlAzureSubscriptionWebServiceCertificate) GetHostNames() *plugin.TValu
 
 func (c *mqlAzureSubscriptionWebServiceCertificate) GetValid() *plugin.TValue[bool] {
 	return &c.Valid
+}
+
+func (c *mqlAzureSubscriptionWebServiceCertificate) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.certificate", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionWebServiceStaticSite for the azure.subscription.webService.staticSite resource
@@ -61787,13 +62632,14 @@ func (c *mqlAzureSubscriptionWebServiceStaticSite) GetSystemMetadata() *plugin.T
 type mqlAzureSubscriptionWebServiceAppsiteHostNameBinding struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceAppsiteHostNameBindingInternal it will be used here
-	Id           plugin.TValue[string]
-	Name         plugin.TValue[string]
-	HostNameType plugin.TValue[string]
-	SslState     plugin.TValue[string]
-	Thumbprint   plugin.TValue[string]
-	VirtualIP    plugin.TValue[string]
+	mqlAzureSubscriptionWebServiceAppsiteHostNameBindingInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	HostNameType   plugin.TValue[string]
+	SslState       plugin.TValue[string]
+	Thumbprint     plugin.TValue[string]
+	VirtualIP      plugin.TValue[string]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppsiteHostNameBinding creates a new instance of this resource
@@ -61857,16 +62703,33 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteHostNameBinding) GetVirtualIP() *p
 	return &c.VirtualIP
 }
 
+func (c *mqlAzureSubscriptionWebServiceAppsiteHostNameBinding) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite.hostNameBinding", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection for the azure.subscription.webService.appsite.virtualNetworkConnection resource
 type mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnectionInternal it will be used here
+	mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnectionInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	VnetResourceId plugin.TValue[string]
 	IsSwift        plugin.TValue[bool]
 	ResyncRequired plugin.TValue[bool]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection creates a new instance of this resource
@@ -61924,6 +62787,22 @@ func (c *mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection) GetIsSwi
 
 func (c *mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection) GetResyncRequired() *plugin.TValue[bool] {
 	return &c.ResyncRequired
+}
+
+func (c *mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.webService.appsite.virtualNetworkConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSqlService for the azure.subscription.sqlService resource
@@ -63028,10 +63907,11 @@ func (c *mqlAzureSubscriptionSqlServiceDatabase) GetGeoBackupPolicy() *plugin.TV
 type mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotectionInternal it will be used here
-	Id           plugin.TValue[string]
-	State        plugin.TValue[string]
-	CreationTime plugin.TValue[*time.Time]
+	mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotectionInternal
+	Id             plugin.TValue[string]
+	State          plugin.TValue[string]
+	CreationTime   plugin.TValue[*time.Time]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection creates a new instance of this resource
@@ -63076,6 +63956,22 @@ func (c *mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection) GetStat
 
 func (c *mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection) GetCreationTime() *plugin.TValue[*time.Time] {
 	return &c.CreationTime
+}
+
+func (c *mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sqlService.database.advancedthreatprotection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSqlServiceDatabaseBackupshorttermretentionpolicy for the azure.subscription.sqlService.database.backupshorttermretentionpolicy resource
@@ -63469,7 +64365,7 @@ func (c *mqlAzureSubscriptionSqlServiceServerEncryptionProtectorConfig) GetKey()
 type mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfigInternal it will be used here
+	mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfigInternal
 	Id                 plugin.TValue[string]
 	State              plugin.TValue[string]
 	DisabledAlerts     plugin.TValue[[]any]
@@ -63478,6 +64374,7 @@ type mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig struct {
 	StorageEndpoint    plugin.TValue[string]
 	RetentionDays      plugin.TValue[int64]
 	CreationTime       plugin.TValue[*time.Time]
+	SystemMetadata     plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig creates a new instance of this resource
@@ -63549,14 +64446,31 @@ func (c *mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig) GetCreat
 	return &c.CreationTime
 }
 
+func (c *mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sqlService.server.securityAlertPolicyConfig", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting for the azure.subscription.sqlService.server.advancedThreatProtectionSetting resource
 type mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSettingInternal it will be used here
-	Id           plugin.TValue[string]
-	State        plugin.TValue[string]
-	CreationTime plugin.TValue[*time.Time]
+	mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSettingInternal
+	Id             plugin.TValue[string]
+	State          plugin.TValue[string]
+	CreationTime   plugin.TValue[*time.Time]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting creates a new instance of this resource
@@ -63608,16 +64522,33 @@ func (c *mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting) Ge
 	return &c.CreationTime
 }
 
+func (c *mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sqlService.server.advancedThreatProtectionSetting", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting for the azure.subscription.sqlService.server.devOpsAuditingSetting resource
 type mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSettingInternal it will be used here
+	mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSettingInternal
 	Id                           plugin.TValue[string]
 	State                        plugin.TValue[string]
 	IsAzureMonitorTargetEnabled  plugin.TValue[bool]
 	StorageAccountSubscriptionId plugin.TValue[string]
 	StorageEndpoint              plugin.TValue[string]
+	SystemMetadata               plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSqlServiceServerDevOpsAuditingSetting creates a new instance of this resource
@@ -63675,6 +64606,22 @@ func (c *mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting) GetStorageAc
 
 func (c *mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting) GetStorageEndpoint() *plugin.TValue[string] {
 	return &c.StorageEndpoint
+}
+
+func (c *mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sqlService.server.devOpsAuditingSetting", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSqlServiceServerKey for the azure.subscription.sqlService.server.key resource
@@ -64242,7 +65189,7 @@ func (c *mqlAzureSubscriptionSqlServiceDatabaseBlobAuditingPolicy) GetStorageEnd
 type mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicyInternal it will be used here
+	mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicyInternal
 	Id                 plugin.TValue[string]
 	State              plugin.TValue[string]
 	DisabledAlerts     plugin.TValue[[]any]
@@ -64251,6 +65198,7 @@ type mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy struct {
 	StorageEndpoint    plugin.TValue[string]
 	RetentionDays      plugin.TValue[int64]
 	CreationTime       plugin.TValue[*time.Time]
+	SystemMetadata     plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy creates a new instance of this resource
@@ -64320,6 +65268,22 @@ func (c *mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy) GetRetention
 
 func (c *mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy) GetCreationTime() *plugin.TValue[*time.Time] {
 	return &c.CreationTime
+}
+
+func (c *mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sqlService.database.securityAlertPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSqlServiceDatabaseVulnerabilityAssessment for the azure.subscription.sqlService.database.vulnerabilityAssessment resource
@@ -66598,7 +67562,7 @@ func (c *mqlAzureSubscriptionMySqlServiceFlexibleServer) GetSystemMetadata() *pl
 type mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMySqlServiceFlexibleServerAdministratorInternal it will be used here
+	mqlAzureSubscriptionMySqlServiceFlexibleServerAdministratorInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -66606,6 +67570,7 @@ type mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator struct {
 	Login             plugin.TValue[string]
 	Sid               plugin.TValue[string]
 	TenantId          plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMySqlServiceFlexibleServerAdministrator creates a new instance of this resource
@@ -66671,6 +67636,22 @@ func (c *mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator) GetSid() *
 
 func (c *mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator) GetTenantId() *plugin.TValue[string] {
 	return &c.TenantId
+}
+
+func (c *mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.mySqlService.flexibleServer.administrator", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionCosmosDbService for the azure.subscription.cosmosDbService resource
@@ -71012,6 +71993,7 @@ type mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy struct {
 	Type              plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
 	VirtualMachines   plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy creates a new instance of this resource
@@ -71088,6 +72070,22 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy) GetVirt
 		}
 
 		return c.virtualMachines()
+	})
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.jitNetworkAccessPolicy", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -71509,7 +72507,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceRegulatoryComplianceControl) Ge
 type mqlAzureSubscriptionCloudDefenderServiceAssessment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceAssessmentInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceAssessmentInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	DisplayName              plugin.TValue[string]
@@ -71537,6 +72535,7 @@ type mqlAzureSubscriptionCloudDefenderServiceAssessment struct {
 	Preview                  plugin.TValue[bool]
 	Description              plugin.TValue[string]
 	SubAssessments           plugin.TValue[[]any]
+	SystemMetadata           plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCloudDefenderServiceAssessment creates a new instance of this resource
@@ -71696,6 +72695,22 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetSubAssessments()
 	})
 }
 
+func (c *mqlAzureSubscriptionCloudDefenderServiceAssessment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.assessment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment for the azure.subscription.cloudDefenderService.assessment.subAssessment resource
 type mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment struct {
 	MqlRuntime *plugin.Runtime
@@ -71819,7 +72834,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment) GetAdd
 type mqlAzureSubscriptionCloudDefenderServiceAlert struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceAlertInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceAlertInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	DisplayName         plugin.TValue[string]
@@ -71835,6 +72850,7 @@ type mqlAzureSubscriptionCloudDefenderServiceAlert struct {
 	TimeGenerated       plugin.TValue[*time.Time]
 	RemediationSteps    plugin.TValue[[]any]
 	ResourceIdentifiers plugin.TValue[[]any]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCloudDefenderServiceAlert creates a new instance of this resource
@@ -71932,6 +72948,22 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceAlert) GetRemediationSteps() *p
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceAlert) GetResourceIdentifiers() *plugin.TValue[[]any] {
 	return &c.ResourceIdentifiers
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceAlert) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.alert", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionCloudDefenderServiceSettings for the azure.subscription.cloudDefenderService.settings resource
@@ -73442,7 +74474,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceDefenderForContainersExtension)
 type mqlAzureSubscriptionCloudDefenderServiceSecurityContact struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCloudDefenderServiceSecurityContactInternal it will be used here
+	mqlAzureSubscriptionCloudDefenderServiceSecurityContactInternal
 	Id                  plugin.TValue[string]
 	Name                plugin.TValue[string]
 	IsEnabled           plugin.TValue[bool]
@@ -73450,6 +74482,7 @@ type mqlAzureSubscriptionCloudDefenderServiceSecurityContact struct {
 	Emails              plugin.TValue[[]any]
 	NotificationSources plugin.TValue[any]
 	NotificationsByRole plugin.TValue[any]
+	SystemMetadata      plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCloudDefenderServiceSecurityContact creates a new instance of this resource
@@ -73515,6 +74548,22 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetNotificatio
 
 func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetNotificationsByRole() *plugin.TValue[any] {
 	return &c.NotificationsByRole
+}
+
+func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cloudDefenderService.securityContact", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionAuthorizationService for the azure.subscription.authorizationService resource
@@ -77205,12 +78254,13 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstance) GetSystemMetadata() *plu
 type mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRuleInternal it will be used here
+	mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRuleInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	Type           plugin.TValue[string]
 	StartIpAddress plugin.TValue[string]
 	EndIpAddress   plugin.TValue[string]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCacheServiceRedisInstanceFirewallRule creates a new instance of this resource
@@ -77270,15 +78320,32 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule) GetEndIpAddr
 	return &c.EndIpAddress
 }
 
+func (c *mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance.firewallRule", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule for the azure.subscription.cacheService.redisInstance.patchSchedule resource
 type mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCacheServiceRedisInstancePatchScheduleInternal it will be used here
-	Id       plugin.TValue[string]
-	Name     plugin.TValue[string]
-	Location plugin.TValue[string]
-	Entries  plugin.TValue[[]any]
+	mqlAzureSubscriptionCacheServiceRedisInstancePatchScheduleInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	Location       plugin.TValue[string]
+	Entries        plugin.TValue[[]any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCacheServiceRedisInstancePatchSchedule creates a new instance of this resource
@@ -77334,11 +78401,27 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule) GetEntries(
 	return &c.Entries
 }
 
+func (c *mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance.patchSchedule", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection for the azure.subscription.cacheService.redisInstance.privateEndpointConnection resource
 type mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnectionInternal it will be used here
+	mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnectionInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -77348,6 +78431,7 @@ type mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection stru
 	Description       plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
 	GroupIds          plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection creates a new instance of this resource
@@ -77433,6 +78517,22 @@ func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection)
 
 func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) GetGroupIds() *plugin.TValue[[]any] {
 	return &c.GroupIds
+}
+
+func (c *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cacheService.redisInstance.privateEndpointConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionDataFactoryService for the azure.subscription.dataFactoryService resource
@@ -77529,6 +78629,7 @@ type mqlAzureSubscriptionDataFactoryServiceFactory struct {
 	LinkedServices          plugin.TValue[[]any]
 	IntegrationRuntimes     plugin.TValue[[]any]
 	ManagedVirtualNetwork   plugin.TValue[*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork]
+	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactory creates a new instance of this resource
@@ -77732,11 +78833,27 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetManagedVirtualNetwork
 	})
 }
 
+func (c *mqlAzureSubscriptionDataFactoryServiceFactory) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService for the azure.subscription.dataFactoryService.factory.linkedService resource
 type mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDataFactoryServiceFactoryLinkedServiceInternal it will be used here
+	mqlAzureSubscriptionDataFactoryServiceFactoryLinkedServiceInternal
 	Id                     plugin.TValue[string]
 	Name                   plugin.TValue[string]
 	Type                   plugin.TValue[string]
@@ -77746,8 +78863,10 @@ type mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService struct {
 	IntegrationRuntimeName plugin.TValue[string]
 	ParameterNames         plugin.TValue[[]any]
 	UsesKeyVaultReference  plugin.TValue[bool]
+	AuthenticationType     plugin.TValue[string]
 	Annotations            plugin.TValue[[]any]
 	TypeProperties         plugin.TValue[any]
+	SystemMetadata         plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactoryLinkedService creates a new instance of this resource
@@ -77823,6 +78942,10 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) GetUsesKeyV
 	return &c.UsesKeyVaultReference
 }
 
+func (c *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) GetAuthenticationType() *plugin.TValue[string] {
+	return &c.AuthenticationType
+}
+
 func (c *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) GetAnnotations() *plugin.TValue[[]any] {
 	return &c.Annotations
 }
@@ -77831,17 +78954,34 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) GetTypeProp
 	return &c.TypeProperties
 }
 
+func (c *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory.linkedService", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime for the azure.subscription.dataFactoryService.factory.integrationRuntime resource
 type mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntimeInternal it will be used here
+	mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntimeInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	Type           plugin.TValue[string]
 	RuntimeType    plugin.TValue[string]
 	Description    plugin.TValue[string]
 	TypeProperties plugin.TValue[any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime creates a new instance of this resource
@@ -77905,17 +79045,34 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime) GetTyp
 	return &c.TypeProperties
 }
 
+func (c *mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory.integrationRuntime", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork for the azure.subscription.dataFactoryService.factory.managedVirtualNetwork resource
 type mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetworkInternal it will be used here
+	mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetworkInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Type             plugin.TValue[string]
 	Alias            plugin.TValue[string]
 	VnetId           plugin.TValue[string]
 	PrivateEndpoints plugin.TValue[[]any]
+	SystemMetadata   plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork creates a new instance of this resource
@@ -77991,11 +79148,27 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork) Get
 	})
 }
 
+func (c *mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory.managedVirtualNetwork", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint for the azure.subscription.dataFactoryService.factory.managedPrivateEndpoint resource
 type mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpointInternal it will be used here
+	mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpointInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	Type                  plugin.TValue[string]
@@ -78007,6 +79180,7 @@ type mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint struct 
 	Fqdns                 plugin.TValue[[]any]
 	Reserved              plugin.TValue[bool]
 	ProvisioningState     plugin.TValue[string]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint creates a new instance of this resource
@@ -78088,6 +79262,22 @@ func (c *mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint) Ge
 
 func (c *mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.dataFactoryService.factory.managedPrivateEndpoint", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionSynapseService for the azure.subscription.synapseService resource
@@ -79083,7 +80273,7 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryEncryption) GetKey(
 type mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerRegistryServiceRegistryWebhookInternal it will be used here
+	mqlAzureSubscriptionContainerRegistryServiceRegistryWebhookInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Location          plugin.TValue[string]
@@ -79093,6 +80283,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook struct {
 	Scope             plugin.TValue[string]
 	Actions           plugin.TValue[[]any]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryWebhook creates a new instance of this resource
@@ -79168,11 +80359,27 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook) GetProvisi
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.webhook", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryReplication for the azure.subscription.containerRegistryService.registry.replication resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryReplication struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerRegistryServiceRegistryReplicationInternal it will be used here
+	mqlAzureSubscriptionContainerRegistryServiceRegistryReplicationInternal
 	Id                    plugin.TValue[string]
 	Name                  plugin.TValue[string]
 	Location              plugin.TValue[string]
@@ -79181,6 +80388,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryReplication struct {
 	RegionEndpointEnabled plugin.TValue[bool]
 	ZoneRedundancy        plugin.TValue[string]
 	ProvisioningState     plugin.TValue[string]
+	SystemMetadata        plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryReplication creates a new instance of this resource
@@ -79252,11 +80460,27 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryReplication) GetPro
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryReplication) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.replication", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap for the azure.subscription.containerRegistryService.registry.scopeMap resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMapInternal it will be used here
+	mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMapInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -79264,6 +80488,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap struct {
 	Actions           plugin.TValue[[]any]
 	CreationDate      plugin.TValue[*time.Time]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryScopeMap creates a new instance of this resource
@@ -79331,6 +80556,22 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap) GetProvis
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.scopeMap", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryToken for the azure.subscription.containerRegistryService.registry.token resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryToken struct {
 	MqlRuntime *plugin.Runtime
@@ -79345,6 +80586,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryToken struct {
 	ScopeMap          plugin.TValue[*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap]
 	Certificates      plugin.TValue[[]any]
 	Passwords         plugin.TValue[[]any]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryToken creates a new instance of this resource
@@ -79432,6 +80674,22 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryToken) GetPasswords
 	return &c.Passwords
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryToken) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.token", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule for the azure.subscription.containerRegistryService.registry.cacheRule resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule struct {
 	MqlRuntime *plugin.Runtime
@@ -79446,6 +80704,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule struct {
 	CredentialSet           plugin.TValue[*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet]
 	CreationDate            plugin.TValue[*time.Time]
 	ProvisioningState       plugin.TValue[string]
+	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryCacheRule creates a new instance of this resource
@@ -79533,11 +80792,27 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule) GetProvi
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.cacheRule", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet for the azure.subscription.containerRegistryService.registry.credentialSet resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSetInternal it will be used here
+	mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSetInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	Type              plugin.TValue[string]
@@ -79546,6 +80821,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet struct {
 	AuthCredentials   plugin.TValue[[]any]
 	CreationDate      plugin.TValue[*time.Time]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryCredentialSet creates a new instance of this resource
@@ -79617,11 +80893,27 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet) GetP
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.credentialSet", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry for the azure.subscription.containerRegistryService.registry.connectedRegistry resource
 type mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistryInternal it will be used here
+	mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistryInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
@@ -79645,6 +80937,7 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry struc
 	ClientTokenIds            plugin.TValue[[]any]
 	NotificationsList         plugin.TValue[[]any]
 	ProvisioningState         plugin.TValue[string]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry creates a new instance of this resource
@@ -79774,6 +81067,22 @@ func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry) 
 
 func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.containerRegistryService.registry.connectedRegistry", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionMonitorServiceWorkspace for the azure.subscription.monitorService.workspace resource
@@ -80678,7 +81987,7 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspaceTable) GetSystemMetadata() *
 type mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionMonitorServiceWorkspaceNspConfigurationInternal it will be used here
+	mqlAzureSubscriptionMonitorServiceWorkspaceNspConfigurationInternal
 	Id                        plugin.TValue[string]
 	Name                      plugin.TValue[string]
 	Type                      plugin.TValue[string]
@@ -80694,6 +82003,7 @@ type mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration struct {
 	AssociationName           plugin.TValue[string]
 	AssociationAccessMode     plugin.TValue[string]
 	ProvisioningIssues        plugin.TValue[[]any]
+	SystemMetadata            plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionMonitorServiceWorkspaceNspConfiguration creates a new instance of this resource
@@ -80791,6 +82101,22 @@ func (c *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) GetAssocia
 
 func (c *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) GetProvisioningIssues() *plugin.TValue[[]any] {
 	return &c.ProvisioningIssues
+}
+
+func (c *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.monitorService.workspace.nspConfiguration", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionMonitorServiceQueryPack for the azure.subscription.monitorService.queryPack resource
@@ -91631,7 +92957,7 @@ func (c *mqlAzureSubscriptionSentinelService) GetWorkspaces() *plugin.TValue[[]a
 type mqlAzureSubscriptionSentinelServiceWorkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionSentinelServiceWorkspaceInternal it will be used here
+	mqlAzureSubscriptionSentinelServiceWorkspaceInternal
 	Id             plugin.TValue[string]
 	Name           plugin.TValue[string]
 	ResourceGroup  plugin.TValue[string]
@@ -91639,6 +92965,7 @@ type mqlAzureSubscriptionSentinelServiceWorkspace struct {
 	Workspace      plugin.TValue[*mqlAzureSubscriptionMonitorServiceWorkspace]
 	AlertRules     plugin.TValue[[]any]
 	DataConnectors plugin.TValue[[]any]
+	SystemMetadata plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionSentinelServiceWorkspace creates a new instance of this resource
@@ -91729,6 +93056,22 @@ func (c *mqlAzureSubscriptionSentinelServiceWorkspace) GetAlertRules() *plugin.T
 func (c *mqlAzureSubscriptionSentinelServiceWorkspace) GetDataConnectors() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.DataConnectors, func() ([]any, error) {
 		return c.dataConnectors()
+	})
+}
+
+func (c *mqlAzureSubscriptionSentinelServiceWorkspace) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.sentinelService.workspace", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
 	})
 }
 
@@ -92380,6 +93723,7 @@ type mqlAzureSubscriptionKustoServiceCluster struct {
 	CmkKeyName                    plugin.TValue[string]
 	CmkKeyVaultUri                plugin.TValue[string]
 	CmkKeyVersion                 plugin.TValue[string]
+	CmkFederatedIdentityClientId  plugin.TValue[string]
 	Databases                     plugin.TValue[[]any]
 	PrincipalAssignments          plugin.TValue[[]any]
 	CalloutPolicies               plugin.TValue[[]any]
@@ -92517,6 +93861,10 @@ func (c *mqlAzureSubscriptionKustoServiceCluster) GetCmkKeyVersion() *plugin.TVa
 	return &c.CmkKeyVersion
 }
 
+func (c *mqlAzureSubscriptionKustoServiceCluster) GetCmkFederatedIdentityClientId() *plugin.TValue[string] {
+	return &c.CmkFederatedIdentityClientId
+}
+
 func (c *mqlAzureSubscriptionKustoServiceCluster) GetDatabases() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Databases, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -92617,7 +93965,7 @@ func (c *mqlAzureSubscriptionKustoServiceCluster) GetSystemMetadata() *plugin.TV
 type mqlAzureSubscriptionKustoServiceClusterDatabase struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionKustoServiceClusterDatabaseInternal it will be used here
+	mqlAzureSubscriptionKustoServiceClusterDatabaseInternal
 	Id                      plugin.TValue[string]
 	Name                    plugin.TValue[string]
 	Location                plugin.TValue[string]
@@ -92633,6 +93981,7 @@ type mqlAzureSubscriptionKustoServiceClusterDatabase struct {
 	LeaderCluster           plugin.TValue[*mqlAzureSubscriptionKustoServiceCluster]
 	PrincipalAssignments    plugin.TValue[[]any]
 	DataConnections         plugin.TValue[[]any]
+	SystemMetadata          plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterDatabase creates a new instance of this resource
@@ -92768,11 +94117,27 @@ func (c *mqlAzureSubscriptionKustoServiceClusterDatabase) GetDataConnections() *
 	})
 }
 
+func (c *mqlAzureSubscriptionKustoServiceClusterDatabase) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.database", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment for the azure.subscription.kustoService.cluster.principalAssignment resource
 type mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionKustoServiceClusterPrincipalAssignmentInternal it will be used here
+	mqlAzureSubscriptionKustoServiceClusterPrincipalAssignmentInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	PrincipalId       plugin.TValue[string]
@@ -92781,6 +94146,7 @@ type mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment struct {
 	Role              plugin.TValue[string]
 	TenantId          plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterPrincipalAssignment creates a new instance of this resource
@@ -92852,11 +94218,27 @@ func (c *mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment) GetProvisio
 	return &c.ProvisioningState
 }
 
+func (c *mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.principalAssignment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
 // mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment for the azure.subscription.kustoService.cluster.database.principalAssignment resource
 type mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignmentInternal it will be used here
+	mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignmentInternal
 	Id                plugin.TValue[string]
 	Name              plugin.TValue[string]
 	PrincipalId       plugin.TValue[string]
@@ -92865,6 +94247,7 @@ type mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment struct {
 	Role              plugin.TValue[string]
 	TenantId          plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment creates a new instance of this resource
@@ -92934,6 +94317,22 @@ func (c *mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment) Get
 
 func (c *mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.database.principalAssignment", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionKustoServiceClusterCalloutPolicy for the azure.subscription.kustoService.cluster.calloutPolicy resource
@@ -93216,6 +94615,7 @@ type mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection struct {
 	SourceResourceId  plugin.TValue[string]
 	ManagedIdentity   plugin.TValue[*mqlAzureSubscriptionManagedIdentity]
 	ProvisioningState plugin.TValue[string]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
 // createAzureSubscriptionKustoServiceClusterDatabaseDataConnection creates a new instance of this resource
@@ -93313,6 +94713,22 @@ func (c *mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection) GetManag
 
 func (c *mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection) GetProvisioningState() *plugin.TValue[string] {
 	return &c.ProvisioningState
+}
+
+func (c *mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.kustoService.cluster.database.dataConnection", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
 }
 
 // mqlAzureSubscriptionAutomationService for the azure.subscription.automationService resource

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -443,6 +443,7 @@ azure.subscription.cacheService.redisInstance.firewallRule.endIpAddress 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRule.id 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRule.name 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRule.startIpAddress 11.4.32
+azure.subscription.cacheService.redisInstance.firewallRule.systemMetadata 13.28.1
 azure.subscription.cacheService.redisInstance.firewallRule.type 11.4.32
 azure.subscription.cacheService.redisInstance.firewallRules 11.4.32
 azure.subscription.cacheService.redisInstance.hostName 11.4.4
@@ -456,6 +457,7 @@ azure.subscription.cacheService.redisInstance.patchSchedule.entries 11.4.32
 azure.subscription.cacheService.redisInstance.patchSchedule.id 11.4.32
 azure.subscription.cacheService.redisInstance.patchSchedule.location 11.4.32
 azure.subscription.cacheService.redisInstance.patchSchedule.name 11.4.32
+azure.subscription.cacheService.redisInstance.patchSchedule.systemMetadata 13.28.1
 azure.subscription.cacheService.redisInstance.patchSchedules 11.4.32
 azure.subscription.cacheService.redisInstance.port 11.4.4
 azure.subscription.cacheService.redisInstance.principalId 13.23.1
@@ -468,6 +470,7 @@ azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateE
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.privateEndpointId 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.provisioningState 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.status 11.4.32
+azure.subscription.cacheService.redisInstance.privateEndpointConnection.systemMetadata 13.28.1
 azure.subscription.cacheService.redisInstance.privateEndpointConnection.type 11.4.32
 azure.subscription.cacheService.redisInstance.privateEndpointConnections 11.4.32
 azure.subscription.cacheService.redisInstance.properties 11.4.4
@@ -505,6 +508,7 @@ azure.subscription.cloudDefenderService.alert.resourceIdentifiers 13.11.3
 azure.subscription.cloudDefenderService.alert.severity 13.11.3
 azure.subscription.cloudDefenderService.alert.startTime 13.11.3
 azure.subscription.cloudDefenderService.alert.status 13.11.3
+azure.subscription.cloudDefenderService.alert.systemMetadata 13.28.1
 azure.subscription.cloudDefenderService.alert.timeGenerated 13.11.3
 azure.subscription.cloudDefenderService.alert.vendorName 13.11.3
 azure.subscription.cloudDefenderService.alertSuppressionRule 13.25.1
@@ -559,6 +563,7 @@ azure.subscription.cloudDefenderService.assessment.subAssessment.statusDescripti
 azure.subscription.cloudDefenderService.assessment.subAssessment.timeGenerated 13.25.1
 azure.subscription.cloudDefenderService.assessment.subAssessment.vulnerabilityId 13.25.1
 azure.subscription.cloudDefenderService.assessment.subAssessments 13.25.1
+azure.subscription.cloudDefenderService.assessment.systemMetadata 13.28.1
 azure.subscription.cloudDefenderService.assessment.tactics 13.14.1
 azure.subscription.cloudDefenderService.assessment.techniques 13.14.1
 azure.subscription.cloudDefenderService.assessment.threats 13.14.1
@@ -754,6 +759,7 @@ azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.kind 13.25.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.location 13.25.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.name 13.25.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.provisioningState 13.25.1
+azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.systemMetadata 13.28.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.type 13.25.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine 13.25.1
 azure.subscription.cloudDefenderService.jitNetworkAccessPolicy.virtualMachine.ports 13.25.1
@@ -808,6 +814,7 @@ azure.subscription.cloudDefenderService.securityContact.name 9.0.1
 azure.subscription.cloudDefenderService.securityContact.notificationSources 11.3.31
 azure.subscription.cloudDefenderService.securityContact.notificationsByRole 9.0.1
 azure.subscription.cloudDefenderService.securityContact.phone 11.6.1
+azure.subscription.cloudDefenderService.securityContact.systemMetadata 13.28.1
 azure.subscription.cloudDefenderService.securityContacts 9.0.1
 azure.subscription.cloudDefenderService.settings 11.3.31
 azure.subscription.cloudDefenderService.settings.id 11.3.31
@@ -1076,6 +1083,7 @@ azure.subscription.computeService.gallery.image.provisioningState 13.7.1
 azure.subscription.computeService.gallery.image.purchasePlan 13.7.1
 azure.subscription.computeService.gallery.image.recommended 13.7.1
 azure.subscription.computeService.gallery.image.releaseNoteUri 13.7.1
+azure.subscription.computeService.gallery.image.systemMetadata 13.28.1
 azure.subscription.computeService.gallery.image.tags 13.7.1
 azure.subscription.computeService.gallery.image.type 13.7.1
 azure.subscription.computeService.gallery.image.version 13.7.1
@@ -1089,6 +1097,7 @@ azure.subscription.computeService.gallery.image.version.replicationStatus 13.7.1
 azure.subscription.computeService.gallery.image.version.safetyProfile 13.7.1
 azure.subscription.computeService.gallery.image.version.securityProfile 13.7.1
 azure.subscription.computeService.gallery.image.version.storageProfile 13.7.1
+azure.subscription.computeService.gallery.image.version.systemMetadata 13.28.1
 azure.subscription.computeService.gallery.image.version.tags 13.7.1
 azure.subscription.computeService.gallery.image.version.type 13.7.1
 azure.subscription.computeService.gallery.image.versions 13.7.1
@@ -1100,6 +1109,7 @@ azure.subscription.computeService.gallery.provisioningState 13.7.1
 azure.subscription.computeService.gallery.sharingProfile 13.7.1
 azure.subscription.computeService.gallery.sharingStatus 13.7.1
 azure.subscription.computeService.gallery.softDeletePolicy 13.7.1
+azure.subscription.computeService.gallery.systemMetadata 13.28.1
 azure.subscription.computeService.gallery.tags 13.7.1
 azure.subscription.computeService.gallery.type 13.7.1
 azure.subscription.computeService.gallery.uniqueName 13.7.1
@@ -1162,6 +1172,7 @@ azure.subscription.computeService.image.provisioningState 13.7.1
 azure.subscription.computeService.image.sourceVirtualMachine 13.22.1
 azure.subscription.computeService.image.sourceVirtualMachineId 13.7.1
 azure.subscription.computeService.image.storageProfile 13.7.1
+azure.subscription.computeService.image.systemMetadata 13.28.1
 azure.subscription.computeService.image.tags 13.7.1
 azure.subscription.computeService.image.type 13.7.1
 azure.subscription.computeService.images 13.7.1
@@ -1173,6 +1184,7 @@ azure.subscription.computeService.proximityPlacementGroup.location 13.7.1
 azure.subscription.computeService.proximityPlacementGroup.name 13.7.1
 azure.subscription.computeService.proximityPlacementGroup.properties 13.7.1
 azure.subscription.computeService.proximityPlacementGroup.proximityPlacementGroupType 13.7.1
+azure.subscription.computeService.proximityPlacementGroup.systemMetadata 13.28.1
 azure.subscription.computeService.proximityPlacementGroup.tags 13.7.1
 azure.subscription.computeService.proximityPlacementGroup.type 13.7.1
 azure.subscription.computeService.proximityPlacementGroup.virtualMachineIds 13.7.1
@@ -1578,6 +1590,7 @@ azure.subscription.containerRegistryService.registry.cacheRule.id 13.5.1
 azure.subscription.containerRegistryService.registry.cacheRule.name 13.5.1
 azure.subscription.containerRegistryService.registry.cacheRule.provisioningState 13.5.1
 azure.subscription.containerRegistryService.registry.cacheRule.sourceRepository 13.5.1
+azure.subscription.containerRegistryService.registry.cacheRule.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.cacheRule.targetRepository 13.5.1
 azure.subscription.containerRegistryService.registry.cacheRule.type 13.5.1
 azure.subscription.containerRegistryService.registry.cacheRules 13.5.1
@@ -1603,6 +1616,7 @@ azure.subscription.containerRegistryService.registry.connectedRegistry.syncMessa
 azure.subscription.containerRegistryService.registry.connectedRegistry.syncSchedule 13.5.1
 azure.subscription.containerRegistryService.registry.connectedRegistry.syncTokenId 13.5.1
 azure.subscription.containerRegistryService.registry.connectedRegistry.syncWindow 13.5.1
+azure.subscription.containerRegistryService.registry.connectedRegistry.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.connectedRegistry.tlsStatus 13.5.1
 azure.subscription.containerRegistryService.registry.connectedRegistry.type 13.5.1
 azure.subscription.containerRegistryService.registry.connectedRegistry.version 13.5.1
@@ -1615,6 +1629,7 @@ azure.subscription.containerRegistryService.registry.credentialSet.identity 13.5
 azure.subscription.containerRegistryService.registry.credentialSet.loginServer 13.5.1
 azure.subscription.containerRegistryService.registry.credentialSet.name 13.5.1
 azure.subscription.containerRegistryService.registry.credentialSet.provisioningState 13.5.1
+azure.subscription.containerRegistryService.registry.credentialSet.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.credentialSet.type 13.5.1
 azure.subscription.containerRegistryService.registry.credentialSets 13.5.1
 azure.subscription.containerRegistryService.registry.dataEndpointEnabled 13.3.3
@@ -1659,6 +1674,7 @@ azure.subscription.containerRegistryService.registry.replication.location 13.3.3
 azure.subscription.containerRegistryService.registry.replication.name 13.3.3
 azure.subscription.containerRegistryService.registry.replication.provisioningState 13.3.3
 azure.subscription.containerRegistryService.registry.replication.regionEndpointEnabled 13.3.3
+azure.subscription.containerRegistryService.registry.replication.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.replication.tags 13.3.3
 azure.subscription.containerRegistryService.registry.replication.type 13.3.3
 azure.subscription.containerRegistryService.registry.replication.zoneRedundancy 13.3.3
@@ -1671,6 +1687,7 @@ azure.subscription.containerRegistryService.registry.scopeMap.description 13.3.3
 azure.subscription.containerRegistryService.registry.scopeMap.id 13.3.3
 azure.subscription.containerRegistryService.registry.scopeMap.name 13.3.3
 azure.subscription.containerRegistryService.registry.scopeMap.provisioningState 13.3.3
+azure.subscription.containerRegistryService.registry.scopeMap.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.scopeMap.type 13.3.3
 azure.subscription.containerRegistryService.registry.scopeMaps 13.3.3
 azure.subscription.containerRegistryService.registry.skuName 13.3.3
@@ -1686,6 +1703,7 @@ azure.subscription.containerRegistryService.registry.token.passwords 13.16.2
 azure.subscription.containerRegistryService.registry.token.provisioningState 13.3.3
 azure.subscription.containerRegistryService.registry.token.scopeMap 13.3.3
 azure.subscription.containerRegistryService.registry.token.status 13.3.3
+azure.subscription.containerRegistryService.registry.token.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.token.type 13.3.3
 azure.subscription.containerRegistryService.registry.tokens 13.3.3
 azure.subscription.containerRegistryService.registry.type 13.3.3
@@ -1698,6 +1716,7 @@ azure.subscription.containerRegistryService.registry.webhook.name 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.provisioningState 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.scope 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.status 13.3.3
+azure.subscription.containerRegistryService.registry.webhook.systemMetadata 13.28.1
 azure.subscription.containerRegistryService.registry.webhook.tags 13.3.3
 azure.subscription.containerRegistryService.registry.webhook.type 13.3.3
 azure.subscription.containerRegistryService.registry.webhooks 13.3.3
@@ -1866,17 +1885,20 @@ azure.subscription.dataFactoryService.factory.integrationRuntime.description 13.
 azure.subscription.dataFactoryService.factory.integrationRuntime.id 13.10.2
 azure.subscription.dataFactoryService.factory.integrationRuntime.name 13.10.2
 azure.subscription.dataFactoryService.factory.integrationRuntime.runtimeType 13.10.2
+azure.subscription.dataFactoryService.factory.integrationRuntime.systemMetadata 13.28.1
 azure.subscription.dataFactoryService.factory.integrationRuntime.type 13.10.2
 azure.subscription.dataFactoryService.factory.integrationRuntime.typeProperties 13.10.2
 azure.subscription.dataFactoryService.factory.integrationRuntimes 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.annotations 13.10.2
+azure.subscription.dataFactoryService.factory.linkedService.authenticationType 13.28.1
 azure.subscription.dataFactoryService.factory.linkedService.description 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.id 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.integrationRuntimeName 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.name 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.parameterNames 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.serviceType 13.10.2
+azure.subscription.dataFactoryService.factory.linkedService.systemMetadata 13.28.1
 azure.subscription.dataFactoryService.factory.linkedService.type 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.typeProperties 13.10.2
 azure.subscription.dataFactoryService.factory.linkedService.usesKeyVaultReference 13.10.2
@@ -1894,12 +1916,14 @@ azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.name 13.10.
 azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.privateLinkResourceId 13.10.2
 azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.provisioningState 13.10.2
 azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.reserved 13.10.2
+azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.systemMetadata 13.28.1
 azure.subscription.dataFactoryService.factory.managedPrivateEndpoint.type 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.alias 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.id 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.name 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.privateEndpoints 13.10.2
+azure.subscription.dataFactoryService.factory.managedVirtualNetwork.systemMetadata 13.28.1
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.type 13.10.2
 azure.subscription.dataFactoryService.factory.managedVirtualNetwork.vnetId 13.10.2
 azure.subscription.dataFactoryService.factory.name 13.3.0
@@ -1907,6 +1931,7 @@ azure.subscription.dataFactoryService.factory.properties 13.3.0
 azure.subscription.dataFactoryService.factory.provisioningState 13.3.0
 azure.subscription.dataFactoryService.factory.publicNetworkAccess 13.3.0
 azure.subscription.dataFactoryService.factory.repoConfiguration 13.3.0
+azure.subscription.dataFactoryService.factory.systemMetadata 13.28.1
 azure.subscription.dataFactoryService.factory.tags 13.3.0
 azure.subscription.dataFactoryService.factory.type 13.3.0
 azure.subscription.dataFactoryService.factory.userAssignedIdentities 13.23.1
@@ -2435,6 +2460,7 @@ azure.subscription.kustoService.cluster.calloutPolicy.calloutId 13.17.1
 azure.subscription.kustoService.cluster.calloutPolicy.calloutType 13.17.1
 azure.subscription.kustoService.cluster.calloutPolicy.calloutUriRegex 13.17.1
 azure.subscription.kustoService.cluster.calloutPolicy.outboundAccess 13.17.1
+azure.subscription.kustoService.cluster.cmkFederatedIdentityClientId 13.28.1
 azure.subscription.kustoService.cluster.cmkKeyName 13.16.2
 azure.subscription.kustoService.cluster.cmkKeyVaultUri 13.16.2
 azure.subscription.kustoService.cluster.cmkKeyVersion 13.16.2
@@ -2455,6 +2481,7 @@ azure.subscription.kustoService.cluster.database.dataConnection.mappingRuleName 
 azure.subscription.kustoService.cluster.database.dataConnection.name 13.17.1
 azure.subscription.kustoService.cluster.database.dataConnection.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.database.dataConnection.sourceResourceId 13.17.1
+azure.subscription.kustoService.cluster.database.dataConnection.systemMetadata 13.28.1
 azure.subscription.kustoService.cluster.database.dataConnection.tableName 13.17.1
 azure.subscription.kustoService.cluster.database.dataConnections 13.17.1
 azure.subscription.kustoService.cluster.database.hotCachePeriod 13.17.1
@@ -2473,10 +2500,12 @@ azure.subscription.kustoService.cluster.database.principalAssignment.principalNa
 azure.subscription.kustoService.cluster.database.principalAssignment.principalType 13.17.1
 azure.subscription.kustoService.cluster.database.principalAssignment.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.database.principalAssignment.role 13.17.1
+azure.subscription.kustoService.cluster.database.principalAssignment.systemMetadata 13.28.1
 azure.subscription.kustoService.cluster.database.principalAssignment.tenantId 13.17.1
 azure.subscription.kustoService.cluster.database.principalAssignments 13.17.1
 azure.subscription.kustoService.cluster.database.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.database.softDeletePeriod 13.17.1
+azure.subscription.kustoService.cluster.database.systemMetadata 13.28.1
 azure.subscription.kustoService.cluster.databases 13.17.1
 azure.subscription.kustoService.cluster.enableDiskEncryption 13.16.2
 azure.subscription.kustoService.cluster.enableDoubleEncryption 13.16.2
@@ -2504,6 +2533,7 @@ azure.subscription.kustoService.cluster.principalAssignment.principalName 13.17.
 azure.subscription.kustoService.cluster.principalAssignment.principalType 13.17.1
 azure.subscription.kustoService.cluster.principalAssignment.provisioningState 13.17.1
 azure.subscription.kustoService.cluster.principalAssignment.role 13.17.1
+azure.subscription.kustoService.cluster.principalAssignment.systemMetadata 13.28.1
 azure.subscription.kustoService.cluster.principalAssignment.tenantId 13.17.1
 azure.subscription.kustoService.cluster.principalAssignments 13.17.1
 azure.subscription.kustoService.cluster.privateEndpointConnection 13.17.1
@@ -2882,6 +2912,7 @@ azure.subscription.monitorService.workspace.nspConfiguration.perimeterLocation 1
 azure.subscription.monitorService.workspace.nspConfiguration.profileName 13.5.1
 azure.subscription.monitorService.workspace.nspConfiguration.provisioningIssues 13.5.1
 azure.subscription.monitorService.workspace.nspConfiguration.provisioningState 13.5.1
+azure.subscription.monitorService.workspace.nspConfiguration.systemMetadata 13.28.1
 azure.subscription.monitorService.workspace.nspConfiguration.type 13.5.1
 azure.subscription.monitorService.workspace.privateLinkScopedResources 13.3.3
 azure.subscription.monitorService.workspace.provisioningState 13.3.3
@@ -2934,6 +2965,7 @@ azure.subscription.mySqlService.flexibleServer.administrator.id 13.23.1
 azure.subscription.mySqlService.flexibleServer.administrator.login 13.23.1
 azure.subscription.mySqlService.flexibleServer.administrator.name 13.23.1
 azure.subscription.mySqlService.flexibleServer.administrator.sid 13.23.1
+azure.subscription.mySqlService.flexibleServer.administrator.systemMetadata 13.28.1
 azure.subscription.mySqlService.flexibleServer.administrator.tenantId 13.23.1
 azure.subscription.mySqlService.flexibleServer.administrator.type 13.23.1
 azure.subscription.mySqlService.flexibleServer.azureAdAdministrators 13.23.1
@@ -3515,6 +3547,7 @@ azure.subscription.networkService.networkManager.connectivityConfiguration.id 13
 azure.subscription.networkService.networkManager.connectivityConfiguration.isGlobal 13.25.1
 azure.subscription.networkService.networkManager.connectivityConfiguration.name 13.25.1
 azure.subscription.networkService.networkManager.connectivityConfiguration.provisioningState 13.25.1
+azure.subscription.networkService.networkManager.connectivityConfiguration.systemMetadata 13.28.1
 azure.subscription.networkService.networkManager.connectivityConfiguration.type 13.25.1
 azure.subscription.networkService.networkManager.connectivityConfigurations 13.25.1
 azure.subscription.networkService.networkManager.description 13.25.1
@@ -3530,6 +3563,7 @@ azure.subscription.networkService.networkManager.networkGroup.memberType 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.name 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.provisioningState 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.resourceGuid 13.25.1
+azure.subscription.networkService.networkManager.networkGroup.systemMetadata 13.28.1
 azure.subscription.networkService.networkManager.networkGroup.type 13.25.1
 azure.subscription.networkService.networkManager.networkGroups 13.25.1
 azure.subscription.networkService.networkManager.provisioningState 13.25.1
@@ -3570,6 +3604,7 @@ azure.subscription.networkService.networkManager.securityAdminConfiguration.rule
 azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection.rules 13.25.1
 azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection.type 13.25.1
 azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollections 13.25.1
+azure.subscription.networkService.networkManager.securityAdminConfiguration.systemMetadata 13.28.1
 azure.subscription.networkService.networkManager.securityAdminConfiguration.type 13.25.1
 azure.subscription.networkService.networkManager.securityAdminConfigurations 13.25.1
 azure.subscription.networkService.networkManager.systemMetadata 13.25.1
@@ -3752,6 +3787,7 @@ azure.subscription.networkService.securityPerimeter.profile.name 13.25.1
 azure.subscription.networkService.securityPerimeter.profile.type 13.25.1
 azure.subscription.networkService.securityPerimeter.profiles 13.25.1
 azure.subscription.networkService.securityPerimeter.provisioningState 13.25.1
+azure.subscription.networkService.securityPerimeter.systemMetadata 13.28.1
 azure.subscription.networkService.securityPerimeter.tags 13.25.1
 azure.subscription.networkService.securityPerimeter.type 13.25.1
 azure.subscription.networkService.securityPerimeters 13.25.1
@@ -4500,6 +4536,7 @@ azure.subscription.sentinelService.workspace.id 13.12.2
 azure.subscription.sentinelService.workspace.name 13.12.2
 azure.subscription.sentinelService.workspace.resourceGroup 13.12.2
 azure.subscription.sentinelService.workspace.subscriptionId 13.12.2
+azure.subscription.sentinelService.workspace.systemMetadata 13.28.1
 azure.subscription.sentinelService.workspace.workspace 13.12.2
 azure.subscription.sentinelService.workspaces 13.12.2
 azure.subscription.serviceBus 13.3.3
@@ -4616,6 +4653,7 @@ azure.subscription.sqlService.database.advancedthreatprotection 11.4.28
 azure.subscription.sqlService.database.advancedthreatprotection.creationTime 11.4.28
 azure.subscription.sqlService.database.advancedthreatprotection.id 11.4.28
 azure.subscription.sqlService.database.advancedthreatprotection.state 11.4.28
+azure.subscription.sqlService.database.advancedthreatprotection.systemMetadata 13.28.1
 azure.subscription.sqlService.database.advisor 9.0.1
 azure.subscription.sqlService.database.auditingPolicy 9.0.1
 azure.subscription.sqlService.database.backupShortTermRetentionPolicy 11.4.28
@@ -4704,6 +4742,7 @@ azure.subscription.sqlService.database.securityAlertPolicy.id 13.8.2
 azure.subscription.sqlService.database.securityAlertPolicy.retentionDays 13.8.2
 azure.subscription.sqlService.database.securityAlertPolicy.state 13.8.2
 azure.subscription.sqlService.database.securityAlertPolicy.storageEndpoint 13.8.2
+azure.subscription.sqlService.database.securityAlertPolicy.systemMetadata 13.28.1
 azure.subscription.sqlService.database.serviceLevelObjective 9.0.1
 azure.subscription.sqlService.database.sourceDatabaseDeletionDate 9.0.1
 azure.subscription.sqlService.database.sourceDatabaseId 9.0.1
@@ -4797,6 +4836,7 @@ azure.subscription.sqlService.server.advancedThreatProtectionSetting 13.8.2
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.creationTime 13.8.2
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.id 13.8.2
 azure.subscription.sqlService.server.advancedThreatProtectionSetting.state 13.8.2
+azure.subscription.sqlService.server.advancedThreatProtectionSetting.systemMetadata 13.28.1
 azure.subscription.sqlService.server.auditingPolicy 9.0.1
 azure.subscription.sqlService.server.azureAdAdministrators 9.0.1
 azure.subscription.sqlService.server.azureAdOnlyAuthentication 13.1.8
@@ -4820,6 +4860,7 @@ azure.subscription.sqlService.server.devOpsAuditingSetting.isAzureMonitorTargetE
 azure.subscription.sqlService.server.devOpsAuditingSetting.state 13.8.2
 azure.subscription.sqlService.server.devOpsAuditingSetting.storageAccountSubscriptionId 13.8.2
 azure.subscription.sqlService.server.devOpsAuditingSetting.storageEndpoint 13.8.2
+azure.subscription.sqlService.server.devOpsAuditingSetting.systemMetadata 13.28.1
 azure.subscription.sqlService.server.encryptionProtector 9.0.1
 azure.subscription.sqlService.server.encryptionProtectorConfig 13.8.2
 azure.subscription.sqlService.server.encryptionProtectorConfig.autoRotationEnabled 13.8.2
@@ -4901,6 +4942,7 @@ azure.subscription.sqlService.server.securityAlertPolicyConfig.id 13.8.2
 azure.subscription.sqlService.server.securityAlertPolicyConfig.retentionDays 13.8.2
 azure.subscription.sqlService.server.securityAlertPolicyConfig.state 13.8.2
 azure.subscription.sqlService.server.securityAlertPolicyConfig.storageEndpoint 13.8.2
+azure.subscription.sqlService.server.securityAlertPolicyConfig.systemMetadata 13.28.1
 azure.subscription.sqlService.server.state 11.4.28
 azure.subscription.sqlService.server.tags 9.0.1
 azure.subscription.sqlService.server.tenantId 13.23.1
@@ -4953,6 +4995,7 @@ azure.subscription.storageService.account.blobInventoryPolicy.id 13.10.2
 azure.subscription.storageService.account.blobInventoryPolicy.lastModifiedTime 13.10.2
 azure.subscription.storageService.account.blobInventoryPolicy.name 13.10.2
 azure.subscription.storageService.account.blobInventoryPolicy.rules 13.10.2
+azure.subscription.storageService.account.blobInventoryPolicy.systemMetadata 13.28.1
 azure.subscription.storageService.account.blobInventoryPolicy.type 13.10.2
 azure.subscription.storageService.account.blobProperties 9.0.1
 azure.subscription.storageService.account.container 9.0.1
@@ -4978,6 +5021,7 @@ azure.subscription.storageService.account.container.objectLevelImmutabilityEnabl
 azure.subscription.storageService.account.container.properties 9.0.1
 azure.subscription.storageService.account.container.publicAccess 11.6.1
 azure.subscription.storageService.account.container.remainingRetentionDays 11.6.2
+azure.subscription.storageService.account.container.systemMetadata 13.28.1
 azure.subscription.storageService.account.container.type 9.0.1
 azure.subscription.storageService.account.containers 9.0.1
 azure.subscription.storageService.account.creationTime 11.6.2
@@ -5015,6 +5059,7 @@ azure.subscription.storageService.account.encryptionScope.name 13.3.3
 azure.subscription.storageService.account.encryptionScope.requireInfrastructureEncryption 13.3.3
 azure.subscription.storageService.account.encryptionScope.source 13.3.3
 azure.subscription.storageService.account.encryptionScope.state 13.3.3
+azure.subscription.storageService.account.encryptionScope.systemMetadata 13.28.1
 azure.subscription.storageService.account.encryptionScope.type 13.3.3
 azure.subscription.storageService.account.encryptionScopes 13.3.3
 azure.subscription.storageService.account.fileProperties 11.4.24
@@ -5051,6 +5096,7 @@ azure.subscription.storageService.account.fileShare.rootSquash 13.10.2
 azure.subscription.storageService.account.fileShare.shareQuotaGiB 13.10.2
 azure.subscription.storageService.account.fileShare.signedIdentifierCount 13.10.2
 azure.subscription.storageService.account.fileShare.snapshotTime 13.10.2
+azure.subscription.storageService.account.fileShare.systemMetadata 13.28.1
 azure.subscription.storageService.account.fileShare.type 13.10.2
 azure.subscription.storageService.account.fileShares 13.10.2
 azure.subscription.storageService.account.id 9.0.1
@@ -5078,6 +5124,7 @@ azure.subscription.storageService.account.localUser.id 13.5.1
 azure.subscription.storageService.account.localUser.isNFSv3Enabled 13.5.1
 azure.subscription.storageService.account.localUser.name 13.5.1
 azure.subscription.storageService.account.localUser.permissionScopes 13.5.1
+azure.subscription.storageService.account.localUser.systemMetadata 13.28.1
 azure.subscription.storageService.account.localUser.type 13.5.1
 azure.subscription.storageService.account.localUser.userId 13.5.1
 azure.subscription.storageService.account.localUsers 13.5.1
@@ -5097,6 +5144,7 @@ azure.subscription.storageService.account.managementPolicy.rule.snapshotActions 
 azure.subscription.storageService.account.managementPolicy.rule.type 13.3.3
 azure.subscription.storageService.account.managementPolicy.rule.versionActions 13.3.3
 azure.subscription.storageService.account.managementPolicy.rules 13.3.3
+azure.subscription.storageService.account.managementPolicy.systemMetadata 13.28.1
 azure.subscription.storageService.account.managementPolicy.type 13.3.3
 azure.subscription.storageService.account.minimumTlsVersion 11.4.28
 azure.subscription.storageService.account.name 9.0.1
@@ -5119,6 +5167,7 @@ azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.
 azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.profileName 13.15.1
 azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.provisioningIssues 13.15.1
 azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.provisioningState 13.15.1
+azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.systemMetadata 13.28.1
 azure.subscription.storageService.account.networkSecurityPerimeterConfiguration.type 13.15.1
 azure.subscription.storageService.account.networkSecurityPerimeterConfigurations 13.15.1
 azure.subscription.storageService.account.objectReplicationPolicies 13.10.2
@@ -5130,6 +5179,7 @@ azure.subscription.storageService.account.objectReplicationPolicy.name 13.10.2
 azure.subscription.storageService.account.objectReplicationPolicy.policyId 13.10.2
 azure.subscription.storageService.account.objectReplicationPolicy.rules 13.10.2
 azure.subscription.storageService.account.objectReplicationPolicy.sourceAccount 13.10.2
+azure.subscription.storageService.account.objectReplicationPolicy.systemMetadata 13.28.1
 azure.subscription.storageService.account.objectReplicationPolicy.tagsReplicationEnabled 13.12.2
 azure.subscription.storageService.account.objectReplicationPolicy.type 13.10.2
 azure.subscription.storageService.account.primaryLocation 11.6.2
@@ -5143,6 +5193,7 @@ azure.subscription.storageService.account.privateEndpointConnection.privateEndpo
 azure.subscription.storageService.account.privateEndpointConnection.privateEndpointId 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.provisioningState 13.10.2
 azure.subscription.storageService.account.privateEndpointConnection.status 13.10.2
+azure.subscription.storageService.account.privateEndpointConnection.systemMetadata 13.28.1
 azure.subscription.storageService.account.privateEndpointConnection.type 13.10.2
 azure.subscription.storageService.account.privateEndpointConnections 13.10.2
 azure.subscription.storageService.account.properties 9.0.1
@@ -5155,6 +5206,7 @@ azure.subscription.storageService.account.queue.approximateMessageCount 13.10.2
 azure.subscription.storageService.account.queue.id 13.10.2
 azure.subscription.storageService.account.queue.metadata 13.10.2
 azure.subscription.storageService.account.queue.name 13.10.2
+azure.subscription.storageService.account.queue.systemMetadata 13.28.1
 azure.subscription.storageService.account.queueProperties 9.0.1
 azure.subscription.storageService.account.queues 13.10.2
 azure.subscription.storageService.account.requireInfrastructureEncryption 13.5.1
@@ -5204,6 +5256,7 @@ azure.subscription.storageService.account.table 13.10.2
 azure.subscription.storageService.account.table.id 13.10.2
 azure.subscription.storageService.account.table.name 13.10.2
 azure.subscription.storageService.account.table.signedIdentifiers 13.10.2
+azure.subscription.storageService.account.table.systemMetadata 13.28.1
 azure.subscription.storageService.account.tableProperties 9.0.1
 azure.subscription.storageService.account.tables 13.10.2
 azure.subscription.storageService.account.tags 9.0.1
@@ -5297,6 +5350,7 @@ azure.subscription.webService.appServicePlan.properties 11.4.32
 azure.subscription.webService.appServicePlan.reserved 11.4.32
 azure.subscription.webService.appServicePlan.sku 11.4.32
 azure.subscription.webService.appServicePlan.status 11.4.32
+azure.subscription.webService.appServicePlan.systemMetadata 13.28.1
 azure.subscription.webService.appServicePlan.tags 11.4.32
 azure.subscription.webService.appServicePlan.zoneRedundant 11.4.32
 azure.subscription.webService.appServicePlans 11.4.32
@@ -5325,6 +5379,7 @@ azure.subscription.webService.appsite.hostNameBinding.hostNameType 11.4.32
 azure.subscription.webService.appsite.hostNameBinding.id 11.4.32
 azure.subscription.webService.appsite.hostNameBinding.name 11.4.32
 azure.subscription.webService.appsite.hostNameBinding.sslState 11.4.32
+azure.subscription.webService.appsite.hostNameBinding.systemMetadata 13.28.1
 azure.subscription.webService.appsite.hostNameBinding.thumbprint 11.4.32
 azure.subscription.webService.appsite.hostNameBinding.virtualIP 11.4.32
 azure.subscription.webService.appsite.hostNameBindings 11.4.32
@@ -5366,6 +5421,7 @@ azure.subscription.webService.appsite.virtualNetworkConnection.id 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.isSwift 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.name 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnection.resyncRequired 11.4.32
+azure.subscription.webService.appsite.virtualNetworkConnection.systemMetadata 13.28.1
 azure.subscription.webService.appsite.virtualNetworkConnection.vnetResourceId 11.4.32
 azure.subscription.webService.appsite.virtualNetworkConnections 11.4.32
 azure.subscription.webService.appsite.virtualNetworkSubnet 13.12.2
@@ -5408,6 +5464,7 @@ azure.subscription.webService.appsiteconfig.properties 9.0.1
 azure.subscription.webService.appsiteconfig.remoteDebuggingEnabled 11.4.28
 azure.subscription.webService.appsiteconfig.scmIpSecurityRestrictions 13.1.8
 azure.subscription.webService.appsiteconfig.scmMinTlsVersion 13.1.8
+azure.subscription.webService.appsiteconfig.systemMetadata 13.28.1
 azure.subscription.webService.appsiteconfig.type 9.0.1
 azure.subscription.webService.appsiteconfig.webSocketsEnabled 13.12.2
 azure.subscription.webService.appslot 11.3.85
@@ -5442,6 +5499,7 @@ azure.subscription.webService.certificate.location 11.4.32
 azure.subscription.webService.certificate.name 11.4.32
 azure.subscription.webService.certificate.properties 11.4.32
 azure.subscription.webService.certificate.subjectName 11.4.32
+azure.subscription.webService.certificate.systemMetadata 13.28.1
 azure.subscription.webService.certificate.tags 11.4.32
 azure.subscription.webService.certificate.thumbprint 11.4.32
 azure.subscription.webService.certificate.valid 11.4.32
@@ -5451,6 +5509,7 @@ azure.subscription.webService.function.id 11.3.3
 azure.subscription.webService.function.kind 11.3.3
 azure.subscription.webService.function.name 11.3.3
 azure.subscription.webService.function.properties 11.3.3
+azure.subscription.webService.function.systemMetadata 13.28.1
 azure.subscription.webService.function.type 11.3.3
 azure.subscription.webService.hostingEnvironment 11.4.4
 azure.subscription.webService.hostingEnvironment.clusterSettings 11.4.4
@@ -5471,6 +5530,7 @@ azure.subscription.webService.hostingEnvironment.properties 11.4.4
 azure.subscription.webService.hostingEnvironment.provisioningState 11.4.4
 azure.subscription.webService.hostingEnvironment.status 11.4.4
 azure.subscription.webService.hostingEnvironment.suspended 11.4.4
+azure.subscription.webService.hostingEnvironment.systemMetadata 13.28.1
 azure.subscription.webService.hostingEnvironment.tags 11.4.4
 azure.subscription.webService.hostingEnvironment.type 11.4.4
 azure.subscription.webService.hostingEnvironment.userWhitelistedIpRanges 11.4.4

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.26.0",
-  "generated_at": "2026-07-06T21:41:00-07:00",
+  "version": "13.28.0",
+  "generated_at": "2026-07-09T21:23:22-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/azure/resources/cloud_defender.go
+++ b/providers/azure/resources/cloud_defender.go
@@ -61,6 +61,14 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) id() (string, 
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionCloudDefenderServiceSecurityContactInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 // commonPricingArgs extracts common pricing fields from an Azure PricingProperties response
 // into a map suitable for CreateResource.
 func commonPricingArgs(props *security.PricingProperties, mqlResourceName, subId string) map[string]*llx.RawData {
@@ -741,6 +749,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) securityContacts() ([]any, er
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(contact.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSecurityContact.(*mqlAzureSubscriptionCloudDefenderServiceSecurityContact).cacheSystemData = sysData
 			res = append(res, mqlSecurityContact)
 		}
 	}
@@ -1279,8 +1292,24 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceAssessment) id() (string, error
 	return a.__id, nil
 }
 
+type mqlAzureSubscriptionCloudDefenderServiceAssessmentInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceAssessment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionCloudDefenderServiceAlert) id() (string, error) {
 	return a.__id, nil
+}
+
+type mqlAzureSubscriptionCloudDefenderServiceAlertInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceAlert) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // assessmentMetadata holds the catalog metadata for a single assessment
@@ -1520,6 +1549,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) assessments() ([]any, error) 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(item.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlResource.(*mqlAzureSubscriptionCloudDefenderServiceAssessment).cacheSystemData = sysData
 			res = append(res, mqlResource)
 		}
 	}
@@ -1624,6 +1658,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) alerts() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(item.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlResource.(*mqlAzureSubscriptionCloudDefenderServiceAlert).cacheSystemData = sysData
 			res = append(res, mqlResource)
 		}
 	}
@@ -1724,6 +1763,11 @@ func (a *mqlAzureSubscriptionCloudDefenderServiceAssessmentSubAssessment) id() (
 
 type mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicyInternal struct {
 	cacheVirtualMachines []*armsecurity.JitNetworkAccessPolicyVirtualMachine
+	cacheSystemData      any
+}
+
+func (a *mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // jitNetworkAccessPolicies lists the subscription's just-in-time VM access
@@ -1775,6 +1819,11 @@ func (a *mqlAzureSubscriptionCloudDefenderService) jitNetworkAccessPolicies() ([
 			if p := pol.Properties; p != nil {
 				mqlPol.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).cacheVirtualMachines = p.VirtualMachines
 			}
+			sysData, err := convert.JsonToDict(pol.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPol.(*mqlAzureSubscriptionCloudDefenderServiceJitNetworkAccessPolicy).cacheSystemData = sysData
 			res = append(res, mqlPol)
 		}
 	}

--- a/providers/azure/resources/compute_extras.go
+++ b/providers/azure/resources/compute_extras.go
@@ -332,7 +332,20 @@ func proximityPlacementGroupToMql(runtime *plugin.Runtime, ppg compute.Proximity
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(ppg.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceProximityPlacementGroup), nil
+}
+
+type mqlAzureSubscriptionComputeServiceProximityPlacementGroupInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceProximityPlacementGroup) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // colocSubResourceIDs flattens a slice of *SubResourceWithColocationStatus
@@ -432,7 +445,20 @@ func imageToMql(runtime *plugin.Runtime, img compute.Image) (*mqlAzureSubscripti
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(img.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceImage).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceImage), nil
+}
+
+type mqlAzureSubscriptionComputeServiceImageInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceImage) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceImage) sourceVirtualMachine() (*mqlAzureSubscriptionComputeServiceVm, error) {
@@ -557,7 +583,20 @@ func galleryToMql(runtime *plugin.Runtime, g compute.Gallery) (*mqlAzureSubscrip
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(g.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceGallery).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceGallery), nil
+}
+
+type mqlAzureSubscriptionComputeServiceGalleryInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceGallery) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceGallery) images() ([]any, error) {
@@ -689,7 +728,20 @@ func galleryImageToMql(runtime *plugin.Runtime, img compute.GalleryImage) (*mqlA
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(img.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceGalleryImage).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceGalleryImage), nil
+}
+
+type mqlAzureSubscriptionComputeServiceGalleryImageInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceGalleryImage) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionComputeServiceGalleryImage) versions() ([]any, error) {
@@ -806,5 +858,18 @@ func galleryImageVersionToMql(runtime *plugin.Runtime, v compute.GalleryImageVer
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(v.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionComputeServiceGalleryImageVersion), nil
+}
+
+type mqlAzureSubscriptionComputeServiceGalleryImageVersionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionComputeServiceGalleryImageVersion) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/containerregistry.go
+++ b/providers/azure/resources/containerregistry.go
@@ -28,12 +28,34 @@ type mqlAzureSubscriptionContainerRegistryServiceRegistryInternal struct {
 	cacheUserAssignedIdentityIds    []string
 }
 
+type mqlAzureSubscriptionContainerRegistryServiceRegistryWebhookInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerRegistryServiceRegistryReplicationInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMapInternal struct {
+	cacheSystemData any
+}
+
 type mqlAzureSubscriptionContainerRegistryServiceRegistryTokenInternal struct {
 	cacheScopeMapID string
+	cacheSystemData any
 }
 
 type mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRuleInternal struct {
 	cacheCredentialSetResourceID string
+	cacheSystemData              any
+}
+
+type mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSetInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistryInternal struct {
+	cacheSystemData any
 }
 
 func (a *mqlAzureSubscriptionContainerRegistryService) id() (string, error) {
@@ -583,6 +605,11 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) webhooks() ([]any
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(wh.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlWh.(*mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook).cacheSystemData = sysData
 			res = append(res, mqlWh)
 		}
 	}
@@ -591,6 +618,10 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) webhooks() ([]any
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryWebhook) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // replications fetches all geo-replications for the registry.
@@ -656,6 +687,11 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) replications() ([
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(repl.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRepl.(*mqlAzureSubscriptionContainerRegistryServiceRegistryReplication).cacheSystemData = sysData
 			res = append(res, mqlRepl)
 		}
 	}
@@ -664,6 +700,10 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) replications() ([
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryReplication) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryReplication) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // scopeMaps fetches all scope maps for the registry.
@@ -751,11 +791,21 @@ func createScopeMapResource(runtime *plugin.Runtime, sm *armcontainerregistry.Sc
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap), nil
+	mqlSm := res.(*mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap)
+	sysData, err := convert.JsonToDict(sm.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlSm.cacheSystemData = sysData
+	return mqlSm, nil
 }
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryScopeMap) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // initAzureSubscriptionContainerRegistryServiceRegistryScopeMap fetches a scope map by ID
@@ -929,12 +979,21 @@ func createTokenResource(runtime *plugin.Runtime, tk *armcontainerregistry.Token
 
 	mqlToken := res.(*mqlAzureSubscriptionContainerRegistryServiceRegistryToken)
 	mqlToken.cacheScopeMapID = scopeMapID
+	sysData, err := convert.JsonToDict(tk.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlToken.cacheSystemData = sysData
 
 	return mqlToken, nil
 }
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryToken) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryToken) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // scopeMap returns a typed reference to the token's scope map.
@@ -1028,6 +1087,11 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) cacheRules() ([]a
 			}
 			mqlCr := mqlRes.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule)
 			mqlCr.cacheCredentialSetResourceID = credSetID
+			sysData, err := convert.JsonToDict(cr.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCr.cacheSystemData = sysData
 			res = append(res, mqlCr)
 		}
 	}
@@ -1036,6 +1100,10 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) cacheRules() ([]a
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryCacheRule) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // credentialSet returns a typed reference to the credential set used by this cache rule.
@@ -1147,11 +1215,21 @@ func createCredentialSetResource(runtime *plugin.Runtime, cs *armcontainerregist
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet), nil
+	mqlCs := res.(*mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet)
+	sysData, err := convert.JsonToDict(cs.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlCs.cacheSystemData = sysData
+	return mqlCs, nil
 }
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryCredentialSet) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // initAzureSubscriptionContainerRegistryServiceRegistryCredentialSet fetches a credential set
@@ -1353,6 +1431,11 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) connectedRegistri
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(cr.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRes.(*mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry).cacheSystemData = sysData
 			res = append(res, mqlRes)
 		}
 	}
@@ -1361,4 +1444,8 @@ func (a *mqlAzureSubscriptionContainerRegistryServiceRegistry) connectedRegistri
 
 func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionContainerRegistryServiceRegistryConnectedRegistry) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }

--- a/providers/azure/resources/datafactory.go
+++ b/providers/azure/resources/datafactory.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -22,6 +22,11 @@ import (
 
 type mqlAzureSubscriptionDataFactoryServiceFactoryInternal struct {
 	cacheUserAssignedIdentityIds []string
+	cacheSystemData              any
+}
+
+func (a *mqlAzureSubscriptionDataFactoryServiceFactory) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionDataFactoryService) id() (string, error) {
@@ -159,6 +164,11 @@ func (a *mqlAzureSubscriptionDataFactoryService) factories() ([]any, error) {
 			}
 			factoryRes := mqlFactory.(*mqlAzureSubscriptionDataFactoryServiceFactory)
 			factoryRes.cacheUserAssignedIdentityIds = userAssignedIdentityIds
+			sysData, err := convert.JsonToDict(factory.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			factoryRes.cacheSystemData = sysData
 			res = append(res, factoryRes)
 		}
 	}

--- a/providers/azure/resources/datafactory_extras.go
+++ b/providers/azure/resources/datafactory_extras.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -32,6 +32,56 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork) id(
 
 func (a *mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionDataFactoryServiceFactoryLinkedServiceInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntimeInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetworkInternal struct {
+	cacheSystemData any
+}
+
+type mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpointInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+func (a *mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+// linkedServiceAuthType extracts the connector's declared authentication mode
+// from the linked-service body. Data Factory names this field differently per
+// connector (authenticationType for most, clusterAuthType /
+// clusterResourceGroupAuthType for the HDInsight connectors), so we probe the
+// known keys inside typeProperties and return the first present value.
+func linkedServiceAuthType(typeProps map[string]any) string {
+	inner, ok := typeProps["typeProperties"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	for _, key := range []string{"authenticationType", "clusterAuthType", "clusterResourceGroupAuthType"} {
+		if v, ok := inner[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // factoryResourceGroup parses the factory ARM id to {resourceGroup, factoryName}.
@@ -123,7 +173,7 @@ func linkedServiceToMQL(runtime *plugin.Runtime, ls *armdatafactory.LinkedServic
 		}
 	}
 
-	return CreateResource(runtime, "azure.subscription.dataFactoryService.factory.linkedService",
+	res, err := CreateResource(runtime, "azure.subscription.dataFactoryService.factory.linkedService",
 		map[string]*llx.RawData{
 			"id":                     llx.StringDataPtr(ls.ID),
 			"name":                   llx.StringDataPtr(ls.Name),
@@ -134,9 +184,19 @@ func linkedServiceToMQL(runtime *plugin.Runtime, ls *armdatafactory.LinkedServic
 			"integrationRuntimeName": llx.StringData(irName),
 			"parameterNames":         llx.ArrayData(parameterNames, types.String),
 			"usesKeyVaultReference":  llx.BoolData(usesKV),
+			"authenticationType":     llx.StringData(linkedServiceAuthType(typeProps)),
 			"annotations":            llx.ArrayData(annotations, types.Dict),
 			"typeProperties":         llx.DictData(typeProps),
 		})
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(ls.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionDataFactoryServiceFactoryLinkedService).cacheSystemData = sysData
+	return res, nil
 }
 
 // sortedParameterNames returns the keys of the parameter map in sorted order so
@@ -238,6 +298,11 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactory) integrationRuntimes() ([
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ir.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlIr.(*mqlAzureSubscriptionDataFactoryServiceFactoryIntegrationRuntime).cacheSystemData = sysData
 			res = append(res, mqlIr)
 		}
 	}
@@ -293,7 +358,13 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactory) managedVirtualNetwork() 
 			if err != nil {
 				return nil, err
 			}
-			return mqlMvn.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork), nil
+			sysData, err := convert.JsonToDict(mvn.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlMvnRes := mqlMvn.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork)
+			mqlMvnRes.cacheSystemData = sysData
+			return mqlMvnRes, nil
 		}
 	}
 
@@ -392,6 +463,11 @@ func (a *mqlAzureSubscriptionDataFactoryServiceFactoryManagedVirtualNetwork) pri
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ep.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlEp.(*mqlAzureSubscriptionDataFactoryServiceFactoryManagedPrivateEndpoint).cacheSystemData = sysData
 			res = append(res, mqlEp)
 		}
 	}

--- a/providers/azure/resources/datafactory_extras_test.go
+++ b/providers/azure/resources/datafactory_extras_test.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v10"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/datafactory/armdatafactory/v11"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/providers/azure/resources/kusto.go
+++ b/providers/azure/resources/kusto.go
@@ -91,7 +91,7 @@ func kustoClusterToMql(runtime *plugin.Runtime, cluster *armkusto.Cluster) (*mql
 
 	var uri, dataIngestionURI, state, provisioningState string
 	var publicNetworkAccess, publicIPType, restrictOutbound string
-	var cmkKeyName, cmkKeyVaultURI, cmkKeyVersion string
+	var cmkKeyName, cmkKeyVaultURI, cmkKeyVersion, cmkFederatedIdentityClientID string
 	var enableDiskEncryption, enableDoubleEncryption, enableStreamingIngest, enablePurge bool
 	allowedIPRangeList := []any{}
 	allowedFqdnList := []any{}
@@ -128,6 +128,7 @@ func kustoClusterToMql(runtime *plugin.Runtime, cluster *armkusto.Cluster) (*mql
 			cmkKeyName = convert.ToValue(kv.KeyName)
 			cmkKeyVaultURI = convert.ToValue(kv.KeyVaultURI)
 			cmkKeyVersion = convert.ToValue(kv.KeyVersion)
+			cmkFederatedIdentityClientID = convert.ToValue(kv.FederatedIdentityClientID)
 		}
 	}
 
@@ -156,6 +157,7 @@ func kustoClusterToMql(runtime *plugin.Runtime, cluster *armkusto.Cluster) (*mql
 			"cmkKeyName":                    llx.StringData(cmkKeyName),
 			"cmkKeyVaultUri":                llx.StringData(cmkKeyVaultURI),
 			"cmkKeyVersion":                 llx.StringData(cmkKeyVersion),
+			"cmkFederatedIdentityClientId":  llx.StringData(cmkFederatedIdentityClientID),
 		})
 	if err != nil {
 		return nil, err
@@ -235,8 +237,37 @@ func (a *mqlAzureSubscriptionKustoServiceClusterManagedPrivateEndpoint) systemMe
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
+type mqlAzureSubscriptionKustoServiceClusterDatabaseInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterDatabase) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionKustoServiceClusterPrincipalAssignmentInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignmentInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 type mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnectionInternal struct {
 	cacheManagedIdentityID string
+	cacheSystemData        any
+}
+
+func (a *mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // initAzureSubscriptionKustoServiceCluster resolves a Data Explorer cluster
@@ -403,6 +434,11 @@ func (a *mqlAzureSubscriptionKustoServiceCluster) databases() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(db.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlDb.(*mqlAzureSubscriptionKustoServiceClusterDatabase).cacheSystemData = sysData
 			res = append(res, mqlDb)
 		}
 	}
@@ -463,6 +499,11 @@ func (a *mqlAzureSubscriptionKustoServiceCluster) principalAssignments() ([]any,
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(pa.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPa.(*mqlAzureSubscriptionKustoServiceClusterPrincipalAssignment).cacheSystemData = sysData
 			res = append(res, mqlPa)
 		}
 	}
@@ -722,6 +763,11 @@ func (a *mqlAzureSubscriptionKustoServiceClusterDatabase) principalAssignments()
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(pa.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPa.(*mqlAzureSubscriptionKustoServiceClusterDatabasePrincipalAssignment).cacheSystemData = sysData
 			res = append(res, mqlPa)
 		}
 	}
@@ -803,6 +849,28 @@ func (a *mqlAzureSubscriptionKustoServiceClusterDatabase) dataConnections() ([]a
 					managedIdentityResourceID = convert.ToValue(p.ManagedIdentityResourceID)
 					provisioningState = string(convert.ToValue(p.ProvisioningState))
 				}
+			case *armkusto.EventHubDataConnectionWithManagedIdentity:
+				if p := d.Properties; p != nil {
+					tableName = convert.ToValue(p.TableName)
+					dataFormat = string(convert.ToValue(p.DataFormat))
+					mappingRuleName = convert.ToValue(p.MappingRuleName)
+					consumerGroup = convert.ToValue(p.ConsumerGroup)
+					databaseRouting = string(convert.ToValue(p.DatabaseRouting))
+					sourceResourceID = convert.ToValue(p.EventHubResourceIDForManagedIdentity)
+					managedIdentityResourceID = convert.ToValue(p.ManagedIdentityResourceID)
+					provisioningState = string(convert.ToValue(p.ProvisioningState))
+				}
+			case *armkusto.EventGridDataConnectionWithManagedIdentity:
+				if p := d.Properties; p != nil {
+					tableName = convert.ToValue(p.TableName)
+					dataFormat = string(convert.ToValue(p.DataFormat))
+					mappingRuleName = convert.ToValue(p.MappingRuleName)
+					consumerGroup = convert.ToValue(p.ConsumerGroup)
+					databaseRouting = string(convert.ToValue(p.DatabaseRouting))
+					sourceResourceID = convert.ToValue(p.StorageAccountResourceIDForManagedIdentity)
+					managedIdentityResourceID = convert.ToValue(p.ManagedIdentityResourceID)
+					provisioningState = string(convert.ToValue(p.ProvisioningState))
+				}
 			}
 			mqlDc, err := CreateResource(a.MqlRuntime, "azure.subscription.kustoService.cluster.database.dataConnection",
 				map[string]*llx.RawData{
@@ -822,6 +890,11 @@ func (a *mqlAzureSubscriptionKustoServiceClusterDatabase) dataConnections() ([]a
 				return nil, err
 			}
 			mqlDc.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).cacheManagedIdentityID = managedIdentityResourceID
+			sysData, err := convert.JsonToDict(dc.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlDc.(*mqlAzureSubscriptionKustoServiceClusterDatabaseDataConnection).cacheSystemData = sysData
 			res = append(res, mqlDc)
 		}
 	}

--- a/providers/azure/resources/loganalytics.go
+++ b/providers/azure/resources/loganalytics.go
@@ -843,14 +843,27 @@ func (a *mqlAzureSubscriptionMonitorServiceWorkspace) networkSecurityPerimeterCo
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(nsp.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlNsp.(*mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration).cacheSystemData = sysData
 			res = append(res, mqlNsp)
 		}
 	}
 	return res, nil
 }
 
+type mqlAzureSubscriptionMonitorServiceWorkspaceNspConfigurationInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionMonitorServiceWorkspaceNspConfiguration) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // workspace returns a typed reference to the Log Analytics workspace from an Application Insight.

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -615,6 +615,14 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator) id() (stri
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionMySqlServiceFlexibleServerAdministratorInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 // threatProtectionState fetches the Microsoft Defender for Cloud advanced threat protection state.
 func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) threatProtectionState() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
@@ -691,6 +699,11 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) azureAdAdministrators()
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAdmin.(*mqlAzureSubscriptionMySqlServiceFlexibleServerAdministrator).cacheSystemData = sysData
 			res = append(res, mqlAdmin)
 		}
 	}

--- a/providers/azure/resources/network_avnm.go
+++ b/providers/azure/resources/network_avnm.go
@@ -180,11 +180,24 @@ func azureNetworkGroupToMql(runtime *plugin.Runtime, g *network.Group) (*mqlAzur
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(g.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlGroup.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).cacheSystemData = sysData
 	return mqlGroup.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup), nil
+}
+
+type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupInternal struct {
+	cacheSystemData any
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // initAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup resolves a
@@ -288,14 +301,27 @@ func (a *mqlAzureSubscriptionNetworkServiceNetworkManager) securityAdminConfigur
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(cfg.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCfg.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).cacheSystemData = sysData
 			res = append(res, mqlCfg)
 		}
 	}
 	return res, nil
 }
 
+type mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration) ruleCollections() ([]any, error) {
@@ -610,6 +636,11 @@ func (a *mqlAzureSubscriptionNetworkServiceNetworkManager) connectivityConfigura
 				return nil, err
 			}
 			mqlCfg.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).cacheAppliesToGroupIds = appliesToGroupIds
+			sysData, err := convert.JsonToDict(cfg.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlCfg.(*mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration).cacheSystemData = sysData
 			res = append(res, mqlCfg)
 		}
 	}
@@ -618,10 +649,15 @@ func (a *mqlAzureSubscriptionNetworkServiceNetworkManager) connectivityConfigura
 
 type mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfigurationInternal struct {
 	cacheAppliesToGroupIds []string
+	cacheSystemData        any
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerConnectivityConfiguration) appliesToGroups() ([]any, error) {

--- a/providers/azure/resources/network_perimeter.go
+++ b/providers/azure/resources/network_perimeter.go
@@ -62,14 +62,27 @@ func (a *mqlAzureSubscriptionNetworkService) securityPerimeters() ([]any, error)
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(nsp.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlNsp.(*mqlAzureSubscriptionNetworkServiceSecurityPerimeter).cacheSystemData = sysData
 			res = append(res, mqlNsp)
 		}
 	}
 	return res, nil
 }
 
+type mqlAzureSubscriptionNetworkServiceSecurityPerimeterInternal struct {
+	cacheSystemData any
+}
+
 func (a *mqlAzureSubscriptionNetworkServiceSecurityPerimeter) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceSecurityPerimeter) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // profiles resolves the access-rule profiles defined on the perimeter. The

--- a/providers/azure/resources/redis.go
+++ b/providers/azure/resources/redis.go
@@ -324,6 +324,11 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) privateEndpointConnectio
 		if err != nil {
 			return nil, err
 		}
+		sysData, err := convert.JsonToDict(pec.SystemData)
+		if err != nil {
+			return nil, err
+		}
+		pecResource.(*mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection).cacheSystemData = sysData
 		res = append(res, pecResource)
 	}
 	return res, nil
@@ -382,6 +387,11 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) firewallRules() ([]any, 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(rule.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRule.(*mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule).cacheSystemData = sysData
 			res = append(res, mqlRule)
 		}
 	}
@@ -450,6 +460,11 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstance) patchSchedules() ([]any,
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(schedule.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlSchedule.(*mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule).cacheSystemData = sysData
 			res = append(res, mqlSchedule)
 		}
 	}
@@ -468,12 +483,36 @@ func (a *mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule) id() (string
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRuleInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCacheServiceRedisInstanceFirewallRule) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionCacheServiceRedisInstancePatchScheduleInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCacheServiceRedisInstancePatchSchedule) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnectionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionCacheServiceRedisInstancePrivateEndpointConnection) privateEndpoint() (*mqlAzureSubscriptionNetworkServicePrivateEndpoint, error) {

--- a/providers/azure/resources/sentinel.go
+++ b/providers/azure/resources/sentinel.go
@@ -43,6 +43,14 @@ func (a *mqlAzureSubscriptionSentinelServiceWorkspace) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionSentinelServiceWorkspaceInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSentinelServiceWorkspace) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionSentinelServiceAlertRule) id() (string, error) {
 	return a.Id.Data, nil
 }
@@ -109,6 +117,11 @@ func (a *mqlAzureSubscriptionSentinelService) workspaces() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(ws.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlWs.(*mqlAzureSubscriptionSentinelServiceWorkspace).cacheSystemData = sysData
 			res = append(res, mqlWs)
 		}
 	}

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -861,6 +861,14 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) auditingPolicy() (any, error) {
 	return convert.JsonToDict(policy.DatabaseBlobAuditingPolicy.Properties)
 }
 
+type mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotectionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionSqlServiceDatabase) advancedThreatProtection() (*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	ctx := context.Background()
@@ -911,6 +919,11 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) advancedThreatProtection() (*mq
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(policy.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionSqlServiceDatabaseAdvancedthreatprotection), nil
 }
 
@@ -1171,12 +1184,36 @@ func (a *mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig) id() (st
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfigInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSettingInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSettingInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionSqlServiceServerKey) id() (string, error) {
@@ -1205,6 +1242,14 @@ func (a *mqlAzureSubscriptionSqlServiceDatabaseBlobAuditingPolicy) id() (string,
 
 func (a *mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionSqlServiceDatabaseVulnerabilityAssessment) id() (string, error) {
@@ -1454,6 +1499,11 @@ func (a *mqlAzureSubscriptionSqlServiceServer) securityAlertPolicyConfig() (*mql
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(resp.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionSqlServiceServerSecurityAlertPolicyConfig), nil
 }
 
@@ -1499,6 +1549,11 @@ func (a *mqlAzureSubscriptionSqlServiceServer) advancedThreatProtectionSetting()
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(resp.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionSqlServiceServerAdvancedThreatProtectionSetting), nil
 }
 
@@ -1558,6 +1613,11 @@ func (a *mqlAzureSubscriptionSqlServiceServer) devOpsAuditingSetting() (*mqlAzur
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(resp.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionSqlServiceServerDevOpsAuditingSetting), nil
 }
 
@@ -2143,6 +2203,11 @@ func (a *mqlAzureSubscriptionSqlServiceDatabase) securityAlertPolicy() (*mqlAzur
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(resp.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionSqlServiceDatabaseSecurityAlertPolicy), nil
 }
 

--- a/providers/azure/resources/storage.go
+++ b/providers/azure/resources/storage.go
@@ -106,6 +106,14 @@ func (a *mqlAzureSubscriptionStorageServiceAccountContainer) id() (string, error
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionStorageServiceAccountContainerInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountContainer) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionStorageServiceAccountDataProtection) id() (string, error) {
 	return a.StorageAccountId.Data + "/dataProtection", nil
 }
@@ -358,6 +366,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) containers() ([]any, error) 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(container.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAzure.(*mqlAzureSubscriptionStorageServiceAccountContainer).cacheSystemData = sysData
 			res = append(res, mqlAzure)
 		}
 	}
@@ -1196,8 +1209,24 @@ func (a *mqlAzureSubscriptionStorageServiceAccountEncryptionScope) id() (string,
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionStorageServiceAccountEncryptionScopeInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountEncryptionScope) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionStorageServiceAccountManagementPolicy) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountManagementPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountManagementPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccountManagementPolicyRule) id() (string, error) {
@@ -1284,6 +1313,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) encryptionScopes() ([]any, e
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(scope.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlScope.(*mqlAzureSubscriptionStorageServiceAccountEncryptionScope).cacheSystemData = sysData
 			res = append(res, mqlScope)
 		}
 	}
@@ -1418,11 +1452,24 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) managementPolicy() (*mqlAzur
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(policy.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy).cacheSystemData = sysData
 	return res.(*mqlAzureSubscriptionStorageServiceAccountManagementPolicy), nil
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccountLocalUser) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountLocalUserInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountLocalUser) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // localUsers fetches local SFTP/SSH user accounts on the storage account.
@@ -1528,6 +1575,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) localUsers() ([]any, error) 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(lu.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlLu.(*mqlAzureSubscriptionStorageServiceAccountLocalUser).cacheSystemData = sysData
 			res = append(res, mqlLu)
 		}
 	}

--- a/providers/azure/resources/storage_extras.go
+++ b/providers/azure/resources/storage_extras.go
@@ -26,8 +26,24 @@ func (a *mqlAzureSubscriptionStorageServiceAccountFileShare) id() (string, error
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionStorageServiceAccountFileShareInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountFileShare) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnectionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // privateEndpoint resolves the consumer-side private endpoint of this
@@ -50,8 +66,24 @@ func (a *mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy) id() 
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func (a *mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicyInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 // storageAccountResourceGroup returns the {resourceGroup, accountName} pair
@@ -163,7 +195,7 @@ func fileShareToMQL(runtime *plugin.Runtime, share *storage.FileShareItem) (plug
 		}
 	}
 
-	return CreateResource(runtime, "azure.subscription.storageService.account.fileShare",
+	mqlShare, err := CreateResource(runtime, "azure.subscription.storageService.account.fileShare",
 		map[string]*llx.RawData{
 			"id":                        llx.StringDataPtr(share.ID),
 			"name":                      llx.StringDataPtr(share.Name),
@@ -186,6 +218,15 @@ func fileShareToMQL(runtime *plugin.Runtime, share *storage.FileShareItem) (plug
 			"leaseDuration":             llx.StringData(leaseDuration),
 			"metadata":                  llx.MapData(metadata, types.String),
 		})
+	if err != nil {
+		return nil, err
+	}
+	sysData, err := convert.JsonToDict(share.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlShare.(*mqlAzureSubscriptionStorageServiceAccountFileShare).cacheSystemData = sysData
+	return mqlShare, nil
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) privateEndpointConnections() ([]any, error) {
@@ -250,6 +291,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) privateEndpointConnections()
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(c.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPe.(*mqlAzureSubscriptionStorageServiceAccountPrivateEndpointConnection).cacheSystemData = sysData
 			res = append(res, mqlPe)
 		}
 	}
@@ -320,6 +366,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) objectReplicationPolicies() 
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(pol.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlPol.(*mqlAzureSubscriptionStorageServiceAccountObjectReplicationPolicy).cacheSystemData = sysData
 			res = append(res, mqlPol)
 		}
 	}
@@ -328,6 +379,14 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) objectReplicationPolicies() 
 
 func (a *mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+type mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfigurationInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) networkSecurityPerimeterConfigurations() ([]any, error) {
@@ -448,6 +507,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) networkSecurityPerimeterConf
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(nsp.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlNsp.(*mqlAzureSubscriptionStorageServiceAccountNetworkSecurityPerimeterConfiguration).cacheSystemData = sysData
 			res = append(res, mqlNsp)
 		}
 	}
@@ -550,6 +614,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) blobInventoryPolicy() (*mqlA
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(pol.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlPol.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy).cacheSystemData = sysData
 	return mqlPol.(*mqlAzureSubscriptionStorageServiceAccountBlobInventoryPolicy), nil
 }
 
@@ -703,11 +772,24 @@ func (a *mqlAzureSubscriptionStorageServiceAccountTable) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+type mqlAzureSubscriptionStorageServiceAccountTableInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountTable) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 type mqlAzureSubscriptionStorageServiceAccountQueueInternal struct {
-	cacheAccountId string
-	countFetched   bool
-	count          int64
-	countLock      sync.Mutex
+	cacheSystemData any
+	cacheAccountId  string
+	countFetched    bool
+	count           int64
+	countLock       sync.Mutex
+}
+
+func (a *mqlAzureSubscriptionStorageServiceAccountQueue) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
 func (a *mqlAzureSubscriptionStorageServiceAccount) queues() ([]any, error) {
@@ -761,6 +843,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) queues() ([]any, error) {
 			}
 			mqlQ := mqlQueue.(*mqlAzureSubscriptionStorageServiceAccountQueue)
 			mqlQ.cacheAccountId = a.Id.Data
+			sysData, err := convert.JsonToDict(q.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlQ.cacheSystemData = sysData
 			res = append(res, mqlQ)
 		}
 	}
@@ -869,6 +956,11 @@ func (a *mqlAzureSubscriptionStorageServiceAccount) tables() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(t.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlTable.(*mqlAzureSubscriptionStorageServiceAccountTable).cacheSystemData = sysData
 			res = append(res, mqlTable)
 		}
 	}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -186,6 +186,62 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) systemMetadata() (*mqlAzureSubsc
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
+type mqlAzureSubscriptionWebServiceFunctionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceFunction) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceAppsiteconfigInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsiteconfig) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceHostingEnvironmentInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceHostingEnvironment) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceAppServicePlanInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppServicePlan) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceCertificateInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceCertificate) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceAppsiteHostNameBindingInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsiteHostNameBinding) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
+type mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnectionInternal struct {
+	cacheSystemData any
+}
+
+func (a *mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 type runtimeStackDescriptor struct {
 	Name         string
 	MinorVersion string
@@ -780,6 +836,11 @@ func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnec
 	if err != nil {
 		return nil, err
 	}
+	sysData, err := convert.JsonToDict(entry.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlAzureSubscriptionWebServiceAppsiteconfig).cacheSystemData = sysData
 
 	return res.(*mqlAzureSubscriptionWebServiceAppsiteconfig), nil
 }
@@ -1115,6 +1176,11 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) functions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAzure.(*mqlAzureSubscriptionWebServiceFunction).cacheSystemData = sysData
 			res = append(res, mqlAzure)
 		}
 	}
@@ -1390,6 +1456,11 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) functions() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlAzure.(*mqlAzureSubscriptionWebServiceFunction).cacheSystemData = sysData
 			res = append(res, mqlAzure)
 		}
 	}
@@ -1730,6 +1801,11 @@ func (a *mqlAzureSubscriptionWebService) appServicePlans() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(plan.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlResource.(*mqlAzureSubscriptionWebServiceAppServicePlan).cacheSystemData = sysData
 			res = append(res, mqlResource)
 		}
 	}
@@ -1798,6 +1874,11 @@ func (a *mqlAzureSubscriptionWebService) certificates() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(cert.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlResource.(*mqlAzureSubscriptionWebServiceCertificate).cacheSystemData = sysData
 			res = append(res, mqlResource)
 		}
 	}
@@ -1868,6 +1949,11 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) hostNameBindings() ([]any, error
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(binding.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteHostNameBinding).cacheSystemData = sysData
 			res = append(res, mqlResource)
 		}
 	}
@@ -1927,6 +2013,11 @@ func (a *mqlAzureSubscriptionWebServiceAppsite) virtualNetworkConnections() ([]a
 		if err != nil {
 			return nil, err
 		}
+		sysData, err := convert.JsonToDict(vnet.SystemData)
+		if err != nil {
+			return nil, err
+		}
+		mqlResource.(*mqlAzureSubscriptionWebServiceAppsiteVirtualNetworkConnection).cacheSystemData = sysData
 		res = append(res, mqlResource)
 	}
 
@@ -2034,6 +2125,11 @@ func (a *mqlAzureSubscriptionWebService) hostingEnvironments() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			sysData, err := convert.JsonToDict(entry.SystemData)
+			if err != nil {
+				return nil, err
+			}
+			mqlRes.(*mqlAzureSubscriptionWebServiceHostingEnvironment).cacheSystemData = sysData
 
 			res = append(res, mqlRes)
 		}


### PR DESCRIPTION
## What

Bumps the two Azure SDK Go modules that had new stable releases, then uses the newly-exposed API surface to broaden provenance and enrichment across the provider.

### Dependency bumps
| Module | Old → New |
|---|---|
| `datafactory/armdatafactory` | `v10.0.0` → `v11.0.0` |
| `kusto/armkusto/v2` | `v2.3.0` → `v2.4.0` |

The only source-breaking change in datafactory v11 (`JiraObjectDataset.TypeProperties` retyped) is not used anywhere in this provider, so v11 is an import-path bump for us. All other Azure deps are already on their latest stable major; the remaining higher majors exist only as betas/pseudo-versions and were intentionally skipped.

### `systemMetadata()` provenance sweep
Adds a typed `systemMetadata() azure.subscription.systemData` accessor to **every resource whose backing Azure SDK struct carries ARM `SystemData` but did not yet expose it** — 58 resources spanning Data Factory, Kusto, Storage, Web/App Service, Container Registry, Compute, Redis, AVNM/Network Security Perimeter, Defender for Cloud, SQL, MySQL, Log Analytics, and Sentinel. Each caches the raw `SystemData` on the resource's `Internal` struct and resolves it through the existing `systemMetadataFromRaw` helper, matching the established pattern.

This makes creation/modification provenance (`createdBy`, `createdAt`, `lastModifiedBy`, ...) queryable consistently across the provider — useful for ownership, drift, and change-window audits.

### Kusto v2.4.0 enrichment
- `cmkFederatedIdentityClientId` on the cluster (cross-tenant customer-managed-key access)
- Handles the new `EventHubDataConnectionWithManagedIdentity` / `EventGridDataConnectionWithManagedIdentity` connection kinds so managed-identity ingestion connections populate fully instead of falling through to base fields
- Enum-doc refresh: `publicNetworkAccess` (+`SecuredByPerimeter`), `dataConnection.kind` (+managed-identity kinds)

### Data Factory v11 enrichment
- `authenticationType` typed field on `linkedService`, surfacing the connector's declared auth mode (e.g. `Basic`, `ManagedServiceIdentity`, `ServicePrincipal`) from `typeProperties` for direct auditing

### Enum-doc accuracy sweep
Audited every enum-listing comment in `azure.lr` against the current SDK enum definitions and corrected ~16:
- **Removed values that no longer exist:** Arc agent `Expired`, App Service `Show401`/`Show403`, Redis private-endpoint `Updating`, Service Bus network-rules `SecuredByPerimeter`, Recovery Services `secureScore` `Healthy`/`Unhealthy`.
- **Added newly-introduced values:** Compute `securityType` `Standard`, Application Gateway listener `Tcp`/`Tls`, SQL replication-link roles (`Source`/`Copy`/`NonReadableSecondary`), AKS `vmType` `VirtualMachines`, Recovery Services `AlwaysON`/`ZoneRedundant`/`Disabled`, Log Analytics `SecuredByPerimeter`.

(Event Hub `publicNetworkAccess` and Kusto `calloutType` were double-checked against the SDK and left unchanged — their existing value lists are correct.)

## Testing
- `go build ./...`, `go vet ./...`, `go test ./resources/...` — all pass
- `mqlr generate` run; generated `azure.lr.go` / `azure.lr.versions` up to date (60 new fields at `13.28.1`)
- `gofmt` clean; `azure.permissions.json` unchanged except the version/timestamp header (no new API calls — provenance reads already-fetched `SystemData`)

## Not included / follow-ups
- Live verification against a real subscription was not run (heavy multi-service infra); recommend a provider-verification pass before/after merge.
- Deferred provenance candidates needing extra work: `policy.exemption` (distinct REST-struct mechanism), Service Bus / Event Hub `networkRules` (synthetic id, low value), `monitor.diagnosticSetting` (raw REST, needs a live check that ARM populates it).
- Noisy operational `provisioningState` enum lists (Redis, Lighthouse) were left as-is rather than exhaustively enumerating every transient state.
- A pre-existing mismatch on `batch...pool.securityEncryptionType` (comment/field name vs the `SecurityProfile.SecurityType` mapping) is noted but out of scope here.
