### PR TITLE
✨ os: expose SSH key algorithm & size (privatekey, authorizedkeys) for PQC readiness

### DIFF
--- a/providers/os/resources/authorizedkeys.go
+++ b/providers/os/resources/authorizedkeys.go
@@ -99,6 +99,7 @@ func (x *mqlAuthorizedkeys) list(file *mqlFile, content string) ([]any, error) {
 			"label":   llx.StringData(entry.Label),
 			"options": llx.ArrayData(llx.TArr2Raw[string](entry.Options), "string"),
 			"file":    llx.ResourceData(file, "file"),
+			"bits":    llx.IntData(entry.Bits()),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/os/resources/authorizedkeys/authorizedkeys.go
+++ b/providers/os/resources/authorizedkeys/authorizedkeys.go
@@ -5,7 +5,7 @@ package authorizedkeys
 
 import (
 	"bufio"
-	"crypto/dsa"
+	"crypto/dsa" //nolint:staticcheck // DSA is deprecated, but we still detect legacy DSA keys for crypto-posture auditing
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"

--- a/providers/os/resources/authorizedkeys/authorizedkeys.go
+++ b/providers/os/resources/authorizedkeys/authorizedkeys.go
@@ -5,6 +5,10 @@ package authorizedkeys
 
 import (
 	"bufio"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"encoding/base64"
 	"io"
 	"strings"
@@ -24,6 +28,35 @@ type Entry struct {
 
 func (e Entry) Base64Key() string {
 	return RawStdEncoding.EncodeToString(e.Key.Marshal())
+}
+
+// Bits returns the key size in bits of the entry's public key. It unwraps SSH
+// certificates to inspect the underlying key and returns 0 when the key type is
+// unknown or does not expose an underlying crypto public key (e.g., security-key
+// backed keys that do not implement ssh.CryptoPublicKey).
+func (e Entry) Bits() int64 {
+	key := e.Key
+	if cert, ok := key.(*ssh.Certificate); ok {
+		key = cert.Key
+	}
+
+	cryptoKey, ok := key.(ssh.CryptoPublicKey)
+	if !ok {
+		return 0
+	}
+
+	switch k := cryptoKey.CryptoPublicKey().(type) {
+	case *rsa.PublicKey:
+		return int64(k.N.BitLen())
+	case *ecdsa.PublicKey:
+		return int64(k.Curve.Params().BitSize)
+	case ed25519.PublicKey:
+		return 256
+	case *dsa.PublicKey:
+		return int64(k.P.BitLen())
+	default:
+		return 0
+	}
 }
 
 func Parse(r io.Reader) ([]Entry, error) {

--- a/providers/os/resources/authorizedkeys/authorizedkeys_test.go
+++ b/providers/os/resources/authorizedkeys/authorizedkeys_test.go
@@ -37,5 +37,9 @@ no-touch-required sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbml
 	assert.Equal(t, int64(3), entries[0].Line)
 	assert.Equal(t, int64(4), entries[1].Line)
 
+	// The ssh-rsa fixture is a 4096-bit RSA key, so Bits reports its modulus
+	// size in bits.
+	assert.Equal(t, int64(4096), entries[0].Bits())
+
 	assert.Equal(t, "AAAAB3NzaC1yc2EAAAADAQABAAACAQDYuKamN4JXNYmolm+A9hM+xYanupG1VgbM/k0NwPiIPUdiU82IPbP7bunsngnOatSDyCrKrhL9FV3wuHFFBX0QE9KpS8bcIcT3ySsi3wgYV95P7anb7YhliDDx2w/QB97kCnAKjGFS1yphS6px0i9B29tGVJa22ODs/hebIKUCYKC9/+fnZ+bIqte1HctDP2lDBzMa/7j8BUXSwnTDXtAuEz5eSMIpv1ZdUdaSuO8xFbB0xrBHQJKuqboLPo3NSOCg6uhopO6GucZuNLJnqVLkyEPTKH0nv/8smz/q3v1GOGz8ZS0DIpkretKZmRB1VDhNqsAiOAWUTmg56xO7VZnlEvQRtyG8qyQHjlj6SDGtvxPDY58lz5nhIV9K6L7gHrOIcbSif5ZCt0e4DrKGaYXgH+mwIh2TMC2OCU6Xr6FRVQ9fBhilqMXuFIIezShN0hZb6mUCLkLVOzBBRKuz17S2a8twsuxix7ixqJPsIF3sI88tbxrFkSGSM02dhrmyZbkMr586rktVBB4T+8A28HJr4l9jkU0uk3l3le5bMcXhEuDkJUBnwEXEXfZa8Lw4sg2VuFgw0Ah0kw0/mAorpsFahXstNgrHhy3HoPKDCw/a/sXL4+fE72I1L96Lb7HOxTrdhEGnd65W4mPlTnbGW9YDQqTfZgRlpuffqQuWWYXolw==", entries[0].Base64Key())
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -802,6 +802,10 @@ privatekey {
   file file
   // Whether the file is encrypted
   encrypted bool
+  // Public key algorithm of the key material (e.g., RSA, ECDSA, Ed25519, DSA)
+  publicKeyAlgorithm() string
+  // Key size in bits (e.g., 2048, 256, 384, 521)
+  publicKeyBits() int
 }
 
 // All user accounts configured on the system
@@ -859,6 +863,8 @@ authorizedkeys.entry @defaults("key") {
   options []string
   // Key file
   file file
+  // Key size in bits (e.g., 2048, 256, 384, 521)
+  bits int
 }
 
 // Group on the system

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3109,6 +3109,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"privatekey.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPrivatekey).GetEncrypted()).ToDataRes(types.Bool)
 	},
+	"privatekey.publicKeyAlgorithm": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrivatekey).GetPublicKeyAlgorithm()).ToDataRes(types.String)
+	},
+	"privatekey.publicKeyBits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPrivatekey).GetPublicKeyBits()).ToDataRes(types.Int)
+	},
 	"users.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlUsers).GetList()).ToDataRes(types.Array(types.Resource("user")))
 	},
