### PR TITLE
🐛 jamf: fix provider ID mismatch that broke all queries

### DIFF
--- a/providers/defaults.go
+++ b/providers/defaults.go
@@ -429,7 +429,7 @@ var DefaultProviders Providers = map[string]*Provider{
 	"jamf": {
 		Provider: &plugin.Provider{
 			Name:            "jamf",
-			ID:              "go.mondoo.com/mql/providers/jamf",
+			ID:              "go.mondoo.com/mql/v13/providers/jamf",
 			ConnectionTypes: []string{"jamf"},
 			Connectors: []plugin.Connector{
 				{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -12,7 +12,7 @@ import (
 
 var Config = plugin.Provider{
 	Name:            "jamf",
-	ID:              "go.mondoo.com/mql/providers/jamf",
+	ID:              "go.mondoo.com/mql/v13/providers/jamf",
 	Version:         "13.1.7",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,


### PR DESCRIPTION
The jamf provider's config.go ID was "go.mondoo.com/mql/providers/jamf" while the schema (derived from jamf.lr's `option provider`) uses "go.mondoo.com/mql/v13/providers/jamf". At providers/runtime.go:931 the runtime compares the resource's owning provider (info.Provider, from the schema) against the connected provider's Instance.ID (from config.go). The missing /v13/ segment made them differ, and since jamf isn't in the cross-provider allowlist, every jamf resource lookup failed with "incorrect provider for asset, not adding
go.mondoo.com/mql/v13/providers/jamf" and returned no data — even though the connection to Jamf Pro succeeded.

Align the config.go ID with the .lr provider option and the go.mod module path (go.mondoo.com/mql/v13/providers/jamf). jamf was the only provider whose .lr provider option and config.go ID disagreed.

Fixes #8868