### PR TITLE
🎉 aws-13.46.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.45.0",
+	Version:         "13.46.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.46.0)
- ✨ aws: extend Athena with encryption enforcement, typed refs, capacity reservations, and catalog databases/tables (#9051)
- ✨ aws: extend AppStream fleet with security fields and typed refs (#9052)
- ✨ aws: extend CodeBuild project with new fields and typed S3/KMS refs (#9053)
- ✨ aws: inspector account status and scan configuration (#9049)
- 🧹 Bump aws, gcp, and stackit provider dependencies (#9042)
- ✨ stackit: certificate contents/usage + cloud dep bumps (#9040)