### PR TITLE
🐛 bicep: strip quotes from object keys so dotted-key lookups resolve

### DIFF
--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -1372,9 +1372,24 @@ func parseBicepObject(body string) map[string]any {
 		if !ok {
 			continue
 		}
-		out[strings.TrimSpace(key)] = parseBicepValue(strings.TrimSpace(value))
+		out[unquoteBicepKey(strings.TrimSpace(key))] = parseBicepValue(strings.TrimSpace(value))
 	}
 	return out
+}
+
+// unquoteBicepKey strips the surrounding quotes from a Bicep object key. Keys
+// that aren't valid bare identifiers must be quoted in Bicep source, so dotted
+// keys such as the API Management `customProperties` entries
+// (`'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10'`)
+// arrive with their quotes attached. Left in place, the quotes become part of
+// the map key and an index lookup written without them
+// (`properties["customProperties"]["Microsoft...Tls10"]`) misses and returns
+// null. Bare-identifier keys carry no quotes and are returned unchanged.
+func unquoteBicepKey(k string) string {
+	if len(k) >= 2 && (k[0] == '\'' || k[0] == '"') && k[len(k)-1] == k[0] {
+		return k[1 : len(k)-1]
+	}
+	return k
 }
 
 func parseBicepValue(v string) any {

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -887,6 +887,34 @@ func TestParseBicepObject(t *testing.T) {
 		assert.Equal(t, `it\'s here`, obj["message"])
 		assert.Equal(t, "plain", obj["other"])
 	})
+
+	// Regression test for #9081: keys that must be quoted in Bicep source
+	// (dotted keys, e.g. API Management `customProperties`) landed in the map
+	// with their quotes attached, so an index lookup written without quotes
+	// missed and returned null. The quotes must be stripped from the key.
+	t.Run("quoted dotted keys are unquoted", func(t *testing.T) {
+		body := `
+  customProperties: {
+    'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10': 'True'
+    publisherName: 'Contoso'
+  }
+`
+		obj := parseBicepObject(body)
+		cp, ok := obj["customProperties"].(map[string]any)
+		require.True(t, ok, "customProperties should be a nested map")
+		assert.Equal(t, "True", cp["Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"])
+		assert.Equal(t, "Contoso", cp["publisherName"])
+		_, quotedPresent := cp["'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10'"]
+		assert.False(t, quotedPresent, "the quoted form must not leak into the map key")
+	})
+
+	t.Run("double-quoted keys are unquoted", func(t *testing.T) {
+		body := `
+  "a.b.c": 'x'
+`
+		obj := parseBicepObject(body)
+		assert.Equal(t, "x", obj["a.b.c"])
+	})
 }
 
 // A brace inside a string literal used to fool the naive


### PR DESCRIPTION
## Summary

Indexing a resource-derived map with a **dotted** string key returned null in the Bicep provider, so a check reading Azure API Management `customProperties` (all dotted keys, e.g. `Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10`) always saw null and silently passed an insecure configuration.

## Root cause

The object parser (`parseBicepObject`) unquoted **values** but never **keys**. Keys that aren't valid bare identifiers must be quoted in Bicep source, so dotted keys arrived with their quotes attached and landed in the map as `'Microsoft.WindowsAzure...Tls10'` (quotes included). An MQL index lookup written without quotes (`properties["customProperties"]["Microsoft...Tls10"]`) then missed and returned null.

This is why the fault correlated with dots: dotted keys are the ones Bicep requires you to quote. Bare-identifier keys were never affected.

## Fix

Strip the surrounding quotes from the key in `parseBicepObject` (via a small `unquoteBicepKey` helper that handles both `'` and `"`). Bare-identifier keys are returned unchanged.

## Tests

Added two subtests to `TestParseBicepObject`:
- quoted dotted keys (the APIM `customProperties` case) resolve to their value, and the quoted form does not leak into the map key
- double-quoted keys are unquoted

Full `providers/bicep/resources` suite passes.

Fixes #9081
