### PR TITLE
✨ Expose soft-deleted Recovery Services vaults and vault cost-management granularity (azure)

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -10906,7 +10906,10 @@ private azure.subscription.recoveryServicesService.deletedVault @defaults("name 
   location string
   // Resource type
   type string
-  // Resource ID of the original vault that was deleted
+  // Resource ID of the deleted vault
+  //
+  // Identifies the original vault that was deleted. The vault no longer
+  // exists as a live resource, so only its resource ID is retained.
   vaultResourceId string
   // Time the vault was deleted (UTC)
   vaultDeletionTime time

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -10824,6 +10824,8 @@ private azure.subscription.recoveryServicesService {
   subscriptionId string
   // List of recovery services vaults
   vaults() []azure.subscription.recoveryServicesService.vault
+  // Soft-deleted recovery services vaults awaiting permanent purge
+  deletedVaults() []azure.subscription.recoveryServicesService.deletedVault
 }
 
 // Azure Recovery Services vault
@@ -10865,6 +10867,8 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   privateEndpointStateForSiteRecovery string
   // Secure score ("Adequate", "Maximum", "Minimum", or "None")
   secureScore string
+  // Cost management report granularity ("ProtectedItemLevel", "ProtectedItemWithParentTag", or "VaultLevel"); empty when unset
+  costManagementGranularityLevel string
   // Security settings (soft delete, immutability, enhanced security)
   securitySettings() azure.subscription.recoveryServicesService.vault.securitySettings
   // Encryption settings
@@ -10881,6 +10885,33 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   backupPolicies() []azure.subscription.recoveryServicesService.vault.backupPolicy
   // Protected (backed-up) items
   protectedItems() []azure.subscription.recoveryServicesService.vault.protectedItem
+  // Creation and last-modification provenance recorded by Azure Resource Manager
+  systemMetadata() azure.subscription.systemData
+}
+
+// Soft-deleted Azure Recovery Services vault
+//
+// Recovery Services vault that has been deleted but is retained in a
+// soft-deleted state until Azure permanently purges it. Surfaces the time
+// the vault was deleted, the scheduled purge time, and the resource ID of
+// the original vault, so an auditor can review the recovery window and
+// undelete opportunities before data is lost. Deleted vaults are enumerated
+// per Azure region.
+private azure.subscription.recoveryServicesService.deletedVault @defaults("name vaultDeletionTime purgeAt") {
+  // Deleted vault resource ID
+  id string
+  // Deleted vault name
+  name string
+  // Azure region the vault was deleted in
+  location string
+  // Resource type
+  type string
+  // Resource ID of the original vault that was deleted
+  vaultResourceId string
+  // Time the vault was deleted (UTC)
+  vaultDeletionTime time
+  // Time the vault will be permanently purged (UTC)
+  purgeAt time
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -355,6 +355,7 @@ const (
 	ResourceAzureSubscriptionMonitorServiceQueryPackQuery                                             string = "azure.subscription.monitorService.queryPack.query"
 	ResourceAzureSubscriptionRecoveryServicesService                                                  string = "azure.subscription.recoveryServicesService"
 	ResourceAzureSubscriptionRecoveryServicesServiceVault                                             string = "azure.subscription.recoveryServicesService.vault"
+	ResourceAzureSubscriptionRecoveryServicesServiceDeletedVault                                      string = "azure.subscription.recoveryServicesService.deletedVault"
 	ResourceAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings                             string = "azure.subscription.recoveryServicesService.vault.securitySettings"
 	ResourceAzureSubscriptionRecoveryServicesServiceVaultEncryption                                   string = "azure.subscription.recoveryServicesService.vault.encryption"
 	ResourceAzureSubscriptionRecoveryServicesServiceVaultMonitoringSettings                           string = "azure.subscription.recoveryServicesService.vault.monitoringSettings"
@@ -1826,6 +1827,10 @@ func init() {
 		"azure.subscription.recoveryServicesService.vault": {
 			Init:   initAzureSubscriptionRecoveryServicesServiceVault,
 			Create: createAzureSubscriptionRecoveryServicesServiceVault,
+		},
+		"azure.subscription.recoveryServicesService.deletedVault": {
+			// to override args, implement: initAzureSubscriptionRecoveryServicesServiceDeletedVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionRecoveryServicesServiceDeletedVault,
 		},
 		"azure.subscription.recoveryServicesService.vault.securitySettings": {
 			// to override args, implement: initAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -14443,6 +14448,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.recoveryServicesService.vaults": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesService).GetVaults()).ToDataRes(types.Array(types.Resource("azure.subscription.recoveryServicesService.vault")))
 	},
+	"azure.subscription.recoveryServicesService.deletedVaults": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesService).GetDeletedVaults()).ToDataRes(types.Array(types.Resource("azure.subscription.recoveryServicesService.deletedVault")))
+	},
 	"azure.subscription.recoveryServicesService.vault.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetId()).ToDataRes(types.String)
 	},
