### PR TITLE
✨ Add support for Azure JWT fetching from a compute environment.

### DIFF
--- a/providers-sdk/v1/upstream/tokenauth/azure.go
+++ b/providers-sdk/v1/upstream/tokenauth/azure.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	// envClientID and envTokenAudience are variables this package defines. When set,
-	// they select the identity to mint a token with, and the audience to mint it for:
+	// envClientID and envTokenAudience are custom environment variables used to
+	// select the identity to mint a token with, and the audience to mint it for:
 	//
 	//	MONDOO_WIF_CLIENT_ID  names one user-assigned identity by its client id, for
 	//	                      environments that expose more than one. Unset selects
@@ -26,18 +26,11 @@ const (
 	//	MONDOO_WIF_AUDIENCE   names the token's aud claim. Azure mints tokens only
 	//	                      for a resource principal registered in the tenant, so
 	//	                      this is an app registration URI (e.g. api://example).
-	//	                      Unset, App Service falls back to the exchange audience,
-	//	                      which a working exchange sets to the same URI; set this
-	//	                      only when the aud claim must differ from that audience.
-	//
-	// Both apply only to endpoints that can act on them: Cloud Shell has neither
-	// user-assigned identities nor an app registration to target, so it reads
-	// neither and always mints for the exchange audience.
 	envClientID      = "MONDOO_WIF_CLIENT_ID"
 	envTokenAudience = "MONDOO_WIF_AUDIENCE"
 
-	// envIdentityEndpoint and envIdentityHeader are injected by Azure rather than
-	// defined here. Their presence identifies an App Service, Function or Container
+	// Those two environment variables are injected by Azure rather than defined
+	// here. Their presence identifies an App Service, Function or Container
 	// App (incl. jobs): the endpoint is the local token URL, and the header is the
 	// secret that authenticates the caller to it.
 	envIdentityEndpoint = "IDENTITY_ENDPOINT"

--- a/providers-sdk/v1/upstream/tokenauth/azure.go
+++ b/providers-sdk/v1/upstream/tokenauth/azure.go
@@ -6,29 +6,232 @@ package tokenauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
 
-// AzureTokenProvider fetches an identity token from Azure IMDS.
-type AzureTokenProvider struct{}
+const (
+	// envClientID and envTokenAudience are variables this package defines. When set,
+	// they select the identity to mint a token with, and the audience to mint it for:
+	//
+	//	MONDOO_WIF_CLIENT_ID  names one user-assigned identity by its client id, for
+	//	                      environments that expose more than one. Unset selects
+	//	                      the system-assigned identity.
+	//	MONDOO_WIF_AUDIENCE   names the token's aud claim. Azure mints tokens only
+	//	                      for a resource principal registered in the tenant, so
+	//	                      this is an app registration URI (e.g. api://example).
+	//	                      Unset, App Service falls back to the exchange audience,
+	//	                      which a working exchange sets to the same URI; set this
+	//	                      only when the aud claim must differ from that audience.
+	//
+	// Both apply only to endpoints that can act on them: Cloud Shell has neither
+	// user-assigned identities nor an app registration to target, so it reads
+	// neither and always mints for the exchange audience.
+	envClientID      = "MONDOO_WIF_CLIENT_ID"
+	envTokenAudience = "MONDOO_WIF_AUDIENCE"
+
+	// envIdentityEndpoint and envIdentityHeader are injected by Azure rather than
+	// defined here. Their presence identifies an App Service, Function or Container
+	// App (incl. jobs): the endpoint is the local token URL, and the header is the
+	// secret that authenticates the caller to it.
+	envIdentityEndpoint = "IDENTITY_ENDPOINT"
+	envIdentityHeader   = "IDENTITY_HEADER"
+
+	// appServiceAPIVersion pins the contract of the App Service token endpoint.
+	appServiceAPIVersion = "2019-08-01"
+
+	// cloudShellTokenURL is fixed rather than read from MSI_ENDPOINT. Cloud Shell's
+	// token endpoint predates IMDS and always listens on this port.
+	cloudShellTokenURL = "http://localhost:50342/oauth2/token"
+
+	tokenFetchTimeout = 2 * time.Second
+)
+
+// AzureTokenProvider fetches an Azure AD access token from whichever managed
+// identity endpoint the current compute environment exposes: App Service, which
+// also covers Functions and Container Apps (incl. jobs), and Cloud Shell.
+//
+// Azure VMs and VM scale sets are deliberately not supported. They mint tokens
+// through IMDS, which is unreachable from every environment above.
+//
+// Both endpoints request a resource — the app registration whose URI becomes the
+// token's aud claim. App Service reads it from MONDOO_WIF_AUDIENCE and falls back
+// to the exchange audience, which a working Azure exchange already sets to that
+// same URI; the override matters only when the two must differ. Cloud Shell always
+// mints for the exchange audience directly.
+type AzureTokenProvider struct {
+	// cloudShellURL overrides the Cloud Shell endpoint. Empty selects
+	// cloudShellTokenURL; only tests set it.
+	cloudShellURL string
+}
 
 func (p *AzureTokenProvider) GetToken(ctx context.Context, audience string) (string, error) {
-	reqUrl := "http://localhost:50342/oauth2/token"
-	data := make(url.Values)
-	data.Set("resource", audience)
+	cloudShell := p.cloudShellURL
+	if cloudShell == "" {
+		cloudShell = cloudShellTokenURL
+	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", reqUrl, strings.NewReader(data.Encode()))
+	reqs, err := azureTokenRequests(audience, cloudShell)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Add("Metadata", "true")
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{Timeout: 2 * time.Second}
+	client := &http.Client{Timeout: tokenFetchTimeout}
+	var errs []error
+	for _, req := range reqs {
+		token, err := req.RequestToken(ctx, client)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", req, err))
+			continue
+		}
+		return token, nil
+	}
+
+	return "", fmt.Errorf("azure managed identity token request failed on all endpoints: %w", errors.Join(errs...))
+}
+
+// azureTokenRequest is one managed identity endpoint we know how to ask for a
+// token. Each implementation carries only the parameters its own endpoint needs,
+// and owns the wire format that endpoint expects — the two differ in method, in
+// where the resource travels, and in how the caller authenticates.
+//
+// String labels the endpoint when GetToken aggregates the failures. It must not
+// leak the App Service secret, which travels in X-IDENTITY-HEADER.
+type azureTokenRequest interface {
+	fmt.Stringer
+	RequestToken(ctx context.Context, client *http.Client) (string, error)
+}
+
+// azureTokenRequests builds the ordered list of endpoints to try. An endpoint is
+// registered only once the environment supplies everything that endpoint needs.
+func azureTokenRequests(audience, cloudShellURL string) ([]azureTokenRequest, error) {
+	reqs := make([]azureTokenRequest, 0, 2)
+
+	// App Service announces itself by injecting the endpoint. Neither of the two
+	// values the request then needs is guessable, and sending an empty one earns a
+	// bodiless 4xx that names nothing, so refuse before the request goes out.
+	if endpoint := os.Getenv(envIdentityEndpoint); endpoint != "" {
+		// Azure injects the header alongside the endpoint, and the endpoint rejects
+		// any request that arrives without it — the header is what defends the local
+		// token service against SSRF. Its absence means this is not the environment
+		// the endpoint implies, so check it before anything we control.
+		header := os.Getenv(envIdentityHeader)
+		if header == "" {
+			return nil, fmt.Errorf(
+				"%s names an azure managed identity endpoint, but %s is unset: the endpoint rejects requests that do not carry it",
+				envIdentityEndpoint, envIdentityHeader)
+		}
+
+		// The resource is the app registration to mint for. MONDOO_WIF_AUDIENCE
+		// overrides it; otherwise it is the exchange audience, which a correctly
+		// configured Azure exchange already sets to the same app registration URI.
+		// Only when both are empty is there nothing to request — send that and Azure
+		// answers with an opaque 400, so refuse before the request goes out.
+		resource := os.Getenv(envTokenAudience)
+		if resource == "" {
+			resource = audience
+		}
+		if resource == "" {
+			return nil, fmt.Errorf(
+				"%s names an azure managed identity endpoint, but no resource to mint for: set %s to the app registration URI, or pass an audience",
+				envIdentityEndpoint, envTokenAudience)
+		}
+
+		reqs = append(reqs, appServiceTokenRequest{
+			endpoint: endpoint,
+			header:   header,
+			resource: resource,
+			clientID: os.Getenv(envClientID),
+		})
+	}
+
+	// Cloud Shell predates the app registration flow and mints for the exchange
+	// audience directly, so it needs nothing from the environment. It is always
+	// tried, with whatever audience the caller passed — this is the exact request
+	// this provider sent before App Service support existed, and an empty audience
+	// is preserved rather than guarded so that behavior stays byte-for-byte intact.
+	reqs = append(reqs, cloudShellTokenRequest{
+		endpoint: cloudShellURL,
+		resource: audience,
+	})
+
+	return reqs, nil
+}
+
+// appServiceTokenRequest covers App Service, Functions and Container Apps. It
+// takes the resource in the query string and authenticates with the secret App
+// Service injects alongside the endpoint.
+type appServiceTokenRequest struct {
+	endpoint string
+	// header is the secret Azure injects alongside the endpoint. It is required:
+	// the endpoint rejects any request that does not carry it.
+	header   string
+	resource string
+	// clientID picks one of several user-assigned identities. Empty falls back to
+	// the system-assigned identity.
+	clientID string
+}
+
+func (r appServiceTokenRequest) String() string {
+	identity := "system-assigned identity"
+	if r.clientID != "" {
+		identity = "client_id=" + r.clientID
+	}
+	return fmt.Sprintf("app service (%s, resource=%s, %s)", r.endpoint, r.resource, identity)
+}
+
+func (r appServiceTokenRequest) RequestToken(ctx context.Context, client *http.Client) (string, error) {
+	q := url.Values{}
+	q.Set("api-version", appServiceAPIVersion)
+	q.Set("resource", r.resource)
+	if r.clientID != "" {
+		q.Set("client_id", r.clientID)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint+"?"+q.Encode(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-IDENTITY-HEADER", r.header)
+
+	return requestAzureToken(client, req)
+}
+
+// cloudShellTokenRequest carries no clientID: Cloud Shell has no user-assigned
+// identities. Its endpoint predates IMDS and wants a form-encoded POST, and its
+// resource is the exchange audience the caller passed.
+type cloudShellTokenRequest struct {
+	endpoint string
+	resource string
+}
+
+func (r cloudShellTokenRequest) String() string {
+	return fmt.Sprintf("cloud shell (%s, resource=%s)", r.endpoint, r.resource)
+}
+
+func (r cloudShellTokenRequest) RequestToken(ctx context.Context, client *http.Client) (string, error) {
+	form := url.Values{}
+	form.Set("resource", r.resource)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Metadata", "true")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return requestAzureToken(client, req)
+}
+
+// requestAzureToken sends a built request and extracts the access token. Both
+// endpoints answer with the same JSON envelope, so they share the response half.
+func requestAzureToken(client *http.Client, req *http.Request) (string, error) {
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -36,7 +239,15 @@ func (p *AzureTokenProvider) GetToken(ctx context.Context, audience string) (str
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("azure IMDS returned non-OK status: %d", resp.StatusCode)
+		// The body carries Azure's actual complaint (invalid resource, no such
+		// identity, ...). Without it a 400 is unactionable. It never contains a
+		// token: an error response has no access_token.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		detail := strings.TrimSpace(string(body))
+		if detail == "" {
+			detail = "<empty body>"
+		}
+		return "", fmt.Errorf("endpoint returned non-OK status %d: %s", resp.StatusCode, detail)
 	}
 
 	var result struct {
@@ -45,6 +256,8 @@ func (p *AzureTokenProvider) GetToken(ctx context.Context, audience string) (str
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
 	}
-
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("endpoint returned an empty access_token")
+	}
 	return result.AccessToken, nil
 }

--- a/providers-sdk/v1/upstream/tokenauth/azure.go
+++ b/providers-sdk/v1/upstream/tokenauth/azure.go
@@ -17,50 +17,29 @@ import (
 )
 
 const (
-	// envClientID and envTokenAudience are custom environment variables used to
-	// select the identity to mint a token with, and the audience to mint it for:
-	//
-	//	MONDOO_WIF_CLIENT_ID  names one user-assigned identity by its client id, for
-	//	                      environments that expose more than one. Unset selects
-	//	                      the system-assigned identity.
-	//	MONDOO_WIF_AUDIENCE   names the token's aud claim. Azure mints tokens only
-	//	                      for a resource principal registered in the tenant, so
-	//	                      this is an app registration URI (e.g. api://example).
+	// MONDOO_WIF_CLIENT_ID names a user-assigned identity by client id; unset
+	// selects the system-assigned identity. MONDOO_WIF_AUDIENCE names the token's
+	// aud claim (an app registration URI, e.g. api://example).
 	envClientID      = "MONDOO_WIF_CLIENT_ID"
 	envTokenAudience = "MONDOO_WIF_AUDIENCE"
-
-	// Those two environment variables are injected by Azure rather than defined
-	// here. Their presence identifies an App Service, Function or Container
-	// App (incl. jobs): the endpoint is the local token URL, and the header is the
-	// secret that authenticates the caller to it.
-	envIdentityEndpoint = "IDENTITY_ENDPOINT"
-	envIdentityHeader   = "IDENTITY_HEADER"
-
-	// appServiceAPIVersion pins the contract of the App Service token endpoint.
+	// Injected by Azure on App Service, Functions and Container Apps: the local
+	// token endpoint and the secret that authenticates callers to it.
+	envIdentityEndpoint  = "IDENTITY_ENDPOINT"
+	envIdentityHeader    = "IDENTITY_HEADER"
 	appServiceAPIVersion = "2019-08-01"
 
-	// cloudShellTokenURL is fixed rather than read from MSI_ENDPOINT. Cloud Shell's
-	// token endpoint predates IMDS and always listens on this port.
+	// Cloud Shell's token endpoint predates IMDS and always listens here.
 	cloudShellTokenURL = "http://localhost:50342/oauth2/token"
 
 	tokenFetchTimeout = 2 * time.Second
 )
 
 // AzureTokenProvider fetches an Azure AD access token from whichever managed
-// identity endpoint the current compute environment exposes: App Service, which
-// also covers Functions and Container Apps (incl. jobs), and Cloud Shell.
-//
-// Azure VMs and VM scale sets are deliberately not supported. They mint tokens
-// through IMDS, which is unreachable from every environment above.
-//
-// Both endpoints request a resource — the app registration whose URI becomes the
-// token's aud claim. App Service reads it from MONDOO_WIF_AUDIENCE and falls back
-// to the exchange audience, which a working Azure exchange already sets to that
-// same URI; the override matters only when the two must differ. Cloud Shell always
-// mints for the exchange audience directly.
+// identity endpoint the compute environment exposes: App Service (which also
+// covers Functions and Container Apps) or Cloud Shell. VMs and scale sets use
+// IMDS and are not supported.
 type AzureTokenProvider struct {
-	// cloudShellURL overrides the Cloud Shell endpoint. Empty selects
-	// cloudShellTokenURL; only tests set it.
+	// cloudShellURL overrides the Cloud Shell endpoint; only tests set it.
 	cloudShellURL string
 }
 
@@ -90,30 +69,24 @@ func (p *AzureTokenProvider) GetToken(ctx context.Context, audience string) (str
 }
 
 // azureTokenRequest is one managed identity endpoint we know how to ask for a
-// token. Each implementation carries only the parameters its own endpoint needs,
-// and owns the wire format that endpoint expects — the two differ in method, in
-// where the resource travels, and in how the caller authenticates.
-//
-// String labels the endpoint when GetToken aggregates the failures. It must not
-// leak the App Service secret, which travels in X-IDENTITY-HEADER.
+// token. String labels it in aggregated errors and must not leak the secret.
 type azureTokenRequest interface {
 	fmt.Stringer
 	RequestToken(ctx context.Context, client *http.Client) (string, error)
 }
 
-// azureTokenRequests builds the ordered list of endpoints to try. An endpoint is
-// registered only once the environment supplies everything that endpoint needs.
+// azureTokenRequests builds the ordered list of endpoints to try, registering
+// each only once the environment supplies what it needs.
 func azureTokenRequests(audience, cloudShellURL string) ([]azureTokenRequest, error) {
 	reqs := make([]azureTokenRequest, 0, 2)
 
-	// App Service announces itself by injecting the endpoint. Neither of the two
-	// values the request then needs is guessable, and sending an empty one earns a
-	// bodiless 4xx that names nothing, so refuse before the request goes out.
+	// App Service announces itself via IDENTITY_ENDPOINT. The header and a resource
+	// are then both required; refuse early rather than send a request Azure answers
+	// with an opaque 4xx that names nothing.
 	if endpoint := os.Getenv(envIdentityEndpoint); endpoint != "" {
-		// Azure injects the header alongside the endpoint, and the endpoint rejects
-		// any request that arrives without it — the header is what defends the local
-		// token service against SSRF. Its absence means this is not the environment
-		// the endpoint implies, so check it before anything we control.
+		// The header authenticates the caller to the local token service (SSRF
+		// defense). Azure injects it alongside the endpoint, so its absence means
+		// this is not really App Service.
 		header := os.Getenv(envIdentityHeader)
 		if header == "" {
 			return nil, fmt.Errorf(
@@ -121,11 +94,7 @@ func azureTokenRequests(audience, cloudShellURL string) ([]azureTokenRequest, er
 				envIdentityEndpoint, envIdentityHeader)
 		}
 
-		// The resource is the app registration to mint for. MONDOO_WIF_AUDIENCE
-		// overrides it; otherwise it is the exchange audience, which a correctly
-		// configured Azure exchange already sets to the same app registration URI.
-		// Only when both are empty is there nothing to request — send that and Azure
-		// answers with an opaque 400, so refuse before the request goes out.
+		// Resource to mint for: MONDOO_WIF_AUDIENCE, else the exchange audience.
 		resource := os.Getenv(envTokenAudience)
 		if resource == "" {
 			resource = audience
@@ -144,11 +113,9 @@ func azureTokenRequests(audience, cloudShellURL string) ([]azureTokenRequest, er
 		})
 	}
 
-	// Cloud Shell predates the app registration flow and mints for the exchange
-	// audience directly, so it needs nothing from the environment. It is always
-	// tried, with whatever audience the caller passed — this is the exact request
-	// this provider sent before App Service support existed, and an empty audience
-	// is preserved rather than guarded so that behavior stays byte-for-byte intact.
+	// Cloud Shell needs nothing from the environment and is always tried, with the
+	// caller's audience verbatim — the exact request sent before App Service
+	// support, empty audience included, so existing users stay unaffected.
 	reqs = append(reqs, cloudShellTokenRequest{
 		endpoint: cloudShellURL,
 		resource: audience,
@@ -157,18 +124,13 @@ func azureTokenRequests(audience, cloudShellURL string) ([]azureTokenRequest, er
 	return reqs, nil
 }
 
-// appServiceTokenRequest covers App Service, Functions and Container Apps. It
-// takes the resource in the query string and authenticates with the secret App
-// Service injects alongside the endpoint.
+// appServiceTokenRequest covers App Service, Functions and Container Apps: the
+// resource travels in the query string, authenticated by the injected secret.
 type appServiceTokenRequest struct {
 	endpoint string
-	// header is the secret Azure injects alongside the endpoint. It is required:
-	// the endpoint rejects any request that does not carry it.
-	header   string
+	header   string // required secret; the endpoint rejects requests without it
 	resource string
-	// clientID picks one of several user-assigned identities. Empty falls back to
-	// the system-assigned identity.
-	clientID string
+	clientID string // user-assigned identity; empty selects system-assigned
 }
 
 func (r appServiceTokenRequest) String() string {
@@ -196,9 +158,8 @@ func (r appServiceTokenRequest) RequestToken(ctx context.Context, client *http.C
 	return requestAzureToken(client, req)
 }
 
-// cloudShellTokenRequest carries no clientID: Cloud Shell has no user-assigned
-// identities. Its endpoint predates IMDS and wants a form-encoded POST, and its
-// resource is the exchange audience the caller passed.
+// cloudShellTokenRequest mints for the caller's audience via a form-encoded POST.
+// Cloud Shell has no user-assigned identities, so there is no clientID.
 type cloudShellTokenRequest struct {
 	endpoint string
 	resource string
@@ -222,8 +183,8 @@ func (r cloudShellTokenRequest) RequestToken(ctx context.Context, client *http.C
 	return requestAzureToken(client, req)
 }
 
-// requestAzureToken sends a built request and extracts the access token. Both
-// endpoints answer with the same JSON envelope, so they share the response half.
+// requestAzureToken sends a built request and extracts the access token; both
+// endpoints share this JSON response envelope.
 func requestAzureToken(client *http.Client, req *http.Request) (string, error) {
 	resp, err := client.Do(req)
 	if err != nil {
@@ -232,9 +193,8 @@ func requestAzureToken(client *http.Client, req *http.Request) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		// The body carries Azure's actual complaint (invalid resource, no such
-		// identity, ...). Without it a 400 is unactionable. It never contains a
-		// token: an error response has no access_token.
+		// Surface Azure's complaint (invalid resource, no such identity, ...); a
+		// bare status is unactionable. An error response never carries a token.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		detail := strings.TrimSpace(string(body))
 		if detail == "" {

--- a/providers-sdk/v1/upstream/tokenauth/azure_test.go
+++ b/providers-sdk/v1/upstream/tokenauth/azure_test.go
@@ -1,0 +1,466 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tokenauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// testResource is the app registration Azure mints the token for.
+	testResource = "api://mondoo-wif"
+	// testExchangeAudience is the Mondoo scope MRN. Azure cannot mint a token for it.
+	testExchangeAudience = "//captain.api.mondoo.app/spaces/test-space"
+	// testCloudShellURL stands in for the fixed Cloud Shell endpoint.
+	testCloudShellURL = "http://localhost:50342/oauth2/token"
+)
+
+// clearAzureEnv isolates a test from the developer's own managed identity vars.
+func clearAzureEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{envTokenAudience, envClientID, envIdentityEndpoint, envIdentityHeader} {
+		t.Setenv(key, "")
+	}
+}
+
+// capturedRequest is a copy of what a request type actually put on the wire. The
+// handler's *http.Request must not escape the handler, so every field is copied.
+type capturedRequest struct {
+	method string
+	url    url.URL
+	header http.Header
+	body   string
+}
+
+// query returns the request's query string parameters.
+func (c capturedRequest) query() url.Values {
+	return c.url.Query()
+}
+
+// form parses the request body as a form submission.
+func (c capturedRequest) form(t *testing.T) url.Values {
+	t.Helper()
+	form, err := url.ParseQuery(c.body)
+	require.NoError(t, err)
+	return form
+}
+
+// tokenServer serves an access token and records the request it answered. The
+// returned func hands back the recorded request, synchronized against the
+// handler goroutine that wrote it.
+func tokenServer(t *testing.T, token string) (*httptest.Server, func() capturedRequest) {
+	t.Helper()
+	var mu sync.Mutex
+	var got *capturedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+
+		mu.Lock()
+		got = &capturedRequest{method: r.Method, url: *r.URL, header: r.Header.Clone(), body: string(body)}
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"` + token + `"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server, func() capturedRequest {
+		mu.Lock()
+		defer mu.Unlock()
+		require.NotNil(t, got, "server was never called")
+		return *got
+	}
+}
+
+func failingServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestAzureTokenRequests checks which endpoints get registered, in what order,
+// and with which parameters — without any network access.
+func TestAzureTokenRequests(t *testing.T) {
+	t.Run("app service first, then cloud shell", func(t *testing.T) {
+		clearAzureEnv(t)
+		t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+		t.Setenv(envIdentityHeader, "secret-header")
+		t.Setenv(envClientID, "client-123")
+		t.Setenv(envTokenAudience, testResource)
+
+		reqs, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 2)
+
+		// App Service mints for the app registration named by the env var.
+		assert.Equal(t, appServiceTokenRequest{
+			endpoint: "http://localhost:12345/msi/token",
+			header:   "secret-header",
+			resource: testResource,
+			clientID: "client-123",
+		}, reqs[0])
+
+		// Cloud Shell mints for the exchange audience, and reads no env vars.
+		assert.Equal(t, cloudShellTokenRequest{
+			endpoint: testCloudShellURL,
+			resource: testExchangeAudience,
+		}, reqs[1])
+	})
+
+	// An empty client id falls back to the system-assigned identity.
+	t.Run("app service without client id", func(t *testing.T) {
+		clearAzureEnv(t)
+		t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+		t.Setenv(envIdentityHeader, "secret-header")
+		t.Setenv(envTokenAudience, testResource)
+
+		reqs, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 2)
+		assert.Empty(t, reqs[0].(appServiceTokenRequest).clientID)
+	})
+
+	t.Run("no identity endpoint: cloud shell only", func(t *testing.T) {
+		clearAzureEnv(t)
+
+		reqs, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 1)
+		assert.Equal(t, cloudShellTokenRequest{
+			endpoint: testCloudShellURL,
+			resource: testExchangeAudience,
+		}, reqs[0])
+	})
+
+	// Unset, App Service falls back to the passed audience — which a working Azure
+	// exchange sets to the same app registration URI, so the operator sets it once.
+	t.Run("app service resource falls back to the passed audience", func(t *testing.T) {
+		clearAzureEnv(t)
+		t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+		t.Setenv(envIdentityHeader, "secret-header")
+
+		reqs, err := azureTokenRequests(testResource, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 2)
+		assert.Equal(t, testResource, reqs[0].(appServiceTokenRequest).resource)
+	})
+
+	// MONDOO_WIF_AUDIENCE overrides the passed audience when the two must differ.
+	t.Run("app service env audience overrides the passed audience", func(t *testing.T) {
+		clearAzureEnv(t)
+		t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+		t.Setenv(envIdentityHeader, "secret-header")
+		t.Setenv(envTokenAudience, "api://override")
+
+		reqs, err := azureTokenRequests(testResource, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 2)
+		assert.Equal(t, "api://override", reqs[0].(appServiceTokenRequest).resource)
+	})
+
+	// MONDOO_WIF_AUDIENCE is for App Service alone. Cloud Shell has no app
+	// registration to target and must keep minting for the exchange audience.
+	t.Run("cloud shell ignores the env audience", func(t *testing.T) {
+		clearAzureEnv(t)
+		t.Setenv(envTokenAudience, testResource)
+		t.Setenv(envClientID, "client-123")
+
+		reqs, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+		require.NoError(t, err)
+		require.Len(t, reqs, 1)
+		assert.Equal(t, testExchangeAudience, reqs[0].(cloudShellTokenRequest).resource)
+	})
+}
+
+// TestAzureTokenRequestsAppServiceRequiresIdentityHeader guards the SSRF secret.
+// Sending an empty X-IDENTITY-HEADER earns a bodiless 401 that names nothing, so
+// the missing variable has to be named here instead.
+func TestAzureTokenRequestsAppServiceRequiresIdentityHeader(t *testing.T) {
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+	t.Setenv(envTokenAudience, testResource)
+
+	_, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), envIdentityHeader)
+
+	// It must not silently degrade to Cloud Shell, which serves a different
+	// environment and would fail with an error naming the wrong endpoint.
+	assert.NotContains(t, err.Error(), "cloud shell")
+}
+
+// TestAzureTokenRequestsNamesTheInjectedVariableFirst pins the order of the two
+// checks. When both are unset, IDENTITY_HEADER is the one to report: Azure injects
+// it, so its absence means the environment is not the one IDENTITY_ENDPOINT
+// implies — which subsumes any misconfiguration of the variables we define.
+func TestAzureTokenRequestsNamesTheInjectedVariableFirst(t *testing.T) {
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+
+	_, err := azureTokenRequests(testExchangeAudience, testCloudShellURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), envIdentityHeader)
+	assert.NotContains(t, err.Error(), envTokenAudience)
+}
+
+// TestAzureTokenRequestsAppServiceRequiresAResource guards the one case the
+// fallback cannot rescue: no env audience and no passed audience leaves App
+// Service nothing to request, which Azure answers with an opaque 400.
+func TestAzureTokenRequestsAppServiceRequiresAResource(t *testing.T) {
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, "http://localhost:12345/msi/token")
+	t.Setenv(envIdentityHeader, "secret-header")
+
+	// Empty passed audience, and MONDOO_WIF_AUDIENCE unset: nothing to fall back to.
+	_, err := azureTokenRequests("", testCloudShellURL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), envTokenAudience)
+
+	// It must not silently degrade to Cloud Shell, which serves a different
+	// environment and would fail with an error naming the wrong endpoint.
+	assert.NotContains(t, err.Error(), "cloud shell")
+}
+
+// TestAzureTokenRequestsAlwaysTriesCloudShell pins backwards compatibility: the
+// pre-App-Service code always POSTed to the Cloud Shell endpoint, even with an
+// empty resource, so Cloud Shell must be registered unconditionally — never gated
+// on the audience being present.
+func TestAzureTokenRequestsAlwaysTriesCloudShell(t *testing.T) {
+	clearAzureEnv(t)
+
+	// No endpoint, and an empty audience: the old code still sent this request.
+	reqs, err := azureTokenRequests("", testCloudShellURL)
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	assert.Equal(t, cloudShellTokenRequest{
+		endpoint: testCloudShellURL,
+		resource: "",
+	}, reqs[0])
+}
+
+// TestAppServiceTokenRequest pins the App Service wire format: a GET with the
+// resource in the query and the injected secret in X-IDENTITY-HEADER.
+func TestAppServiceTokenRequest(t *testing.T) {
+	t.Run("with a user-assigned identity", func(t *testing.T) {
+		server, captured := tokenServer(t, "eyJfake.appservice.token")
+
+		req := appServiceTokenRequest{
+			endpoint: server.URL,
+			header:   "hdr-secret",
+			resource: testResource,
+			clientID: "client-abc",
+		}
+		token, err := req.RequestToken(context.Background(), server.Client())
+		require.NoError(t, err)
+		assert.Equal(t, "eyJfake.appservice.token", token)
+
+		got := captured()
+		assert.Equal(t, http.MethodGet, got.method)
+		assert.Equal(t, "hdr-secret", got.header.Get("X-IDENTITY-HEADER"))
+		q := got.query()
+		assert.Equal(t, appServiceAPIVersion, q.Get("api-version"))
+		assert.Equal(t, testResource, q.Get("resource"))
+		assert.Equal(t, "client-abc", q.Get("client_id"))
+	})
+
+	// No client_id at all, rather than an empty one, which Azure rejects.
+	t.Run("with the system-assigned identity", func(t *testing.T) {
+		server, captured := tokenServer(t, "eyJfake.appservice.token")
+
+		req := appServiceTokenRequest{endpoint: server.URL, header: "hdr-secret", resource: testResource}
+		_, err := req.RequestToken(context.Background(), server.Client())
+		require.NoError(t, err)
+
+		assert.False(t, captured().query().Has("client_id"))
+	})
+
+	// The label must name the endpoint and resource, and never the secret.
+	t.Run("label", func(t *testing.T) {
+		withID := appServiceTokenRequest{endpoint: "http://msi", header: "hdr-secret", resource: testResource, clientID: "client-abc"}
+		assert.Equal(t, "app service (http://msi, resource=api://mondoo-wif, client_id=client-abc)", withID.String())
+		assert.NotContains(t, withID.String(), "hdr-secret")
+
+		systemAssigned := appServiceTokenRequest{endpoint: "http://msi", header: "hdr-secret", resource: testResource}
+		assert.Equal(t, "app service (http://msi, resource=api://mondoo-wif, system-assigned identity)", systemAssigned.String())
+	})
+}
+
+// TestCloudShellTokenRequest pins the Cloud Shell wire format: a form-encoded
+// POST with no client_id and no api-version.
+func TestCloudShellTokenRequest(t *testing.T) {
+	server, captured := tokenServer(t, "eyJcloudshell.token")
+
+	req := cloudShellTokenRequest{endpoint: server.URL, resource: testExchangeAudience}
+	token, err := req.RequestToken(context.Background(), server.Client())
+	require.NoError(t, err)
+	assert.Equal(t, "eyJcloudshell.token", token)
+
+	got := captured()
+	assert.Equal(t, http.MethodPost, got.method)
+	assert.Equal(t, "true", got.header.Get("Metadata"))
+	assert.Equal(t, "application/x-www-form-urlencoded", got.header.Get("Content-Type"))
+
+	form := got.form(t)
+	assert.Equal(t, testExchangeAudience, form.Get("resource"))
+	assert.False(t, form.Has("client_id"))
+	assert.False(t, form.Has("api-version"))
+
+	assert.Equal(t, "cloud shell ("+server.URL+", resource="+testExchangeAudience+")", req.String())
+}
+
+// TestCloudShellRequestMatchesLegacyWireFormat pins the Cloud Shell request to
+// the exact request this provider sent before App Service support was added, so
+// an existing Cloud Shell user cannot be broken by a refactor here.
+func TestCloudShellRequestMatchesLegacyWireFormat(t *testing.T) {
+	// The endpoint the old code hardcoded.
+	assert.Equal(t, "http://localhost:50342/oauth2/token", cloudShellTokenURL)
+
+	server, captured := tokenServer(t, "eyJcloudshell.token")
+
+	// No identity endpoint: the environment the old code always assumed. The
+	// resource is the audience the caller passed, exactly as before.
+	clearAzureEnv(t)
+
+	reqs, err := azureTokenRequests(testExchangeAudience, server.URL+"/oauth2/token")
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+	_, err = reqs[0].RequestToken(context.Background(), server.Client())
+	require.NoError(t, err)
+	got := captured()
+
+	// Verbatim reconstruction of the pre-PR implementation.
+	legacyData := make(url.Values)
+	legacyData.Set("resource", testExchangeAudience)
+	legacy, err := http.NewRequestWithContext(
+		context.Background(), "POST", server.URL+"/oauth2/token", strings.NewReader(legacyData.Encode()))
+	require.NoError(t, err)
+	legacy.Header.Add("Metadata", "true")
+	legacy.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	assert.Equal(t, legacy.Method, got.method)
+	assert.Equal(t, legacy.URL.Path, got.url.Path)
+	assert.Equal(t, legacy.URL.RawQuery, got.url.RawQuery)
+	for _, header := range []string{"Metadata", "Content-Type"} {
+		assert.Equal(t, legacy.Header.Get(header), got.header.Get(header), header)
+	}
+
+	legacyBody, err := io.ReadAll(legacy.Body)
+	require.NoError(t, err)
+	assert.Equal(t, string(legacyBody), got.body)
+}
+
+// TestAzureTokenProvider_GetToken_AppService covers Function Apps and Container
+// Apps jobs, which both expose IDENTITY_ENDPOINT and IDENTITY_HEADER.
+func TestAzureTokenProvider_GetToken_AppService(t *testing.T) {
+	server, captured := tokenServer(t, "eyJfake.appservice.token")
+
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, server.URL)
+	t.Setenv(envIdentityHeader, "hdr-secret")
+	t.Setenv(envClientID, "client-abc")
+	t.Setenv(envTokenAudience, testResource)
+
+	p := &AzureTokenProvider{}
+	token, err := p.GetToken(context.Background(), testExchangeAudience)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJfake.appservice.token", token)
+
+	// resource comes from the env var, not the exchange audience (an MRN).
+	assert.Equal(t, testResource, captured().query().Get("resource"))
+}
+
+// TestAzureTokenProvider_GetToken_CloudShell guards the pre-IMDS localhost:50342
+// endpoint, which Cloud Shell still serves today.
+func TestAzureTokenProvider_GetToken_CloudShell(t *testing.T) {
+	server, captured := tokenServer(t, "eyJcloudshell.token")
+
+	clearAzureEnv(t)
+	// Set, and ignored: Cloud Shell mints for the exchange audience.
+	t.Setenv(envTokenAudience, testResource)
+
+	p := &AzureTokenProvider{cloudShellURL: server.URL}
+	token, err := p.GetToken(context.Background(), testExchangeAudience)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJcloudshell.token", token)
+
+	assert.Equal(t, testExchangeAudience, captured().form(t).Get("resource"))
+}
+
+// TestAzureTokenProvider_GetToken_Fallback verifies the try-until-success behavior.
+func TestAzureTokenProvider_GetToken_Fallback(t *testing.T) {
+	cloudShell, _ := tokenServer(t, "eyJfallback.cloudshell.token")
+
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, failingServer(t, http.StatusInternalServerError).URL)
+	t.Setenv(envIdentityHeader, "hdr-secret")
+	t.Setenv(envTokenAudience, testResource)
+
+	p := &AzureTokenProvider{cloudShellURL: cloudShell.URL}
+	token, err := p.GetToken(context.Background(), testExchangeAudience)
+	require.NoError(t, err)
+	assert.Equal(t, "eyJfallback.cloudshell.token", token)
+}
+
+// TestAzureTokenProvider_GetToken_AllFail verifies the aggregated error names
+// every endpoint that was tried.
+func TestAzureTokenProvider_GetToken_AllFail(t *testing.T) {
+	clearAzureEnv(t)
+	t.Setenv(envIdentityEndpoint, failingServer(t, http.StatusForbidden).URL)
+	t.Setenv(envIdentityHeader, "hdr-secret")
+	t.Setenv(envTokenAudience, testResource)
+
+	p := &AzureTokenProvider{cloudShellURL: failingServer(t, http.StatusNotFound).URL}
+	_, err := p.GetToken(context.Background(), testExchangeAudience)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed on all endpoints")
+	assert.Contains(t, err.Error(), "app service")
+	assert.Contains(t, err.Error(), "cloud shell")
+	assert.NotContains(t, err.Error(), "hdr-secret")
+}
+
+// TestRequestAzureTokenSurfacesErrorBody pins the diagnostic: a non-OK response
+// must carry Azure's explanation, otherwise a 400 is unactionable.
+func TestRequestAzureTokenSurfacesErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_request","error_description":"AADSTS500011: resource principal not found"}`))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	_, err = requestAzureToken(server.Client(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.Contains(t, err.Error(), "AADSTS500011")
+}
+
+// TestRequestAzureTokenRejectsEmptyToken guards against a 200 with no token,
+// which would otherwise be handed to the exchange as an empty credential.
+func TestRequestAzureTokenRejectsEmptyToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	_, err = requestAzureToken(server.Client(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty access_token")
+}


### PR DESCRIPTION
Relies on 2 custom env vars to be injected into the workload that would select the exact identity to use when minting the token and the target audience for which the token applies.

In the future, we can modify this to maybe use parameters, or extend the WIF config json, but for now environment variables should suffice.