### PR TITLE
🐛 terraform: resolve jsonencode([...]) list arguments

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -806,10 +806,16 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		subVal, err := t.Value(ctx)
 		if err == nil && subVal.Type() == cty.String {
 			if t.Name == "jsonencode" {
-				res := map[string]any{}
-				err := json.Unmarshal([]byte(subVal.AsString()), &res)
-				if err == nil {
-					results = append(results, res)
+				// Decode into `any` so both a JSON object (`jsonencode({...})`)
+				// and a JSON array (`jsonencode([...])`) resolve. Unmarshalling
+				// into a map[string]any silently failed for a top-level array,
+				// leaving the argument empty so a check iterating the encoded
+				// list saw nothing and passed vacuously. appendCtyResult keeps
+				// the object case list-wrapped while flattening a decoded list
+				// into the result so it stays iterable.
+				var res any
+				if err := json.Unmarshal([]byte(subVal.AsString()), &res); err == nil {
+					appendCtyResult(&results, res)
 				}
 			} else {
 				results = append(results, subVal.AsString())

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -167,6 +167,39 @@ subnet_id_by_az_suffix = {
 		"result should reference data.aws_subnet.ec2, got: %#v", v)
 }
 
+// TestGetCtyValue_JsonencodeList is a regression test for #9079: a top-level
+// `jsonencode([...])` list argument decoded into a map[string]any, which fails
+// for a JSON array, leaving the argument empty so a check iterating the encoded
+// list passed vacuously. The encoded list must surface as an iterable list.
+func TestGetCtyValue_JsonencodeList(t *testing.T) {
+	attrs := parseAttrs(t, `container_definitions = jsonencode([{ name = "app", image = "x", privileged = true }])`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+
+	list, ok := got["container_definitions"].([]any)
+	require.True(t, ok, "expected a list, got: %#v", got["container_definitions"])
+	require.Len(t, list, 1)
+	elem, ok := list[0].(map[string]any)
+	require.True(t, ok, "expected a map element, got: %#v", list[0])
+	assert.Equal(t, "app", elem["name"])
+	assert.Equal(t, true, elem["privileged"])
+}
+
+// TestGetCtyValue_JsonencodeMap verifies the object form still resolves
+// (list-wrapped, indexable via `.first`) after the list fix.
+func TestGetCtyValue_JsonencodeMap(t *testing.T) {
+	attrs := parseAttrs(t, `policy = jsonencode({ Version = "2012-10-17", Effect = "Allow" })`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+
+	list, ok := got["policy"].([]any)
+	require.True(t, ok, "expected a list-wrapped map, got: %#v", got["policy"])
+	require.Len(t, list, 1)
+	elem, ok := list[0].(map[string]any)
+	require.True(t, ok, "expected a map element, got: %#v", list[0])
+	assert.Equal(t, "Allow", elem["Effect"])
+}
+
 // TestGetCtyValue_ConditionalExpr_UnboundVars verifies that ternaries
 // involving unbound variables return the references in the branches instead
 // of an empty list.


### PR DESCRIPTION
## Summary

A Terraform argument assigned with `jsonencode([ ... ])` (a JSON list) evaluated to an empty value in MQL, so a check iterating the encoded list saw nothing and passed vacuously (e.g. ECS `container_definitions` with a privileged container).

## Root cause

`getCtyValue` fully evaluates `jsonencode(...)` to a JSON string, then re-parses it. The unmarshal target was hardcoded to `map[string]any`:
- `jsonencode({map})` → JSON object → decodes fine → list-wrapped, indexable via `.first`.
- `jsonencode([list])` → JSON array → `json.Unmarshal` into `map[string]any` **fails**; the error was swallowed and the argument stayed empty.

## Fix

Decode into `any` (handles both objects and arrays) and append via the existing `appendCtyResult` helper. The object case stays list-wrapped as before; a decoded top-level list is flattened into the result, so the argument becomes an iterable list.

## Tests

Added to `hcl_test.go`:
- `jsonencode([{name="app", privileged=true}])` → iterable list whose element resolves (`name == "app"`, `privileged == true`)
- `jsonencode({...})` → still list-wrapped map (guards the preserved behavior)

Full `providers/terraform/resources` suite passes.

Fixes #9079