@@ -3141,6 +3147,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"authorizedkeys.entry.file": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAuthorizedkeysEntry).GetFile()).ToDataRes(types.Resource("file"))
+	},
+	"authorizedkeys.entry.bits": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAuthorizedkeysEntry).GetBits()).ToDataRes(types.Int)
 	},
 	"group.gid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGroup).GetGid()).ToDataRes(types.Int)
@@ -12785,6 +12794,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPrivatekey).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"privatekey.publicKeyAlgorithm": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrivatekey).PublicKeyAlgorithm, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"privatekey.publicKeyBits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPrivatekey).PublicKeyBits, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
 	"users.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlUsers).__id, ok = v.Value.(string)
 		return
@@ -12839,6 +12856,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"authorizedkeys.entry.file": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAuthorizedkeysEntry).File, ok = plugin.RawToTValue[*mqlFile](v.Value, v.Error)
+		return
+	},
+	"authorizedkeys.entry.bits": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAuthorizedkeysEntry).Bits, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"group.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -29620,10 +29641,12 @@ type mqlPrivatekey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlPrivatekeyInternal it will be used here
-	Pem       plugin.TValue[string]
-	Path      plugin.TValue[string]
-	File      plugin.TValue[*mqlFile]
-	Encrypted plugin.TValue[bool]
+	Pem                plugin.TValue[string]
+	Path               plugin.TValue[string]
+	File               plugin.TValue[*mqlFile]
+	Encrypted          plugin.TValue[bool]
+	PublicKeyAlgorithm plugin.TValue[string]
+	PublicKeyBits      plugin.TValue[int64]
 }
 
 // createPrivatekey creates a new instance of this resource
@@ -29677,6 +29700,18 @@ func (c *mqlPrivatekey) GetFile() *plugin.TValue[*mqlFile] {
 
 func (c *mqlPrivatekey) GetEncrypted() *plugin.TValue[bool] {
 	return &c.Encrypted
+}
+
+func (c *mqlPrivatekey) GetPublicKeyAlgorithm() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.PublicKeyAlgorithm, func() (string, error) {
+		return c.publicKeyAlgorithm()
+	})
+}
+
+func (c *mqlPrivatekey) GetPublicKeyBits() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.PublicKeyBits, func() (int64, error) {
+		return c.publicKeyBits()
+	})
 }
 
 // mqlUsers for the users resource
