### PR TITLE
✨ aws: expose Site-to-Site VPN tunnel IKE crypto (phase1/phase2 algorithms, DH groups)

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15757,6 +15757,8 @@ private aws.ec2.vpnconnection @defaults("arn id state") {
   tags map[string]string
   // List of telemetry data for the VPN
   vgwTelemetry []aws.ec2.vgwtelemetry
+  // IKE phase 1/phase 2 cryptographic options for each VPN tunnel
+  tunnelOptions []aws.ec2.vpnconnection.tunnelOption
 }
 
 // Amazon EC2 VPN tunnel telemetry
@@ -15767,6 +15769,28 @@ private aws.ec2.vgwtelemetry {
   status string
   // VPN tunnel status message
   statusMessage string
+}
+
+// Amazon EC2 Site-to-Site VPN tunnel IKE cryptographic options
+private aws.ec2.vpnconnection.tunnelOption {
+  // External IP address of the VPN tunnel
+  outsideIpAddress string
+  // Range of inside IPv4 addresses for the tunnel (may be empty)
+  tunnelInsideCidr string
+  // IKE versions permitted for the VPN tunnel
+  ikeVersions []string
+  // Permitted encryption algorithms for phase 1 IKE negotiations
+  phase1EncryptionAlgorithms []string
+  // Permitted encryption algorithms for phase 2 IKE negotiations
+  phase2EncryptionAlgorithms []string
+  // Permitted integrity algorithms for phase 1 IKE negotiations
+  phase1IntegrityAlgorithms []string
+  // Permitted integrity algorithms for phase 2 IKE negotiations
+  phase2IntegrityAlgorithms []string
+  // Permitted Diffie-Hellman group numbers for phase 1 IKE negotiations
+  phase1DHGroupNumbers []int
+  // Permitted Diffie-Hellman group numbers for phase 2 IKE negotiations
+  phase2DHGroupNumbers []int
 }
 
 // Amazon EC2 internet gateway

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -565,6 +565,7 @@ const (
 	ResourceAwsEc2NetworkaclEntryPortrange                                      string = "aws.ec2.networkacl.entry.portrange"
 	ResourceAwsEc2Vpnconnection                                                 string = "aws.ec2.vpnconnection"
 	ResourceAwsEc2Vgwtelemetry                                                  string = "aws.ec2.vgwtelemetry"
+	ResourceAwsEc2VpnconnectionTunnelOption                                     string = "aws.ec2.vpnconnection.tunnelOption"
 	ResourceAwsEc2Internetgateway                                               string = "aws.ec2.internetgateway"
 	ResourceAwsEc2Transitgateway                                                string = "aws.ec2.transitgateway"
 	ResourceAwsEc2TransitgatewayAttachment                                      string = "aws.ec2.transitgateway.attachment"
@@ -3135,6 +3136,10 @@ func init() {
 		"aws.ec2.vgwtelemetry": {
 			// to override args, implement: initAwsEc2Vgwtelemetry(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsEc2Vgwtelemetry,
+		},
+		"aws.ec2.vpnconnection.tunnelOption": {
+			// to override args, implement: initAwsEc2VpnconnectionTunnelOption(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsEc2VpnconnectionTunnelOption,
 		},
 		"aws.ec2.internetgateway": {
 			Init:   initAwsEc2Internetgateway,
@@ -21984,6 +21989,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.vpnconnection.vgwTelemetry": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Vpnconnection).GetVgwTelemetry()).ToDataRes(types.Array(types.Resource("aws.ec2.vgwtelemetry")))
 	},
+	"aws.ec2.vpnconnection.tunnelOptions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Vpnconnection).GetTunnelOptions()).ToDataRes(types.Array(types.Resource("aws.ec2.vpnconnection.tunnelOption")))
+	},
 	"aws.ec2.vgwtelemetry.outsideIpAddress": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Vgwtelemetry).GetOutsideIpAddress()).ToDataRes(types.String)
 	},
