### PR TITLE
🐛 terraform: resolve non-string ternary results to their scalar value

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -817,14 +817,19 @@ func getCtyValue(expr hcl.Expression, ctx *hcl.EvalContext) any {
 		}
 		return results
 	case *hclsyntax.ConditionalExpr:
-		results := []any{}
-		subVal, err := t.Value(ctx)
-		if err == nil && subVal.Type() == cty.String {
-			results = append(results, subVal.AsString())
-			return results
+		// When the whole ternary resolves to a concrete value (the condition
+		// and chosen branch are statically knowable, e.g. `var.x ? a : b` with
+		// var defaults in ctx), return that value. The previous fast path only
+		// accepted a string result, so a bool/number ternary — the natural
+		// output of `... ? true : false` — fell through to reference-surfacing
+		// and returned the branch list `[cond, true, false]` instead of the
+		// scalar, defeating a `!= true` scalar-equality check.
+		if subVal, diags := t.Value(ctx); !diags.HasErrors() && subVal.IsKnown() && !subVal.IsNull() {
+			return ctyValueToGo(subVal)
 		}
 		// Unbound variables/refs: surface the references in each branch so
 		// policies can still inspect what the conditional depends on.
+		results := []any{}
 		appendCtyResult(&results, getCtyValue(t.Condition, ctx))
 		appendCtyResult(&results, getCtyValue(t.TrueResult, ctx))
 		appendCtyResult(&results, getCtyValue(t.FalseResult, ctx))

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -332,6 +332,28 @@ func TestGetCtyValue_StaticTernaryStillEvaluates(t *testing.T) {
 		"static ternary should evaluate to 'yes', got: %#v", got["pick"])
 }
 
+// TestGetCtyValue_BoolTernary_Resolved is a regression test for #9078: a
+// ternary that resolves to a non-string (the natural `... ? true : false`
+// output) used to fall through to reference-surfacing and return the branch
+// list instead of the scalar, so a `!= true` scalar-equality check never
+// matched. With var defaults in the context it must resolve to the scalar.
+func TestGetCtyValue_BoolTernary_Resolved(t *testing.T) {
+	attrs := parseAttrs(t, `privileged_mode = var.privileged ? true : false`)
+	ctx := resolvingCtx(map[string]cty.Value{"privileged": cty.True}, nil)
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, got["privileged_mode"])
+}
+
+// TestGetCtyValue_StaticBoolTernary verifies a statically-knowable bool ternary
+// resolves to the scalar even without any variable context.
+func TestGetCtyValue_StaticBoolTernary(t *testing.T) {
+	attrs := parseAttrs(t, `enabled = true ? false : true`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+	assert.Equal(t, false, got["enabled"])
+}
+
 // TestHclAttributesToDict_NoUnknownTypeWarning regression-tests the customer
 // case: parsing a file with for-expressions, conditionals and index
 // expressions must not panic, must not return nil for any attribute, and


### PR DESCRIPTION
## Summary

The Terraform provider left conditional/ternary expressions (`cond ? a : b`) unresolved during HCL static analysis when the result was not a string. A scalar-equality assertion therefore compared against the ternary's *branch list* rather than the effective value, producing a false result.

```hcl
variable "privileged" { type = bool; default = true }
resource "aws_codebuild_project" "ternary" {
  environment { privileged_mode = var.privileged ? true : false }
}
```
A check asserting `privileged_mode != true` did not fire.

## Root cause

`getCtyValue`'s `ConditionalExpr` fast path only returned a value when `subVal.Type() == cty.String`. A bool/number ternary — the natural output of `... ? true : false` — failed that check and fell through to reference-surfacing, which returned the branch list `[cond, true, false]` instead of the scalar `true`. The eval context already carries `var` defaults (via the existing variable-resolution machinery), so `t.Value(ctx)` already evaluates the whole ternary correctly; only the string-only gate discarded the result.

## Fix

Return the fully-evaluated value (any type) via the existing `ctyValueToGo` helper when the ternary is statically knowable (`!diags.HasErrors() && IsKnown() && !IsNull()`). The reference-surfacing fallback is preserved for genuinely unresolved conditionals (unbound vars, data/resource refs).

## Tests

Added to `hcl_test.go`:
- `var.privileged ? true : false` with `var.privileged = true` in context → scalar `true`
- static `true ? false : true` → scalar `false`

The existing `TestGetCtyValue_StaticTernaryStillEvaluates` (string ternary) and `TestGetCtyValue_ConditionalExpr_UnboundVars` (fallback) stay green. Full `providers/terraform/resources` suite passes.

Note: this is distinct from #8753 (variable resolution in authenticated/platform scans); it fixes source-level ternaries whose result is non-string.

Fixes #9078
