### PR TITLE
🧹 Bump aws, gcp, and stackit provider dependencies

### DIFF
--- a/providers/aws/go.mod
+++ b/providers/aws/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.0
-	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.71.0
@@ -54,7 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/drs v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.15.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.0
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.315.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.88.0
@@ -74,14 +74,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.82.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.38.0
-	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.51.0
+	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.52.0
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.54.0
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.49.0
-	github.com/aws/aws-sdk-go-v2/service/lambda v1.96.0
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.97.0
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.53.0
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.35.0
@@ -101,7 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.72.0
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.257.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.258.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/securityhub v1.73.0

--- a/providers/aws/go.sum
+++ b/providers/aws/go.sum
@@ -169,8 +169,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.36.0 h1:IVCto5++rvaE/yqTHEP7M
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.36.0/go.mod h1:1WsIfcEBX1L0UFN/5drG1KkOzhf5Y2ZqJ5up9JTDEXA=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.0 h1:Ww19rIXIy39XwYDNWjfSujU36GrI3rpBZvNqYJ5SE3w=
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.57.0/go.mod h1:WbDasAgg1UxPx3TjF9wsbDKCXTcI4jsB5synkB8CCB8=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0 h1:wvV1Dd0OGEMYsLkDrFVxk0c/hOhdiXCuBLTaeHsW/Vc=
-github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.62.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0 h1:08KUBEtOMByhBOjXsbWYGx4ECPCatdJSMKWP8zMpm1g=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.0/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0 h1:5W/KOwsnZrdi7RD97G5Vto3XEuM70FAavWScfsli7gA=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0/go.mod h1:h1Iw2nkdpmAUJaa89RvX3cg/HGLgdSkCWpMNgKvBSHA=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.40.0 h1:NDzQgQx7oV5VPqxoXUwwrsjXKgDqu1ofqGGSftPTxDg=
@@ -211,8 +211,8 @@ github.com/aws/aws-sdk-go-v2/service/dsql v1.15.0 h1:OnSd99KLOlFTdJMW04f7rfGQW1P
 github.com/aws/aws-sdk-go-v2/service/dsql v1.15.0/go.mod h1:fc/BhRYnEcEnXzww3tEe9MAqRYHgiK5xc8+HlMx0Kn4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.0 h1:wnyC01GGkqvRvVI73+xRTr8qDyIZMzqjHlsFqWUUVSo=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.0/go.mod h1:HnWoC3m6VmjUSg+kBL6OgQsXdyRAGzBYWb7B3J2f+JM=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.315.0 h1:d7gXFRwpyFY6i5womw/2NoPbMIwugnUJqGSM8GiFRxY=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.315.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0 h1:LlxNun/oe5B2XMff8Mkh/3bJeHl1K7Fod+rMYtjagw4=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.0/go.mod h1:eoF0SIRbTgKWnTcTPYckiURPba/7ilfEkvwL4V1iHK4=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.34.0 h1:XXDQPhGhcUpyhlj6+36zQv1DcHCOxDWiZriFLGcBbl0=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.34.0/go.mod h1:QZtKpmYNqd2gcEouzy0iD3HRGLy4JuvWvcroBEk7Ayo=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.59.0 h1:H1dHU54MQVblAmsvlIfMdJmXyDKFSKnHrCmaWqwQ0Vs=
@@ -253,8 +253,8 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.55.0 h1:yHGUjdpLS+QrE/2UypKn2yNGuAJJ
 github.com/aws/aws-sdk-go-v2/service/iam v1.55.0/go.mod h1:5H/UUroHvcKm6l2qaqh3CMM6R9K91ls8Y8rVX6cG3ts=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.38.0 h1:umm0AGaNvkBpJzZxP3h6ol/Dd+vEE3fTmwrMmpOfKSw=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.38.0/go.mod h1:2WTt/aM4Gshgb6iGqpClSu3cLkzRxqACpAjiptfMUEk=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.51.0 h1:TpqCGgwm8cBljy6scvpgL7oN04hvZUT79e2siXdwXqs=
-github.com/aws/aws-sdk-go-v2/service/inspector2 v1.51.0/go.mod h1:VEQnuB52NF3MOc0tn76II/rh9ShfJtxiZiFCobv3gOY=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.52.0 h1:0pjqZJz0F2jwrrIuqQaQRwzA5cZGA/UNpnHjdrXBuGo=
+github.com/aws/aws-sdk-go-v2/service/inspector2 v1.52.0/go.mod h1:VEQnuB52NF3MOc0tn76II/rh9ShfJtxiZiFCobv3gOY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 h1:mbRIur/BiHK6SKPjoBIXSE/hJ6g6JGRLuxQy1jGjlN4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13/go.mod h1:ITg9em2KbJx1s0y4aqRX5OYWG6HBZ5TVR//OdpEZ2CQ=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.23 h1:9Fjh6fi/U5JEStVZijmaMpUwE/gvBJj7x2B/PjbO9To=
@@ -277,8 +277,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.54.0 h1:XOfYhrscVxDr0fLbgA4lE5UbQh5w
 github.com/aws/aws-sdk-go-v2/service/kms v1.54.0/go.mod h1:0RXNc6Yf3AvSMldGD6Lcch96Ojlw2TtGnHsqfD/L4u8=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.49.0 h1:xq0RTGuCKJgfYcqPWEtsOtXGpI4kZoBBXhLJaZK/BoU=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.49.0/go.mod h1:eh92LwMy7CLynlJjegwtsPXKNNK134WbhEEUpjKzMJo=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.96.0 h1:LQFghb8Azoe9vAmambrUCUoM/wfi437AMd70wQjCa20=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.96.0/go.mod h1:gKWVtxlMTgoLU9m6FDw7z6FAEFh8u8CoaPJx0zWk5J8=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.97.0 h1:k/rVQdLBLbfoNfp1pdTO4+RGGt0DhZM/KZ7lgviPA6I=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.97.0/go.mod h1:gKWVtxlMTgoLU9m6FDw7z6FAEFh8u8CoaPJx0zWk5J8=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.57.0 h1:lxAHuQZr6F4quhbzrF/rwOTuTkLY4T4SdczGP9PeXU0=
 github.com/aws/aws-sdk-go-v2/service/lightsail v1.57.0/go.mod h1:YxlIET2KuBmXV0oXA5gew4Tf8T8fkEr7Z3xjyLXWewY=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.53.0 h1:50bPRfULwSdn9XdAzMrkU0bjTW5EKDYE/vzsvkU+iXw=