@@ -21992,6 +22000,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.vgwtelemetry.statusMessage": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Vgwtelemetry).GetStatusMessage()).ToDataRes(types.String)
+	},
+	"aws.ec2.vpnconnection.tunnelOption.outsideIpAddress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetOutsideIpAddress()).ToDataRes(types.String)
+	},
+	"aws.ec2.vpnconnection.tunnelOption.tunnelInsideCidr": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetTunnelInsideCidr()).ToDataRes(types.String)
+	},
+	"aws.ec2.vpnconnection.tunnelOption.ikeVersions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetIkeVersions()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1EncryptionAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase1EncryptionAlgorithms()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2EncryptionAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase2EncryptionAlgorithms()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1IntegrityAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase1IntegrityAlgorithms()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2IntegrityAlgorithms": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase2IntegrityAlgorithms()).ToDataRes(types.Array(types.String))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1DHGroupNumbers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase1DHGroupNumbers()).ToDataRes(types.Array(types.Int))
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2DHGroupNumbers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2VpnconnectionTunnelOption).GetPhase2DHGroupNumbers()).ToDataRes(types.Array(types.Int))
 	},
 	"aws.ec2.internetgateway.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Internetgateway).GetArn()).ToDataRes(types.String)
@@ -59535,6 +59570,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Vpnconnection).VgwTelemetry, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.vpnconnection.tunnelOptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Vpnconnection).TunnelOptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.vgwtelemetry.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Vgwtelemetry).__id, ok = v.Value.(string)
 		return
@@ -59549,6 +59588,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.vgwtelemetry.statusMessage": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Vgwtelemetry).StatusMessage, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.outsideIpAddress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).OutsideIpAddress, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.tunnelInsideCidr": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).TunnelInsideCidr, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.ikeVersions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).IkeVersions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1EncryptionAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase1EncryptionAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2EncryptionAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase2EncryptionAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1IntegrityAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase1IntegrityAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2IntegrityAlgorithms": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase2IntegrityAlgorithms, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase1DHGroupNumbers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase1DHGroupNumbers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.vpnconnection.tunnelOption.phase2DHGroupNumbers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2VpnconnectionTunnelOption).Phase2DHGroupNumbers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.internetgateway.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -143510,6 +143589,7 @@ type mqlAwsEc2Vpnconnection struct {
 	TunnelInsideIpVersion plugin.TValue[string]
 	Tags                  plugin.TValue[map[string]any]
 	VgwTelemetry          plugin.TValue[[]any]
+	TunnelOptions         plugin.TValue[[]any]
 }
 
 // createAwsEc2Vpnconnection creates a new instance of this resource
@@ -143661,6 +143741,10 @@ func (c *mqlAwsEc2Vpnconnection) GetVgwTelemetry() *plugin.TValue[[]any] {
 	return &c.VgwTelemetry
 }
 
