### PR TITLE
🐛 nutanix: harden all creators against nil ExtId + fix sub-resource cache collisions

### DIFF
--- a/providers/nutanix/provider/provider.go
+++ b/providers/nutanix/provider/provider.go
@@ -46,7 +46,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		conf.Host = string(x.Value)
 	}
 	if x, ok := flags["port"]; ok && len(x.Value) != 0 {
-		conf.Options["port"] = fmt.Sprintf("%d", x.RawData().Value.(int64))
+		if v, ok := x.RawData().Value.(int64); ok {
+			conf.Options["port"] = fmt.Sprintf("%d", v)
+		}
 	}
 
 	user := ""

--- a/providers/nutanix/resources/helpers_test.go
+++ b/providers/nutanix/resources/helpers_test.go
@@ -118,3 +118,55 @@ func TestIPSubnetToString(t *testing.T) {
 		t.Errorf("got %q, want 10.0.0.0/24", got)
 	}
 }
+
+func TestSubResourceID(t *testing.T) {
+	// A present ExtId is used verbatim, ignoring the parent/kind/index.
+	if got := subResourceID("disk-ext-id", "vm-1", "disk", 3); got != "disk-ext-id" {
+		t.Errorf("got %q, want disk-ext-id", got)
+	}
+	// A missing ExtId falls back to a parent-qualified, index-stamped key.
+	if got := subResourceID("", "vm-1", "disk", 3); got != "vm-1/disk/3" {
+		t.Errorf("got %q, want vm-1/disk/3", got)
+	}
+
+	// The whole point of the fallback is uniqueness: two siblings with no
+	// ExtId under the same parent must not share a cache key, otherwise
+	// CreateResource de-dupes them onto the first one built.
+	first := subResourceID("", "vm-1", "nic", 0)
+	second := subResourceID("", "vm-1", "nic", 1)
+	if first == second {
+		t.Errorf("siblings collided on %q; index must disambiguate", first)
+	}
+}
+
+func TestMetadataProvenance(t *testing.T) {
+	name, owner, project := metadataProvenance(nil)
+	if name != "" || owner != "" || project != "" {
+		t.Errorf("nil metadata: got (%q, %q, %q), want all empty", name, owner, project)
+	}
+
+	// Fields are independently optional; a partial metadata must not bleed
+	// one field's value into another.
+	name, owner, project = metadataProvenance(&netcommon.Metadata{
+		ProjectName:      sp("prod"),
+		OwnerReferenceId: sp("owner-42"),
+	})
+	if name != "prod" {
+		t.Errorf("projectName = %q, want prod", name)
+	}
+	if owner != "owner-42" {
+		t.Errorf("ownerId = %q, want owner-42", owner)
+	}
+	if project != "" {
+		t.Errorf("projectId = %q, want empty (ProjectReferenceId unset)", project)
+	}
+
+	name, owner, project = metadataProvenance(&netcommon.Metadata{
+		ProjectName:        sp("dev"),
+		OwnerReferenceId:   sp("owner-1"),
+		ProjectReferenceId: sp("proj-9"),
+	})
+	if name != "dev" || owner != "owner-1" || project != "proj-9" {
+		t.Errorf("got (%q, %q, %q), want (dev, owner-1, proj-9)", name, owner, project)
+	}
+}

