### PR TITLE
🐛 ms365: recover from nil-element panic in Graph page iterator

### DIFF
--- a/providers/ms365/resources/iterator.go
+++ b/providers/ms365/resources/iterator.go
@@ -9,10 +9,35 @@ import (
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
 	msgraphgocore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	"github.com/rs/zerolog/log"
 )
 
-func iterate[T any](ctx context.Context, res any, adapter abstractions.RequestAdapter, constructorFunc serialization.ParsableFactory) ([]T, error) {
+// iterate walks every page of a Microsoft Graph collection response and returns
+// the flattened list of items.
+//
+// It recovers from panics raised inside the SDK's page iterator. The SDK's
+// convertToPage (msgraph-sdk-go-core page_iterator.go) type-asserts every
+// element of a page's `value` collection to T without a nil check. When Graph
+// returns a null entry in the collection, the SDK's own deserializer stores it
+// as a nil interface (see e.g. ServicePrincipalCollectionResponse: nil elements
+// are left as the zero value), and the subsequent assertion panics with
+// "interface conversion: interface {} is nil". A single malformed page must not
+// crash the whole scan, so we recover and return whatever was collected before
+// the panic, following the provider's "continue with accessible resources"
+// error-handling convention.
+func iterate[T any](ctx context.Context, res any, adapter abstractions.RequestAdapter, constructorFunc serialization.ParsableFactory) (result []T, err error) {
 	resp := []T{}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warn().
+				Interface("recover", r).
+				Int("collected", len(resp)).
+				Msg("ms365> recovered from panic while paging Graph results; returning partial results")
+			result = resp
+			err = nil
+		}
+	}()
+
 	iterator, err := msgraphgocore.NewPageIterator[T](res, adapter, constructorFunc)
 	if err != nil {
 		return nil, transformError(err)

--- a/providers/ms365/resources/iterator.go
+++ b/providers/ms365/resources/iterator.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"runtime"
 
 	abstractions "github.com/microsoft/kiota-abstractions-go"
 	"github.com/microsoft/kiota-abstractions-go/serialization"
@@ -15,24 +16,29 @@ import (
 // iterate walks every page of a Microsoft Graph collection response and returns
 // the flattened list of items.
 //
-// It recovers from panics raised inside the SDK's page iterator. The SDK's
-// convertToPage (msgraph-sdk-go-core page_iterator.go) type-asserts every
-// element of a page's `value` collection to T without a nil check. When Graph
-// returns a null entry in the collection, the SDK's own deserializer stores it
-// as a nil interface (see e.g. ServicePrincipalCollectionResponse: nil elements
-// are left as the zero value), and the subsequent assertion panics with
-// "interface conversion: interface {} is nil". A single malformed page must not
-// crash the whole scan, so we recover and return whatever was collected before
-// the panic, following the provider's "continue with accessible resources"
-// error-handling convention.
+// It recovers from the failed type assertion raised inside the SDK's page
+// iterator. The SDK's convertToPage (msgraph-sdk-go-core page_iterator.go)
+// type-asserts every element of a page's `value` collection to T without a nil
+// check. When Graph returns a null entry in the collection, the SDK's own
+// deserializer stores it as a nil interface (see e.g.
+// ServicePrincipalCollectionResponse: nil elements are left as the zero value),
+// and the subsequent assertion panics with "interface conversion: interface {}
+// is nil" (a *runtime.TypeAssertionError). A single malformed page must not
+// crash the whole scan, so we recover from that specific panic and return
+// whatever was collected before it, following the provider's "continue with
+// accessible resources" error-handling convention. Any other panic is
+// re-raised unchanged so genuine bugs are not silently swallowed.
 func iterate[T any](ctx context.Context, res any, adapter abstractions.RequestAdapter, constructorFunc serialization.ParsableFactory) (result []T, err error) {
 	resp := []T{}
 	defer func() {
 		if r := recover(); r != nil {
+			if _, ok := r.(*runtime.TypeAssertionError); !ok {
+				panic(r) // not the known SDK nil-element panic; preserve normal panic semantics
+			}
 			log.Warn().
 				Interface("recover", r).
 				Int("collected", len(resp)).
-				Msg("ms365> recovered from panic while paging Graph results; returning partial results")
+				Msg("ms365> recovered from nil-element panic while paging Graph results; returning partial results")
 			result = resp
 			err = nil
 		}


### PR DESCRIPTION
## What

Make the shared `iterate` helper in the ms365 provider resilient to a panic raised deep inside the Microsoft Graph SDK's page iterator. On a panic it now logs a warning and returns the items collected before the panic instead of crashing the scan.

## Why

We hit a recovered `GetData` panic in production:

```
interface conversion: interface {} is nil, not *models.ServicePrincipal
  msgraph-sdk-go-core@v1.4.1/page_iterator.go:234  convertToPage[...]
  providers/ms365/resources/iterator.go:16          iterate[...]
  providers/ms365/resources/serviceprincipals.go:308 fetchServicePrincipals
```

The SDK's `convertToPage` type-asserts every element of a page's `value` collection to `T` with **no nil check**:

```go
collected = append(collected, value.Index(i).Interface().(T)) // panics on a nil element
```

When Microsoft Graph returns a `null` entry in a collection, the SDK's own deserializer leaves that slot as a nil interface (e.g. `ServicePrincipalCollectionResponse` populates `res[i]` only `if v != nil`). Asserting a nil interface to any type panics. This is intermittent (only tenants whose response contains a null trip it) and affects **every** `iterate[...]` caller (~40), not just service principals. v1.4.1 is the latest `msgraph-sdk-go-core`, so there is no upstream fix to pull in.

## How

Added a `defer`/`recover` in `iterate` that returns the partial results collected so far and logs a warning, consistent with the provider's existing "continue with accessible resources" error handling. The panic propagates synchronously through `iterate` (the SDK page iterator is single-goroutine), so the recover reliably catches both first-page (`NewPageIterator`) and subsequent-page panics.

## Testing

Builds clean (`go build ./resources/`), gofmt clean. The trigger requires a live tenant returning a null collection element, which is not reproducible locally; the fix is a defensive recover with no behavior change on the happy path.