### PR TITLE
🎉 aws-13.48.0, azure-13.31.0, gcp-13.31.1, digitalocean-13.13.1

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.47.0",
+	Version:         "13.48.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.30.0",
+	Version:   "13.31.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.13.0",
+	Version:         "13.13.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.31.0",
+	Version: "13.31.1",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Release version bumps for four providers.

| Provider | Bump | Version |
|---|---|---|
| aws | minor | 13.47.0 → **13.48.0** |
| azure | minor | 13.30.0 → **13.31.0** |
| gcp | patch | 13.31.0 → **13.31.1** |
| digitalocean | patch | 13.13.0 → **13.13.1** |

## Changes since last release

### aws (13.47.0 → 13.48.0)
- 🐛 aws: don't create blank singular resources from an empty asset ARN (#9089)
- ✨ bump cloud SDKs and surface new fields (aws/azure/stackit/digitalocean) (#9090)
- 🧹 aws: collapse 114 client getters into a generic factory (#8935)
- 🧹 aws: unify 27 tag→map converters onto one generic helper (#8937)

### azure (13.30.0 → 13.31.0)
- ✨ bump cloud SDKs and surface new fields (aws/azure/stackit/digitalocean) (#9090)
- ✨ Expose soft-deleted Recovery Services vaults and vault cost-management granularity (#9072)
- 🧹 bump azure armrecoveryservices/v3 v3.0.0 -> v3.1.0 (#9071)

### gcp (13.31.0 → 13.31.1)
- ✨ bump cloud SDKs and surface new fields (#9090)

### digitalocean (13.13.0 → 13.13.1)
- ✨ bump cloud SDKs and surface new fields (aws/azure/stackit/digitalocean) (#9090)