--- a/providers/nutanix/resources/iam.go
+++ b/providers/nutanix/resources/iam.go
@@ -21,6 +21,9 @@ import (
 // ---------------------------------------------------------------------------
 
 func newMqlUser(runtime *plugin.Runtime, u *authn.User) (*mqlNutanixIamUser, error) {
+	if u.ExtId == nil {
+		return nil, nil
+	}
 	userType := ""
 	if u.UserType != nil {
 		userType = u.UserType.GetName()
@@ -87,6 +90,9 @@ func (a *mqlNutanix) users() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			if mqlUser == nil {
+				continue
+			}
 			res = append(res, mqlUser)
 		}
 		if len(items) < limit {
@@ -149,6 +155,9 @@ func (a *mqlNutanix) userGroups() ([]any, error) {
 		}
 		for i := range items {
 			g := items[i]
+			if g.ExtId == nil {
+				continue
+			}
 			groupType := ""
 			if g.GroupType != nil {
 				groupType = g.GroupType.GetName()
@@ -181,6 +190,9 @@ func (a *mqlNutanix) userGroups() ([]any, error) {
 // ---------------------------------------------------------------------------
 
 func newMqlRole(runtime *plugin.Runtime, r *authz.Role) (*mqlNutanixIamRole, error) {
+	if r.ExtId == nil {
+		return nil, nil
+	}
 	operations := []any{}
 	for _, op := range r.Operations {
 		operations = append(operations, op)
@@ -236,6 +248,9 @@ func (a *mqlNutanix) roles() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			if mqlRole == nil {
+				continue
+			}
 			res = append(res, mqlRole)
 		}
 		if len(items) < limit {
@@ -272,6 +287,9 @@ func (a *mqlNutanix) authorizationPolicies() ([]any, error) {
 		}
 		for i := range items {
 			ap := items[i]
+			if ap.ExtId == nil {
+				continue
+			}
 			policyType := ""
 			if ap.AuthorizationPolicyType != nil {
 				policyType = ap.AuthorizationPolicyType.GetName()
@@ -376,6 +394,9 @@ func (a *mqlNutanix) directoryServices() ([]any, error) {
 		}
 		for i := range items {
 			ds := items[i]
+			if ds.ExtId == nil {
+				continue
+			}
 			directoryType := ""
 			if ds.DirectoryType != nil {
 				directoryType = ds.DirectoryType.GetName()
@@ -464,6 +485,9 @@ func (a *mqlNutanix) samlIdentityProviders() ([]any, error) {
 		}
 		for i := range items {
 			idp := items[i]
+			if idp.ExtId == nil {
+				continue
+			}
 			mqlIdp, err := CreateResource(a.MqlRuntime, "nutanix.iam.samlIdentityProvider", map[string]*llx.RawData{
 				"__id":                    llx.StringDataPtr(idp.ExtId),
 				"id":                      llx.StringDataPtr(idp.ExtId),

--- a/providers/nutanix/resources/image.go
+++ b/providers/nutanix/resources/image.go
@@ -13,6 +13,9 @@ import (
 )
 
 func newMqlImage(runtime *plugin.Runtime, img *vmmcontent.Image) (*mqlNutanixImage, error) {
+	if img.ExtId == nil {
+		return nil, nil
+	}
 	imageType := ""
 	if img.Type != nil {
 		imageType = img.Type.GetName()
@@ -72,6 +75,9 @@ func (a *mqlNutanix) images() ([]any, error) {
 		mqlImg, err := newMqlImage(a.MqlRuntime, &imgs[i])
 		if err != nil {
 			return nil, err
+		}
+		if mqlImg == nil {
+			continue
 		}
 		res = append(res, mqlImg)
 	}

--- a/providers/nutanix/resources/network.go
+++ b/providers/nutanix/resources/network.go
@@ -50,6 +50,9 @@ func ipSubnetToString(s *netconfig.IPSubnet) string {
 // ---------------------------------------------------------------------------
 
 func newMqlVpc(runtime *plugin.Runtime, v *netconfig.Vpc) (*mqlNutanixNetworkVpc, error) {
+	if v.ExtId == nil {
+		return nil, nil
+	}
 	vpcType := ""
 	if v.VpcType != nil {
 		vpcType = v.VpcType.GetName()
@@ -148,6 +151,9 @@ func (a *mqlNutanix) vpcs() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
+			if mqlVpc == nil {
+				continue
+			}
 			res = append(res, mqlVpc)
 		}
 		if len(items) < limit {
@@ -185,6 +191,9 @@ func vpcByID(runtime *plugin.Runtime, vpcID string) (*mqlNutanixNetworkVpc, erro
 // ---------------------------------------------------------------------------
 
 func newMqlSubnet(runtime *plugin.Runtime, s *netconfig.Subnet) (*mqlNutanixNetworkSubnet, error) {
+	if s.ExtId == nil {
+		return nil, nil
+	}
 	subnetType := ""
 	if s.SubnetType != nil {
 		subnetType = s.SubnetType.GetName()
@@ -265,6 +274,9 @@ func (a *mqlNutanix) subnets() ([]any, error) {
 			mqlSubnet, err := newMqlSubnet(a.MqlRuntime, &s)
 			if err != nil {
 				return nil, err
+			}
+			if mqlSubnet == nil {
+				continue
 			}
 			res = append(res, mqlSubnet)
 		}
@@ -376,6 +388,9 @@ func (a *mqlNutanix) floatingIps() ([]any, error) {
 		}
 		for i := range items {
 			f := items[i]
+			if f.ExtId == nil {
+				continue
+			}
 			associationStatus := ""
 			if f.AssociationStatus != nil {
 				associationStatus = *f.AssociationStatus

--- a/providers/nutanix/resources/nutanix.go
+++ b/providers/nutanix/resources/nutanix.go
@@ -141,6 +141,9 @@ func (a *mqlNutanix) clusters() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		if mqlCluster == nil {
+			continue
+		}
 		res = append(res, mqlCluster)
 	}
 	return res, nil
@@ -168,6 +171,9 @@ func (a *mqlNutanix) hosts() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		if mqlHost == nil {
+			continue
+		}
 		res = append(res, mqlHost)
 	}
 	return res, nil
@@ -194,6 +200,9 @@ func (a *mqlNutanix) vms() ([]any, error) {
 		mqlVm, err := newMqlVm(a.MqlRuntime, &vm)
 		if err != nil {
 			return nil, err
+		}
+		if mqlVm == nil {
+			continue
 		}
 		res = append(res, mqlVm)
 	}
@@ -293,6 +302,9 @@ func listVms(conn *connection.NutanixConnection) ([]vmmconfig.Vm, error) {
 // ---------------------------------------------------------------------------
 
 func newMqlCluster(runtime *plugin.Runtime, c *clustermgmtconfig.Cluster) (*mqlNutanixCluster, error) {
+	if c.ExtId == nil {
+		return nil, nil
+	}
 	hypervisorTypes := []any{}
 	functions := []any{}
 	encryptionOptions := []any{}
@@ -600,8 +612,14 @@ func (a *mqlNutanixCluster) nodes() ([]any, error) {
 		if n.NodeUuid != nil {
 			nodeUuid = *n.NodeUuid
 		}
+		// NodeUuid is the node's identity; fall back to a parent-qualified key
+		// so nodes without one don't collide on an empty cache id.
+		nodeID := nodeUuid
+		if nodeID == "" {
+			nodeID = fmt.Sprintf("%s/node/%d", a.clusterId, i)
+		}
 		mqlNode, err := CreateResource(a.MqlRuntime, "nutanix.cluster.node", map[string]*llx.RawData{
-			"__id":           llx.StringData(nodeUuid),
+			"__id":           llx.StringData(nodeID),
 			"id":             llx.StringData(nodeUuid),
 			"hostIp":         llx.StringData(clusterIPToString(n.HostIp)),
 			"controllerVmIp": llx.StringData(clusterIPToString(n.ControllerVmIp)),
@@ -652,6 +670,9 @@ func (a *mqlNutanixClusterNode) host() (*mqlNutanixHost, error) {
 }
 
 func newMqlHost(runtime *plugin.Runtime, h *clustermgmtconfig.Host) (*mqlNutanixHost, error) {
+	if h.ExtId == nil {
+		return nil, nil
+	}
 	hypervisorType := ""
 	hypervisorFullName := ""
 	hypervisorState := ""
@@ -807,12 +828,18 @@ func (a *mqlNutanixHost) disks() ([]any, error) {
 		if d.Uuid != nil {
 			uuid = *d.Uuid
 		}
+		// Uuid identifies the disk; fall back to a parent-qualified key so
+		// disks without one don't collide on an empty cache id.
+		diskID := uuid
+		if diskID == "" {
+			diskID = fmt.Sprintf("%s/disk/%d", a.hostId, i)
+		}
 		storageTier := ""
 		if d.StorageTier != nil {
 			storageTier = d.StorageTier.GetName()
 		}
 		mqlDisk, err := CreateResource(a.MqlRuntime, "nutanix.host.disk", map[string]*llx.RawData{
-			"__id":        llx.StringData(uuid),
+			"__id":        llx.StringData(diskID),
 			"id":          llx.StringData(uuid),
 			"mountPath":   llx.StringDataPtr(d.MountPath),
 			"serialId":    llx.StringDataPtr(d.SerialId),
@@ -828,6 +855,9 @@ func (a *mqlNutanixHost) disks() ([]any, error) {
 }
 
 func newMqlVm(runtime *plugin.Runtime, vm *vmmconfig.Vm) (*mqlNutanixVm, error) {
+	if vm.ExtId == nil {
+		return nil, nil
+	}
 	powerState := ""
 	if vm.PowerState != nil {
 		powerState = vm.PowerState.GetName()
@@ -935,6 +965,12 @@ func (a *mqlNutanixVm) disks() ([]any, error) {
 		if d.ExtId != nil {
 			extId = *d.ExtId
 		}
+		// ExtId identifies the disk; fall back to a parent-qualified key so
+		// disks without one don't collide on an empty cache id.
+		diskID := extId
+		if diskID == "" {
+			diskID = fmt.Sprintf("%s/disk/%d", a.vmId, i)
+		}
 		busType := ""
 		busIndex := int64(0)
 		if d.DiskAddress != nil {
@@ -984,7 +1020,7 @@ func (a *mqlNutanixVm) disks() ([]any, error) {
 			}
 		}
 		mqlDisk, err := CreateResource(a.MqlRuntime, "nutanix.vm.disk", map[string]*llx.RawData{
-			"__id":                  llx.StringData(extId),
+			"__id":                  llx.StringData(diskID),
 			"id":                    llx.StringData(extId),
 			"tenantId":              llx.StringData(tenantId),
 			"busType":               llx.StringData(busType),
@@ -1065,6 +1101,12 @@ func (a *mqlNutanixVm) nics() ([]any, error) {
 		if n.ExtId != nil {
 			extId = *n.ExtId
 		}
+		// ExtId identifies the NIC; fall back to a parent-qualified key so
+		// NICs without one don't collide on an empty cache id.
+		nicID := extId
+		if nicID == "" {
+			nicID = fmt.Sprintf("%s/nic/%d", a.vmId, i)
+		}
 		macAddress := ""
 		model := ""
 		isConnected := false
@@ -1108,7 +1150,7 @@ func (a *mqlNutanixVm) nics() ([]any, error) {
 			}
 		}
 		mqlNic, err := CreateResource(a.MqlRuntime, "nutanix.vm.nic", map[string]*llx.RawData{
-			"__id":               llx.StringData(extId),
+			"__id":               llx.StringData(nicID),
 			"id":                 llx.StringData(extId),
 			"macAddress":         llx.StringData(macAddress),
 			"model":              llx.StringData(model),
@@ -1154,6 +1196,12 @@ func (a *mqlNutanixVm) gpus() ([]any, error) {
 		if g.ExtId != nil {
 			extId = *g.ExtId
 		}
+		// ExtId identifies the GPU; fall back to a parent-qualified key so
+		// GPUs without one don't collide on an empty cache id.
+		gpuID := extId
+		if gpuID == "" {
+			gpuID = fmt.Sprintf("%s/gpu/%d", a.vmId, i)
+		}
 		mode := ""
 		if g.Mode != nil {
 			mode = g.Mode.GetName()
@@ -1163,7 +1211,7 @@ func (a *mqlNutanixVm) gpus() ([]any, error) {
 			vendor = g.Vendor.GetName()
 		}
 		mqlGpu, err := CreateResource(a.MqlRuntime, "nutanix.vm.gpu", map[string]*llx.RawData{
-			"__id":                   llx.StringData(extId),
+			"__id":                   llx.StringData(gpuID),
 			"id":                     llx.StringData(extId),
 			"name":                   llx.StringDataPtr(g.Name),
 			"mode":                   llx.StringData(mode),
@@ -1190,6 +1238,12 @@ func (a *mqlNutanixVm) cdRoms() ([]any, error) {
 		if c.ExtId != nil {
 			extId = *c.ExtId
 		}
+		// ExtId identifies the CD-ROM; fall back to a parent-qualified key so
+		// CD-ROMs without one don't collide on an empty cache id.
+		cdromID := extId
+		if cdromID == "" {
+			cdromID = fmt.Sprintf("%s/cdrom/%d", a.vmId, i)
+		}
 		isoType := ""
 		if c.IsoType != nil {
 			isoType = c.IsoType.GetName()
@@ -1211,7 +1265,7 @@ func (a *mqlNutanixVm) cdRoms() ([]any, error) {
 			}
 		}
 		mqlCdRom, err := CreateResource(a.MqlRuntime, "nutanix.vm.cdrom", map[string]*llx.RawData{
-			"__id":      llx.StringData(extId),
+			"__id":      llx.StringData(cdromID),
 			"id":        llx.StringData(extId),
 			"isoType":   llx.StringData(isoType),
 			"busType":   llx.StringData(busType),

--- a/providers/nutanix/resources/nutanix.go
+++ b/providers/nutanix/resources/nutanix.go
@@ -73,6 +73,18 @@ func derefBool(v *bool) bool {
 	return *v
 }
 
+// subResourceID returns extID when it is set, otherwise a stable
+// parent-qualified fallback of the form "<parentID>/<kind>/<index>". Child
+// records (disks, NICs, nodes, ...) whose ExtId/UUID the API omits would
+// otherwise all share an empty cache key and collapse onto the first sibling
+// built, so the index makes each one unique within its parent.
+func subResourceID(extID, parentID, kind string, index int) string {
+	if extID != "" {
+		return extID
+	}
+	return fmt.Sprintf("%s/%s/%d", parentID, kind, index)
+}
+
 // usecsToTime converts a microsecond Unix timestamp pointer to a *time.Time,
 // returning nil when the source is nil or zero.
 func usecsToTime(usecs *int64) *time.Time {
@@ -612,14 +624,8 @@ func (a *mqlNutanixCluster) nodes() ([]any, error) {
 		if n.NodeUuid != nil {
 			nodeUuid = *n.NodeUuid
 		}
-		// NodeUuid is the node's identity; fall back to a parent-qualified key
-		// so nodes without one don't collide on an empty cache id.
-		nodeID := nodeUuid
-		if nodeID == "" {
-			nodeID = fmt.Sprintf("%s/node/%d", a.clusterId, i)
-		}
 		mqlNode, err := CreateResource(a.MqlRuntime, "nutanix.cluster.node", map[string]*llx.RawData{
-			"__id":           llx.StringData(nodeID),
+			"__id":           llx.StringData(subResourceID(nodeUuid, a.clusterId, "node", i)),
 			"id":             llx.StringData(nodeUuid),
 			"hostIp":         llx.StringData(clusterIPToString(n.HostIp)),
 			"controllerVmIp": llx.StringData(clusterIPToString(n.ControllerVmIp)),
@@ -828,18 +834,12 @@ func (a *mqlNutanixHost) disks() ([]any, error) {
 		if d.Uuid != nil {
 			uuid = *d.Uuid
 		}
-		// Uuid identifies the disk; fall back to a parent-qualified key so
-		// disks without one don't collide on an empty cache id.
-		diskID := uuid
-		if diskID == "" {
-			diskID = fmt.Sprintf("%s/disk/%d", a.hostId, i)
-		}
 		storageTier := ""
 		if d.StorageTier != nil {
 			storageTier = d.StorageTier.GetName()
 		}
 		mqlDisk, err := CreateResource(a.MqlRuntime, "nutanix.host.disk", map[string]*llx.RawData{
-			"__id":        llx.StringData(diskID),
+			"__id":        llx.StringData(subResourceID(uuid, a.hostId, "disk", i)),
 			"id":          llx.StringData(uuid),
 			"mountPath":   llx.StringDataPtr(d.MountPath),
 			"serialId":    llx.StringDataPtr(d.SerialId),
@@ -965,12 +965,6 @@ func (a *mqlNutanixVm) disks() ([]any, error) {
 		if d.ExtId != nil {
 			extId = *d.ExtId
 		}
-		// ExtId identifies the disk; fall back to a parent-qualified key so
-		// disks without one don't collide on an empty cache id.
-		diskID := extId
-		if diskID == "" {
-			diskID = fmt.Sprintf("%s/disk/%d", a.vmId, i)
-		}
 		busType := ""
 		busIndex := int64(0)
 		if d.DiskAddress != nil {
@@ -1020,7 +1014,7 @@ func (a *mqlNutanixVm) disks() ([]any, error) {
 			}
 		}
 		mqlDisk, err := CreateResource(a.MqlRuntime, "nutanix.vm.disk", map[string]*llx.RawData{
-			"__id":                  llx.StringData(diskID),
+			"__id":                  llx.StringData(subResourceID(extId, a.vmId, "disk", i)),
 			"id":                    llx.StringData(extId),
 			"tenantId":              llx.StringData(tenantId),
 			"busType":               llx.StringData(busType),
@@ -1101,12 +1095,6 @@ func (a *mqlNutanixVm) nics() ([]any, error) {
 		if n.ExtId != nil {
 			extId = *n.ExtId
 		}
-		// ExtId identifies the NIC; fall back to a parent-qualified key so
-		// NICs without one don't collide on an empty cache id.
-		nicID := extId
-		if nicID == "" {
-			nicID = fmt.Sprintf("%s/nic/%d", a.vmId, i)
-		}
 		macAddress := ""
 		model := ""
 		isConnected := false
@@ -1150,7 +1138,7 @@ func (a *mqlNutanixVm) nics() ([]any, error) {
 			}
 		}
 		mqlNic, err := CreateResource(a.MqlRuntime, "nutanix.vm.nic", map[string]*llx.RawData{
-			"__id":               llx.StringData(nicID),
+			"__id":               llx.StringData(subResourceID(extId, a.vmId, "nic", i)),
 			"id":                 llx.StringData(extId),
 			"macAddress":         llx.StringData(macAddress),
 			"model":              llx.StringData(model),
@@ -1196,12 +1184,6 @@ func (a *mqlNutanixVm) gpus() ([]any, error) {
 		if g.ExtId != nil {
 			extId = *g.ExtId
 		}
-		// ExtId identifies the GPU; fall back to a parent-qualified key so
-		// GPUs without one don't collide on an empty cache id.
-		gpuID := extId
-		if gpuID == "" {
-			gpuID = fmt.Sprintf("%s/gpu/%d", a.vmId, i)
-		}
 		mode := ""
 		if g.Mode != nil {
 			mode = g.Mode.GetName()
@@ -1211,7 +1193,7 @@ func (a *mqlNutanixVm) gpus() ([]any, error) {
 			vendor = g.Vendor.GetName()
 		}
 		mqlGpu, err := CreateResource(a.MqlRuntime, "nutanix.vm.gpu", map[string]*llx.RawData{
-			"__id":                   llx.StringData(gpuID),
+			"__id":                   llx.StringData(subResourceID(extId, a.vmId, "gpu", i)),
 			"id":                     llx.StringData(extId),
 			"name":                   llx.StringDataPtr(g.Name),
 			"mode":                   llx.StringData(mode),
@@ -1238,12 +1220,6 @@ func (a *mqlNutanixVm) cdRoms() ([]any, error) {
 		if c.ExtId != nil {
 			extId = *c.ExtId
 		}
-		// ExtId identifies the CD-ROM; fall back to a parent-qualified key so
-		// CD-ROMs without one don't collide on an empty cache id.
-		cdromID := extId
-		if cdromID == "" {
-			cdromID = fmt.Sprintf("%s/cdrom/%d", a.vmId, i)
-		}
 		isoType := ""
 		if c.IsoType != nil {
 			isoType = c.IsoType.GetName()
@@ -1265,7 +1241,7 @@ func (a *mqlNutanixVm) cdRoms() ([]any, error) {
 			}
 		}
 		mqlCdRom, err := CreateResource(a.MqlRuntime, "nutanix.vm.cdrom", map[string]*llx.RawData{
-			"__id":      llx.StringData(cdromID),
+			"__id":      llx.StringData(subResourceID(extId, a.vmId, "cdrom", i)),
 			"id":        llx.StringData(extId),
 			"isoType":   llx.StringData(isoType),
 			"busType":   llx.StringData(busType),

--- a/providers/nutanix/resources/storage.go
+++ b/providers/nutanix/resources/storage.go
@@ -47,6 +47,13 @@ func listStorageContainers(conn *connection.NutanixConnection) ([]clustermgmtcon
 }
 
 func newMqlStorageContainer(runtime *plugin.Runtime, c *clustermgmtconfig.StorageContainer) (*mqlNutanixStorageContainer, error) {
+	// ExtId is the container's stable identity and becomes the resource __id.
+	// The API can return a container without one (e.g. system/partially
+	// provisioned containers); such a container cannot be cached or
+	// cross-referenced, so skip it rather than fail the whole listing.
+	if c.ExtId == nil {
+		return nil, nil
+	}
 	onDiskDedup := ""
 	if c.OnDiskDedup != nil {
 		onDiskDedup = c.OnDiskDedup.GetName()
@@ -117,6 +124,9 @@ func storageContainersForCluster(runtime *plugin.Runtime, conn *connection.Nutan
 		mqlContainer, err := newMqlStorageContainer(runtime, &c)
 		if err != nil {
 			return nil, err
+		}
+		if mqlContainer == nil {
+			continue
 		}
 		res = append(res, mqlContainer)
 	}

--- a/providers/nutanix/resources/storage.go
+++ b/providers/nutanix/resources/storage.go
@@ -205,6 +205,9 @@ func (a *mqlNutanix) volumeGroups() ([]any, error) {
 		}
 		for i := range items {
 			vg := items[i]
+			if vg.ExtId == nil {
+				continue
+			}
 			sharingStatus := ""
 			if vg.SharingStatus != nil {
 				sharingStatus = vg.SharingStatus.GetName()


### PR DESCRIPTION
## Summary

Started as a fix for one crashing check, then a review sweep of the provider turned up the same bug class in every creator plus a silent data-loss bug in sub-resources. This PR covers all three, and adds unit tests.

## 1. nil `ExtId` → `__id` crash (the reported bug)

Every storage-container check failed with:

```
error: [nutanix]
cannot set '__id' in resource 'nutanix.storage.container', type does not match
```

**Cause:** a `StorageContainer` from the v4 API had a nil `ExtId`. The creator passed it straight into `__id` via `llx.StringDataPtr`, which returns `NilData` (`{Type: Nil}`, `Value: nil`). The generated `__id` setter does `v.Value.(string)`; `nil.(string)` fails and `SetData` returns `type does not match`, aborting the whole listing. Since every storage-container check binds to `nutanix.storage.containers`, all of them failed at once.

**Fix + scope:** the identical pattern existed in **all 15 top-level creators** (user, group, role, authorization policy, directory service, SAML IdP, VPC, subnet, floating IP, image, cluster, host, VM, volume group, storage container). Each creator now skips an element with a nil `ExtId`, and the calling loops skip nil returns.

## 2. Sub-resource cache collisions (found in review)

Six child creators (`cluster.node`, `host.disk`, `vm.disk`, `vm.nic`, `vm.gpu`, `vm.cdrom`) derived `__id` from a nilable id with a `""` fallback. `CreateResource` de-dupes by cache key, so every sibling with an empty id collapsed onto the same `name+"\x00"+""` key and all resolved to the *first* one built — silent data loss / duplicated rows.

**Fix:** a shared `subResourceID` helper falls back to a parent-qualified `<parent>/<kind>/<index>` key when the real id is absent (mirroring the existing `volumeGroupDisk` pattern). The public `id` field keeps the real (possibly empty) value.

## 3. `ParseCLI` robustness (found in review)

The `port` flag used an unchecked `int64` type assertion that would panic `ParseCLI` on an unexpected primitive. Switched to comma-ok, matching the neighboring `insecure` flag.

## Tests

- `TestSubResourceID` — both branches of the fallback + the sibling-uniqueness guarantee.
- `TestMetadataProvenance` — the previously-untested provenance extractor (nil + partial metadata).

`go build ./...`, `go vet`, and `go test ./...` (incl. `-race`) all pass. A live re-test against a Prism Central that returns a nil-`ExtId` container is still pending (no such environment in this session).
