### PR TITLE
🧹 llx: attribute malformed-primitive errors to asset + query

### DIFF
--- a/llx/llx.go
+++ b/llx/llx.go
@@ -167,6 +167,14 @@ func NewExecutorV2(code *CodeV2, runtime Runtime, props map[string]*Primitive, c
 		blockExecutors: []*blockExecutor{},
 	}
 
+	// A malformed (typeless) primitive baked into the code is an upstream
+	// compiler bug (see mqlc.addValueFieldChunks). At runtime it silently
+	// coerces to null and only surfaces as an anonymous "primitive with no
+	// type information" flood — one line per data element, per asset, with no
+	// way to tell which asset or query is at fault. Here we still have the full
+	// code and the asset, so report it once, actionably, up front.
+	reportMalformedPrimitives(code, runtime.AssetMRN())
+
 	exec, err := res._newBlockExecutor(1<<32, callback, nil)
 	if err != nil {
 		return nil, err
@@ -175,6 +183,77 @@ func NewExecutorV2(code *CodeV2, runtime Runtime, props map[string]*Primitive, c
 	res.blockExecutors = append(res.blockExecutors, exec)
 
 	return res, nil
+}
+
+// primitiveHasNoType reports whether p — or, recursively, any element of an
+// array/map primitive — carries no type information. A genuine null is
+// types.Nil (a 1-byte type), so an empty Type string is never legitimate: it
+// only appears when an upstream layer emits a broken primitive.
+func primitiveHasNoType(p *Primitive) bool {
+	if p == nil {
+		return false
+	}
+	if len(p.Type) == 0 {
+		return true
+	}
+	for _, e := range p.Array {
+		if primitiveHasNoType(e) {
+			return true
+		}
+	}
+	for _, e := range p.Map {
+		if primitiveHasNoType(e) {
+			return true
+		}
+	}
+	return false
+}
+
+// reportMalformedPrimitives scans compiled code for typeless primitives and
+// logs an actionable diagnostic for each offending chunk: the asset, the query
+// (code) checksum, and the chunk (its id — usually the field/function name —
+// plus its ref and checksum). It runs once per executor, so a broken query
+// reports one line per asset instead of one line per data element, and every
+// line points straight at the asset+query+field to fix. It never changes
+// execution: the runtime still coerces the value to null as before.
+func reportMalformedPrimitives(code *CodeV2, assetMRN string) {
+	if code == nil {
+		return
+	}
+
+	for blockIdx, block := range code.Blocks {
+		if block == nil {
+			continue
+		}
+		blockRef := uint64(blockIdx+1) << 32
+		for chunkIdx, chunk := range block.Chunks {
+			if chunk == nil {
+				continue
+			}
+
+			malformed := primitiveHasNoType(chunk.Primitive)
+			if !malformed && chunk.Function != nil {
+				for _, arg := range chunk.Function.Args {
+					if primitiveHasNoType(arg) {
+						malformed = true
+						break
+					}
+				}
+			}
+			if !malformed {
+				continue
+			}
+
+			ref := blockRef | uint64(chunkIdx+1)
+			log.Error().
+				Str("asset", assetMRN).
+				Str("query", code.GetId()).
+				Str("field", chunk.Id).
+				Uint64("ref", ref).
+				Str("chunk-checksum", code.Checksums[ref]).
+				Msg("llx: malformed primitive (no type information) baked into compiled code; it will coerce to null at runtime. This is an upstream/compiler bug (see mqlc.addValueFieldChunks) — the asset, query, and field above identify where to look.")
+		}
+	}
 }
 
 func (c *MQLExecutorV2) _newBlockExecutor(blockRef uint64, callback ResultCallback, parent *blockExecutor) (*blockExecutor, error) {

--- a/llx/malformed_primitive_test.go
+++ b/llx/malformed_primitive_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package llx
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func TestPrimitiveHasNoType(t *testing.T) {
+	tests := []struct {
+		name string
+		prim *Primitive
+		want bool
+	}{
+		{"nil primitive", nil, false},
+		{"typed primitive", StringPrimitive("a"), false},
+		{"genuine null keeps its 1-byte type", NilPrimitive, false},
+		{"typeless primitive", &Primitive{}, true},
+		{
+			name: "typeless element inside a typed array",
+			prim: &Primitive{Type: string(types.Array(types.String)), Array: []*Primitive{
+				StringPrimitive("ok"),
+				{}, // malformed element
+			}},
+			want: true,
+		},
+		{
+			name: "typeless value inside a typed map",
+			prim: &Primitive{Type: string(types.Map(types.String, types.String)), Map: map[string]*Primitive{
+				"good": StringPrimitive("ok"),
+				"bad":  {},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, primitiveHasNoType(tc.prim))
+		})
+	}
+}
+
+func TestReportMalformedPrimitives(t *testing.T) {
+	// Capture the global logger so we can assert on the diagnostic.
+	var buf bytes.Buffer
+	orig := zlog.Logger
+	zlog.Logger = zerolog.New(&buf)
+	defer func() { zlog.Logger = orig }()
+
+	// A code bundle whose block 1, chunk 2 carries a typeless primitive — the
+	// shape the compiler bug produces.
+	code := &CodeV2{
+		Id: "//query/checksum/abc",
+		Blocks: []*Block{
+			{
+				Chunks: []*Chunk{
+					{Call: Chunk_PRIMITIVE, Id: "healthy", Primitive: StringPrimitive("ok")},
+					{Call: Chunk_PRIMITIVE, Id: "brokenField", Primitive: &Primitive{}},
+				},
+			},
+		},
+		Checksums: map[uint64]string{
+			(1 << 32) | 2: "chunk-checksum-xyz",
+		},
+	}
+
+	reportMalformedPrimitives(code, "//assets/asset-42")
+
+	out := buf.String()
+	require.Contains(t, out, "malformed primitive")
+	require.Contains(t, out, "//assets/asset-42", "asset MRN must be in the diagnostic")
+	require.Contains(t, out, "//query/checksum/abc", "query id must be in the diagnostic")
+	require.Contains(t, out, "brokenField", "offending field/chunk id must be in the diagnostic")
+	require.Contains(t, out, "chunk-checksum-xyz", "chunk checksum must be in the diagnostic")
+	// Only the malformed chunk is reported, not the healthy one.
+	require.Equal(t, 1, strings.Count(out, "malformed primitive"))
+}
+
+func TestReportMalformedPrimitives_clean(t *testing.T) {
+	var buf bytes.Buffer
+	orig := zlog.Logger
+	zlog.Logger = zerolog.New(&buf)
+	defer func() { zlog.Logger = orig }()
+
+	code := &CodeV2{
+		Id: "//query/ok",
+		Blocks: []*Block{
+			{Chunks: []*Chunk{
+				{Call: Chunk_PRIMITIVE, Id: "a", Primitive: StringPrimitive("ok")},
+				{Call: Chunk_FUNCTION, Id: "==", Function: &Function{Args: []*Primitive{BoolPrimitive(true)}}},
+			}},
+		},
+	}
+
+	reportMalformedPrimitives(code, "//assets/asset-1")
+	require.Empty(t, buf.String(), "well-typed code must not produce any diagnostic")
+}


### PR DESCRIPTION
## What

When compiled MQL code contains a **typeless (malformed) primitive**, the runtime coerces it to null and logs an anonymous `llx: encountered a primitive with no type information` line — one per data element, per asset. On a 400+ asset AWS scan this becomes a flood with no way to tell which asset or query is at fault (reported by Tim).

This adds a **one-time validation pass in `NewExecutorV2`** — the one place that holds both the full compiled `CodeV2` (every chunk) and the asset (`runtime.AssetMRN()`). It walks each chunk (primitive + function args, recursing into array/map elements) and, for every malformed one, logs a single actionable diagnostic naming the **asset**, the **query** checksum, and the **offending chunk** (field id + ref + checksum):

```
ERR llx: malformed primitive (no type information) baked into compiled code; it will
coerce to null at runtime. This is an upstream/compiler bug (see mqlc.addValueFieldChunks)...
  asset=//assets/asset-42  query=//query/checksum/abc  field=brokenField  ref=4294967298  chunk-checksum=...
```

One line per affected asset instead of one per data element, and every line points straight at the asset + query + field to fix.

## Why

The existing log fires deep in a context-free converter (`Primitive.RawData()`), so it can't say which asset or query it's serving — making the flood nearly impossible to act on. The malformed primitive itself is an upstream/compiler bug (`mqlc.addValueFieldChunks`); this change doesn't fix that root cause but makes it debuggable so it can be tracked down per asset/query.

## Behavior

**Execution is unchanged** — the value still coerces to null exactly as before. This is purely a diagnostic improvement.

## Tests

- `TestPrimitiveHasNoType`, `TestReportMalformedPrimitives`, `TestReportMalformedPrimitives_clean` in new `llx/malformed_primitive_test.go`
- Full `./llx/` suite + `go build ./...` green; gofmt + go vet clean

## Caveat

Targets the documented source (compiler-baked chunks in the code bundle). Malformed primitives arriving from provider-returned data would bypass this pass, but that is not what `addValueFieldChunks` produces.