@@ -29839,6 +29874,7 @@ type mqlAuthorizedkeysEntry struct {
 	Label   plugin.TValue[string]
 	Options plugin.TValue[[]any]
 	File    plugin.TValue[*mqlFile]
+	Bits    plugin.TValue[int64]
 }
 
 // createAuthorizedkeysEntry creates a new instance of this resource
@@ -29900,6 +29936,10 @@ func (c *mqlAuthorizedkeysEntry) GetOptions() *plugin.TValue[[]any] {
 
 func (c *mqlAuthorizedkeysEntry) GetFile() *plugin.TValue[*mqlFile] {
 	return &c.File
+}
+
+func (c *mqlAuthorizedkeysEntry) GetBits() *plugin.TValue[int64] {
+	return &c.Bits
 }
 
 // mqlGroup for the group resource

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -29640,7 +29640,7 @@ func (c *mqlUser) GetNtuserDat() *plugin.TValue[string] {
 type mqlPrivatekey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlPrivatekeyInternal it will be used here
+	mqlPrivatekeyInternal
 	Pem                plugin.TValue[string]
 	Path               plugin.TValue[string]
 	File               plugin.TValue[*mqlFile]

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -186,6 +186,7 @@ augment.skills 13.13.1
 authorizedkeys 9.0.0
 authorizedkeys.content 9.0.0
 authorizedkeys.entry 9.0.0
+authorizedkeys.entry.bits 13.34.4
 authorizedkeys.entry.file 9.0.0
 authorizedkeys.entry.key 9.0.0
 authorizedkeys.entry.label 9.0.0
@@ -2179,6 +2180,8 @@ privatekey.encrypted 9.0.0
 privatekey.file 9.0.0
 privatekey.path 9.0.0
 privatekey.pem 9.0.0
+privatekey.publicKeyAlgorithm 13.34.4
+privatekey.publicKeyBits 13.34.4
 process 9.0.1
 process.command 9.0.1
 process.executable 9.0.1

--- a/providers/os/resources/privatekey.go
+++ b/providers/os/resources/privatekey.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"crypto/dsa"
+	"crypto/dsa" //nolint:staticcheck // DSA is deprecated, but we still detect legacy DSA keys for crypto-posture auditing
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"

--- a/providers/os/resources/privatekey.go
+++ b/providers/os/resources/privatekey.go
@@ -4,10 +4,15 @@
 package resources
 
 import (
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"errors"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"golang.org/x/crypto/ssh"
 )
 
 func initPrivatekey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -40,4 +45,70 @@ func (r *mqlPrivatekey) id() (string, error) {
 	}
 
 	return "privatekey:" + file.Data.Path.Data, nil
+}
+
+// parseKey parses the resource's PEM payload into a Go crypto private key.
+// Encrypted keys (which require a passphrase to introspect) return a nil key
+// and a nil error, letting callers report empty/zero values instead of failing.
+func (r *mqlPrivatekey) parseKey() (any, error) {
+	pem := r.GetPem()
+	if pem.Error != nil {
+		return nil, pem.Error
+	}
+	if pem.Data == "" {
+		return nil, nil
+	}
+
+	key, err := ssh.ParseRawPrivateKey([]byte(pem.Data))
+	if err != nil {
+		// Encrypted keys cannot be introspected without the passphrase; treat
+		// them as "unknown" rather than a hard failure.
+		var passphraseErr *ssh.PassphraseMissingError
+		if errors.As(err, &passphraseErr) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func (r *mqlPrivatekey) publicKeyAlgorithm() (string, error) {
+	key, err := r.parseKey()
+	if err != nil {
+		return "", err
+	}
+
+	switch key.(type) {
+	case *rsa.PrivateKey:
+		return "RSA", nil
+	case *ecdsa.PrivateKey:
+		return "ECDSA", nil
+	case ed25519.PrivateKey, *ed25519.PrivateKey:
+		return "Ed25519", nil
+	case *dsa.PrivateKey:
+		return "DSA", nil
+	default:
+		return "", nil
+	}
+}
+
+func (r *mqlPrivatekey) publicKeyBits() (int64, error) {
+	key, err := r.parseKey()
+	if err != nil {
+		return 0, err
+	}
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		return int64(k.N.BitLen()), nil
+	case *ecdsa.PrivateKey:
+		return int64(k.Curve.Params().BitSize), nil
+	case ed25519.PrivateKey, *ed25519.PrivateKey:
+		return 256, nil
+	case *dsa.PrivateKey:
+		return int64(k.P.BitLen()), nil
+	default:
+		return 0, nil
+	}
 }

--- a/providers/os/resources/privatekey.go
+++ b/providers/os/resources/privatekey.go
@@ -9,11 +9,22 @@ import (
 	"crypto/ed25519"
 	"crypto/rsa"
 	"errors"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"golang.org/x/crypto/ssh"
 )
+
+// mqlPrivatekeyInternal caches the parsed PEM key so the independently
+// lazy-loaded publicKeyAlgorithm and publicKeyBits accessors don't each
+// re-parse the payload. The result is computed inside parseOnce, whose
+// happens-before guarantee makes the captured key/err safe to read afterward.
+type mqlPrivatekeyInternal struct {
+	parseOnce sync.Once
+	parsedKey any
+	parseErr  error
+}
 
 func initPrivatekey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if x, ok := args["path"]; ok {
@@ -47,10 +58,20 @@ func (r *mqlPrivatekey) id() (string, error) {
 	return "privatekey:" + file.Data.Path.Data, nil
 }
 
-// parseKey parses the resource's PEM payload into a Go crypto private key.
+// parseKey parses the resource's PEM payload into a Go crypto private key once
+// and caches the result, so the independently lazy-loaded publicKeyAlgorithm and
+// publicKeyBits accessors share a single parse per query.
+func (r *mqlPrivatekey) parseKey() (any, error) {
+	r.parseOnce.Do(func() {
+		r.parsedKey, r.parseErr = r.doParseKey()
+	})
+	return r.parsedKey, r.parseErr
+}
+
+// doParseKey parses the resource's PEM payload into a Go crypto private key.
 // Encrypted keys (which require a passphrase to introspect) return a nil key
 // and a nil error, letting callers report empty/zero values instead of failing.
-func (r *mqlPrivatekey) parseKey() (any, error) {
+func (r *mqlPrivatekey) doParseKey() (any, error) {
 	pem := r.GetPem()
 	if pem.Error != nil {
 		return nil, pem.Error

--- a/providers/os/resources/privatekey_test.go
+++ b/providers/os/resources/privatekey_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// pkcs8PEM marshals a private key to an unencrypted PKCS#8 PEM block.
+func pkcs8PEM(t *testing.T, key any) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// newPrivatekey builds a privatekey resource whose static pem field is set,
+// so the computed publicKeyAlgorithm/publicKeyBits helpers can be exercised
+// without a live connection.
+func newPrivatekey(pemStr string) *mqlPrivatekey {
+	return &mqlPrivatekey{
+		Pem: plugin.TValue[string]{Data: pemStr, State: plugin.StateIsSet},
+	}
+}
+
+func TestPrivatekeyPublicKeyIntrospection(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		pem           string
+		wantAlgorithm string
+		wantBits      int64
+	}{
+		{
+			name:          "RSA-2048",
+			pem:           pkcs8PEM(t, rsaKey),
+			wantAlgorithm: "RSA",
+			wantBits:      2048,
+		},
+		{
+			name:          "ECDSA P-256",
+			pem:           pkcs8PEM(t, ecKey),
+			wantAlgorithm: "ECDSA",
+			wantBits:      256,
+		},
+		{
+			name:          "Ed25519",
+			pem:           pkcs8PEM(t, edKey),
+			wantAlgorithm: "Ed25519",
+			wantBits:      256,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pk := newPrivatekey(tc.pem)
+
+			algo, err := pk.publicKeyAlgorithm()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAlgorithm, algo)
+
+			bits, err := pk.publicKeyBits()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantBits, bits)
+		})
+	}
+}
+
+func TestPrivatekeyEncryptedKeyGraceful(t *testing.T) {
+	// An encrypted (passphrase-protected) key cannot be introspected without
+	// the passphrase and must yield empty/zero values without erroring.
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+	//nolint:staticcheck // x509.EncryptPEMBlock is deprecated but still the
+	// simplest way to produce an encrypted PEM fixture for this test.
+	encBlock, err := x509.EncryptPEMBlock(rand.Reader, "RSA PRIVATE KEY", der, []byte("secret"), x509.PEMCipherAES256)
+	require.NoError(t, err)
+
+	pk := newPrivatekey(string(pem.EncodeToMemory(encBlock)))
+
+	algo, err := pk.publicKeyAlgorithm()
+	require.NoError(t, err)
+	require.Equal(t, "", algo)
+
+	bits, err := pk.publicKeyBits()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), bits)
+}
+
+func TestPrivatekeyGarbagePEM(t *testing.T) {
+	pk := newPrivatekey("not a valid pem")
+
+	_, err := pk.publicKeyAlgorithm()
+	require.Error(t, err)
+
+	_, err = pk.publicKeyBits()
+	require.Error(t, err)
+}

