### PR TITLE
✨ add "exclude" digests option

### DIFF
--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -87,6 +87,12 @@ Examples:
 					Desc:    "Filter out container images matching the given image references during discovery (comma-separated, glob supported)",
 				},
 				{
+					Long:    "digests-exclude",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Filter out container images matching the given digests during discovery (comma-separated)",
+				},
+				{
 					Long:    "kubelogin",
 					Type:    plugin.FlagType_Bool,
 					Default: "false",

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -90,7 +90,7 @@ Examples:
 					Long:    "digests-exclude",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "Filter out container images matching the given digests during discovery (comma-separated)",
+					Desc:    "Filter out container images matching the given digests during discovery (comma-separated, e.g. sha256:abc123)",
 				},
 				{
 					Long:    "kubelogin",

--- a/providers/k8s/connection/shared/connection.go
+++ b/providers/k8s/connection/shared/connection.go
@@ -24,6 +24,7 @@ const (
 	OPTION_NAMESPACE_EXCLUDE = "namespaces-exclude"
 	OPTION_IMAGES            = "images"
 	OPTION_IMAGES_EXCLUDE    = "images-exclude"
+	OPTION_DIGESTS_EXCLUDE   = "digests-exclude"
 	OPTION_ADMISSION         = "k8s-admission-review"
 	OPTION_OBJECT_KIND       = "object-kind"
 	OPTION_CONTEXT           = "context"

--- a/providers/k8s/resources/container_image_filter_test.go
+++ b/providers/k8s/resources/container_image_filter_test.go
@@ -81,3 +81,40 @@ func TestSetImageFiltersExcludeOnly(t *testing.T) {
 	assert.Empty(t, f.include)
 	assert.Equal(t, []string{"quay.io/*"}, f.exclude)
 }
+
+func TestDigestExcludeSet(t *testing.T) {
+	cfg := &inventory.Config{
+		Options: map[string]string{
+			shared.OPTION_DIGESTS_EXCLUDE: "sha256:abc123,sha256:def456",
+		},
+	}
+	set := digestExcludeSet(cfg)
+	assert.Contains(t, set, "sha256:abc123")
+	assert.Contains(t, set, "sha256:def456")
+	assert.NotContains(t, set, "sha256:other")
+}
+
+func TestDigestExcludeSetEmpty(t *testing.T) {
+	cfg := &inventory.Config{
+		Options: map[string]string{},
+	}
+	set := digestExcludeSet(cfg)
+	assert.Nil(t, set)
+}
+
+func TestExtractDigest(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		want     string
+	}{
+		{name: "standard digest ref", imageRef: "docker.io/library/nginx@sha256:abc123", want: "sha256:abc123"},
+		{name: "no digest", imageRef: "docker.io/library/nginx:latest", want: ""},
+		{name: "complex ref with digest", imageRef: "gcr.io/my-project/deep/path/app@sha256:deadbeef", want: "sha256:deadbeef"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractDigest(tt.imageRef))
+		})
+	}
+}

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -124,6 +124,7 @@ func discoverLegacy(runtime *plugin.Runtime, conn shared.Connection, invConfig *
 	if err != nil {
 		return nil, err
 	}
+	digestExclude := digestExcludeSet(invConfig)
 
 	resFilters, err := resourceFilters(invConfig)
 	if err != nil {
@@ -167,7 +168,7 @@ func discoverLegacy(runtime *plugin.Runtime, conn shared.Connection, invConfig *
 		od := NewPlatformIdOwnershipIndex(ns.PlatformIds[0])
 
 		// We don't want to discover the namespaces again since we have already done this above
-		assets, err := discoverAssets(runtime, conn, invConfig, ns.PlatformIds[0], k8s, nsFilter, resFilters, od, imgFilter)
+		assets, err := discoverAssets(runtime, conn, invConfig, ns.PlatformIds[0], k8s, nsFilter, resFilters, od, imgFilter, digestExclude)
 		if err != nil {
 			return nil, err
 		}
@@ -288,6 +289,7 @@ func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, inv
 	if err != nil {
 		return nil, err
 	}
+	digestExclude := digestExcludeSet(invConfig)
 
 	resFilters, err := resourceFilters(invConfig)
 	if err != nil {
@@ -307,7 +309,7 @@ func discoverNamespaceStage(runtime *plugin.Runtime, conn shared.Connection, inv
 
 	od := NewPlatformIdOwnershipIndex(namespacePlatformId)
 
-	assets, err := discoverAssets(runtime, conn, invConfig, namespacePlatformId, k8s, nsFilter, resFilters, od, imgFilter)
+	assets, err := discoverAssets(runtime, conn, invConfig, namespacePlatformId, k8s, nsFilter, resFilters, od, imgFilter, digestExclude)
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +328,7 @@ func discoverAssets(
 	resFilters *ResourceFilters,
 	od *PlatformIdOwnershipIndex,
 	imgFilter FilterOpts,
+	digestExclude map[string]struct{},
 ) ([]*inventory.Asset, error) {
 	var assets []*inventory.Asset
 	var err error
@@ -402,7 +405,7 @@ func discoverAssets(
 			assets = append(assets, list...)
 		}
 		if target == DiscoveryContainerImages || target == DiscoveryAll {
-			list, err = discoverContainerImages(conn, runtime, invConfig, k8s, nsFilter, imgFilter)
+			list, err = discoverContainerImages(conn, runtime, invConfig, k8s, nsFilter, imgFilter, digestExclude)
 			if err != nil {
 				return nil, err
 			}
@@ -1103,7 +1106,7 @@ func discoverNamespaces(
 	return assetList, nil
 }
 
-func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, invConfig *inventory.Config, k8s *mqlK8s, nsFilter FilterOpts, imgFilter FilterOpts) ([]*inventory.Asset, error) {
+func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, invConfig *inventory.Config, k8s *mqlK8s, nsFilter FilterOpts, imgFilter FilterOpts, digestExclude map[string]struct{}) ([]*inventory.Asset, error) {
 	pods := k8s.GetPods()
 	if pods.Error != nil {
 		return nil, pods.Error
@@ -1138,6 +1141,13 @@ func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, in
 	for _, i := range runningImages {
 		if imgFilter.skip(i.resolvedImage) {
 			continue
+		}
+		if digestExclude != nil {
+			if digest := extractDigest(i.resolvedImage); digest != "" {
+				if _, excluded := digestExclude[digest]; excluded {
+					continue
+				}
+			}
 		}
 		assetList = append(assetList, &inventory.Asset{
 			Connections: []*inventory.Config{
@@ -1416,6 +1426,26 @@ func setImageFilters(cfg *inventory.Config) (FilterOpts, error) {
 		return FilterOpts{}, fmt.Errorf("--images and --images-exclude are mutually exclusive")
 	}
 	return newFilterOpts(includeVals, excludeVals)
+}
+
+func digestExcludeSet(cfg *inventory.Config) map[string]struct{} {
+	vals := splitFilterValues(cfg.Options[shared.OPTION_DIGESTS_EXCLUDE])
+	if len(vals) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(vals))
+	for _, v := range vals {
+		set[v] = struct{}{}
+	}
+	return set
+}
+
+func extractDigest(imageRef string) string {
+	idx := strings.LastIndex(imageRef, "@")
+	if idx < 0 {
+		return ""
+	}
+	return imageRef[idx+1:]
 }
 
 func setNamespaceFilters(cfg *inventory.Config) (FilterOpts, error) {

--- a/providers/k8s/resources/discovery.go
+++ b/providers/k8s/resources/discovery.go
@@ -1142,11 +1142,9 @@ func discoverContainerImages(conn shared.Connection, runtime *plugin.Runtime, in
 		if imgFilter.skip(i.resolvedImage) {
 			continue
 		}
-		if digestExclude != nil {
-			if digest := extractDigest(i.resolvedImage); digest != "" {
-				if _, excluded := digestExclude[digest]; excluded {
-					continue
-				}
+		if digest := extractDigest(i.resolvedImage); digest != "" {
+			if _, excluded := digestExclude[digest]; excluded {
+				continue
 			}
 		}
 		assetList = append(assetList, &inventory.Asset{


### PR DESCRIPTION
This is mostly an optimization feature for apps such as mondoo operator, allowing skipping already scanned images. If user wishes to skip/include specific images, they should use images and images-exclude flags