@@ -14485,6 +14493,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.recoveryServicesService.vault.secureScore": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSecureScore()).ToDataRes(types.String)
 	},
+	"azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetCostManagementGranularityLevel()).ToDataRes(types.String)
+	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSecuritySettings()).ToDataRes(types.Resource("azure.subscription.recoveryServicesService.vault.securitySettings"))
 	},
@@ -14511,6 +14522,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.recoveryServicesService.vault.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.location": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetLocation()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetType()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.vaultResourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetVaultResourceId()).ToDataRes(types.String)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.vaultDeletionTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetVaultDeletionTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.purgeAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetPurgeAt()).ToDataRes(types.Time)
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings).GetId()).ToDataRes(types.String)
@@ -35514,6 +35549,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionRecoveryServicesService).Vaults, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.recoveryServicesService.deletedVaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesService).DeletedVaults, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.recoveryServicesService.vault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).__id, ok = v.Value.(string)
 		return
@@ -35574,6 +35613,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).SecureScore, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).CostManagementGranularityLevel, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).SecuritySettings, ok = plugin.RawToTValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings](v.Value, v.Error)
 		return
@@ -35608,6 +35651,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.recoveryServicesService.vault.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionRecoveryServicesServiceVault).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.vaultResourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).VaultResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.vaultDeletionTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).VaultDeletionTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.purgeAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).PurgeAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.recoveryServicesService.deletedVault.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.recoveryServicesService.vault.securitySettings.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83148,6 +83227,7 @@ type mqlAzureSubscriptionRecoveryServicesService struct {
 	// optional: if you define mqlAzureSubscriptionRecoveryServicesServiceInternal it will be used here
 	SubscriptionId plugin.TValue[string]
 	Vaults         plugin.TValue[[]any]
+	DeletedVaults  plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionRecoveryServicesService creates a new instance of this resource
@@ -83207,6 +83287,22 @@ func (c *mqlAzureSubscriptionRecoveryServicesService) GetVaults() *plugin.TValue
 	})
 }
 
+func (c *mqlAzureSubscriptionRecoveryServicesService) GetDeletedVaults() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.DeletedVaults, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.recoveryServicesService", c.__id, "deletedVaults")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.deletedVaults()
+	})
+}
+
 // mqlAzureSubscriptionRecoveryServicesServiceVault for the azure.subscription.recoveryServicesService.vault resource
 type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	MqlRuntime *plugin.Runtime
@@ -83226,6 +83322,7 @@ type mqlAzureSubscriptionRecoveryServicesServiceVault struct {
 	PrivateEndpointStateForBackup       plugin.TValue[string]
 	PrivateEndpointStateForSiteRecovery plugin.TValue[string]
 	SecureScore                         plugin.TValue[string]
+	CostManagementGranularityLevel      plugin.TValue[string]
 	SecuritySettings                    plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings]
 	Encryption                          plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultEncryption]
 	MonitoringSettings                  plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultMonitoringSettings]
