### PR TITLE
🎉 gcp-13.31.0, hetzner-13.7.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.30.1",
+	Version: "13.31.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.6.0",
+	Version:         "13.7.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for the **GCP** and **Hetzner** providers.

| Provider | Old | New |
|----------|-----|-----|
| gcp | 13.30.1 | 13.31.0 |
| hetzner | 13.6.0 | 13.7.0 |

## What's new

### gcp — 13.31.0

- **New `instanceSshKeys()` accessor on compute instances** (#9063). Parses the SSH keys from instance metadata into a list with `username`, `algorithm`, `bits`, `publicKey`, and `comment`, surfacing the classical crypto posture (RSA-2048 vs Ed25519, etc.) needed to assess post-quantum-cryptography readiness. Parsing is in-process from key material already fetched — no new API calls. SSH parsing now lives in the shared `providers-sdk/v1/util/sshutil` package.
- Cloud SDK and shared dependency bumps, including `ranger-rpc` v0.8.1 (#9040, #9060, #9061), with a `gcp.permissions.json` refresh.

### hetzner — 13.7.0

- No schema changes. Internal refactor to consume the shared `sshutil` SDK package for SSH key parsing (`golang.org/x/crypto` becomes an indirect dependency) (#9063).
- Cloud SDK and shared dependency bumps, including `ranger-rpc` v0.8.1 (#8998, #9060, #9061).
