### PR TITLE
🐛 propagate mondoo labels to every discovered asset generically

### DIFF
--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -398,11 +398,48 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 		}
 	}
 
+	// Providers only propagate provider-native labels (project labels, account
+	// tags) to the assets they discover. Mondoo-specific labels on the
+	// connecting asset (e.g. an integration MRN supplied via the inventory)
+	// must reach every discovered asset too, and this is the one spot all
+	// providers' discovery results pass through — including assets that are
+	// later consumed without ever being connected client-side.
+	propagateMondooLabelsToDiscoveredAssets(r.Provider.Connection)
+
 	if !r.Provider.Connection.Asset.Connections[0].DelayDiscovery {
 		r.Recording().EnsureAsset(r.Provider.Connection.Asset, r.Provider.Instance.ID, r.Provider.Connection.Id, asset.Connections[0])
 	}
 	// r.schema.prioritizeIDs(BuiltinCoreID, r.Provider.Instance.ID)
 	return nil
+}
+
+// propagateMondooLabelsToDiscoveredAssets merges the mondoo-specific labels
+// (`mondoo.com/*`) of a connection's asset into every asset that connection
+// discovered, including their direct RelatedAssets (upstream mints real asset
+// records from those, so a missing label there surfaces as an asset without
+// e.g. its integration MRN). This cascades through nested discovery: when a
+// discovered asset is connected later, its own connection re-runs this and
+// hands the labels down another level (e.g. org -> project -> instance).
+//
+// Note: only the first level of RelatedAssets is stamped for now — no
+// provider nests them deeper today. If that changes, this needs recursion
+// with cycle protection.
+func propagateMondooLabelsToDiscoveredAssets(conn *plugin.ConnectRes) {
+	if conn == nil || conn.Asset == nil || conn.Inventory == nil || conn.Inventory.Spec == nil {
+		return
+	}
+	for _, discovered := range conn.Inventory.Spec.Assets {
+		if discovered == nil {
+			continue
+		}
+		discovered.AddMondooLabels(conn.Asset)
+		for _, related := range discovered.RelatedAssets {
+			if related == nil {
+				continue
+			}
+			related.AddMondooLabels(conn.Asset)
+		}
+	}
 }
 
 func (r *Runtime) AssetUpdated(asset *inventory.Asset) {

--- a/providers/runtime_test.go
+++ b/providers/runtime_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	inventory "go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/recording"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
 	"go.uber.org/mock/gomock"
@@ -868,4 +870,60 @@ func mustIndex(t *testing.T, s, sub string) int {
 	}
 	t.Fatalf("substring %q not found in %q", sub, s)
 	return -1
+}
+
+func TestPropagateMondooLabelsToDiscoveredAssets(t *testing.T) {
+	connAsset := &inventory.Asset{
+		Labels: map[string]string{
+			"mondoo.com/integration-mrn": "//integration.api.mondoo.app/spaces/x/integrations/y",
+			"k8s.mondoo.com/something":   "val",
+			"some-plain-label":           "must-not-propagate",
+		},
+	}
+
+	t.Run("stamps mondoo labels on all discovered assets", func(t *testing.T) {
+		related := &inventory.Asset{Labels: map[string]string{"gcp-label": "raw"}}
+		conn := &plugin.ConnectRes{
+			Asset: connAsset,
+			Inventory: &inventory.Inventory{Spec: &inventory.InventorySpec{
+				Assets: []*inventory.Asset{
+					{Labels: map[string]string{"own-label": "kept"}, RelatedAssets: []*inventory.Asset{related}},
+					{}, // nil labels map
+				},
+			}},
+		}
+
+		propagateMondooLabelsToDiscoveredAssets(conn)
+
+		for _, discovered := range append(conn.Inventory.Spec.Assets, related) {
+			assert.Equal(t, "//integration.api.mondoo.app/spaces/x/integrations/y", discovered.Labels["mondoo.com/integration-mrn"])
+			assert.Equal(t, "val", discovered.Labels["k8s.mondoo.com/something"])
+			assert.NotContains(t, discovered.Labels, "some-plain-label")
+		}
+		assert.Equal(t, "kept", conn.Inventory.Spec.Assets[0].Labels["own-label"])
+		assert.Equal(t, "raw", related.Labels["gcp-label"])
+	})
+
+	t.Run("stamps only the first level of related assets", func(t *testing.T) {
+		nested := &inventory.Asset{}
+		related := &inventory.Asset{RelatedAssets: []*inventory.Asset{nested}}
+		conn := &plugin.ConnectRes{
+			Asset: connAsset,
+			Inventory: &inventory.Inventory{Spec: &inventory.InventorySpec{
+				Assets: []*inventory.Asset{{RelatedAssets: []*inventory.Asset{related}}},
+			}},
+		}
+
+		propagateMondooLabelsToDiscoveredAssets(conn)
+
+		assert.Equal(t, "val", related.Labels["k8s.mondoo.com/something"])
+		assert.NotContains(t, nested.Labels, "k8s.mondoo.com/something")
+	})
+
+	t.Run("tolerates nil connection, asset, and inventory", func(t *testing.T) {
+		propagateMondooLabelsToDiscoveredAssets(nil)
+		propagateMondooLabelsToDiscoveredAssets(&plugin.ConnectRes{})
+		propagateMondooLabelsToDiscoveredAssets(&plugin.ConnectRes{Asset: connAsset})
+		propagateMondooLabelsToDiscoveredAssets(&plugin.ConnectRes{Asset: connAsset, Inventory: &inventory.Inventory{}})
+	})
 }