@@ -83340,6 +83437,10 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetPrivateEndpointSta
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSecureScore() *plugin.TValue[string] {
 	return &c.SecureScore
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetCostManagementGranularityLevel() *plugin.TValue[string] {
+	return &c.CostManagementGranularityLevel
 }
 
 func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSecuritySettings() *plugin.TValue[*mqlAzureSubscriptionRecoveryServicesServiceVaultSecuritySettings] {
@@ -83474,6 +83575,102 @@ func (c *mqlAzureSubscriptionRecoveryServicesServiceVault) GetSystemMetadata() *
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
 			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.recoveryServicesService.vault", c.__id, "systemMetadata")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionSystemData), nil
+			}
+		}
+
+		return c.systemMetadata()
+	})
+}
+
+// mqlAzureSubscriptionRecoveryServicesServiceDeletedVault for the azure.subscription.recoveryServicesService.deletedVault resource
+type mqlAzureSubscriptionRecoveryServicesServiceDeletedVault struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureSubscriptionRecoveryServicesServiceDeletedVaultInternal
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	Location          plugin.TValue[string]
+	Type              plugin.TValue[string]
+	VaultResourceId   plugin.TValue[string]
+	VaultDeletionTime plugin.TValue[*time.Time]
+	PurgeAt           plugin.TValue[*time.Time]
+	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
+}
+
+// createAzureSubscriptionRecoveryServicesServiceDeletedVault creates a new instance of this resource
+func createAzureSubscriptionRecoveryServicesServiceDeletedVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionRecoveryServicesServiceDeletedVault{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.recoveryServicesService.deletedVault", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) MqlName() string {
+	return "azure.subscription.recoveryServicesService.deletedVault"
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetLocation() *plugin.TValue[string] {
+	return &c.Location
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetVaultResourceId() *plugin.TValue[string] {
+	return &c.VaultResourceId
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetVaultDeletionTime() *plugin.TValue[*time.Time] {
+	return &c.VaultDeletionTime
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetPurgeAt() *plugin.TValue[*time.Time] {
+	return &c.PurgeAt
+}
+
+func (c *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.recoveryServicesService.deletedVault", c.__id, "systemMetadata")
 			if err != nil {
 				return nil, err
 			}

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -4452,6 +4452,16 @@ azure.subscription.purviewService.accounts 13.11.2
 azure.subscription.purviewService.subscriptionId 13.11.2
 azure.subscription.recoveryServices 13.3.3
 azure.subscription.recoveryServicesService 13.3.3
+azure.subscription.recoveryServicesService.deletedVault 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.id 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.location 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.name 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.purgeAt 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.systemMetadata 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.type 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.vaultDeletionTime 13.30.1
+azure.subscription.recoveryServicesService.deletedVault.vaultResourceId 13.30.1
+azure.subscription.recoveryServicesService.deletedVaults 13.30.1
 azure.subscription.recoveryServicesService.subscriptionId 13.3.3
 azure.subscription.recoveryServicesService.vault 13.3.3
 azure.subscription.recoveryServicesService.vault.backupConfig 13.3.3
@@ -4468,6 +4478,7 @@ azure.subscription.recoveryServicesService.vault.backupPolicy.name 13.3.3
 azure.subscription.recoveryServicesService.vault.backupPolicy.properties 13.3.3
 azure.subscription.recoveryServicesService.vault.backupPolicy.type 13.3.3
 azure.subscription.recoveryServicesService.vault.backupStorageVersion 13.3.3
+azure.subscription.recoveryServicesService.vault.costManagementGranularityLevel 13.30.1
 azure.subscription.recoveryServicesService.vault.encryption 13.3.3
 azure.subscription.recoveryServicesService.vault.encryption.id 13.3.3
 azure.subscription.recoveryServicesService.vault.encryption.infrastructureEncryption 13.3.3

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.28.0",
-  "generated_at": "2026-07-09T21:23:22-07:00",
+  "version": "13.30.0",
+  "generated_at": "2026-07-15T13:57:13+02:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -205,6 +205,7 @@
     "Microsoft.RecoveryServices/Vaults/backupPolicies/read",
     "Microsoft.RecoveryServices/Vaults/backupProtectedItems/read",
     "Microsoft.RecoveryServices/Vaults/backupconfig/read",
+    "Microsoft.RecoveryServices/deletedVaults/read",
     "Microsoft.RecoveryServices/vaults/read",
     "Microsoft.Resources/deployments/read",
     "Microsoft.Resources/resources/read",
@@ -1548,6 +1549,12 @@
       "source_file": "recoveryservices.go"
     },
     {
+      "permission": "Microsoft.RecoveryServices/deletedVaults/read",
+      "service": "Microsoft.RecoveryServices",
+      "action": "NewListBySubscriptionIDPager",
+      "source_file": "recoveryservices.go"
+    },
+    {
       "permission": "Microsoft.RecoveryServices/vaults/read",
       "service": "Microsoft.RecoveryServices",
       "action": "Get",
@@ -1576,6 +1583,12 @@
       "service": "Microsoft.Resources",
       "action": "NewListPager",
       "source_file": "client_subscriptions.go"
+    },
+    {
+      "permission": "Microsoft.Resources/subscriptions/read",
+      "service": "Microsoft.Resources",
+      "action": "NewListLocationsPager",
+      "source_file": "recoveryservices.go"
     },
     {
       "permission": "Microsoft.Resources/subscriptions/read",

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
 	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -191,9 +192,14 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 		return nil, err
 	}
 
+	// Each deleted vault is paired with the region it was queried from, since
+	// the DeletedVault payload itself carries no location.
+	type deletedVaultEntry struct {
+		vault    *armrecoveryservices.DeletedVault
+		location string
+	}
 	var mu sync.Mutex
-	var deleted []*armrecoveryservices.DeletedVault
-	locationByID := map[string]string{}
+	var deleted []deletedVaultEntry
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(10)
 	for _, location := range locations {
@@ -202,8 +208,9 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 			for pager.More() {
 				page, err := pager.NextPage(gctx)
 				if err != nil {
-					// A region the subscription cannot reach shouldn't fail the
-					// whole listing; skip it and continue with the rest.
+					// One unreachable or access-denied region shouldn't fail the
+					// whole listing; log it and continue with the rest.
+					log.Warn().Err(err).Str("location", location).Msg("could not list deleted recovery services vaults in region")
 					return nil
 				}
 				mu.Lock()
@@ -211,10 +218,7 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 					if dv == nil {
 						continue
 					}
-					deleted = append(deleted, dv)
-					if dv.ID != nil {
-						locationByID[*dv.ID] = location
-					}
+					deleted = append(deleted, deletedVaultEntry{vault: dv, location: location})
 				}
 				mu.Unlock()
 			}
@@ -226,12 +230,8 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, er
 	}
 
 	var res []any
-	for _, dv := range deleted {
-		location := ""
-		if dv.ID != nil {
-			location = locationByID[*dv.ID]
-		}
-		mqlDeletedVault, err := createDeletedVaultResource(a.MqlRuntime, dv, location)
+	for _, entry := range deleted {
+		mqlDeletedVault, err := createDeletedVaultResource(a.MqlRuntime, entry.vault, entry.location)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/azure/resources/recoveryservices.go
+++ b/providers/azure/resources/recoveryservices.go
@@ -8,16 +8,20 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservices/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4"
+	subscriptions "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/azure/connection"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 )
 
 type mqlAzureSubscriptionRecoveryServicesServiceVaultInternal struct {
@@ -28,6 +32,10 @@ type mqlAzureSubscriptionRecoveryServicesServiceVaultInternal struct {
 	cachePrivateEndpointConn     []*armrecoveryservices.PrivateEndpointConnectionVaultProperties
 	cacheSystemData              any
 	cacheUserAssignedIdentityIds []string
+}
+
+type mqlAzureSubscriptionRecoveryServicesServiceDeletedVaultInternal struct {
+	cacheSystemData any
 }
 
 func (a *mqlAzureSubscriptionRecoveryServicesService) id() (string, error) {
@@ -139,6 +147,144 @@ func (a *mqlAzureSubscriptionRecoveryServicesService) vaults() ([]any, error) {
 	return res, nil
 }
 
+// deletedVaults lists soft-deleted Recovery Services vaults awaiting purge.
+// The Azure API only lists deleted vaults per region, so the subscription's
+// physical regions are enumerated and queried concurrently.
+func (a *mqlAzureSubscriptionRecoveryServicesService) deletedVaults() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	token := conn.Token()
+	subId := a.SubscriptionId.Data
+
+	subClient, err := subscriptions.NewClient(token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var locations []string
+	locPager := subClient.NewListLocationsPager(subId, nil)
+	for locPager.More() {
+		page, err := locPager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, loc := range page.Value {
+			if loc == nil || loc.Name == nil {
+				continue
+			}
+			// Skip logical regions (e.g. edge zones); deleted vaults live in
+			// physical regions only.
+			if loc.Metadata != nil && loc.Metadata.RegionType != nil &&
+				*loc.Metadata.RegionType != subscriptions.RegionTypePhysical {
+				continue
+			}
+			locations = append(locations, *loc.Name)
+		}
+	}
+
+	client, err := armrecoveryservices.NewDeletedVaultsClient(subId, token, &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var mu sync.Mutex
+	var deleted []*armrecoveryservices.DeletedVault
+	locationByID := map[string]string{}
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+	for _, location := range locations {
+		g.Go(func() error {
+			pager := client.NewListBySubscriptionIDPager(location, nil)
+			for pager.More() {
+				page, err := pager.NextPage(gctx)
+				if err != nil {
+					// A region the subscription cannot reach shouldn't fail the
+					// whole listing; skip it and continue with the rest.
+					return nil
+				}
+				mu.Lock()
+				for _, dv := range page.Value {
+					if dv == nil {
+						continue
+					}
+					deleted = append(deleted, dv)
+					if dv.ID != nil {
+						locationByID[*dv.ID] = location
+					}
+				}
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	var res []any
+	for _, dv := range deleted {
+		location := ""
+		if dv.ID != nil {
+			location = locationByID[*dv.ID]
+		}
+		mqlDeletedVault, err := createDeletedVaultResource(a.MqlRuntime, dv, location)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlDeletedVault)
+	}
+	return res, nil
+}
+
+func createDeletedVaultResource(runtime *plugin.Runtime, dv *armrecoveryservices.DeletedVault, location string) (*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault, error) {
+	var vaultResourceId string
+	var vaultDeletionTime *time.Time
+	var purgeAt *time.Time
+	if dv.Properties != nil {
+		if dv.Properties.VaultID != nil {
+			vaultResourceId = *dv.Properties.VaultID
+		}
+		vaultDeletionTime = dv.Properties.VaultDeletionTime
+		purgeAt = dv.Properties.PurgeAt
+	}
+
+	resource, err := CreateResource(runtime, ResourceAzureSubscriptionRecoveryServicesServiceDeletedVault,
+		map[string]*llx.RawData{
+			"id":                llx.StringDataPtr(dv.ID),
+			"name":              llx.StringDataPtr(dv.Name),
+			"location":          llx.StringData(location),
+			"type":              llx.StringDataPtr(dv.Type),
+			"vaultResourceId":   llx.StringData(vaultResourceId),
+			"vaultDeletionTime": llx.TimeDataPtr(vaultDeletionTime),
+			"purgeAt":           llx.TimeDataPtr(purgeAt),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	mqlDeletedVault := resource.(*mqlAzureSubscriptionRecoveryServicesServiceDeletedVault)
+
+	sysData, err := convert.JsonToDict(dv.SystemData)
+	if err != nil {
+		return nil, err
+	}
+	mqlDeletedVault.cacheSystemData = sysData
+
+	return mqlDeletedVault, nil
+}
+
+func (a *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionRecoveryServicesServiceDeletedVault) systemMetadata() (*mqlAzureSubscriptionSystemData, error) {
+	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
+}
+
 func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vault) (*mqlAzureSubscriptionRecoveryServicesServiceVault, error) {
 	props := vault.Properties
 	if props == nil {
@@ -190,6 +336,11 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 		secureScore = string(*props.SecureScore)
 	}
 
+	var costManagementGranularityLevel string
+	if props.CostManagementSettings != nil && props.CostManagementSettings.GranularityLevel != nil {
+		costManagementGranularityLevel = string(*props.CostManagementSettings.GranularityLevel)
+	}
+
 	resource, err := CreateResource(runtime, ResourceAzureSubscriptionRecoveryServicesServiceVault,
 		map[string]*llx.RawData{
 			"id":                                  llx.StringDataPtr(vault.ID),
@@ -205,6 +356,7 @@ func createVaultResource(runtime *plugin.Runtime, vault *armrecoveryservices.Vau
 			"privateEndpointStateForBackup":       llx.StringData(privateEndpointStateForBackup),
 			"privateEndpointStateForSiteRecovery": llx.StringData(privateEndpointStateForSiteRecovery),
 			"secureScore":                         llx.StringData(secureScore),
+			"costManagementGranularityLevel":      llx.StringData(costManagementGranularityLevel),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Builds on the new API surface in `armrecoveryservices/v3` v3.1.0 (merged in #9071) to expose two things that weren't previously modeled.

## 1. Soft-deleted Recovery Services vaults

New `azure.subscription.recoveryServicesService.deletedVaults()` collection. When a Recovery Services vault is deleted it enters a soft-deleted state and is retained until Azure permanently purges it. Each `deletedVault` exposes:

- `vaultResourceId` — resource ID of the original vault that was deleted
- `vaultDeletionTime` — when the vault was deleted (UTC)
- `purgeAt` — when the vault will be permanently purged (UTC)
- `id`, `name`, `location`, `type`, `systemMetadata()`

This gives auditors visibility into the recovery/undelete window before backup data is lost.

**Per-region API:** `DeletedVaultsClient.NewListBySubscriptionIDPager` is keyed by region (`/locations/{location}/deletedVaults`) with no subscription-wide variant, so the implementation enumerates the subscription's physical regions (`armsubscriptions` ListLocations, filtered to `Physical`) and queries them concurrently via a bounded `errgroup` (limit 10). Unreachable regions are skipped rather than failing the whole listing. Because it's a computed accessor, the per-region fan-out only runs when `.deletedVaults` is actually queried.

## 2. Vault cost-management granularity

New scalar `costManagementGranularityLevel` on the vault (`"ProtectedItemLevel"`, `"ProtectedItemWithParentTag"`, or `"VaultLevel"`), read from the per-vault `Get` already performed during listing. A single scalar, so it's flattened onto the vault rather than made a sub-resource.

## Example queries

```
azure.subscription.recoveryServicesService.deletedVaults {
  name vaultResourceId vaultDeletionTime purgeAt
}

azure.subscription.recoveryServicesService.vaults {
  name costManagementGranularityLevel
}
```

## Notes

- New `.lr.versions` entries at **13.30.1**.
- Regenerated `azure.permissions.json` picks up `Microsoft.RecoveryServices/deletedVaults/read` and `Microsoft.Resources/subscriptions/read` (no other drift).
- No provider `Version` bump (release flow).

## Verification

- `go build ./...` ✅
- `go vet ./resources/...` ✅
- `go test ./resources/...` ✅
- `gofmt -l` clean ✅

Live verification against a tenant with soft-deleted vaults is a sensible follow-up (it requires actually soft-deleting a vault), but the build and unit tests pass.
