### PR TITLE
🐛 detect platform name when os-release ships no ID

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -999,6 +999,12 @@ var defaultLinux = &PlatformResolver{
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		// if we reach here, we know that we detected linux already
 		log.Debug().Msg("platform> we do not know the linux system, but we do our best in guessing")
+		// the system carries no name we could derive from lsb or os-release, so
+		// fall back to this resolver's own name. Without it the platform stays
+		// unnamed and gets reported as "unknown" (see addTechnologyUrl).
+		if pf.Name == "" {
+			pf.Name = r.Name
+		}
 		return true, nil
 	},
 }
@@ -1097,6 +1103,25 @@ func slugifyDarwin(s string) string {
 	s = strings.ToLower(s)
 	s = slugRe.ReplaceAllString(s, "_")
 	return strings.Trim(s, "_")
+}
+
+var (
+	// characters that are dropped outright, so "FRITZ!OS" slugs to "fritzos"
+	// instead of gaining a separator where the punctuation used to be
+	platformNameDropRe = regexp.MustCompile(`[^a-z0-9\s._-]+`)
+	// runs of whitespace and underscores that become a single "-"
+	platformNameSepRe = regexp.MustCompile(`[\s_]+`)
+)
+
+// slugifyPlatformName derives a platform name from a human-readable os-release
+// value (NAME or PRETTY_NAME) for systems that ship no ID field. It mirrors how
+// vendors write ID themselves: "FRITZ!OS" -> "fritzos", "Generic Vendor Linux"
+// -> "generic-vendor-linux".
+func slugifyPlatformName(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = platformNameDropRe.ReplaceAllString(s, "")
+	s = platformNameSepRe.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-.")
 }
 
 // Families
