### PR TITLE
🐛 logout: preserve config file format (JSON stays JSON)

### DIFF
--- a/apps/mql/cmd/logout.go
+++ b/apps/mql/cmd/logout.go
@@ -16,7 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/providers"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/upstream"
 	rangerUtils "go.mondoo.com/mql/v13/utils/ranger"
-	"sigs.k8s.io/yaml"
 )
 
 func init() {
@@ -108,13 +107,17 @@ ensure the credentials cannot be used in the future.
 
 			opts.AgentMrn = ""
 
-			data, err := yaml.Marshal(opts)
-			if err != nil {
-				log.Error().Err(err).Msg("could not update Mondoo config")
-			}
-			err = os.WriteFile(path, data, fi.Mode())
-			if err != nil {
-				log.Error().Err(err).Msg("could not update Mondoo config")
+			// Preserve the on-disk serialization format and file mode: a config
+			// loaded from JSON must be written back as JSON, not silently
+			// converted to YAML, and a credentials file's permissions must not be
+			// widened.
+			data, marshalErr := config.MarshalConfig(path, opts)
+			if marshalErr != nil {
+				// Don't write on a marshal failure; a nil payload would truncate
+				// the existing config file.
+				log.Error().Err(marshalErr).Msg("could not update Mondoo config")
+			} else if writeErr := os.WriteFile(path, data, fi.Mode()); writeErr != nil {
+				log.Error().Err(writeErr).Msg("could not update Mondoo config")
 			}
 		}
 

--- a/cli/config/store.go
+++ b/cli/config/store.go
@@ -4,17 +4,37 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
+	"sigs.k8s.io/yaml"
 )
 
 // list of field keys to avoid writing to disk
 var fieldKeysToOmit = []string{"force"}
+
+// MarshalConfig serializes cfg using the serialization format implied by the
+// config file path's extension: a ".json" path produces JSON, everything else
+// (".yaml", ".yml", or no extension) produces YAML. This mirrors viper's own
+// extension-based format detection (used by WriteConfig) so a config file
+// loaded as JSON is written back as JSON rather than silently converted to
+// YAML.
+//
+// Both formats key off the struct's json tags (sigs.k8s.io/yaml marshals via
+// JSON under the hood), so the on-disk key names are identical regardless of
+// format.
+func MarshalConfig(path string, cfg *Config) ([]byte, error) {
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		return json.MarshalIndent(cfg, "", "  ")
+	}
+	return yaml.Marshal(cfg)
+}
 
 func StoreConfig() error {
 	path := viper.ConfigFileUsed()

--- a/cli/config/store_test.go
+++ b/cli/config/store_test.go
@@ -4,16 +4,18 @@
 package config_test
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 
 	subject "go.mondoo.com/mql/v13/cli/config"
-	"gopkg.in/yaml.v2"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestStoreConfig(t *testing.T) {
@@ -83,5 +85,70 @@ func TestStoreConfig(t *testing.T) {
 
 		err := subject.StoreConfig()
 		assert.Error(t, err)
+	})
+}
+
+func TestMarshalConfig(t *testing.T) {
+	newConfig := func() *subject.Config {
+		cfg := &subject.Config{}
+		cfg.AgentMrn = "//agents.api.mondoo.app/spaces/space-1/agents/agent-1"
+		cfg.ServiceAccountMrn = "//agents.api.mondoo.app/spaces/space-1/serviceaccounts/sa-1"
+		cfg.PrivateKey = "private-key"
+		cfg.APIEndpoint = "https://api.example.com"
+		return cfg
+	}
+
+	t.Run("a .json path is written as JSON", func(t *testing.T) {
+		data, err := subject.MarshalConfig("/etc/opt/mondoo/credentials.json", newConfig())
+		require.NoError(t, err)
+
+		// The output must parse as JSON. YAML output (e.g. `mrn: ...`) would not.
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed), "output should be valid JSON")
+
+		assert.Equal(t, "//agents.api.mondoo.app/spaces/space-1/serviceaccounts/sa-1", parsed["mrn"])
+		assert.Equal(t, "https://api.example.com", parsed["api_endpoint"])
+	})
+
+	t.Run("a .yaml path is written as YAML", func(t *testing.T) {
+		data, err := subject.MarshalConfig("/etc/opt/mondoo/mondoo.yaml", newConfig())
+		require.NoError(t, err)
+
+		// sigs.k8s.io/yaml honors json tags, so keys stay snake_case in YAML too.
+		var parsed map[string]any
+		require.NoError(t, sigsyaml.Unmarshal(data, &parsed), "output should be valid YAML")
+
+		assert.Equal(t, "//agents.api.mondoo.app/spaces/space-1/serviceaccounts/sa-1", parsed["mrn"])
+		assert.Equal(t, "https://api.example.com", parsed["api_endpoint"])
+	})
+
+	t.Run("an extensionless path defaults to YAML", func(t *testing.T) {
+		data, err := subject.MarshalConfig("/etc/opt/mondoo/mondoo", newConfig())
+		require.NoError(t, err)
+
+		// JSON would begin with '{'; the YAML default must not.
+		assert.NotEqual(t, byte('{'), data[0], "extensionless path should default to YAML, not JSON")
+
+		var parsed map[string]any
+		require.NoError(t, sigsyaml.Unmarshal(data, &parsed))
+		assert.Equal(t, "https://api.example.com", parsed["api_endpoint"])
+	})
+
+	t.Run("cleared agent_mrn is omitted, unrelated keys retained", func(t *testing.T) {
+		cfg := newConfig()
+		cfg.AgentMrn = "" // logout clears this before writing
+
+		for _, path := range []string{"credentials.json", "mondoo.yaml"} {
+			data, err := subject.MarshalConfig(path, cfg)
+			require.NoError(t, err)
+
+			var parsed map[string]any
+			require.NoError(t, sigsyaml.Unmarshal(data, &parsed))
+
+			_, hasAgentMrn := parsed["agent_mrn"]
+			assert.False(t, hasAgentMrn, "%s: cleared agent_mrn should be omitted", path)
+			assert.Equal(t, "private-key", parsed["private_key"], "%s: unrelated keys should be retained", path)
+			assert.Equal(t, "//agents.api.mondoo.app/spaces/space-1/serviceaccounts/sa-1", parsed["mrn"], "%s: unrelated keys should be retained", path)
+		}
 	})
 }


