### PR TITLE
🧹 bump azure armrecoveryservices/v3 v3.0.0 -> v3.1.0

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v5 v5.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v2 v2.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments/v2 v2.0.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -146,8 +146,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns/v2 v2.0.0/go.mod h1:bM1rJt5FapRKM0cO01k9nMNJJWvYDh7NSMRYLOzlhPo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0 h1:ZQaGjVbDGmFxdhZK4YMVKl/FPnYh+JOKNYaGj9byrKo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/purview/armpurview v1.2.0/go.mod h1:B/ISjKE6y8n0C9rnrIoVjv6RnXii3xIXjwYjKo/smh0=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.0.0 h1:NL2xAjIyGs6oinJgHlz73RrJsnoplIxVMZKvxBOCbCY=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.0.0/go.mod h1:fttUxQBURFqpMTKc3IprpRfHO8QWXL9oL4rVZKNbIpg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0 h1:uWMMZcg8Lg9EMjlZQiig9pGnNdvDXphCSNMPVoeFDBk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3 v3.1.0/go.mod h1:g3X+LCYOwmSxuN0qx3clm33onm8e3f6fbN0Em11XFJs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0 h1:GOtQKZTIc4/HnWIEqGqtkMHLXIlwa4GpT8BB5JGH+tc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0/go.mod h1:o1BW30aoyqKYcQKAMNWs0UAkT30Z2FZzmCNo7hrGHjM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4 v4.0.0 h1:xXVDKm0Nd3I9Sz2AcRm/L4+fm7xZjAWI/AkU73m0Ato=


### PR DESCRIPTION
Refreshes the Azure SDK Go dependencies in the azure provider.

A stable-only probe of all 68 `github.com/Azure/...` and `github.com/AzureAD/...` dependencies found a single available stable upgrade:

- `armrecoveryservices/v3` `v3.0.0` → `v3.1.0`

This is a minor bump within the same major, so no import-path rewrites or call-site changes were required.

### Everything else
- The rest of the Azure/AzureAD deps are already on their latest stable versions (`azcore` v1.22.0, `azidentity` v1.14.0, `armnetwork/v10`, `armcompute/v8`, `armcontainerservice/v9`, `armresources/v4`, keyvault `az*` v1.5.0, MSAL v1.7.2, etc.).
- ~23 modules have a newer major available, but only as a pre-GA **beta** or pseudo-version (e.g. `armapimanagement` v4.0.0-beta.1, `armcosmos` v4.0.0-beta.3, `armsql` v2.0.0-beta.8, `armauthorization` v3.0.0-beta.3). These are intentionally **skipped** — Azure SDK betas churn their API surface for months before GA.

### Verification
- `go mod tidy` ✅
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./resources/...` ✅

Sum verification was preserved throughout (`GOSUMDB` untouched).
