### PR TITLE
⚡ os: skip Firefox addon search for browsers that aren't installed

### DIFF
--- a/providers/os/resources/firefox.go
+++ b/providers/os/resources/firefox.go
@@ -187,6 +187,16 @@ func (f *mqlFirefox) addons() ([]any, error) {
 		for _, browserCfg := range configs {
 			browserDir := filepath.Join(homeDir, browserCfg.relPath)
 
+			// Skip browsers this user doesn't have installed. A recursive search
+			// is expensive on Windows, where files.find has no native backend and
+			// each call spawns a PowerShell process, so the vast majority of
+			// (user x browser) combinations would pay a process start-up just to
+			// learn the directory is absent.
+			// See https://github.com/mondoohq/mql/issues/9104
+			if !firefoxBrowserDirExists(afs, browserDir) {
+				continue
+			}
+
 			// Use files.find to efficiently search for extensions.json files
 			// Standard Firefox: BrowserDir/Profiles/profile_name/extensions.json (depth 3)
 			// Tor/Mullvad: BrowserDir/profile.default/extensions.json (depth 2)
@@ -324,6 +334,18 @@ func (f *mqlFirefox) addons() ([]any, error) {
 	}
 
 	return addons, nil
+}
+
+// firefoxBrowserDirExists reports whether a browser's profile directory is
+// present, treating an unreadable path or a non-directory as absent so the
+// caller skips the search rather than failing the whole resource.
+func firefoxBrowserDirExists(afs *afero.Afero, dir string) bool {
+	exists, err := afs.DirExists(dir)
+	if err != nil {
+		log.Debug().Err(err).Str("path", dir).Msg("could not check browser directory")
+		return false
+	}
+	return exists
 }
 
 // readFirefoxExtensionsJSON reads and parses a Firefox extensions.json file

--- a/providers/os/resources/firefox_test.go
+++ b/providers/os/resources/firefox_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -165,6 +166,41 @@ func TestFirefoxSystemAddonDetection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.isSystem, isFirefoxSystemAddon(tt.addon))
+		})
+	}
+}
+
+func TestFirefoxBrowserDirExists(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/home/user/.mozilla/firefox/Profiles/abc.default", 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/home/user/.librewolf", []byte("not a dir"), 0o644))
+	afs := &afero.Afero{Fs: fs}
+
+	tests := []struct {
+		name   string
+		dir    string
+		exists bool
+	}{
+		{
+			name:   "installed browser",
+			dir:    "/home/user/.mozilla/firefox",
+			exists: true,
+		},
+		{
+			name:   "browser not installed",
+			dir:    "/home/user/.mozilla/firefox-nightly",
+			exists: false,
+		},
+		{
+			name:   "path exists but is a file",
+			dir:    "/home/user/.librewolf",
+			exists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.exists, firefoxBrowserDirExists(afs, tt.dir))
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`firefox.addons` iterates every valid user home and, for each one, runs a `files.find` for **all 9** Firefox-based browser configs (Firefox, Dev Edition, Nightly, LibreWolf, Waterfox, Floorp, Zen, Tor, Mullvad), whether or not the browser is installed.

On Windows, `files.find` has no native backend for local connections (only tar/fs connections declare `Capability_FindFile`), so every one of those searches falls through to `windowsPowershellCmd()` and spawns a full PowerShell process running `Get-ChildItem -Recurse`. That is up to `9 x users` process start-ups per evaluation, and the large majority of them exist only to discover that the directory isn't there. PowerShell cold-start is expensive (worse under AV/AMSI), so on multi-profile machines such as terminal/RDS servers the cost compounds badly.

## Change

Stat the browser profile directory before issuing the recursive search, and skip the search when it isn't a directory — suggested fix 3 from the issue. An unreadable path or a non-directory counts as absent, so the resource skips that browser instead of failing.

`chrome.go` already guards its `files.find` calls with an `afs.DirExists` check on the browser directory, so despite the issue's expectation it needs no equivalent change.

## Verification

Measured on macOS, where the same loop shells out to `find` rather than PowerShell, counting process spawns with `--log-level debug` on a host with one valid user home and only Firefox installed:

| | `find` spawns |
|---|---|
| before | 9 |
| after | 1 |

Addon data is unchanged (`firefox.addons { name version browser }` still returns the installed extension). On Windows the same ratio applies to PowerShell spawns.

New unit test `TestFirefoxBrowserDirExists` covers the guard's three cases: installed browser, missing directory, and a path that exists but is a file. Full `providers/os/resources` package passes.

## Scope

Partial fix for #9104 — deliberately the conservative option. Browsers that *are* installed still pay one PowerShell spawn per (user x browser) on Windows. The issue's suggested fix 2 (a native Go walk for local Windows connections, which would benefit every `files.find` caller) is not attempted here; it needs the native backend's `name` handling fixed first, since `fsFilesFind` compiles `name` as a regex matched against the whole path while both command backends treat it as a glob on the basename — so `name: "extensions.json"` matches nothing natively today. That also means it should stay gated to Windows, as the walker ignores `-xdev`, which the unix `find` backend honors.
