### PR TITLE
🐛 terraform: surface dynamic block content as type == "X" blocks

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -1049,13 +1049,21 @@ func listHclBlocks(runtime *plugin.Runtime, rawBody any, file *hcl.File) ([]any,
 	switch body := rawBody.(type) {
 	case *hclsyntax.Body:
 		for i := range body.Blocks {
-			mqlBlock, err := newMqlHclBlock(runtime, body.Blocks[i].AsHCLBlock(), file)
-			if err != nil {
-				return nil, err
+			for _, hb := range normalizeHclSyntaxBlock(body.Blocks[i]) {
+				mqlBlock, err := newMqlHclBlock(runtime, hb, file)
+				if err != nil {
+					return nil, err
+				}
+				mqlHclBlocks = append(mqlHclBlocks, mqlBlock)
 			}
-			mqlHclBlocks = append(mqlHclBlocks, mqlBlock)
 		}
 	case hcl.Body:
+		// Native-syntax .tf files (where `dynamic "x" {}` blocks are written)
+		// always parse to *hclsyntax.Body above, so normalizeHclSyntaxBlock only
+		// needs to run there. This branch handles JSON-syntax HCL and plan/state
+		// bodies, which do not carry native `dynamic` blocks (JSON encodes them
+		// differently and PartialContent's typed schema would not surface them),
+		// so no normalization is applied here.
 		content, _, _ := body.PartialContent(connection.TerraformSchema_1)
 		for i := range content.Blocks {
 			mqlBlock, err := newMqlHclBlock(runtime, content.Blocks[i], file)
@@ -1069,6 +1077,36 @@ func listHclBlocks(runtime *plugin.Runtime, rawBody any, file *hcl.File) ([]any,
 	}
 
 	return mqlHclBlocks, nil
+}
+
+// normalizeHclSyntaxBlock expands a `dynamic "X"` block into the `content { ... }`
+// sub-blocks it generates, retyped as `X`, so `blocks.where(type == "X")` sees
+// them the same as a statically written `X { ... }` block. A dynamic block's
+// real fields live one level deeper inside `content`, and the block itself
+// parses as type=="dynamic"/nameLabel=="X" — without this normalization every
+// block-iterating check is blind to the (extremely common) dynamic form, so a
+// violation-detection check passes vacuously and a presence check false-fails.
+// Any non-dynamic block is returned unchanged; a malformed dynamic block with
+// no `content` sub-block falls back to itself rather than being dropped.
+func normalizeHclSyntaxBlock(block *hclsyntax.Block) []*hcl.Block {
+	if block.Type != "dynamic" || len(block.Labels) != 1 {
+		return []*hcl.Block{block.AsHCLBlock()}
+	}
+
+	var out []*hcl.Block
+	for _, inner := range block.Body.Blocks {
+		if inner.Type != "content" {
+			continue
+		}
+		hb := inner.AsHCLBlock()
+		hb.Type = block.Labels[0]
+		hb.Labels = nil
+		out = append(out, hb)
+	}
+	if len(out) == 0 {
+		return []*hcl.Block{block.AsHCLBlock()}
+	}
+	return out
 }
 
 func (g *mqlTerraformBlock) related() ([]any, error) {
@@ -1301,6 +1339,12 @@ func getBlockByName(hb *hcl.Block, name string) *hcl.Block {
 			}
 		}
 	case hcl.Body:
+		// Native-syntax .tf files (where `dynamic "x" {}` blocks are written)
+		// always parse to *hclsyntax.Body above, so normalizeHclSyntaxBlock only
+		// needs to run there. This branch handles JSON-syntax HCL and plan/state
+		// bodies, which do not carry native `dynamic` blocks (JSON encodes them
+		// differently and PartialContent's typed schema would not surface them),
+		// so no normalization is applied here.
 		content, _, _ := body.PartialContent(connection.TerraformSchema_1)
 		for i := range content.Blocks {
 			b := content.Blocks[i]

--- a/providers/terraform/resources/hcl_dynamic_test.go
+++ b/providers/terraform/resources/hcl_dynamic_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// TestTerraformBlocks_DynamicBlockUnwrapped is a regression test for #9077: a
+// `dynamic "ingress" { content { ... } }` block must surface as a
+// type == "ingress" block whose arguments are the content{} fields, so
+// blocks.where(type == "ingress") is not blind to the dynamic form.
+func TestTerraformBlocks_DynamicBlockUnwrapped(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+resource "aws_security_group" "ex" {
+  name = "allow-ssh"
+  dynamic "ingress" {
+    for_each = ["0.0.0.0/0"]
+    content {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+}
+`), 0o600))
+	rt := newRuntimeForDir(t, dir, nil)
+
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	list := args["list"].Value.([]any)
+	require.Len(t, list, 1)
+	sg := list[0].(*mqlTerraformBlock)
+
+	children, err := sg.blocks()
+	require.NoError(t, err)
+
+	var ingress *mqlTerraformBlock
+	for _, c := range children {
+		b := c.(*mqlTerraformBlock)
+		// The dynamic block is retyped to its label, so match on the block
+		// type (labels are cleared to mirror a statically written block).
+		if b.Type.Data == "ingress" {
+			ingress = b
+		}
+		require.NotEqual(t, "dynamic", b.Type.Data,
+			"the dynamic wrapper must not surface as a type==dynamic block")
+	}
+	require.NotNil(t, ingress, `dynamic "ingress" must appear as a type==ingress block`)
+
+	a, err := ingress.arguments()
+	require.NoError(t, err)
+	require.Equal(t, float64(22), a["from_port"])
+	require.Equal(t, float64(22), a["to_port"])
+	require.Equal(t, "tcp", a["protocol"])
+}
+
+// TestTerraformBlocks_StaticBlockUnaffected verifies a statically written block
+// still surfaces normally alongside the dynamic-block normalization.
+func TestTerraformBlocks_StaticBlockUnaffected(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+resource "aws_security_group" "ex" {
+  ingress {
+    from_port = 443
+    to_port   = 443
+  }
+}
+`), 0o600))
+	rt := newRuntimeForDir(t, dir, nil)
+
+	args, _, err := initTerraformResources(rt, map[string]*llx.RawData{})
+	require.NoError(t, err)
+	sg := args["list"].Value.([]any)[0].(*mqlTerraformBlock)
+
+	children, err := sg.blocks()
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	ingress := children[0].(*mqlTerraformBlock)
+	require.Equal(t, "ingress", ingress.Type.Data)
+
+	a, err := ingress.arguments()
+	require.NoError(t, err)
+	require.Equal(t, float64(443), a["from_port"])
+}


### PR DESCRIPTION
## Summary

The Terraform provider did not surface the body of a `dynamic "X"` block to `blocks.where(type == "X")`. A `dynamic "ingress" { content { ... } }` block parsed with `type == "dynamic"` and `nameLabel == "ingress"`, and its real fields sat one level deeper inside a `content` block. Any check iterating nested blocks with `blocks.where(type == "ingress")` was blind to the dynamic form — an extremely common real-world idiom.

- Violation-detection checks (`.all()`/`.none()`) passed **vacuously** on a violating `dynamic` config → false negative.
- Presence checks (`!= empty`/`.any()`) **failed** on a compliant `dynamic` config → false positive.

## Fix

Normalize `dynamic "X"` at the block-parsing choke point (`listHclBlocks`, the single funnel every `blocks` accessor routes through): expand each `dynamic "X"` block into the `content { ... }` sub-blocks it generates, retyped as `X` with labels cleared, so they surface identically to a statically written `X { ... }` block. Their `arguments()` then resolve the real fields.

Because nested `terraform.block.blocks()` also routes through `listHclBlocks`, deeply nested dynamic blocks are covered by the same change. A malformed `dynamic` block with no `content` sub-block falls back to itself rather than being dropped.

This is a structural normalization; it does not resolve `for_each` values, but it fixes the block-visibility issue behind the ~422 affected `blocks.where(type == "X")` checks at once.

## Tests

Added `hcl_dynamic_test.go` (e2e, through the real HCL connection):
- `dynamic "ingress"` surfaces as a `type == "ingress"` block whose `arguments` are the `content{}` fields (`from_port == 22`, …), and no `type == "dynamic"` block leaks through
- a statically written `ingress { ... }` block is unaffected

Full `providers/terraform/resources` suite passes.

Fixes #9077
