### PR TITLE
🎉 jamf-13.1.8, activedirectory-13.1.6, ansible-13.2.7, arista-13.3.9, atlassian-13.3.9, bicep-13.4.2, claude-13.0.8, cloudflare-13.6.2, cloudformation-13.2.2, datadog-13.0.15, depsdev-13.1.2, equinix-13.0.22, github-13.7.1, gitlab-13.5.1, google-workspace-13.2.5, grafana-13.1.14, helm-13.3.5, huggingface-13.1.8, ipinfo-13.0.21, ipmi-13.0.21, kustomize-13.1.7, mikrotik-13.0.4, mistral-13.0.8, mondoo-13.1.11

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.1.5",
+	Version:         "13.1.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{

--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.6",
+	Version:         "13.2.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "13.3.8",
+	Version:         "13.3.9",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.3.8",
+	Version:   "13.3.9",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.1",
+	Version:         "13.4.2",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "claude",
 	ID:              "go.mondoo.com/mql/providers/claude",
-	Version:         "13.0.7",
+	Version:         "13.0.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.6.1",
+	Version:         "13.6.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.2.1",
+	Version:         "13.2.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "datadog",
 	ID:              "go.mondoo.com/mql/providers/datadog",
-	Version:         "13.0.14",
+	Version:         "13.0.15",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "depsdev",
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
-	Version:         "13.1.1",
+	Version:         "13.1.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.21",
+	Version:         "13.0.22",
 	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.7.0",
+	Version:         "13.7.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.5.0",
+	Version: "13.5.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.2.4",
+	Version:         "13.2.5",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.13",
+	Version:         "13.1.14",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.4",
+	Version:         "13.3.5",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "huggingface",
 	ID:              "go.mondoo.com/mql/providers/huggingface",
-	Version:         "13.1.7",
+	Version:         "13.1.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipinfo",
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
-	Version:         "13.0.20",
+	Version:         "13.0.21",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "13.0.20",
+	Version:         "13.0.21",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/v13/providers/jamf",
-	Version:         "13.1.7",
+	Version:         "13.1.8",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.1.6",
+	Version:         "13.1.7",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mikrotik",
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
-	Version:         "13.0.3",
+	Version:         "13.0.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mistral/config/config.go
+++ b/providers/mistral/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mistral",
 	ID:              "go.mondoo.com/mql/providers/mistral",
-	Version:         "13.0.7",
+	Version:         "13.0.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mondoo",
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
-	Version:         "13.1.10",
+	Version:         "13.1.11",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Patch release bumping 24 providers.

This release was created by mql's provider versioning bot (`providers-sdk/v1/util/version`).
