### PR TITLE
🎉 aws-13.45.0, azure-13.29.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.44.0",
+	Version:         "13.45.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.28.0",
+	Version:   "13.29.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,


### PR DESCRIPTION
Minor version bumps for two providers:

- `aws`: `13.44.0` → `13.45.0`
- `azure`: `13.28.0` → `13.29.0`

## aws changes since 13.44.0

- ✨ Expose `arn` on 20 more resources with synthesizable ARNs (#9027)
- ✨ Expose `arn` on `aws.directoryservice.directory` (#9025, #9026)
- ✨ Discover six more AWS resource types as scannable assets (#9013)
- ✨ `aws.lambda.function`: expose durable-execution encryption settings (#8999)
- 🧹 Filter for AWS S3 bucket and Google storage bucket (#9017)
- 🧹 Update deps for mql and providers (#8998)

## azure changes since 13.28.0

- ✨ Bump datafactory v11 + kusto v2.4.0, sweep systemMetadata provenance & enum docs (#9031)