### PR DESCRIPTION
## Problem

During GCP project scans, certain assets end up on the platform without the `mondoo.com/integration-mrn` label supplied via the inventory's root asset, so they aren't associated with their integration.

## Root cause

The generic propagation already exists client-side: `AssetExplorer.Connect` → `prepareAsset` → `Asset.AddMondooLabels` stamps every `mondoo.com/*` label from the scan's root asset onto each discovered asset *when it gets connected*, right before it's synced upstream. AWS assets only ever reach the platform through that path — which is why AWS needs no provider code and always works.

GCP has a second channel that bypasses the stamp: its discovery attaches the raw discovered list as `RelatedAssets` on the emitted project/folder asset. The platform mints real asset records from those related entries — carrying only the raw provider labels, no integration MRN. Any related asset that never gets an individually-synced scan afterwards (connect errors, non-scannable, filtered) keeps that label-less record. k8s and the OS provider (docker) also attach `RelatedAssets` and are exposed to the same gap; AWS never does.

## Fix

One generic client-side change, no provider or cnspec changes: at the end of `Runtime.Connect` — the single choke point every provider's discovery results pass through — stamp the connected asset's `mondoo.com/*` labels onto every asset in the discovered inventory, **including their direct `RelatedAssets`** (first level only for now — no provider nests them deeper today; noted in the code). An asset's non-mondoo labels are untouched; plain inventory labels do not propagate. Cascades through nested discovery (org → project → instance) and works with already-shipped provider binaries — cnspec picks it up via dep bump.

The previous GCP-only provider-side fix on this branch is dropped.

## Verification

- Unit tests: stamping incl. direct `RelatedAssets`, first-level-only behavior, plain labels excluded, nil tolerance (`go test ./providers/`).
- Live run against `mondoo-gcp-integration-test-1` with the **stock** gcp provider (built from main, 13.31.2) and only this core change, inventory root carrying `mondoo.com/integration-mrn` + a plain label:
  - discovered `gcp-project` asset: integration MRN ✓, plain label correctly absent ✓
  - the project's `related_assets` (gcp-compute-network): integration MRN ✓ (previously never labeled — these entries become asset records upstream)
  - discovered `gcp-compute-network` asset: integration MRN ✓

## Note

Old cnspec binaries in the field keep minting label-less related records until updated. A complementary server-side fix (inherit `mondoo.com/*` labels from the sync request's root assets when creating `Related` records) would make this version-proof; can follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