### PR DESCRIPTION
## Problem

Fixes mondoohq/cnspec#3015.

When a credentials file is loaded as **JSON**, `cnspec logout --config <credentials.json> --force` rewrites it as **YAML**. Login preserves the format; logout does not.

## Root cause

`logout` rewrites the config with a hardcoded `yaml.Marshal(opts)`, bypassing viper:

```go
data, err := yaml.Marshal(opts)      // always YAML, regardless of source format
err = os.WriteFile(path, data, fi.Mode())
```

`login`, by contrast, writes through `viper.WriteConfig()`, which selects the serialization format from the **file extension**. That asymmetry is the bug: login preserves JSON, logout silently converts it to YAML.

## Fix

- Add `config.MarshalConfig(path, cfg)` in `cli/config/store.go`, mirroring viper's own extension-based detection: `.json` → JSON, everything else (`.yaml`/`.yml`/no extension) → YAML. Both paths key off the struct's `json` tags (`sigs.k8s.io/yaml` marshals via JSON), so the on-disk key names are identical across formats.
- `logout` now calls `config.MarshalConfig` and additionally:
  - preserves the original file mode via `fi.Mode()`, so a credentials file's permissions aren't widened (a plain switch to `viper.WriteConfig()` would have reset it to `0644`);
  - **skips the write on a marshal error** rather than writing a `nil` payload that would truncate the existing file.

The cleared `agent_mrn` is dropped from output for both formats (the field is `omitempty`), matching the pre-existing logout behavior.

## Testing

- `TestMarshalConfig` in `cli/config/store_test.go` covers: JSON output for `.json`, YAML output for `.yaml`, extensionless → YAML default, cleared `agent_mrn` omitted, and unrelated keys retained.
- `go test ./cli/config/`, `go build`, and `go vet` all pass.
- Verified the full logout write path against a real `0600` `credentials.json`: file stays JSON, mode stays `0600`, `agent_mrn` removed, other keys intact.

## Note on repo

The `logout` command lives in **mql**; cnspec re-exports it via `cnquery_app.LogoutCmd`. Fixing it here resolves the cnspec issue once cnspec picks up the mql dependency.
