### PR TITLE
📄 aws/k8s/oci: correct stale enum values in .lr resource docs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -14067,7 +14067,7 @@ private aws.ecr.image @defaults("uri region") {
   lastRecordedPullTime time
   // Status of the most recent image scan
   //
-  // One of: COMPLETE, FAILED, IN_PROGRESS, UNSUPPORTED_IMAGE, ACTIVE, SCAN_ELIGIBILITY_EXPIRED, FINDINGS_UNAVAILABLE, or NOT_SCANNED.
+  // One of: COMPLETE, FAILED, IN_PROGRESS, UNSUPPORTED_IMAGE, ACTIVE, PENDING, SCAN_ELIGIBILITY_EXPIRED, FINDINGS_UNAVAILABLE, LIMIT_EXCEEDED, IMAGE_ARCHIVED, or NOT_SCANNED.
   scanStatus() string
   // Findings from the most recent image scan (basic scan findings; private repositories only)
   scanFindings() []aws.ecr.image.scanFinding

--- a/providers/k8s/resources/k8s.lr
+++ b/providers/k8s/resources/k8s.lr
@@ -1477,7 +1477,7 @@ private k8s.job @defaults("namespace name succeeded failed created") @context("k
   startTime() time
   // Time the job entered a terminal state
   completionTime() time
-  // Status conditions (Complete, Failed, FailureTarget, Suspended)
+  // Status conditions (Complete, Failed, FailureTarget, SuccessCriteriaMet, Suspended)
   conditions() []dict
 }
 

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -2185,7 +2185,7 @@ private oci.vault.secret @defaults("name") {
   description string
   // Lifecycle state (e.g., CREATING, ACTIVE, UPDATING, DELETING, DELETED, SCHEDULING_DELETION, PENDING_DELETION, CANCELLING_DELETION, FAILED)
   state string
-  // Rotation status (NOT_ENABLED, CANCELLING, ROTATING)
+  // Rotation status (NOT_ENABLED, SCHEDULED, IN_PROGRESS, CANCELLING)
   rotationStatus string
   // Last rotation time
   lastRotationTime time
@@ -2223,7 +2223,7 @@ private oci.vault.secretVersion @defaults("versionNumber") {
   versionNumber int
   // Version name
   name string
-  // Content type (BASE64, BUNDLE)
+  // Content type (BASE64)
   contentType string
   // Version lifecycle stages (CURRENT, PENDING, LATEST, PREVIOUS, DEPRECATED)
   stages []string
@@ -2754,7 +2754,7 @@ private oci.containerInstances.instance @defaults("name") {
   compartment() oci.compartment
   // Availability domain
   availabilityDomain string
-  // Lifecycle state (CREATING, ACTIVE, UPDATING, DELETING, DELETED, FAILED)
+  // Lifecycle state (CREATING, ACTIVE, INACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
   // Compute shape
   shape string
@@ -2802,7 +2802,7 @@ private oci.containerInstances.container @defaults("name") {
   compartment() oci.compartment
   // Availability domain
   availabilityDomain string
-  // Lifecycle state (CREATING, ACTIVE, STOPPING, STOPPED, EXITED, FAILED)
+  // Lifecycle state (CREATING, ACTIVE, INACTIVE, UPDATING, DELETING, DELETED, FAILED)
   state string
   // Parent container instance OCID
   containerInstanceId string


### PR DESCRIPTION
## What

Audited the enum value lists documented in provider `.lr` doc-comments against the **current vendored SDKs** and corrected six that were stale, incomplete, or listed values the SDK never defined. These lists are machine-parsed into the rendered resource docs, so wrong values mislead anyone writing `.where(field == "...")` audits.

| Location | SDK enum | Fix |
|---|---|---|
| `aws.ecr.image.scanStatus` | `ecr/types.ScanStatus` | add `PENDING`, `LIMIT_EXCEEDED`, `IMAGE_ARCHIVED` (kept `NOT_SCANNED`, which mql synthesizes on `ScanNotFoundException`) |
| `k8s.job.conditions` | `batch/v1.JobConditionType` | add `SuccessCriteriaMet` (JobSuccessPolicy, GA in k8s 1.33) |
| `oci.vault.secret.rotationStatus` | `vault.SecretRotationStatusEnum` | `ROTATING` isn't a value; corrected to `NOT_ENABLED, SCHEDULED, IN_PROGRESS, CANCELLING` |
| `oci.vault.secretVersion.contentType` | `vault.SecretVersionSummaryContentTypeEnum` | only `BASE64` is valid for this field; removed `BUNDLE` |
| `oci.containerInstances.instance.state` | `ContainerInstanceLifecycleStateEnum` | add `INACTIVE` |
| `oci.containerInstances.container.state` | `ContainerLifecycleStateEnum` | `STOPPING/STOPPED/EXITED` don't exist; corrected to the real 7-value set |

## Verification

- Every value cross-checked against the enum constants in the vendored SDK module (`GetMappingXxxEnum` / `Values()` blocks), not from memory or API docs.
- Comment-only changes: `mqlr generate` for aws/k8s/oci runs clean with **no `.lr.versions` churn** and no changes to tracked generated files (`.resources.json` is gitignored).
- Sibling `state` docs that share the same text but map to different enums (dataSafe `sensitiveType`/`sensitiveDataModel`, vulnerabilityScanning `hostScanRecipe`/`hostScanTarget`) were verified to be **correct as-is** (their enums genuinely lack `INACTIVE`) and left untouched.

## Scope / follow-up

This is the first batch from a broader enum audit spanning every non-Azure provider (Azure was already covered separately). The remaining provider audits (gcp, ms365, google-workspace, github, okta, openstack, nutanix, vsphere, gitlab, os, and the LLM/long-tail providers) were interrupted mid-run by a session usage limit and will land in follow-up PRs. A few unconfirmed leads still need verification: AWS `networkInterface.interfaceType` (`evs` looks spurious, but `natGateway`/`efa-only` are real API values the Go enum type omits), vSphere `vspanSession.sessionType` / `macManagementPolicy.macLearningLimitPolicy`, and GitLab pipeline `source`.
