### PR TITLE
🎉 terraform-13.3.5

### DIFF
--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.4",
+	Version:   "13.3.5",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### terraform (13.3.5)
- 🐛 terraform: resolve non-string ternary results to their scalar value (#9085)
- 🐛 terraform: apply unary operators so negative literals keep their sign (#9083)
- bump: ranger-rpc v0.8.1 (#9061)
- 🧹 Update deps for mql and providers 20260713 (#9060)