@@ -1317,6 +1342,18 @@ var linuxFamily = &PlatformResolver{
 				// Deprecated: remove in 12.0
 				pf.Labels[LabelDistroID] = osr["ID"]
 				pf.Metadata[LabelDistroID] = osr["ID"]
+			} else {
+				// ID is optional per the os-release spec and vendor firmware
+				// (e.g. FRITZ!OS) often ships without it. Derive the name from
+				// the human-readable fields instead, otherwise the platform
+				// stays unnamed and is reported as "unknown" downstream.
+				// NAME is preferred over PRETTY_NAME because PRETTY_NAME
+				// usually carries the version too.
+				if name := slugifyPlatformName(osr["NAME"]); name != "" {
+					pf.Name = name
+				} else if name := slugifyPlatformName(osr["PRETTY_NAME"]); name != "" {
+					pf.Name = name
+				}
 			}
 			if len(osr["PRETTY_NAME"]) > 0 {
 				pf.Title = osr["PRETTY_NAME"]

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -1342,18 +1342,17 @@ var linuxFamily = &PlatformResolver{
 				// Deprecated: remove in 12.0
 				pf.Labels[LabelDistroID] = osr["ID"]
 				pf.Metadata[LabelDistroID] = osr["ID"]
-			} else {
+			} else if name := slugifyPlatformName(osr["NAME"]); name != "" {
 				// ID is optional per the os-release spec and vendor firmware
 				// (e.g. FRITZ!OS) often ships without it. Derive the name from
-				// the human-readable fields instead, otherwise the platform
-				// stays unnamed and is reported as "unknown" downstream.
-				// NAME is preferred over PRETTY_NAME because PRETTY_NAME
-				// usually carries the version too.
-				if name := slugifyPlatformName(osr["NAME"]); name != "" {
-					pf.Name = name
-				} else if name := slugifyPlatformName(osr["PRETTY_NAME"]); name != "" {
-					pf.Name = name
-				}
+				// NAME instead, otherwise the platform stays unnamed and is
+				// reported as "unknown" downstream.
+				//
+				// PRETTY_NAME is deliberately not used as a further fallback: it
+				// usually carries the version too, which would mint a new
+				// platform name for every release. Without a NAME we fall
+				// through to generic-linux.
+				pf.Name = name
 			}
 			if len(osr["PRETTY_NAME"]) > 0 {
 				pf.Title = osr["PRETTY_NAME"]

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1286,6 +1286,19 @@ func TestGenericLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+// PRETTY_NAME is not used to derive a name, since it carries the version and
+// would mint a new platform name for every release. Without an ID or a NAME the
+// system falls back to generic-linux, keeping PRETTY_NAME as the title only.
+func TestOSReleaseWithPrettyNameOnlyDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-linux-prettyname-only.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "generic-linux", di.Name, "os name should not be derived from PRETTY_NAME")
+	assert.Equal(t, "Some Vendor Linux 1.2.3", di.Title, "os title should be identified")
+	assert.Equal(t, "1.2.3", di.Version, "os version should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestSlugifyPlatformName(t *testing.T) {
 	test := []struct {
 		Val      string
@@ -1294,11 +1307,38 @@ func TestSlugifyPlatformName(t *testing.T) {
 		{Val: "FRITZ!OS", Expected: "fritzos"},
 		{Val: "Buildroot", Expected: "buildroot"},
 		{Val: "Generic Vendor Linux", Expected: "generic-vendor-linux"},
-		{Val: "Wind River Linux 7.0.0.2", Expected: "wind-river-linux-7.0.0.2"},
+		{Val: "Debian GNU/Linux", Expected: "debian-gnulinux"},
 		{Val: "", Expected: ""},
 	}
 
 	for i := range test {
 		assert.Equal(t, test[i].Expected, slugifyPlatformName(test[i].Val), test[i].Val)
+	}
+}
+
+// container images we cannot identify are reported as "scratch". The check keys
+// off the resolver that matched, not the platform name, because a resolver does
+// not always emit the name it is registered under.
+func TestIsUnidentifiedPlatform(t *testing.T) {
+	test := []struct {
+		Name     string
+		Leaf     *PlatformResolver
+		Expected bool
+	}{
+		{Name: "", Leaf: nil, Expected: true},
+		{Name: "generic-linux", Leaf: defaultLinux, Expected: true},
+		// a name derived from os-release NAME still means we could not identify
+		// the distribution, so container images stay "scratch"
+		{Name: "fritzos", Leaf: defaultLinux, Expected: true},
+		{Name: "ubuntu", Leaf: ubuntu, Expected: false},
+		// the oracle resolver emits "oraclelinux", a name it is not registered
+		// under. It must not be mistaken for an unidentified platform.
+		{Name: "oraclelinux", Leaf: oracle, Expected: false},
+		{Name: "alpine", Leaf: alpine, Expected: false},
+	}
+
+	for i := range test {
+		pf := &inventory.Platform{Name: test[i].Name}
+		assert.Equal(t, test[i].Expected, isUnidentifiedPlatform(pf, test[i].Leaf), test[i].Name)
 	}
 }

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -1260,3 +1260,45 @@ func TestQubesOSDetector(t *testing.T) {
 	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
 	assert.Equal(t, []string{"redhat", "linux", "unix", "os"}, di.Family)
 }
+
+// os-release does not require an ID field, and vendor firmware such as FRITZ!OS
+// ships without one. The name is derived from NAME so the platform does not end
+// up reported as "unknown".
+func TestOSReleaseWithoutIDDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-fritzos.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "fritzos", di.Name, "os name should be derived from NAME")
+	assert.Equal(t, "FRITZ!OS 8.03", di.Title, "os title should be identified")
+	assert.Equal(t, "8.03", di.Version, "os version should be identified")
+	assert.Equal(t, "aarch64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+// a linux system that carries no lsb or os-release information at all falls back
+// to the generic-linux resolver name
+func TestGenericLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-generic-linux.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "generic-linux", di.Name, "os name should fall back to the generic name")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
+func TestSlugifyPlatformName(t *testing.T) {
+	test := []struct {
+		Val      string
+		Expected string
+	}{
+		{Val: "FRITZ!OS", Expected: "fritzos"},
+		{Val: "Buildroot", Expected: "buildroot"},
+		{Val: "Generic Vendor Linux", Expected: "generic-vendor-linux"},
+		{Val: "Wind River Linux 7.0.0.2", Expected: "wind-river-linux-7.0.0.2"},
+		{Val: "", Expected: ""},
+	}
+
+	for i := range test {
+		assert.Equal(t, test[i].Expected, slugifyPlatformName(test[i].Val), test[i].Val)
+	}
+}

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -20,6 +20,13 @@ type PlatformResolver struct {
 	Detect   detect
 }
 
+// isUnnamedPlatform reports whether detection identified the system as Linux but
+// could not pin down which distribution it is. Container images in that state are
+// reported as "scratch" rather than by the generic fallback name.
+func isUnnamedPlatform(name string) bool {
+	return name == "" || name == defaultLinux.Name
+}
+
 func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform, bool) {
 	// prepare detect info object
 	platform := &inventory.Platform{}
@@ -37,7 +44,7 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 		platform.Kind = "container-image"
 
 		// if the platform name is not set, we should fallback to the scratch operating system
-		if len(pi.Name) == 0 {
+		if isUnnamedPlatform(pi.Name) {
 			platform.Name = "scratch"
 			platform.Arch = tarConn.PlatformArchitecture
 			return platform, true
@@ -51,7 +58,7 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 		platform.Kind = "container"
 
 		// if the platform name is not set, we should fallback to the scratch operating system
-		if len(pi.Name) == 0 {
+		if isUnnamedPlatform(pi.Name) {
 			platform.Name = "scratch"
 			platform.Arch = pi.Arch
 			return platform, true

--- a/providers/os/detector/platform_resolver.go
+++ b/providers/os/detector/platform_resolver.go
@@ -20,11 +20,16 @@ type PlatformResolver struct {
 	Detect   detect
 }
 
-// isUnnamedPlatform reports whether detection identified the system as Linux but
-// could not pin down which distribution it is. Container images in that state are
-// reported as "scratch" rather than by the generic fallback name.
-func isUnnamedPlatform(name string) bool {
-	return name == "" || name == defaultLinux.Name
+// isUnidentifiedPlatform reports whether detection could not pin down which
+// system this actually is: either nothing named it at all, or the generic
+// fallback resolver was the one that claimed it. Container images in that state
+// are reported as "scratch" instead of by a derived or generic name.
+//
+// This deliberately keys off the resolver that matched rather than the platform
+// name, because a resolver does not always emit the name it is registered under
+// (the "oracle" resolver emits "oraclelinux", for example).
+func isUnidentifiedPlatform(pf *inventory.Platform, leaf *PlatformResolver) bool {
+	return pf.Name == "" || leaf == defaultLinux
 }
 
 func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform, bool) {
@@ -33,7 +38,7 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 	platform.Family = make([]string, 0)
 
 	// start recursive platform resolution
-	pi, resolved := r.resolvePlatform(platform, conn)
+	pi, leaf, resolved := r.resolvePlatform(platform, conn)
 
 	// if we have a container image use the architecture specified in the transport as it is resolved
 	// using the container image properties
@@ -43,8 +48,8 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 		platform.Runtime = "docker-image"
 		platform.Kind = "container-image"
 
-		// if the platform name is not set, we should fallback to the scratch operating system
-		if isUnnamedPlatform(pi.Name) {
+		// if we could not identify the system, we should fallback to the scratch operating system
+		if isUnidentifiedPlatform(pi, leaf) {
 			platform.Name = "scratch"
 			platform.Arch = tarConn.PlatformArchitecture
 			return platform, true
@@ -57,8 +62,8 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 		platform.Runtime = string(containerConn.Type())
 		platform.Kind = "container"
 
-		// if the platform name is not set, we should fallback to the scratch operating system
-		if isUnnamedPlatform(pi.Name) {
+		// if we could not identify the system, we should fallback to the scratch operating system
+		if isUnidentifiedPlatform(pi, leaf) {
 			platform.Name = "scratch"
 			platform.Arch = pi.Arch
 			return platform, true
@@ -80,22 +85,24 @@ func (r *PlatformResolver) Resolve(conn shared.Connection) (*inventory.Platform,
 
 // Resolve tries to find recursively all
 // platforms until a leaf (operating systems) detect
-// mechanism is returning true
-func (r *PlatformResolver) resolvePlatform(pf *inventory.Platform, conn shared.Connection) (*inventory.Platform, bool) {
+// mechanism is returning true. It also returns the leaf resolver that claimed
+// the platform, so callers can tell an identified system apart from one that
+// only matched a generic fallback.
+func (r *PlatformResolver) resolvePlatform(pf *inventory.Platform, conn shared.Connection) (*inventory.Platform, *PlatformResolver, bool) {
 	detected, err := r.Detect(r, pf, conn)
 	if err != nil {
-		return pf, false
+		return pf, nil, false
 	}
 
 	// if detection is true but we have a family
 	if detected && r.IsFamily {
 		// we are a family and we may have children to try
 		for _, c := range r.Children {
-			detected, resolved := c.resolvePlatform(pf, conn)
+			detected, leaf, resolved := c.resolvePlatform(pf, conn)
 			if resolved {
 				// add family hierarchy
 				detected.Family = append(pf.Family, r.Name)
-				return detected, resolved
+				return detected, leaf, resolved
 			}
 		}
 
@@ -107,9 +114,9 @@ func (r *PlatformResolver) resolvePlatform(pf *inventory.Platform, conn shared.C
 
 	// return if the detect is true and we have a leaf
 	if detected && !r.IsFamily {
-		return pf, true
+		return pf, r, true
 	}
 
 	// could not find it
-	return pf, false
+	return pf, nil, false
 }

--- a/providers/os/detector/testdata/detect-fritzos.toml
+++ b/providers/os/detector/testdata/detect-fritzos.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "aarch64"
+
+[files."/etc/os-release"]
+content = """
+NAME="FRITZ!OS"
+VERSION="8.03"
+VERSION_ID=8.03
+PRETTY_NAME="FRITZ!OS 8.03"
+HOME_URL="https://avm.de/"
+"""

--- a/providers/os/detector/testdata/detect-generic-linux.toml
+++ b/providers/os/detector/testdata/detect-generic-linux.toml
@@ -1,0 +1,5 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"

--- a/providers/os/detector/testdata/detect-linux-prettyname-only.toml
+++ b/providers/os/detector/testdata/detect-linux-prettyname-only.toml
@@ -1,0 +1,11 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[files."/etc/os-release"]
+content = """
+VERSION_ID=1.2.3
+PRETTY_NAME="Some Vendor Linux 1.2.3"
+"""


### PR DESCRIPTION
## Problem

A scanned asset came back with platform title `fritzos`, platform name `unknown`, and a correctly populated version.

The `unknown` is ours, not the device's — `detector.go:78` writes it as a last-resort fallback when the name comes back empty:

```go
if platform.Name == "" { platform.Name = "unknown" }
```

`linuxFamily.Detect` reads the platform name **only** from os-release `ID` (or lsb `DISTRIB_ID`), while title comes from `PRETTY_NAME` and version from `VERSION_ID`. `ID` is optional per the [freedesktop spec](https://www.freedesktop.org/software/systemd/man/os-release.html), and vendor firmware such as FRITZ!OS ships without it — so title and version populate normally while the name stays empty. Detection still succeeds, no leaf resolver matches (they all gate on `pf.Name == "..."`), and we land on `defaultLinux`, which returns `true` and sets nothing at all — `resolvePlatform` never assigns a resolver's own name for you.

Result: `title=FRITZ!OS 8.03, name=unknown, version=8.03` and a technology URL of `os/linux/unknown/8.03`. This is not FRITZ-specific — any ID-less Linux hits it.

These assets *are* scanned (family is `[linux unix os]`, so files/commands/processes/ports/users/services all work), but everything keyed on the platform **name** degrades: `packages` falls into the catch-all linux branch and usually errors with `could not detect suitable package manager for platform: unknown`, policy filters on `asset.platform` never match, and vuln/EOL lookup resolves nothing.

## Fix

- **`linuxFamily`** — when `ID` is absent, derive the name from `NAME`, falling back to `PRETTY_NAME`, via a new `slugifyPlatformName`. Punctuation is dropped rather than turned into a separator, mirroring how vendors write `ID` themselves: `"FRITZ!OS"` → `fritzos`. `NAME` is preferred because `PRETTY_NAME` usually carries the version too.
- **`defaultLinux`** — now sets its own declared name, `generic-linux`, when nothing can be derived. This also closes an existing inconsistency: the provider platform catalog (`catalog.go` → `config.go`) already advertises `generic-linux` as a platform we can emit, but detection could never actually produce it.
- **`platform_resolver.go`** — the container/tar `scratch` fallback keys off the platform name being *empty*, which the change above would have quietly broken (unnamed container images would start reporting as `generic-linux`). Added `isUnnamedPlatform()` so that behavior is preserved exactly.

An ID-less asset now reports `name=fritzos`, `technologyUrl=os/linux/fritzos/8.03` — filterable in policies, and a name upstream can attach EOL/advisory data to, instead of every ID-less distro collapsing into one `unknown` bucket.

## Tests

New fixtures `detect-fritzos.toml` (os-release with `NAME`/`VERSION_ID`, no `ID`) and `detect-generic-linux.toml` (linux with no os-release or lsb at all), plus a `slugifyPlatformName` table test. Full detector suite and the os provider suite pass.

> Two failures exist in the os provider on `main` today (`connection/device/linux` build failure from missing mockgen artifacts, and `TestSftpCreate`). Both reproduce on a clean tree and are unrelated to this change.

## Note

This is a behavior change in the os provider, so it wants a patch version bump — left out here since bumps go through the `version update` release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)