@@ -317,8 +317,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0 h1:XptwLL+UHXgafYMIHTy59IRovLbh
 github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0/go.mod h1:zdmCoFO/dSI7GlrwsPqFJI+WlFnSU4Tc8TJnlXrM1Do=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.72.0 h1:Fm2iI2ik3SZH0cmQjRb87kI5awRjVjZbZfMUgeKm9eM=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.72.0/go.mod h1:tu1PvcXO61r71Q/aqtJNdXHvpkC7/jU4YRAX0wUMXfs=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.257.0 h1:AjmVRphbA9OREBmvmlIIzLN4hk0kgP2egsY9Lwja5fY=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.257.0/go.mod h1:CivQlQhQJ/KgONEX70dPCPtPls/vHyhGHiqY5o1GSCw=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.258.0 h1:mq7mW5L7EjWZHYH46s0wanH6PZsNT0HlsNH4Rou8GcE=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.258.0/go.mod h1:CivQlQhQJ/KgONEX70dPCPtPls/vHyhGHiqY5o1GSCw=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.19.0 h1:++w0dEQKMmd1TLhzp1hSHD8sVbahO63UnkjnWC4IDaQ=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.19.0/go.mod h1:x40w+dIjoZxpTV+G5SPAavT4jY+N0supIZn3y5quci8=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.43.0 h1:5RbF+fv7+6MU1ImSFQHGHT0RDOkABOM9I9Y71/cRNcM=

--- a/providers/stackit/go.mod
+++ b/providers/stackit/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0
-	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.1
+	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.1.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.1.1
 	github.com/stackitcloud/stackit-sdk-go/services/redis v1.1.1

--- a/providers/stackit/go.sum
+++ b/providers/stackit/go.sum
@@ -424,8 +424,8 @@ github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0 h1:KhuWPXr1hl8BFLGLSi6wjxh5o6OQXH9amfquMhYQROU=
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.24.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
-github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.1 h1:ADkDceNWeJPM+o/JffIJzlpOH/QF0Pf7NtzGki5jXqM=
-github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.1/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
+github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.1.0 h1:hooc/E9Qabn8xno1NUd3uJQfUbW5KoY6mgURlnd776c=
+github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.1.0/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.10.0 h1:Ia8FWqG14hkl7rWAUDjSKwd+8NPvrPGOpUC0jLB1sR0=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.10.0/go.mod h1:yzlakB+f8ur4yAHR6lyCABO+HcEtZG3G2Faj6m5/uW8=
 github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v1.1.1 h1:Vly7OKWAwfrbE31N/tUMmLkl7pKybSnek0IPh8offRk=


### PR DESCRIPTION
## What

Routine dependency refresh across three provider modules.

**aws** — `aws-sdk-go-v2` config/credentials plus service clients: `ec2`, `ecs`, `cloudwatch`, `lambda`, `sagemaker`, `guardduty`, `inspector2`, `bedrockagentcorecontrol`, and the `signin` indirect dep.

**gcp** — `cloud.google.com/go` `firestore` (v1.22→v1.23) and `longrunning` (v1.1→v1.2).

**stackit** — `alb`, `certificates`, `opensearch`, `sqlserverflex`, `telemetrylink`.

## Breaking change handled: stackit sqlserverflex v1.15.0 → v1.16.0

The SDK promotes its **v3 API to the package root** and moves the v2 API to a `/v2api` subpackage (v2api is now deprecated, removal after 2026-09-30). This removed `sqlserverflex.Instance`, `ListInstancesExecute`, and `GetInstanceExecute` from the root package our code imported.

Rather than migrate to the v3 API — whose parameter order and region/id semantics changed and would need live verification — I re-pointed our import at the `/v2api` subpackage, preserving identical runtime behavior. This matches the existing aliasing pattern already used for `telemetrylink` and `telemetryrouter` (both imported from `/v1betaapi` subpackages).

The v2api subpackage was regenerated with newer stackit codegen, so three small adaptations were needed at the call sites:

- Calls route through the `DefaultAPI` service field + request-builder `.Execute()` instead of flat convenience methods (`client.DefaultAPI.ListInstances(ctx, ...).Execute()`).
- `GetInstanceResponse.GetItemOk()` now returns a `*Instance` (was a value) — dropped the `&` when caching the detail.
- `Instance.GetReplicas()` now returns `int32` (was `int64`) — added an explicit cast.

Behavior is unchanged.

## Verification

- `go build ./...` passes for all three provider modules (aws, gcp, stackit).
- `go vet` clean on the changed stackit packages.
- `go mod tidy` produces no changes beyond the version bumps.

Live query verification against real STACKIT infrastructure was not run (no test project available); the change is a same-endpoint import re-point with no logic change.
