### PR TITLE
🐛 terraform: apply unary operators so negative literals keep their sign

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -851,6 +851,14 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		appendCtyResult(&results, getCtyValue(t.RHS, ctx))
 		return results
 	case *hclsyntax.UnaryOpExpr:
+		// `-1` and `!true` parse as a unary op wrapping a literal. Evaluate the
+		// whole expression so the operator is actually applied — a bare descent
+		// into t.Val drops the negation and surfaces the positive magnitude
+		// (e.g. the `-1` sentinel becoming `1`). Fall back to the operand's
+		// references when it can't be evaluated statically (e.g. `-var.x`).
+		if val, diags := t.Value(ctx); !diags.HasErrors() {
+			return ctyValueToGo(val)
+		}
 		return getCtyValue(t.Val, ctx)
 	case *hclsyntax.SplatExpr:
 		results := []any{}

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -185,6 +185,38 @@ func TestGetCtyValue_ConditionalExpr_UnboundVars(t *testing.T) {
 		"result should reference data.aws_ami.shared_image.id, got: %#v", v)
 }
 
+// TestGetCtyValue_NegativeNumber is a regression test for #9080: a negative
+// numeric literal parses as a unary-negate op wrapping a number literal, and
+// must retain its sign instead of collapsing to the positive magnitude (which
+// broke checks comparing against a negative sentinel, e.g. Lambda's `-1`
+// "unreserved" value or a security-group protocol of `-1`).
+func TestGetCtyValue_NegativeNumber(t *testing.T) {
+	attrs := parseAttrs(t, `reserved_concurrent_executions = -1`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	assert.Equal(t, float64(-1), got["reserved_concurrent_executions"])
+}
+
+// TestGetCtyValue_LogicalNot verifies the other unary operator (`!`) is applied
+// rather than dropped.
+func TestGetCtyValue_LogicalNot(t *testing.T) {
+	attrs := parseAttrs(t, `disabled = !true`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	assert.Equal(t, false, got["disabled"])
+}
+
+// TestGetCtyValue_UnaryOp_UnboundOperand verifies a unary op over an unbound
+// operand (e.g. `-var.x`) still surfaces the operand's references instead of
+// failing, preserving the reference-surfacing fallback.
+func TestGetCtyValue_UnaryOp_UnboundOperand(t *testing.T) {
+	attrs := parseAttrs(t, `capacity = -var.desired_capacity`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	assert.True(t, containsString(got["capacity"], "var.desired_capacity"),
+		"result should reference var.desired_capacity, got: %#v", got["capacity"])
+}
+
 // resolvingCtx builds an eval context with resolved var.*/local.* values,
 // mimicking what Connection.VariableEvalContext produces when the
 // TerraformResolveVars feature flag is active.


### PR DESCRIPTION
## Summary

A negative numeric literal in HCL (e.g. `-1`) was normalized to its positive magnitude (`1`) by the Terraform provider, so a check treating a negative sentinel specially could not evaluate it. `reserved_concurrent_executions = -1` (AWS Lambda's "unreserved" sentinel) read as `1`, and a `> 0` assertion wrongly passed.

## Root cause

In HCL, `-1` does not parse as a single negative number literal — it parses as a `*hclsyntax.UnaryOpExpr` (`OpNegate`) wrapping the number literal `1`. `getCtyValue`'s `UnaryOpExpr` case recursed straight into the operand (`t.Val`) and never applied the operator, so the sign (and any `!` logical-not) was dropped.

## Fix

Evaluate the whole unary expression so the operator is actually applied, converting the result via the existing `ctyValueToGo` helper. When the operand can't be evaluated statically (e.g. `-var.x`), fall back to surfacing the operand's references — preserving the existing reference-surfacing behavior.

## Tests

Added to `hcl_test.go`:
- `-1` → `-1`
- `!true` → `false`
- `-var.desired_capacity` (unbound) still surfaces `var.desired_capacity`

Full `providers/terraform/resources` suite passes.

Fixes #9080
