### PR TITLE
🐛 Evaluate AI-agent skills for all users, not just one

### DIFF
--- a/providers/os/resources/ai_agents.go
+++ b/providers/os/resources/ai_agents.go
@@ -4,59 +4,11 @@
 package resources
 
 import (
-	"os"
 	"path/filepath"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
-
-// skillsFromDir reads SKILL.md files from subdirectories of skillsDir and
-// returns them as MQL resources of the given resourceType. This is the shared
-// implementation used by all simple skill-only agent resources.
-func skillsFromDir(runtime *plugin.Runtime, skillsDir, resourceType string) ([]interface{}, error) {
-	afs := connectionAfs(runtime)
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(runtime, resourceType, map[string]*llx.RawData{
-			"__id":         llx.StringData(resourceType + "/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
-}
 
 // --- Roo Code ---
 
@@ -71,10 +23,11 @@ func (r *mqlRoo) id() (string, error) {
 }
 
 func (r *mqlRoo) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "roo.skill")
+	return agentSkills(r.MqlRuntime, "roo.skill", r.ConfigPath.Data, defaultRooConfigDir,
+		filepath.Join(defaultRooConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlRooSkill) id() (string, error)     { return "roo.skill/" + r.Name.Data, nil }
+func (r *mqlRooSkill) id() (string, error)     { return "roo.skill/" + r.Source.Data, nil }
 func (r *mqlRooSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Cline ---
@@ -90,15 +43,14 @@ func (r *mqlCline) id() (string, error) {
 }
 
 func (r *mqlCline) skills() ([]interface{}, error) {
-	// Cline uses a shared ~/.agents/skills/ directory (not relative to its
-	// own ~/.cline config dir). This matches the vercel-labs/skills definition.
-	// When a custom configPath is provided, derive the skills path from the
-	// same parent directory to stay consistent.
-	skillsDir := filepath.Join(filepath.Dir(r.ConfigPath.Data), ".agents", "skills")
-	return skillsFromDir(r.MqlRuntime, skillsDir, "cline.skill")
+	// Cline reads skills from the shared ~/.agents/skills directory (not its own
+	// ~/.cline config dir), matching the vercel-labs/skills convention.
+	return agentSkills(r.MqlRuntime, "cline.skill", r.ConfigPath.Data, defaultClineConfigDir,
+		filepath.Join(".agents", "skills"),
+		filepath.Join(filepath.Dir(r.ConfigPath.Data), ".agents", "skills"))
 }
 
-func (r *mqlClineSkill) id() (string, error)     { return "cline.skill/" + r.Name.Data, nil }
+func (r *mqlClineSkill) id() (string, error)     { return "cline.skill/" + r.Source.Data, nil }
 func (r *mqlClineSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Kiro CLI ---
@@ -114,10 +66,11 @@ func (r *mqlKiro) id() (string, error) {
 }
 
 func (r *mqlKiro) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "kiro.skill")
+	return agentSkills(r.MqlRuntime, "kiro.skill", r.ConfigPath.Data, defaultKiroConfigDir,
+		filepath.Join(defaultKiroConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlKiroSkill) id() (string, error)     { return "kiro.skill/" + r.Name.Data, nil }
+func (r *mqlKiroSkill) id() (string, error)     { return "kiro.skill/" + r.Source.Data, nil }
 func (r *mqlKiroSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Continue ---
@@ -133,10 +86,11 @@ func (r *mqlContinuedev) id() (string, error) {
 }
 
 func (r *mqlContinuedev) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "continuedev.skill")
+	return agentSkills(r.MqlRuntime, "continuedev.skill", r.ConfigPath.Data, defaultContinueConfigDir,
+		filepath.Join(defaultContinueConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlContinuedevSkill) id() (string, error)     { return "continuedev.skill/" + r.Name.Data, nil }
+func (r *mqlContinuedevSkill) id() (string, error)     { return "continuedev.skill/" + r.Source.Data, nil }
 func (r *mqlContinuedevSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Trae ---
@@ -152,10 +106,11 @@ func (r *mqlTrae) id() (string, error) {
 }
 
 func (r *mqlTrae) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "trae.skill")
+	return agentSkills(r.MqlRuntime, "trae.skill", r.ConfigPath.Data, defaultTraeConfigDir,
+		filepath.Join(defaultTraeConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlTraeSkill) id() (string, error)     { return "trae.skill/" + r.Name.Data, nil }
+func (r *mqlTraeSkill) id() (string, error)     { return "trae.skill/" + r.Source.Data, nil }
 func (r *mqlTraeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- OpenCode ---
@@ -171,10 +126,11 @@ func (r *mqlOpencode) id() (string, error) {
 }
 
 func (r *mqlOpencode) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "opencode.skill")
+	return agentSkills(r.MqlRuntime, "opencode.skill", r.ConfigPath.Data, defaultOpenCodeConfigDir,
+		filepath.Join(defaultOpenCodeConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlOpencodeSkill) id() (string, error)     { return "opencode.skill/" + r.Name.Data, nil }
+func (r *mqlOpencodeSkill) id() (string, error)     { return "opencode.skill/" + r.Source.Data, nil }
 func (r *mqlOpencodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Pi ---
@@ -190,10 +146,11 @@ func (r *mqlPi) id() (string, error) {
 }
 
 func (r *mqlPi) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "pi.skill")
+	return agentSkills(r.MqlRuntime, "pi.skill", r.ConfigPath.Data, defaultPiConfigDir,
+		filepath.Join(defaultPiConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlPiSkill) id() (string, error)     { return "pi.skill/" + r.Name.Data, nil }
+func (r *mqlPiSkill) id() (string, error)     { return "pi.skill/" + r.Source.Data, nil }
 func (r *mqlPiSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Mistral Vibe ---
@@ -209,10 +166,11 @@ func (r *mqlMistralVibe) id() (string, error) {
 }
 
 func (r *mqlMistralVibe) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "mistral.vibe.skill")
+	return agentSkills(r.MqlRuntime, "mistral.vibe.skill", r.ConfigPath.Data, defaultMistralVibeConfigDir,
+		filepath.Join(defaultMistralVibeConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlMistralVibeSkill) id() (string, error)     { return "mistral.vibe.skill/" + r.Name.Data, nil }
+func (r *mqlMistralVibeSkill) id() (string, error)     { return "mistral.vibe.skill/" + r.Source.Data, nil }
 func (r *mqlMistralVibeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Antigravity (Google) ---
@@ -228,10 +186,11 @@ func (r *mqlAntigravity) id() (string, error) {
 }
 
 func (r *mqlAntigravity) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "antigravity.skill")
+	return agentSkills(r.MqlRuntime, "antigravity.skill", r.ConfigPath.Data, defaultAntigravityConfigDir,
+		filepath.Join(defaultAntigravityConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlAntigravitySkill) id() (string, error)     { return "antigravity.skill/" + r.Name.Data, nil }
+func (r *mqlAntigravitySkill) id() (string, error)     { return "antigravity.skill/" + r.Source.Data, nil }
 func (r *mqlAntigravitySkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- IBM Bob ---
@@ -247,10 +206,11 @@ func (r *mqlIbmBob) id() (string, error) {
 }
 
 func (r *mqlIbmBob) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "ibm.bob.skill")
+	return agentSkills(r.MqlRuntime, "ibm.bob.skill", r.ConfigPath.Data, defaultBobConfigDir,
+		filepath.Join(defaultBobConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlIbmBobSkill) id() (string, error)     { return "ibm.bob.skill/" + r.Name.Data, nil }
+func (r *mqlIbmBobSkill) id() (string, error)     { return "ibm.bob.skill/" + r.Source.Data, nil }
 func (r *mqlIbmBobSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- OpenClaw ---
@@ -266,10 +226,11 @@ func (r *mqlOpenclaw) id() (string, error) {
 }
 
 func (r *mqlOpenclaw) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "openclaw.skill")
+	return agentSkills(r.MqlRuntime, "openclaw.skill", r.ConfigPath.Data, defaultOpenClawConfigDir,
+		filepath.Join(defaultOpenClawConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlOpenclawSkill) id() (string, error)     { return "openclaw.skill/" + r.Name.Data, nil }
+func (r *mqlOpenclawSkill) id() (string, error)     { return "openclaw.skill/" + r.Source.Data, nil }
 func (r *mqlOpenclawSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Snowflake Cortex Code ---
@@ -285,11 +246,12 @@ func (r *mqlSnowflakeCortex) id() (string, error) {
 }
 
 func (r *mqlSnowflakeCortex) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "snowflake.cortex.skill")
+	return agentSkills(r.MqlRuntime, "snowflake.cortex.skill", r.ConfigPath.Data, defaultCortexConfigDir,
+		filepath.Join(defaultCortexConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
 func (r *mqlSnowflakeCortexSkill) id() (string, error) {
-	return "snowflake.cortex.skill/" + r.Name.Data, nil
+	return "snowflake.cortex.skill/" + r.Source.Data, nil
 }
 func (r *mqlSnowflakeCortexSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
@@ -306,10 +268,11 @@ func (r *mqlJunie) id() (string, error) {
 }
 
 func (r *mqlJunie) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "junie.skill")
+	return agentSkills(r.MqlRuntime, "junie.skill", r.ConfigPath.Data, defaultJunieConfigDir,
+		filepath.Join(defaultJunieConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlJunieSkill) id() (string, error)     { return "junie.skill/" + r.Name.Data, nil }
+func (r *mqlJunieSkill) id() (string, error)     { return "junie.skill/" + r.Source.Data, nil }
 func (r *mqlJunieSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Augment ---
@@ -325,10 +288,11 @@ func (r *mqlAugment) id() (string, error) {
 }
 
 func (r *mqlAugment) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "augment.skill")
+	return agentSkills(r.MqlRuntime, "augment.skill", r.ConfigPath.Data, defaultAugmentConfigDir,
+		filepath.Join(defaultAugmentConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlAugmentSkill) id() (string, error)     { return "augment.skill/" + r.Name.Data, nil }
+func (r *mqlAugmentSkill) id() (string, error)     { return "augment.skill/" + r.Source.Data, nil }
 func (r *mqlAugmentSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Warp ---
@@ -344,12 +308,13 @@ func (r *mqlWarp) id() (string, error) {
 }
 
 func (r *mqlWarp) skills() ([]interface{}, error) {
-	// Warp uses shared ~/.agents/skills/ directory
-	skillsDir := filepath.Join(filepath.Dir(r.ConfigPath.Data), ".agents", "skills")
-	return skillsFromDir(r.MqlRuntime, skillsDir, "warp.skill")
+	// Warp reads skills from the shared ~/.agents/skills directory.
+	return agentSkills(r.MqlRuntime, "warp.skill", r.ConfigPath.Data, defaultWarpConfigDir,
+		filepath.Join(".agents", "skills"),
+		filepath.Join(filepath.Dir(r.ConfigPath.Data), ".agents", "skills"))
 }
 
-func (r *mqlWarpSkill) id() (string, error)     { return "warp.skill/" + r.Name.Data, nil }
+func (r *mqlWarpSkill) id() (string, error)     { return "warp.skill/" + r.Source.Data, nil }
 func (r *mqlWarpSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Kilo Code ---
@@ -365,10 +330,11 @@ func (r *mqlKilocode) id() (string, error) {
 }
 
 func (r *mqlKilocode) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "kilocode.skill")
+	return agentSkills(r.MqlRuntime, "kilocode.skill", r.ConfigPath.Data, defaultKiloCodeConfigDir,
+		filepath.Join(defaultKiloCodeConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlKilocodeSkill) id() (string, error)     { return "kilocode.skill/" + r.Name.Data, nil }
+func (r *mqlKilocodeSkill) id() (string, error)     { return "kilocode.skill/" + r.Source.Data, nil }
 func (r *mqlKilocodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- OpenHands ---
@@ -384,10 +350,11 @@ func (r *mqlOpenhands) id() (string, error) {
 }
 
 func (r *mqlOpenhands) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "openhands.skill")
+	return agentSkills(r.MqlRuntime, "openhands.skill", r.ConfigPath.Data, defaultOpenHandsConfigDir,
+		filepath.Join(defaultOpenHandsConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlOpenhandsSkill) id() (string, error)     { return "openhands.skill/" + r.Name.Data, nil }
+func (r *mqlOpenhandsSkill) id() (string, error)     { return "openhands.skill/" + r.Source.Data, nil }
 func (r *mqlOpenhandsSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }
 
 // --- Qwen Code ---
@@ -403,8 +370,9 @@ func (r *mqlQwenCode) id() (string, error) {
 }
 
 func (r *mqlQwenCode) skills() ([]interface{}, error) {
-	return skillsFromDir(r.MqlRuntime, filepath.Join(r.ConfigPath.Data, "skills"), "qwen.code.skill")
+	return agentSkills(r.MqlRuntime, "qwen.code.skill", r.ConfigPath.Data, defaultQwenCodeConfigDir,
+		filepath.Join(defaultQwenCodeConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
-func (r *mqlQwenCodeSkill) id() (string, error)     { return "qwen.code.skill/" + r.Name.Data, nil }
+func (r *mqlQwenCodeSkill) id() (string, error)     { return "qwen.code.skill/" + r.Source.Data, nil }
 func (r *mqlQwenCodeSkill) sha256() (string, error) { return contentSHA256(r.Content.Data), nil }

--- a/providers/os/resources/ai_coding_tools.go
+++ b/providers/os/resources/ai_coding_tools.go
@@ -8,13 +8,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/types"
 	"sigs.k8s.io/yaml"
 )
 
@@ -166,36 +169,26 @@ func parseSkillMd(name, sourcePath, content string) skillInfo {
 	return info
 }
 
-// targetHomeDir resolves a real user's home directory on the target.
-// It prefers a currently logged-in user (via loggedInUsers / "who"),
-// falling back to the first non-system user if no one is logged in.
+// targetHomeDir resolves a single user's home as the anchor for a default
+// configPath: the logged-in user if any, else the first real user. Data that
+// must cover every account (e.g. agent skills) should use targetUserHomes.
 func targetHomeDir(runtime *plugin.Runtime) (string, error) {
-	usersResource, err := CreateResource(runtime, "users", map[string]*llx.RawData{})
+	users, err := targetUserHomes(runtime)
 	if err != nil {
-		return "", fmt.Errorf("cannot list users on target: %w", err)
-	}
-
-	userList := usersResource.(*mqlUsers).GetList()
-	if userList.Error != nil {
-		return "", fmt.Errorf("cannot list users on target: %w", userList.Error)
+		return "", err
 	}
 
 	conn := runtime.Connection.(shared.Connection)
 	loggedIn, _ := loggedInUsers(runtime, conn)
 
 	var fallback string
-	for _, u := range userList.Data {
-		user := u.(*mqlUser)
-		home := user.GetHome().Data
-		if home == "" || isSystemHomeDir(home) {
-			continue
-		}
+	for _, u := range users {
 		// Prefer a user that is currently logged in.
-		if loggedIn[user.GetName().Data] {
-			return home, nil
+		if loggedIn[u.name] {
+			return u.home, nil
 		}
 		if fallback == "" {
-			fallback = home
+			fallback = u.home
 		}
 	}
 
@@ -203,4 +196,128 @@ func targetHomeDir(runtime *plugin.Runtime) (string, error) {
 		return fallback, nil
 	}
 	return "", fmt.Errorf("no valid user home directory found on target")
+}
+
+// collectSkillFiles reads SKILL.md files from the subdirectories of each
+// skillsDir, deduped by source path. Unreadable dirs (missing or
+// permission-denied when scanning another user's home) are skipped.
+func collectSkillFiles(afs *afero.Afero, skillsDirs []string) []skillInfo {
+	var result []skillInfo
+	seen := map[string]struct{}{}
+	for _, skillsDir := range skillsDirs {
+		subdirs, err := listSubdirsAfero(afs, skillsDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Debug().Err(err).Str("path", skillsDir).Msg("skipping unreadable AI agent skills directory")
+			}
+			continue
+		}
+
+		for _, dir := range subdirs {
+			skillPath := filepath.Join(dir.path, "SKILL.md")
+			if _, ok := seen[skillPath]; ok {
+				continue
+			}
+			// Mark seen before reading so an unreadable file isn't retried when
+			// the same skills dir appears more than once.
+			seen[skillPath] = struct{}{}
+			data, err := afs.ReadFile(skillPath)
+			if err != nil {
+				continue
+			}
+			result = append(result, parseSkillMd(dir.name, skillPath, string(data)))
+		}
+	}
+	return result
+}
+
+// readSkillsFromDirs reads SKILL.md files across skillsDirs and returns them as
+// MQL resources of resourceType, keyed by source path so same-named skills from
+// different users are all reported.
+func readSkillsFromDirs(runtime *plugin.Runtime, skillsDirs []string, resourceType string) ([]interface{}, error) {
+	skills := collectSkillFiles(connectionAfs(runtime), skillsDirs)
+
+	result := make([]interface{}, 0, len(skills))
+	for _, skill := range skills {
+		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
+		for i, t := range skill.allowedTools {
+			allowedToolsAny[i] = t
+		}
+
+		res, err := NewResource(runtime, resourceType, map[string]*llx.RawData{
+			"__id":         llx.StringData(resourceType + "/" + skill.source),
+			"name":         llx.StringData(skill.name),
+			"description":  llx.StringData(skill.description),
+			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
+			"argumentHint": llx.StringData(skill.argumentHint),
+			"source":       llx.StringData(skill.source),
+			"content":      llx.StringData(skill.content),
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, res)
+	}
+	return result, nil
+}
+
+// resolvePerUserDirs resolves a per-user directory list for a resource.
+// homeRelDir is the directory relative to each home (e.g. ".cursor/skills").
+// When configPath is a per-user default — it matches home/defaultConfigDir for
+// some enumerated user — it returns homeRelDir under every user's home, deduped.
+// Otherwise (a custom configPath override, or no users could be enumerated) it
+// returns just overrideDir, honoring the override exactly.
+func resolvePerUserDirs(runtime *plugin.Runtime, configPath, defaultConfigDir, homeRelDir, overrideDir string) []string {
+	users, err := targetUserHomes(runtime)
+	if err != nil {
+		log.Debug().Err(err).Msg("cannot enumerate users; using configPath only")
+		return []string{overrideDir}
+	}
+
+	// Detect the default case first so the per-user list is built only when used.
+	// No match (including an empty user list) means a custom override.
+	isDefault := false
+	for _, u := range users {
+		if filepath.Join(u.home, defaultConfigDir) == configPath {
+			isDefault = true
+			break
+		}
+	}
+	if !isDefault {
+		return []string{overrideDir}
+	}
+
+	seen := map[string]struct{}{}
+	var dirs []string
+	for _, u := range users {
+		d := filepath.Join(u.home, homeRelDir)
+		if _, ok := seen[d]; ok {
+			continue
+		}
+		seen[d] = struct{}{}
+		dirs = append(dirs, d)
+	}
+	return dirs
+}
+
+// agentSkills reads an agent's skills across every user, honoring a configPath
+// override. For agents whose skills sit at a fixed path under each home.
+func agentSkills(runtime *plugin.Runtime, resourceType, configPath, defaultConfigDir, homeRelSkillsDir, overrideSkillsDir string) ([]interface{}, error) {
+	dirs := resolvePerUserDirs(runtime, configPath, defaultConfigDir, homeRelSkillsDir, overrideSkillsDir)
+	return readSkillsFromDirs(runtime, dirs, resourceType)
+}
+
+// skillsAllUsers reads skills from homeRelSkillsDir under every user's home, for
+// agents whose skills location is independent of configPath (e.g. Copilot).
+func skillsAllUsers(runtime *plugin.Runtime, homeRelSkillsDir, resourceType string) ([]interface{}, error) {
+	users, err := targetUserHomes(runtime)
+	if err != nil {
+		log.Debug().Err(err).Msg("cannot enumerate users for AI agent skills")
+		return nil, nil
+	}
+	dirs := make([]string, 0, len(users))
+	for _, u := range users {
+		dirs = append(dirs, filepath.Join(u.home, homeRelSkillsDir))
+	}
+	return readSkillsFromDirs(runtime, dirs, resourceType)
 }

--- a/providers/os/resources/ai_coding_tools_test.go
+++ b/providers/os/resources/ai_coding_tools_test.go
@@ -1,0 +1,107 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRealUserHome(t *testing.T) {
+	tests := []struct {
+		home string
+		want bool
+	}{
+		{"/home/alice", true},
+		{"/Users/bob", true},
+		{"/root", true},
+		{"/usr/home/carol", true}, // FreeBSD
+		{`C:\Users\dave`, true},
+		{"", false},
+		{"/var/lib/nobody", false},  // system
+		{"/Users/Shared", false},    // shared profile
+		{`C:\Users\Public`, false},  // shared profile
+		{`C:\Users\Default`, false}, // system profile
+		{"/nonexistent/prefix", false},
+	}
+	for _, tt := range tests {
+		assert.Equalf(t, tt.want, isRealUserHome(tt.home), "isRealUserHome(%q)", tt.home)
+	}
+}
+
+// denyFs wraps an afero.Fs and returns a permission error for any path under
+// deny, simulating an unprivileged scan of another user's home.
+type denyFs struct {
+	afero.Fs
+	deny string
+}
+
+func (d *denyFs) permErr(op, name string) error {
+	return &os.PathError{Op: op, Path: name, Err: os.ErrPermission}
+}
+
+func (d *denyFs) Open(name string) (afero.File, error) {
+	if strings.HasPrefix(name, d.deny) {
+		return nil, d.permErr("open", name)
+	}
+	return d.Fs.Open(name)
+}
+
+func (d *denyFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	if strings.HasPrefix(name, d.deny) {
+		return nil, d.permErr("open", name)
+	}
+	return d.Fs.OpenFile(name, flag, perm)
+}
+
+func (d *denyFs) Stat(name string) (os.FileInfo, error) {
+	if strings.HasPrefix(name, d.deny) {
+		return nil, d.permErr("stat", name)
+	}
+	return d.Fs.Stat(name)
+}
+
+func writeSkill(t *testing.T, fs afero.Fs, dir, name string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(dir+"/"+name, 0o755))
+	content := "---\nname: " + name + "\ndescription: " + name + " skill.\n---\n# " + name + "\n"
+	require.NoError(t, afero.WriteFile(fs, dir+"/"+name+"/SKILL.md", []byte(content), 0o644))
+}
+
+func TestCollectSkillFilesSkipsUnreadableDir(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	writeSkill(t, mem, "/home/alice/.cursor/skills", "readable")
+	writeSkill(t, mem, "/home/bob/.cursor/skills", "hidden")
+
+	// bob's home is unreadable (permission denied), alice's is fine.
+	afs := &afero.Afero{Fs: &denyFs{Fs: mem, deny: "/home/bob"}}
+
+	skills := collectSkillFiles(afs, []string{
+		"/home/alice/.cursor/skills",
+		"/home/bob/.cursor/skills",
+		"/home/carol/.cursor/skills", // missing entirely
+	})
+
+	require.Len(t, skills, 1, "should return only the readable user's skill")
+	assert.Equal(t, "readable", skills[0].name)
+	assert.Contains(t, skills[0].source, "/home/alice/")
+}
+
+func TestCollectSkillFilesDedupsSourcePaths(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	writeSkill(t, mem, "/home/alice/.cursor/skills", "foo")
+	afs := &afero.Afero{Fs: mem}
+
+	// same dir passed twice (e.g. default path == override path) yields one skill
+	skills := collectSkillFiles(afs, []string{
+		"/home/alice/.cursor/skills",
+		"/home/alice/.cursor/skills",
+	})
+	require.Len(t, skills, 1)
+}

--- a/providers/os/resources/claude_code.go
+++ b/providers/os/resources/claude_code.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spf13/afero"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
 
 const defaultClaudeCodeConfigDir = ".claude"
@@ -180,47 +179,8 @@ func (r *mqlClaudeCode) plugins() ([]interface{}, error) {
 }
 
 func (r *mqlClaudeCode) skills() ([]interface{}, error) {
-	afs := r.afs()
-	skillsDir := filepath.Join(r.configDir(), "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "claude.code.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("claude.code.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	return agentSkills(r.MqlRuntime, "claude.code.skill", r.configDir(), defaultClaudeCodeConfigDir,
+		filepath.Join(defaultClaudeCodeConfigDir, "skills"), filepath.Join(r.configDir(), "skills"))
 }
 
 func (r *mqlClaudeCode) projects() ([]interface{}, error) {
@@ -398,7 +358,7 @@ func (r *mqlClaudeCodePlugin) id() (string, error) {
 }
 
 func (r *mqlClaudeCodeSkill) id() (string, error) {
-	return "claude.code.skill/" + r.Name.Data, nil
+	return "claude.code.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlClaudeCodeSkill) sha256() (string, error) {

--- a/providers/os/resources/cursor.go
+++ b/providers/os/resources/cursor.go
@@ -112,47 +112,8 @@ func (r *mqlCursor) rules() ([]interface{}, error) {
 }
 
 func (r *mqlCursor) skills() ([]interface{}, error) {
-	afs := connectionAfs(r.MqlRuntime)
-	skillsDir := filepath.Join(r.ConfigPath.Data, "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "cursor.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("cursor.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	return agentSkills(r.MqlRuntime, "cursor.skill", r.ConfigPath.Data, defaultCursorConfigDir,
+		filepath.Join(defaultCursorConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
 // Child resource ID methods
@@ -166,7 +127,7 @@ func (r *mqlCursorRule) id() (string, error) {
 }
 
 func (r *mqlCursorSkill) id() (string, error) {
-	return "cursor.skill/" + r.Name.Data, nil
+	return "cursor.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlCursorSkill) sha256() (string, error) {

--- a/providers/os/resources/gemini.go
+++ b/providers/os/resources/gemini.go
@@ -91,47 +91,8 @@ func (r *mqlGemini) mcpServers() ([]interface{}, error) {
 }
 
 func (r *mqlGemini) skills() ([]interface{}, error) {
-	afs := connectionAfs(r.MqlRuntime)
-	skillsDir := filepath.Join(r.ConfigPath.Data, "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "gemini.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("gemini.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	return agentSkills(r.MqlRuntime, "gemini.skill", r.ConfigPath.Data, defaultGeminiConfigDir,
+		filepath.Join(defaultGeminiConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
 // Child resource ID methods
@@ -141,7 +102,7 @@ func (r *mqlGeminiMcpServer) id() (string, error) {
 }
 
 func (r *mqlGeminiSkill) id() (string, error) {
-	return "gemini.skill/" + r.Name.Data, nil
+	return "gemini.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlGeminiSkill) sha256() (string, error) {

--- a/providers/os/resources/github_copilot.go
+++ b/providers/os/resources/github_copilot.go
@@ -105,52 +105,8 @@ func (r *mqlGithubCopilot) mcpServers() ([]interface{}, error) {
 }
 
 func (r *mqlGithubCopilot) skills() ([]interface{}, error) {
-	afs := connectionAfs(r.MqlRuntime)
-	// Copilot skills live at ~/.copilot/skills/ (separate from config dir)
-	home, err := targetHomeDir(r.MqlRuntime)
-	if err != nil {
-		return nil, nil
-	}
-	skillsDir := filepath.Join(home, ".copilot", "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "github.copilot.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("github.copilot.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	// Copilot skills live at ~/.copilot/skills/, independent of the config dir.
+	return skillsAllUsers(r.MqlRuntime, filepath.Join(".copilot", "skills"), "github.copilot.skill")
 }
 
 // Child resource ID methods
@@ -164,7 +120,7 @@ func (r *mqlGithubCopilotMcpServer) id() (string, error) {
 }
 
 func (r *mqlGithubCopilotSkill) id() (string, error) {
-	return "github.copilot.skill/" + r.Name.Data, nil
+	return "github.copilot.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlGithubCopilotSkill) sha256() (string, error) {

--- a/providers/os/resources/goose.go
+++ b/providers/os/resources/goose.go
@@ -10,7 +10,6 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 	"sigs.k8s.io/yaml"
 )
 
@@ -100,48 +99,8 @@ func (r *mqlGoose) extensions() ([]interface{}, error) {
 }
 
 func (r *mqlGoose) skills() ([]interface{}, error) {
-	afs := connectionAfs(r.MqlRuntime)
-	// Goose skills live at $XDG_CONFIG_HOME/goose/skills/ (same base as config)
-	skillsDir := filepath.Join(r.ConfigPath.Data, "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "goose.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("goose.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	return agentSkills(r.MqlRuntime, "goose.skill", r.ConfigPath.Data, defaultGooseConfigDir,
+		filepath.Join(defaultGooseConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
 // Child resource ID methods
@@ -151,7 +110,7 @@ func (r *mqlGooseExtension) id() (string, error) {
 }
 
 func (r *mqlGooseSkill) id() (string, error) {
-	return "goose.skill/" + r.Name.Data, nil
+	return "goose.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlGooseSkill) sha256() (string, error) {

--- a/providers/os/resources/openai_codex.go
+++ b/providers/os/resources/openai_codex.go
@@ -152,51 +152,68 @@ func (r *mqlOpenaiCodex) plugins() ([]interface{}, error) {
 func (r *mqlOpenaiCodex) skills() ([]interface{}, error) {
 	afs := r.afs()
 	var result []interface{}
+	seen := map[string]struct{}{}
 
-	// Collect system skills
-	systemSkillsDir := filepath.Join(r.codexDir(), "skills", ".system")
-	if subdirs, err := listSubdirsAfero(afs, systemSkillsDir); err == nil {
-		for _, dir := range subdirs {
-			skillPath := filepath.Join(dir.path, "SKILL.md")
-			data, err := afs.ReadFile(skillPath)
-			if err != nil {
-				continue
-			}
-			skill := parseSkillMd(dir.name, skillPath, string(data))
-			res, err := newCodexSkillResource(r.MqlRuntime, skill, "system")
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, res)
-		}
-	}
-
-	// Collect plugin skills
-	pluginsDir := filepath.Join(r.codexDir(), ".tmp", "plugins", "plugins")
-	if pluginDirs, err := listSubdirsAfero(afs, pluginsDir); err == nil {
-		for _, pluginDir := range pluginDirs {
-			skillsDir := filepath.Join(pluginDir.path, "skills")
-			skillDirs, err := listSubdirsAfero(afs, skillsDir)
-			if err != nil {
-				continue
-			}
-			for _, skillDir := range skillDirs {
-				skillPath := filepath.Join(skillDir.path, "SKILL.md")
-				data, err := afs.ReadFile(skillPath)
-				if err != nil {
-					continue
-				}
-				skill := parseSkillMd(skillDir.name, skillPath, string(data))
-				res, err := newCodexSkillResource(r.MqlRuntime, skill, pluginDir.name)
+	for _, codexDir := range r.codexDirs() {
+		// system skills
+		systemSkillsDir := filepath.Join(codexDir, "skills", ".system")
+		if subdirs, err := listSubdirsAfero(afs, systemSkillsDir); err == nil {
+			for _, dir := range subdirs {
+				res, err := r.readCodexSkill(afs, dir.name, dir.path, "system", seen)
 				if err != nil {
 					return nil, err
 				}
-				result = append(result, res)
+				if res != nil {
+					result = append(result, res)
+				}
+			}
+		}
+
+		// plugin skills
+		pluginsDir := filepath.Join(codexDir, ".tmp", "plugins", "plugins")
+		if pluginDirs, err := listSubdirsAfero(afs, pluginsDir); err == nil {
+			for _, pluginDir := range pluginDirs {
+				skillDirs, err := listSubdirsAfero(afs, filepath.Join(pluginDir.path, "skills"))
+				if err != nil {
+					continue
+				}
+				for _, skillDir := range skillDirs {
+					res, err := r.readCodexSkill(afs, skillDir.name, skillDir.path, pluginDir.name, seen)
+					if err != nil {
+						return nil, err
+					}
+					if res != nil {
+						result = append(result, res)
+					}
+				}
 			}
 		}
 	}
 
 	return result, nil
+}
+
+// codexDirs returns the codex config dirs to scan: every user's ~/.codex, or
+// the explicit configPath override when it is not a per-user default.
+func (r *mqlOpenaiCodex) codexDirs() []string {
+	return resolvePerUserDirs(r.MqlRuntime, r.codexDir(), defaultCodexConfigDir, defaultCodexConfigDir, r.codexDir())
+}
+
+// readCodexSkill reads a single SKILL.md, deduping by source path. Returns nil
+// when the file is unreadable or already seen.
+func (r *mqlOpenaiCodex) readCodexSkill(afs *afero.Afero, name, dirPath, plugin string, seen map[string]struct{}) (*mqlOpenaiCodexSkill, error) {
+	skillPath := filepath.Join(dirPath, "SKILL.md")
+	if _, ok := seen[skillPath]; ok {
+		return nil, nil
+	}
+	// Mark seen before reading so an unreadable file isn't retried when the same
+	// path appears under more than one codex dir (matches collectSkillFiles).
+	seen[skillPath] = struct{}{}
+	data, err := afs.ReadFile(skillPath)
+	if err != nil {
+		return nil, nil
+	}
+	return newCodexSkillResource(r.MqlRuntime, parseSkillMd(name, skillPath, string(data)), plugin)
 }
 
 func (r *mqlOpenaiCodex) mcpServers() ([]interface{}, error) {
@@ -343,7 +360,7 @@ func (r *mqlOpenaiCodex) loadAuth() (*codexAuthJSON, error) {
 
 func newCodexSkillResource(runtime *plugin.Runtime, skill skillInfo, pluginName string) (*mqlOpenaiCodexSkill, error) {
 	res, err := NewResource(runtime, "openai.codex.skill", map[string]*llx.RawData{
-		"__id":        llx.StringData("openai.codex.skill/" + pluginName + "/" + skill.name),
+		"__id":        llx.StringData("openai.codex.skill/" + skill.source),
 		"name":        llx.StringData(skill.name),
 		"description": llx.StringData(skill.description),
 		"source":      llx.StringData(skill.source),
@@ -363,7 +380,7 @@ func (r *mqlOpenaiCodexPlugin) id() (string, error) {
 }
 
 func (r *mqlOpenaiCodexSkill) id() (string, error) {
-	return "openai.codex.skill/" + r.Plugin.Data + "/" + r.Name.Data, nil
+	return "openai.codex.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlOpenaiCodexSkill) sha256() (string, error) {

--- a/providers/os/resources/user_homes.go
+++ b/providers/os/resources/user_homes.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// targetUser is a real (non-system) user account on the target.
+type targetUser struct {
+	name string
+	home string
+	uid  int64
+}
+
+// sharedProfileLeaves are home leaf names for shared/system profiles, not real
+// users (e.g. /Users/Shared, C:\Users\Public).
+var sharedProfileLeaves = map[string]struct{}{
+	"shared":       {},
+	"public":       {},
+	"default":      {},
+	"default user": {},
+	"all users":    {},
+}
+
+// isRealUserHome reports whether home is a genuine per-user home. Superset of
+// the browser/editor filters: a known user-home prefix (incl. FreeBSD's
+// /usr/home) minus shared/system profile dirs.
+func isRealUserHome(home string) bool {
+	if isSystemHomeDir(home) {
+		return false
+	}
+	leaf := home
+	if i := strings.LastIndexAny(leaf, `/\`); i >= 0 {
+		leaf = leaf[i+1:]
+	}
+	if _, ok := sharedProfileLeaves[strings.ToLower(leaf)]; ok {
+		return false
+	}
+	return true
+}
+
+// targetUserHomes enumerates every real user on the target, deduped by home.
+// Shared basis for resources inspecting per-user state across all accounts
+// (browser/editor extensions, AI-agent skills). Missing uid defaults to -1.
+func targetUserHomes(runtime *plugin.Runtime) ([]targetUser, error) {
+	usersResource, err := CreateResource(runtime, "users", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list users on target: %w", err)
+	}
+
+	userList := usersResource.(*mqlUsers).GetList()
+	if userList.Error != nil {
+		return nil, fmt.Errorf("cannot list users on target: %w", userList.Error)
+	}
+
+	seen := map[string]struct{}{}
+	var result []targetUser
+	for _, u := range userList.Data {
+		user := u.(*mqlUser)
+		home := user.GetHome().Data
+		if !isRealUserHome(home) {
+			continue
+		}
+		if _, ok := seen[home]; ok {
+			continue
+		}
+		seen[home] = struct{}{}
+
+		uid := int64(-1)
+		if uidVal := user.GetUid(); uidVal.Error == nil {
+			uid = uidVal.Data
+		}
+		result = append(result, targetUser{name: user.GetName().Data, home: home, uid: uid})
+	}
+	return result, nil
+}

--- a/providers/os/resources/windsurf.go
+++ b/providers/os/resources/windsurf.go
@@ -110,48 +110,8 @@ func (r *mqlWindsurf) mcpServers() ([]interface{}, error) {
 }
 
 func (r *mqlWindsurf) skills() ([]interface{}, error) {
-	afs := connectionAfs(r.MqlRuntime)
-	// Windsurf skills live at ~/.codeium/windsurf/skills/
-	skillsDir := filepath.Join(r.ConfigPath.Data, "skills")
-
-	subdirs, err := listSubdirsAfero(afs, skillsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	var result []interface{}
-	for _, dir := range subdirs {
-		skillPath := filepath.Join(dir.path, "SKILL.md")
-		data, err := afs.ReadFile(skillPath)
-		if err != nil {
-			continue
-		}
-
-		skill := parseSkillMd(dir.name, skillPath, string(data))
-
-		allowedToolsAny := make([]interface{}, len(skill.allowedTools))
-		for i, t := range skill.allowedTools {
-			allowedToolsAny[i] = t
-		}
-
-		res, err := NewResource(r.MqlRuntime, "windsurf.skill", map[string]*llx.RawData{
-			"__id":         llx.StringData("windsurf.skill/" + dir.name),
-			"name":         llx.StringData(skill.name),
-			"description":  llx.StringData(skill.description),
-			"allowedTools": llx.ArrayData(allowedToolsAny, types.String),
-			"argumentHint": llx.StringData(skill.argumentHint),
-			"source":       llx.StringData(skill.source),
-			"content":      llx.StringData(skill.content),
-		})
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, res)
-	}
-	return result, nil
+	return agentSkills(r.MqlRuntime, "windsurf.skill", r.ConfigPath.Data, defaultWindsurfConfigDir,
+		filepath.Join(defaultWindsurfConfigDir, "skills"), filepath.Join(r.ConfigPath.Data, "skills"))
 }
 
 // Child resource ID methods
@@ -165,7 +125,7 @@ func (r *mqlWindsurfMcpServer) id() (string, error) {
 }
 
 func (r *mqlWindsurfSkill) id() (string, error) {
-	return "windsurf.skill/" + r.Name.Data, nil
+	return "windsurf.skill/" + r.Source.Data, nil
 }
 
 func (r *mqlWindsurfSkill) sha256() (string, error) {


### PR DESCRIPTION
## What

AI-agent `skills` resources (cursor, cline, warp, goose, claude.code, …) resolved their skills directory through `targetHomeDir()`, which returns **a single user's home** — the first logged-in user, else the first non-system user. Skills installed by any other user were never discovered, so the AI-security policy checks (`<agent>.skills.none()`) **silently under-reported on any multi-user host**. Browser/editor resources (chrome/firefox/vscode) already iterate all users; the newer AI-agent resources did not.

Fixes the coverage side of #9099.

## Changes

- **New shared helper `targetUserHomes()`** (`user_homes.go`) — enumerates every real user on the target, deduped, using a platform-agnostic superset home filter (`isRealUserHome`: valid home prefixes incl. FreeBSD's `/usr/home`, minus shared profiles like `/Users/Shared`, `C:\Users\Public`, `C:\Users\Default`). Deliberately general so chrome/firefox/vscode can migrate onto it in a follow-up (they currently hand-roll three near-duplicate loops).
- **All `skills()` accessors scan every user** via shared helpers:
  - `collectSkillFiles` (pure, afero-based) reads `SKILL.md` files, deduped **by source path** so identically named skills from different users are all reported.
  - `agentSkills` / `skillsAllUsers` are the one-line entry points each accessor calls.
- **Graceful failure:** a per-user skills dir that is missing *or* permission-denied (e.g. another user's home in an unprivileged scan) is logged at debug and skipped — it never fails the accessor. Only a total failure to list users returns an error.
- **`configPath` override preserved:** an explicit override that isn't any user's default scans only that path.
- Skill `__id`/`id()` switched to **source-path based** to prevent cross-user cache collisions (same-named skills from two users would otherwise dedupe to one).
- Removed four inline duplicate skill-scan loops and the old single-dir `skillsFromDir`.

## Scope

- **Skills only.** `mcpServers` / `rules` / `config` remain single-user (out of scope for #9099).
- **Browser/editor migration** onto `targetUserHomes` is a deliberate follow-up.
- Windows path correctness is tracked separately in #9100.

## Verification

- Unit tests (`ai_coding_tools_test.go`): `isRealUserHome` table, **permission-denied dir is skipped** (via a `denyFs` afero wrapper), and source-path dedup.
- Interactive (installed os provider): `cursor.skills` / `warp.skills` / `cline.skills` find real skills incl. the shared `~/.agents/skills`; an agent with no skills returns empty (no error); `configPath` override to a missing dir returns empty without falling back to all-users; an override matching a user's default triggers the all-users scan.
- `go build ./...`, `go vet`, full `go test ./resources/`, `gofmt`, and `golangci-lint run` (root + os module) all clean. No generated-file diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)