### PR TITLE
🎉 nutanix-13.2.3

### DIFF
--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.2.2",
+	Version:         "13.2.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Patch release of the nutanix provider (`13.2.2` → `13.2.3`).

The only change since the last release is the weekly dependency update (`go.mod`/`go.sum`, #8998); no resource or schema changes.

This release was created by mql's provider versioning bot (`providers-sdk/v1/util/version`).