+func (c *mqlAwsEc2Vpnconnection) GetTunnelOptions() *plugin.TValue[[]any] {
+	return &c.TunnelOptions
+}
+
 // mqlAwsEc2Vgwtelemetry for the aws.ec2.vgwtelemetry resource
 type mqlAwsEc2Vgwtelemetry struct {
 	MqlRuntime *plugin.Runtime
@@ -143718,6 +143802,95 @@ func (c *mqlAwsEc2Vgwtelemetry) GetStatus() *plugin.TValue[string] {
 
 func (c *mqlAwsEc2Vgwtelemetry) GetStatusMessage() *plugin.TValue[string] {
 	return &c.StatusMessage
+}
+
+// mqlAwsEc2VpnconnectionTunnelOption for the aws.ec2.vpnconnection.tunnelOption resource
+type mqlAwsEc2VpnconnectionTunnelOption struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsEc2VpnconnectionTunnelOptionInternal it will be used here
+	OutsideIpAddress           plugin.TValue[string]
+	TunnelInsideCidr           plugin.TValue[string]
+	IkeVersions                plugin.TValue[[]any]
+	Phase1EncryptionAlgorithms plugin.TValue[[]any]
+	Phase2EncryptionAlgorithms plugin.TValue[[]any]
+	Phase1IntegrityAlgorithms  plugin.TValue[[]any]
+	Phase2IntegrityAlgorithms  plugin.TValue[[]any]
+	Phase1DHGroupNumbers       plugin.TValue[[]any]
+	Phase2DHGroupNumbers       plugin.TValue[[]any]
+}
+
+// createAwsEc2VpnconnectionTunnelOption creates a new instance of this resource
+func createAwsEc2VpnconnectionTunnelOption(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsEc2VpnconnectionTunnelOption{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.ec2.vpnconnection.tunnelOption", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) MqlName() string {
+	return "aws.ec2.vpnconnection.tunnelOption"
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetOutsideIpAddress() *plugin.TValue[string] {
+	return &c.OutsideIpAddress
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetTunnelInsideCidr() *plugin.TValue[string] {
+	return &c.TunnelInsideCidr
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetIkeVersions() *plugin.TValue[[]any] {
+	return &c.IkeVersions
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase1EncryptionAlgorithms() *plugin.TValue[[]any] {
+	return &c.Phase1EncryptionAlgorithms
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase2EncryptionAlgorithms() *plugin.TValue[[]any] {
+	return &c.Phase2EncryptionAlgorithms
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase1IntegrityAlgorithms() *plugin.TValue[[]any] {
+	return &c.Phase1IntegrityAlgorithms
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase2IntegrityAlgorithms() *plugin.TValue[[]any] {
+	return &c.Phase2IntegrityAlgorithms
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase1DHGroupNumbers() *plugin.TValue[[]any] {
+	return &c.Phase1DHGroupNumbers
+}
+
+func (c *mqlAwsEc2VpnconnectionTunnelOption) GetPhase2DHGroupNumbers() *plugin.TValue[[]any] {
+	return &c.Phase2DHGroupNumbers
 }
 
 // mqlAwsEc2Internetgateway for the aws.ec2.internetgateway resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -143831,12 +143831,7 @@ func createAwsEc2VpnconnectionTunnelOption(runtime *plugin.Runtime, args map[str
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.ec2.vpnconnection.tunnelOption", res.__id)

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3661,6 +3661,17 @@ aws.ec2.vpnconnection.staticRoutesOnly 13.6.3
 aws.ec2.vpnconnection.tags 13.6.3
 aws.ec2.vpnconnection.transitGateway 13.6.3
 aws.ec2.vpnconnection.tunnelInsideIpVersion 13.6.3
+aws.ec2.vpnconnection.tunnelOption 13.46.1
+aws.ec2.vpnconnection.tunnelOption.ikeVersions 13.46.1
+aws.ec2.vpnconnection.tunnelOption.outsideIpAddress 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase1DHGroupNumbers 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase1EncryptionAlgorithms 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase1IntegrityAlgorithms 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase2DHGroupNumbers 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase2EncryptionAlgorithms 13.46.1
+aws.ec2.vpnconnection.tunnelOption.phase2IntegrityAlgorithms 13.46.1
+aws.ec2.vpnconnection.tunnelOption.tunnelInsideCidr 13.46.1
+aws.ec2.vpnconnection.tunnelOptions 13.46.1
 aws.ec2.vpnconnection.type 13.6.3
 aws.ec2.vpnconnection.vgwTelemetry 11.15.2
 aws.ec2.vpnconnection.vpnGateway 13.6.3

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3464,10 +3464,6 @@ func (a *mqlAwsEc2Vgwtelemetry) id() (string, error) {
 	return a.OutsideIpAddress.Data, nil
 }
 
-func (a *mqlAwsEc2VpnconnectionTunnelOption) id() (string, error) {
-	return a.OutsideIpAddress.Data, nil
-}
-
 // listValuesToStrings extracts the Value field from AWS SDK "...ListValue"
 // structs into a []any of strings, guarding nil pointers.
 func listValuesToStrings[T any](values []T, get func(T) *string) []any {
@@ -3530,10 +3526,14 @@ func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID strin
 		outsideIpType = convert.ToValue(opts.OutsideIpAddressType)
 		tunnelIpVersion = string(opts.TunnelInsideIpVersion)
 
-		for _, tun := range opts.TunnelOptions {
+		vpnConnID := convert.ToValue(vpnConn.VpnConnectionId)
+		for i, tun := range opts.TunnelOptions {
+			outsideIP := convert.ToValue(tun.OutsideIpAddress)
 			mqlTunnelOpt, err := CreateResource(runtime, ResourceAwsEc2VpnconnectionTunnelOption,
 				map[string]*llx.RawData{
-					"outsideIpAddress":           llx.StringData(convert.ToValue(tun.OutsideIpAddress)),
+					// index disambiguates tunnels whose outside IP is still empty during provisioning
+					"__id":                       llx.StringData(fmt.Sprintf("%s/tunnelOption/%d/%s", vpnConnID, i, outsideIP)),
+					"outsideIpAddress":           llx.StringData(outsideIP),
 					"tunnelInsideCidr":           llx.StringData(convert.ToValue(tun.TunnelInsideCidr)),
 					"ikeVersions":                llx.ArrayData(listValuesToStrings(tun.IkeVersions, func(v ec2types.IKEVersionsListValue) *string { return v.Value }), types.String),
 					"phase1EncryptionAlgorithms": llx.ArrayData(listValuesToStrings(tun.Phase1EncryptionAlgorithms, func(v ec2types.Phase1EncryptionAlgorithmsListValue) *string { return v.Value }), types.String),

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3464,6 +3464,34 @@ func (a *mqlAwsEc2Vgwtelemetry) id() (string, error) {
 	return a.OutsideIpAddress.Data, nil
 }
 
+func (a *mqlAwsEc2VpnconnectionTunnelOption) id() (string, error) {
+	return a.OutsideIpAddress.Data, nil
+}
+
+// listValuesToStrings extracts the Value field from AWS SDK "...ListValue"
+// structs into a []any of strings, guarding nil pointers.
+func listValuesToStrings[T any](values []T, get func(T) *string) []any {
+	result := []any{}
+	for i := range values {
+		if v := get(values[i]); v != nil {
+			result = append(result, *v)
+		}
+	}
+	return result
+}
+
+// dhGroupNumbersToInts extracts the *int32 Value field from AWS SDK DH-group
+// "...ListValue" structs into a []any of int64, guarding nil pointers.
+func dhGroupNumbersToInts[T any](values []T, get func(T) *int32) []any {
+	result := []any{}
+	for i := range values {
+		if v := get(values[i]); v != nil {
+			result = append(result, int64(*v))
+		}
+	}
+	return result
+}
+
 // VPN connection enhancement (#3)
 
 type mqlAwsEc2VpnconnectionInternal struct {
@@ -3491,6 +3519,7 @@ func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID strin
 
 	var staticRoutesOnly, enableAcceleration bool
 	var localIpv4, remoteIpv4, localIpv6, remoteIpv6, outsideIpType, tunnelIpVersion string
+	mqlTunnelOpts := []any{}
 	if opts := vpnConn.Options; opts != nil {
 		staticRoutesOnly = convert.ToValue(opts.StaticRoutesOnly)
 		enableAcceleration = convert.ToValue(opts.EnableAcceleration)
@@ -3500,6 +3529,25 @@ func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID strin
 		remoteIpv6 = convert.ToValue(opts.RemoteIpv6NetworkCidr)
 		outsideIpType = convert.ToValue(opts.OutsideIpAddressType)
 		tunnelIpVersion = string(opts.TunnelInsideIpVersion)
+
+		for _, tun := range opts.TunnelOptions {
+			mqlTunnelOpt, err := CreateResource(runtime, ResourceAwsEc2VpnconnectionTunnelOption,
+				map[string]*llx.RawData{
+					"outsideIpAddress":           llx.StringData(convert.ToValue(tun.OutsideIpAddress)),
+					"tunnelInsideCidr":           llx.StringData(convert.ToValue(tun.TunnelInsideCidr)),
+					"ikeVersions":                llx.ArrayData(listValuesToStrings(tun.IkeVersions, func(v ec2types.IKEVersionsListValue) *string { return v.Value }), types.String),
+					"phase1EncryptionAlgorithms": llx.ArrayData(listValuesToStrings(tun.Phase1EncryptionAlgorithms, func(v ec2types.Phase1EncryptionAlgorithmsListValue) *string { return v.Value }), types.String),
+					"phase2EncryptionAlgorithms": llx.ArrayData(listValuesToStrings(tun.Phase2EncryptionAlgorithms, func(v ec2types.Phase2EncryptionAlgorithmsListValue) *string { return v.Value }), types.String),
+					"phase1IntegrityAlgorithms":  llx.ArrayData(listValuesToStrings(tun.Phase1IntegrityAlgorithms, func(v ec2types.Phase1IntegrityAlgorithmsListValue) *string { return v.Value }), types.String),
+					"phase2IntegrityAlgorithms":  llx.ArrayData(listValuesToStrings(tun.Phase2IntegrityAlgorithms, func(v ec2types.Phase2IntegrityAlgorithmsListValue) *string { return v.Value }), types.String),
+					"phase1DHGroupNumbers":       llx.ArrayData(dhGroupNumbersToInts(tun.Phase1DHGroupNumbers, func(v ec2types.Phase1DHGroupNumbersListValue) *int32 { return v.Value }), types.Int),
+					"phase2DHGroupNumbers":       llx.ArrayData(dhGroupNumbersToInts(tun.Phase2DHGroupNumbers, func(v ec2types.Phase2DHGroupNumbersListValue) *int32 { return v.Value }), types.Int),
+				})
+			if err != nil {
+				return nil, err
+			}
+			mqlTunnelOpts = append(mqlTunnelOpts, mqlTunnelOpt)
+		}
 	}
 
 	mqlVpnConn, err := CreateResource(runtime, ResourceAwsEc2Vpnconnection,
@@ -3520,6 +3568,7 @@ func newMqlVpnConnection(runtime *plugin.Runtime, region string, accountID strin
 			"tunnelInsideIpVersion": llx.StringData(tunnelIpVersion),
 			"tags":                  llx.MapData(toInterfaceMap(ec2TagsToMap(vpnConn.Tags)), types.String),
 			"vgwTelemetry":          llx.ArrayData(mqlVgwT, types.Resource(ResourceAwsEc2Vgwtelemetry)),
+			"tunnelOptions":         llx.ArrayData(mqlTunnelOpts, types.Resource(ResourceAwsEc2VpnconnectionTunnelOption)),
 		})
 	if err != nil {
 		return nil, err

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -240,6 +240,117 @@ func TestNewMqlVpnConnection(t *testing.T) {
 		assert.Nil(t, result.cacheTransitGatewayId)
 		assert.Nil(t, result.cacheCustomerGatewayId)
 	})
+
+	t.Run("populates tunnel IKE crypto options", func(t *testing.T) {
+		vpnConn := ec2types.VpnConnection{
+			VpnConnectionId: aws.String("vpn-tunnels"),
+			State:           ec2types.VpnStateAvailable,
+			Options: &ec2types.VpnConnectionOptions{
+				TunnelOptions: []ec2types.TunnelOption{
+					{
+						OutsideIpAddress: aws.String("203.0.113.10"),
+						TunnelInsideCidr: aws.String("169.254.10.0/30"),
+						IkeVersions: []ec2types.IKEVersionsListValue{
+							{Value: aws.String("ikev2")},
+						},
+						Phase1EncryptionAlgorithms: []ec2types.Phase1EncryptionAlgorithmsListValue{
+							{Value: aws.String("AES256")},
+							{Value: aws.String("AES256-GCM-16")},
+						},
+						Phase2EncryptionAlgorithms: []ec2types.Phase2EncryptionAlgorithmsListValue{
+							{Value: aws.String("AES256")},
+						},
+						Phase1IntegrityAlgorithms: []ec2types.Phase1IntegrityAlgorithmsListValue{
+							{Value: aws.String("SHA2-256")},
+						},
+						Phase2IntegrityAlgorithms: []ec2types.Phase2IntegrityAlgorithmsListValue{
+							{Value: aws.String("SHA2-512")},
+						},
+						Phase1DHGroupNumbers: []ec2types.Phase1DHGroupNumbersListValue{
+							{Value: aws.Int32(20)},
+							{Value: aws.Int32(21)},
+						},
+						Phase2DHGroupNumbers: []ec2types.Phase2DHGroupNumbersListValue{
+							{Value: aws.Int32(20)},
+						},
+					},
+					{
+						// second tunnel with mostly nil pointers to exercise nil-safety
+						OutsideIpAddress: aws.String("203.0.113.20"),
+					},
+				},
+			},
+		}
+
+		result, err := newMqlVpnConnection(runtime, "us-east-1", "123456789012", vpnConn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		tunnels := result.TunnelOptions.Data
+		require.Len(t, tunnels, 2)
+
+		t0 := tunnels[0].(*mqlAwsEc2VpnconnectionTunnelOption)
+		assert.Equal(t, "203.0.113.10", t0.OutsideIpAddress.Data)
+		assert.Equal(t, "169.254.10.0/30", t0.TunnelInsideCidr.Data)
+		assert.Equal(t, []any{"ikev2"}, t0.IkeVersions.Data)
+		assert.Equal(t, []any{"AES256", "AES256-GCM-16"}, t0.Phase1EncryptionAlgorithms.Data)
+		assert.Equal(t, []any{"AES256"}, t0.Phase2EncryptionAlgorithms.Data)
+		assert.Equal(t, []any{"SHA2-256"}, t0.Phase1IntegrityAlgorithms.Data)
+		assert.Equal(t, []any{"SHA2-512"}, t0.Phase2IntegrityAlgorithms.Data)
+		assert.Equal(t, []any{int64(20), int64(21)}, t0.Phase1DHGroupNumbers.Data)
+		assert.Equal(t, []any{int64(20)}, t0.Phase2DHGroupNumbers.Data)
+
+		t1 := tunnels[1].(*mqlAwsEc2VpnconnectionTunnelOption)
+		assert.Equal(t, "203.0.113.20", t1.OutsideIpAddress.Data)
+		assert.Empty(t, t1.TunnelInsideCidr.Data)
+		assert.Empty(t, t1.IkeVersions.Data)
+		assert.Empty(t, t1.Phase1DHGroupNumbers.Data)
+	})
+
+	t.Run("empty tunnel options list", func(t *testing.T) {
+		vpnConn := ec2types.VpnConnection{
+			VpnConnectionId: aws.String("vpn-no-tunnels"),
+			Options:         &ec2types.VpnConnectionOptions{},
+		}
+		result, err := newMqlVpnConnection(runtime, "us-east-1", "123456789012", vpnConn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Empty(t, result.TunnelOptions.Data)
+	})
+}
+
+func TestTunnelOptionValueHelpers(t *testing.T) {
+	t.Run("listValuesToStrings extracts values and skips nil", func(t *testing.T) {
+		in := []ec2types.IKEVersionsListValue{
+			{Value: aws.String("ikev1")},
+			{Value: nil},
+			{Value: aws.String("ikev2")},
+		}
+		out := listValuesToStrings(in, func(v ec2types.IKEVersionsListValue) *string { return v.Value })
+		assert.Equal(t, []any{"ikev1", "ikev2"}, out)
+	})
+
+	t.Run("listValuesToStrings on nil slice returns empty (non-nil)", func(t *testing.T) {
+		out := listValuesToStrings(nil, func(v ec2types.IKEVersionsListValue) *string { return v.Value })
+		assert.NotNil(t, out)
+		assert.Empty(t, out)
+	})
+
+	t.Run("dhGroupNumbersToInts converts int32 to int64 and skips nil", func(t *testing.T) {
+		in := []ec2types.Phase1DHGroupNumbersListValue{
+			{Value: aws.Int32(14)},
+			{Value: nil},
+			{Value: aws.Int32(24)},
+		}
+		out := dhGroupNumbersToInts(in, func(v ec2types.Phase1DHGroupNumbersListValue) *int32 { return v.Value })
+		assert.Equal(t, []any{int64(14), int64(24)}, out)
+	})
+
+	t.Run("dhGroupNumbersToInts on nil slice returns empty (non-nil)", func(t *testing.T) {
+		out := dhGroupNumbersToInts(nil, func(v ec2types.Phase1DHGroupNumbersListValue) *int32 { return v.Value })
+		assert.NotNil(t, out)
+		assert.Empty(t, out)
+	})
 }
 
 func TestEipNullStateOnMissingCache(t *testing.T) {

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -307,6 +307,33 @@ func TestNewMqlVpnConnection(t *testing.T) {
 		assert.Empty(t, t1.Phase1DHGroupNumbers.Data)
 	})
 
+	t.Run("tunnels with empty outside IPs get distinct ids", func(t *testing.T) {
+		// Both tunnels of a Site-to-Site VPN report an empty outside IP while
+		// still provisioning; the __id must stay unique so they don't collide
+		// in the resource cache.
+		vpnConn := ec2types.VpnConnection{
+			VpnConnectionId: aws.String("vpn-provisioning"),
+			Options: &ec2types.VpnConnectionOptions{
+				TunnelOptions: []ec2types.TunnelOption{
+					{},
+					{},
+				},
+			},
+		}
+
+		result, err := newMqlVpnConnection(runtime, "us-east-1", "123456789012", vpnConn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		tunnels := result.TunnelOptions.Data
+		require.Len(t, tunnels, 2)
+
+		id0 := tunnels[0].(*mqlAwsEc2VpnconnectionTunnelOption).MqlID()
+		id1 := tunnels[1].(*mqlAwsEc2VpnconnectionTunnelOption).MqlID()
+		assert.NotEqual(t, id0, id1)
+		assert.Contains(t, id0, "vpn-provisioning")
+	})
+
 	t.Run("empty tunnel options list", func(t *testing.T) {
 		vpnConn := ec2types.VpnConnection{
 			VpnConnectionId: aws.String("vpn-no-tunnels"),


### PR DESCRIPTION
## What

Adds IKE phase 1 / phase 2 cryptographic detail to the AWS Site-to-Site VPN resource. `aws.ec2.vpnconnection` previously exposed topology and telemetry (`vgwTelemetry`) but nothing about how each tunnel negotiates keys — so policies could not assess VPN key-exchange strength.

New sub-resource **`aws.ec2.vpnconnection.tunnelOption`** and a new field **`tunnelOptions []aws.ec2.vpnconnection.tunnelOption`** on `aws.ec2.vpnconnection`.

`tunnelOption` fields:
- `outsideIpAddress string` — external IP of the tunnel
- `tunnelInsideCidr string` — inside IPv4 range (may be empty)
- `ikeVersions []string`
- `phase1EncryptionAlgorithms []string`
- `phase2EncryptionAlgorithms []string`
- `phase1IntegrityAlgorithms []string`
- `phase2IntegrityAlgorithms []string`
- `phase1DHGroupNumbers []int` — Diffie-Hellman group numbers (`*int32` → `int64`)
- `phase2DHGroupNumbers []int`

## Why

Assessing Diffie-Hellman group strength and the permitted phase 1/phase 2 algorithms is a network-layer input to post-quantum-cryptography (PQC) and general crypto-posture assessment. Exposing these values lets policies flag weak DH groups (e.g. group 2) or deprecated algorithms on Site-to-Site VPN tunnels.

## How

Values are read from `DescribeVpnConnections` → `Options.TunnelOptions`, populated at creation inside `newMqlVpnConnection` using the same static-field / `CreateResource` idiom as the sibling `vgwTelemetry`. All SDK pointer fields are nil-guarded; the `...ListValue` wrappers are unwrapped via two small generic helpers (`listValuesToStrings`, `dhGroupNumbersToInts`), the latter converting `*int32` → `int64`.

## Tests

Extended `TestNewMqlVpnConnection` (populated tunnel + a mostly-nil tunnel for nil-safety, plus an empty list) and added `TestTunnelOptionValueHelpers` for the pure helpers. `go test ./resources/...` passes; `make providers/build/aws` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)