--- a/providers/os/resources/privatekey_test.go
+++ b/providers/os/resources/privatekey_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"golang.org/x/crypto/ssh"
 )
 
 // pkcs8PEM marshals a private key to an unencrypted PKCS#8 PEM block.
@@ -23,6 +24,17 @@ func pkcs8PEM(t *testing.T, key any) string {
 	der, err := x509.MarshalPKCS8PrivateKey(key)
 	require.NoError(t, err)
 	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// opensshPEM marshals a private key to an OpenSSH-format PEM block. This is the
+// default output of `ssh-keygen`, and unlike PKCS#8 it makes ParseRawPrivateKey
+// return a *pointer* (e.g. *ed25519.PrivateKey), which the introspection
+// switches must handle alongside the PKCS#8 value type.
+func opensshPEM(t *testing.T, key any) string {
+	t.Helper()
+	block, err := ssh.MarshalPrivateKey(key, "")
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(block))
 }
 
 // newPrivatekey builds a privatekey resource whose static pem field is set,
@@ -65,6 +77,14 @@ func TestPrivatekeyPublicKeyIntrospection(t *testing.T) {
 		{
 			name:          "Ed25519",
 			pem:           pkcs8PEM(t, edKey),
+			wantAlgorithm: "Ed25519",
+			wantBits:      256,
+		},
+		{
+			// OpenSSH format yields a *ed25519.PrivateKey (pointer), unlike the
+			// PKCS#8 case above which yields the value type. Both must resolve.
+			name:          "Ed25519 (OpenSSH)",
+			pem:           opensshPEM(t, edKey),
 			wantAlgorithm: "Ed25519",
 			wantBits:      256,
 		},


### PR DESCRIPTION
This is Phase 3 of the post-quantum-cryptography (PQC) signature-migration work: surface the cryptographic algorithm and key size of SSH-related key material so policies can inventory and flag classical keys (e.g., RSA-2048) that will need migration toward quantum-resistant signatures.

## What

New schema fields on the `os` provider:

- `privatekey.publicKeyAlgorithm() string` — `RSA`, `ECDSA`, `Ed25519`, or `DSA`
- `privatekey.publicKeyBits() int` — key size in bits (e.g. 2048, 256, 384, 521)
- `authorizedkeys.entry.bits int` — key size in bits of each authorized key

## Why

Policies need to enumerate SSH key material across the fleet and identify keys using classical signature algorithms and weak sizes so they can be prioritized for PQC migration.

## Notes

- `privatekey` fields parse the PEM once via `ssh.ParseRawPrivateKey`. Encrypted (passphrase-protected) keys cannot be introspected without the passphrase, so they return empty string / `0` with **no error** rather than hard-failing. Genuine parse errors are still surfaced.
- `authorizedkeys.entry.bits` derives the size from the parsed `ssh.PublicKey` via `ssh.CryptoPublicKey`, unwrapping `*ssh.Certificate` to inspect the underlying key. Unknown/opaque key types fall back to `0`.
- Tests generate keys in-process (RSA-2048, EC P-256, Ed25519) and assert algorithm + bits, plus graceful handling of encrypted and garbage PEM; the existing `authorizedkeys` ssh-rsa fixture is asserted at 4096 bits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)