### PR TITLE
🐛 ci: align codeql-action/init pin with analyze (v4.36.3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}


### PR DESCRIPTION
## Problem

Every PR's `Analyze (actions)` CodeQL job fails with:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
CodeQL job status was configuration error.
```

## Cause

`.github/workflows/codeql.yml` pinned the two `github/codeql-action` subactions to different releases:

- `init` → `8aad20d…` **v4.36.2**
- `analyze` → `54f647b…` **v4.36.3**

`github/codeql-action` is a monorepo whose subactions (`init`, `analyze`, `upload-sarif`) are released at the same tag and must be pinned in lockstep. `analyze` reads the config `init` wrote and aborts when the versions differ. This was a partial Dependabot bump (it advanced `analyze` and `xgrep.yaml`'s `upload-sarif` to v4.36.3 but left `init` at v4.36.2).

## Fix

Bump `init` to the v4.36.3 SHA (`54f647b…`) so both steps match. One line.
