### PR TITLE
🐛 os: fix rsyslog $IncludeConfig expansion matching nothing

### DIFF
--- a/providers-sdk/v1/testutils/testdata/arch.json
+++ b/providers-sdk/v1/testutils/testdata/arch.json
@@ -740,7 +740,7 @@
         },
         {
           "Resource": "files.find",
-          "ID": "/etc/rsyslog.d -xdev type=file name=^[^/]*\\.conf$ depth=1 permissions=0",
+          "ID": "/etc/rsyslog.d -xdev type=file depth=1 permissions=0",
           "Fields": {
             "list": {
               "type": "\u0019\u001bfile",

--- a/providers/os/resources/rsyslog.go
+++ b/providers/os/resources/rsyslog.go
@@ -191,48 +191,22 @@ func stripRsyslogComment(line string) string {
 }
 
 // resolveRsyslogInclude turns a (possibly relative, possibly globbed) include
-// pattern into a directory + basename-regex pair suitable for passing to
-// files.find. The returned regex is anchored on both ends and matches the
-// basename only. A pattern with no glob meta-characters resolves to a regex
-// that matches that single name exactly.
-func resolveRsyslogInclude(parentDir, pattern string) (dir, nameRegex string) {
+// pattern into the directory to search and the basename glob to match inside
+// it. A pattern with no glob meta-characters yields a glob that matches that
+// single name exactly.
+func resolveRsyslogInclude(parentDir, pattern string) (dir, baseGlob string) {
 	if !filepath.IsAbs(pattern) {
 		pattern = filepath.Join(parentDir, pattern)
 	}
-	dir = filepath.Dir(pattern)
-	base := filepath.Base(pattern)
-	return dir, "^" + globToRegex(base) + "$"
+	return filepath.Dir(pattern), filepath.Base(pattern)
 }
 
-// globToRegex converts a shell glob (the only metas rsyslog needs in
-// practice are `*`, `?`, and character classes) into a regular expression
-// suitable for files.find's `name` parameter, which is compiled as regexp.
-// Glob `*` becomes `[^/]*`, `?` becomes `[^/]`, `[abc]` is passed through.
-// Everything else is regex-escaped.
-func globToRegex(glob string) string {
-	var b strings.Builder
-	b.Grow(len(glob) + 4)
-	inClass := false
-	for i := 0; i < len(glob); i++ {
-		c := glob[i]
-		switch {
-		case inClass:
-			b.WriteByte(c)
-			if c == ']' {
-				inClass = false
-			}
-		case c == '[':
-			b.WriteByte(c)
-			inClass = true
-		case c == '*':
-			b.WriteString(`[^/]*`)
-		case c == '?':
-			b.WriteString(`[^/]`)
-		default:
-			b.WriteString(regexp.QuoteMeta(string(c)))
-		}
-	}
-	return b.String()
+// rsyslogIncludeMatches reports whether a path's basename satisfies an
+// include's glob. A malformed glob matches nothing, mirroring glob(3), which
+// reports no matches rather than failing.
+func rsyslogIncludeMatches(baseGlob, path string) bool {
+	ok, err := filepath.Match(baseGlob, filepath.Base(path))
+	return err == nil && ok
 }
 
 // maxRsyslogIncludeDepth bounds how many levels of nested includes we
@@ -343,16 +317,21 @@ func (s *mqlRsyslogConf) files(path string) ([]any, error) {
 // parentDir if not absolute) into the list of files it matches, using
 // files.find against the asset's filesystem.
 //
+// The glob is applied here rather than handed to files.find's `name`, whose
+// meaning differs by backend: the command backends read it as a glob on the
+// basename (`find -name`, PowerShell `-like`), while the native backend
+// compiles it as a regex matched against the whole path. Matching locally
+// keeps rsyslog's own glob(3) semantics identical on every connection type.
+//
 // depth=1 restricts the search to the immediate directory, matching
 // rsyslog's own glob(3) semantics: `$IncludeConfig /etc/rsyslog.d/*.conf`
 // does not pick up `/etc/rsyslog.d/nested/extra.conf`.
 func (s *mqlRsyslogConf) expandIncludePattern(parentDir, pattern string) ([]string, error) {
-	dir, nameRegex := resolveRsyslogInclude(parentDir, pattern)
+	dir, baseGlob := resolveRsyslogInclude(parentDir, pattern)
 
 	o, err := CreateResource(s.MqlRuntime, "files.find", map[string]*llx.RawData{
 		"from":  llx.StringData(dir),
 		"type":  llx.StringData("file"),
-		"name":  llx.StringData(nameRegex),
 		"depth": llx.IntData(1),
 	})
 	if err != nil {
@@ -366,9 +345,14 @@ func (s *mqlRsyslogConf) expandIncludePattern(parentDir, pattern string) ([]stri
 
 	paths := make([]string, 0, len(list.Data))
 	for _, item := range list.Data {
-		if mf, ok := item.(*mqlFile); ok {
-			paths = append(paths, mf.Path.Data)
+		mf, ok := item.(*mqlFile)
+		if !ok {
+			continue
 		}
+		if !rsyslogIncludeMatches(baseGlob, mf.Path.Data) {
+			continue
+		}
+		paths = append(paths, mf.Path.Data)
 	}
 	return paths, nil
 }

--- a/providers/os/resources/rsyslog_include_internal_test.go
+++ b/providers/os/resources/rsyslog_include_internal_test.go
@@ -1,0 +1,162 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// rsyslogFixtureFiles resolves rsyslog.conf.files against the include fixture
+// and returns the paths it reports.
+func rsyslogFixtureFiles(t *testing.T) []string {
+	t.Helper()
+
+	fixturePath, err := filepath.Abs("testdata/rsyslog_includes.toml")
+	require.NoError(t, err)
+
+	asset := &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "arch",
+			Family: []string{"linux", "unix"},
+		},
+	}
+	conn, err := mock.New(0, asset, mock.WithPath(fixturePath))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	raw, err := CreateResource(runtime, "rsyslog.conf", map[string]*llx.RawData{
+		"path": llx.StringData("/etc/rsyslog.conf"),
+	})
+	require.NoError(t, err)
+
+	files := raw.(*mqlRsyslogConf).GetFiles()
+	require.NoError(t, files.Error)
+
+	paths := make([]string, 0, len(files.Data))
+	for _, f := range files.Data {
+		paths = append(paths, f.(*mqlFile).Path.Data)
+	}
+	return paths
+}
+
+// $IncludeConfig patterns are globs, and they have to resolve for directories
+// other than the conventional `<conf>.d` — that one is also picked up by the
+// legacy fallback, which masks a broken include expansion.
+func TestRsyslogConf_IncludeExpansion(t *testing.T) {
+	paths := rsyslogFixtureFiles(t)
+
+	t.Run("reports every included file exactly once", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{
+			"/etc/rsyslog.conf",
+			"/etc/rsyslog.d/50-default.conf",
+			"/etc/rsyslog.extra/10-site.conf",
+			"/etc/rsyslog.single.conf",
+			"/etc/rsyslog.deep/90-deep.conf",
+		}, paths)
+	})
+
+	t.Run("expands a glob outside the conventional .d directory", func(t *testing.T) {
+		assert.Contains(t, paths, "/etc/rsyslog.extra/10-site.conf")
+	})
+
+	t.Run("applies the glob to the listing", func(t *testing.T) {
+		assert.NotContains(t, paths, "/etc/rsyslog.extra/notes.txt",
+			"notes.txt shares the directory but does not match *.conf")
+	})
+
+	t.Run("an exact include pulls in only the named file", func(t *testing.T) {
+		assert.Contains(t, paths, "/etc/rsyslog.single.conf")
+		assert.NotContains(t, paths, "/etc/other.conf",
+			"other.conf shares /etc with the include target but was not named")
+	})
+
+	t.Run("follows includes nested inside a fragment", func(t *testing.T) {
+		assert.Contains(t, paths, "/etc/rsyslog.deep/90-deep.conf")
+	})
+
+	t.Run("skips an include pointing at a missing directory", func(t *testing.T) {
+		// /etc/rsyslog.absent has no recorded listing. The walk must carry on
+		// and still report the files it could resolve.
+		for _, p := range paths {
+			assert.NotContains(t, p, "rsyslog.absent")
+		}
+		assert.Contains(t, paths, "/etc/rsyslog.conf")
+	})
+}
+
+func TestRsyslogIncludeMatches(t *testing.T) {
+	tests := []struct {
+		name  string
+		glob  string
+		match []string // full paths that should match
+		miss  []string // full paths that should NOT match
+	}{
+		{
+			name:  "star",
+			glob:  "*.conf",
+			match: []string{"/etc/rsyslog.d/foo.conf", "/etc/rsyslog.d/00-local.conf", "/etc/rsyslog.d/.conf"},
+			miss:  []string{"/etc/rsyslog.d/foo.conf.bak", "/etc/rsyslog.d/foo"},
+		},
+		{
+			name:  "question mark",
+			glob:  "0?-local.conf",
+			match: []string{"/etc/rsyslog.d/00-local.conf", "/etc/rsyslog.d/0a-local.conf"},
+			miss:  []string{"/etc/rsyslog.d/000-local.conf", "/etc/rsyslog.d/0-local.conf"},
+		},
+		{
+			name:  "character class",
+			glob:  "[0-9]*.conf",
+			match: []string{"/etc/rsyslog.d/0foo.conf", "/etc/rsyslog.d/9.conf"},
+			miss:  []string{"/etc/rsyslog.d/afoo.conf"},
+		},
+		{
+			name:  "regex metacharacters in the pattern are literal",
+			glob:  "foo.bar+.conf",
+			match: []string{"/etc/rsyslog.d/foo.bar+.conf"},
+			miss:  []string{"/etc/rsyslog.d/fooxbar+.conf", "/etc/rsyslog.d/foo.bar.conf"},
+		},
+		{
+			name:  "no metas",
+			glob:  "local.conf",
+			match: []string{"/etc/rsyslog.d/local.conf"},
+			miss:  []string{"/etc/rsyslog.d/localxconf", "/etc/rsyslog.d/local.conf.bak"},
+		},
+		{
+			name:  "matches the basename, not the directory",
+			glob:  "*.conf",
+			match: []string{"/etc/rsyslog.d/sub/foo.conf", "/foo.conf"},
+			miss:  []string{"/etc/foo.conf/bar"},
+		},
+		{
+			name:  "malformed glob matches nothing",
+			glob:  "[",
+			match: nil,
+			miss:  []string{"/etc/rsyslog.d/[", "/etc/rsyslog.d/foo.conf"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, m := range tt.match {
+				assert.True(t, rsyslogIncludeMatches(tt.glob, m), "expected %q to match glob %q", m, tt.glob)
+			}
+			for _, m := range tt.miss {
+				assert.False(t, rsyslogIncludeMatches(tt.glob, m), "expected %q NOT to match glob %q", m, tt.glob)
+			}
+		})
+	}
+}

--- a/providers/os/resources/rsyslog_internal_test.go
+++ b/providers/os/resources/rsyslog_internal_test.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
@@ -291,107 +290,69 @@ func TestCountUnquotedParens(t *testing.T) {
 	}
 }
 
-func TestGlobToRegex(t *testing.T) {
-	tests := []struct {
-		name  string
-		glob  string
-		want  string
-		match []string // basenames that should match the resulting regex (with anchors)
-		miss  []string // basenames that should NOT match
-	}{
-		{
-			name:  "star",
-			glob:  "*.conf",
-			want:  `[^/]*\.conf`,
-			match: []string{"foo.conf", "00-local.conf", ".conf"},
-			miss:  []string{"foo.conf.bak", "foo", "sub/foo.conf"},
-		},
-		{
-			name:  "question mark",
-			glob:  "0?-local.conf",
-			want:  `0[^/]-local\.conf`,
-			match: []string{"00-local.conf", "0a-local.conf"},
-			miss:  []string{"000-local.conf", "0-local.conf"},
-		},
-		{
-			name:  "character class passed through",
-			glob:  "[0-9]*.conf",
-			want:  `[0-9][^/]*\.conf`,
-			match: []string{"0foo.conf", "9.conf"},
-			miss:  []string{"afoo.conf"},
-		},
-		{
-			name:  "regex meta in literal portion is escaped",
-			glob:  "foo.bar+.conf",
-			want:  `foo\.bar\+\.conf`,
-			match: []string{"foo.bar+.conf"},
-			miss:  []string{"fooxbar+.conf", "foo.bar.conf"},
-		},
-		{
-			name:  "no metas",
-			glob:  "local.conf",
-			want:  `local\.conf`,
-			match: []string{"local.conf"},
-			miss:  []string{"localxconf"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := globToRegex(tt.glob)
-			assert.Equal(t, tt.want, got)
-			anchored := regexp.MustCompile("^" + got + "$")
-			for _, m := range tt.match {
-				assert.True(t, anchored.MatchString(m), "expected %q to match %q", m, "^"+got+"$")
-			}
-			for _, m := range tt.miss {
-				assert.False(t, anchored.MatchString(m), "expected %q NOT to match %q", m, "^"+got+"$")
-			}
-		})
-	}
-}
-
 func TestResolveRsyslogInclude(t *testing.T) {
 	tests := []struct {
 		name      string
 		parentDir string
 		pattern   string
 		wantDir   string
-		wantName  string
+		wantGlob  string
 	}{
 		{
 			name:      "absolute path with glob",
 			parentDir: "/etc",
 			pattern:   "/etc/rsyslog.d/*.conf",
 			wantDir:   "/etc/rsyslog.d",
-			wantName:  `^[^/]*\.conf$`,
+			wantGlob:  "*.conf",
 		},
 		{
 			name:      "absolute path with no glob",
 			parentDir: "/etc",
 			pattern:   "/etc/rsyslog.d/00-local.conf",
 			wantDir:   "/etc/rsyslog.d",
-			wantName:  `^00-local\.conf$`,
+			wantGlob:  "00-local.conf",
 		},
 		{
 			name:      "relative path is anchored at parent dir",
 			parentDir: "/etc/rsyslog.d",
 			pattern:   "local.conf",
 			wantDir:   "/etc/rsyslog.d",
-			wantName:  `^local\.conf$`,
+			wantGlob:  "local.conf",
 		},
 		{
 			name:      "relative path with subdir",
 			parentDir: "/etc/rsyslog.d",
 			pattern:   "extras/local.conf",
 			wantDir:   "/etc/rsyslog.d/extras",
-			wantName:  `^local\.conf$`,
+			wantGlob:  "local.conf",
+		},
+		{
+			name:      "relative path with glob",
+			parentDir: "/etc/rsyslog.d",
+			pattern:   "extras/*.conf",
+			wantDir:   "/etc/rsyslog.d/extras",
+			wantGlob:  "*.conf",
+		},
+		{
+			name:      "glob metacharacters are left intact for the matcher",
+			parentDir: "/etc",
+			pattern:   "/etc/rsyslog.d/[0-9]?-local.conf",
+			wantDir:   "/etc/rsyslog.d",
+			wantGlob:  "[0-9]?-local.conf",
+		},
+		{
+			name:      "parent traversal is cleaned",
+			parentDir: "/etc/rsyslog.d",
+			pattern:   "../rsyslog.extra/*.conf",
+			wantDir:   "/etc/rsyslog.extra",
+			wantGlob:  "*.conf",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, name := resolveRsyslogInclude(tt.parentDir, tt.pattern)
+			dir, glob := resolveRsyslogInclude(tt.parentDir, tt.pattern)
 			assert.Equal(t, tt.wantDir, dir)
-			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantGlob, glob)
 		})
 	}
 }

--- a/providers/os/resources/testdata/rsyslog_includes.toml
+++ b/providers/os/resources/testdata/rsyslog_includes.toml
@@ -1,0 +1,94 @@
+# A Linux host exercising every shape of rsyslog include:
+#
+#   * the conventional /etc/rsyslog.d/*.conf
+#   * a site-specific directory outside the conventional .d
+#   * a nested include, reached from a fragment rather than the main conf
+#   * an exact filename with no glob metacharacters
+#   * a directory that doesn't exist on the host
+#
+# The recorded `find` output is what a real host returns for each command.
+# /etc/rsyslog.extra holds a notes.txt that does not match the include's
+# `*.conf`, and /etc holds unrelated files that the exact-name include must not
+# drag in, so the glob has to be applied to each listing.
+#
+# /etc/rsyslog.absent has no recorded `find`, standing in for an include
+# pointing at a directory that isn't there.
+
+[files."/etc/rsyslog.conf"]
+path = "/etc/rsyslog.conf"
+content = """$ModLoad imuxsock
+
+*.info;mail.none /var/log/messages
+
+# Standard fragment directory
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Site-specific fragments, outside the conventional .d directory
+$IncludeConfig /etc/rsyslog.extra/*.conf
+
+# A single file, no glob metacharacters
+$IncludeConfig /etc/rsyslog.single.conf
+
+# A directory that does not exist on this host
+$IncludeConfig /etc/rsyslog.absent/*.conf
+"""
+
+[files."/etc/rsyslog.d/50-default.conf"]
+path = "/etc/rsyslog.d/50-default.conf"
+content = """kern.* /var/log/kern.log
+"""
+
+# Reached from the main conf, and pulls in a further directory itself.
+[files."/etc/rsyslog.extra/10-site.conf"]
+path = "/etc/rsyslog.extra/10-site.conf"
+content = """local0.* /var/log/site.log
+
+$IncludeConfig /etc/rsyslog.deep/*.conf
+"""
+
+# Shares a directory with 10-site.conf but doesn't match `*.conf`.
+[files."/etc/rsyslog.extra/notes.txt"]
+path = "/etc/rsyslog.extra/notes.txt"
+content = """not a config fragment
+"""
+
+[files."/etc/rsyslog.single.conf"]
+path = "/etc/rsyslog.single.conf"
+content = """local1.* /var/log/single.log
+"""
+
+[files."/etc/rsyslog.deep/90-deep.conf"]
+path = "/etc/rsyslog.deep/90-deep.conf"
+content = """local2.* /var/log/deep.log
+"""
+
+# Lives in /etc alongside the exact-name include target; must not be included.
+[files."/etc/other.conf"]
+path = "/etc/other.conf"
+content = """unrelated
+"""
+
+# Include expansion: list the immediate directory.
+[commands."find -L \"/etc/rsyslog.d\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.d/50-default.conf
+"""
+
+[commands."find -L \"/etc/rsyslog.extra\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.extra/10-site.conf
+/etc/rsyslog.extra/notes.txt
+"""
+
+[commands."find -L \"/etc/rsyslog.deep\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.deep/90-deep.conf
+"""
+
+[commands."find -L \"/etc\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.conf
+/etc/rsyslog.single.conf
+/etc/other.conf
+"""
+
+# Legacy `<conf>.d` auto-discovery, which runs regardless of the includes.
+[commands."find -L \"/etc/rsyslog.d\" -xdev -type f -perm -0"]
+stdout = """/etc/rsyslog.d/50-default.conf
+"""


### PR DESCRIPTION
## Problem

`rsyslog.conf`'s `$IncludeConfig` expansion resolved to **nothing**, on every backend.

`expandIncludePattern` converted the include's glob into a regex (`globToRegex`) and passed it to `files.find`'s `name` parameter, on the belief — stated in the code comment — that `name` "is compiled as regexp". It isn't a regex on any backend:

- **Command backends** (local/ssh unix, windows): `name` is a **glob matched against the basename** (`find -name`, PowerShell `-like $_.Name`). `find -name '^[^/]*\.conf$'` looks for a file literally named that.
- **Native backend** (tar/fs/device connections): `name` is compiled as a **regex matched against the whole path** (`files.go:129-133`; `fsutil` requires `FindString(path) == path`). A basename pattern such as `^[^/]*\.conf$` cannot match `/etc/rsyslog.d/50-default.conf` — the `[^/]*` forbids the separators.

Verified against the real `find` path:

```
files.find(from: <dir>, type: 'file', name: '*.conf')          -> 2 files
files.find(from: <dir>, type: 'file', name: '^[^/]*\.conf$')   -> []
```

The bug was invisible because the legacy `<conf>.d` auto-discovery lists that directory *unfiltered*, so the conventional `$IncludeConfig /etc/rsyslog.d/*.conf` layout still produced the right file list via the fallback. What was silently dropped from `rsyslog.conf.files` — and therefore from the aggregated `content` and `settings` — was:

- includes pointing at any directory other than `<conf>.d` (site-specific fragment dirs)
- includes naming a single file with no glob metacharacters
- includes nested inside a fragment

## Change

List the directory with `files.find` and apply the glob locally via `filepath.Match` on the basename. This keeps rsyslog's own glob(3) semantics identical on every connection type instead of depending on a backend's reading of `name`. `globToRegex` is deleted.

Passing the glob through as `name` instead would fix the command backends but leave the native ones broken; matching locally is the only form that works for both without reconciling `name`'s split meaning first.

Side effect: includes targeting the same directory now share one `files.find` (identical resource id, so it hits the resource cache) rather than issuing one search per distinct pattern. The tradeoff is that filtering moves off the host, so a listing returns the directory's files rather than just the matches — bounded by one directory at `depth: 1`, and the command count is unchanged.

## Why tests didn't catch it

`arch.json` records at the **`files.find` resource level**, and its entry for the buggy query id was hand-written to return the fragment — encoding the intended answer for a query that returns nothing on a real host. The test and the code agreed with each other while both disagreed with `find`. `TestGlobToRegex` only asserted the generated regex string, never running a search.

That entry is corrected to the id the fixed code issues. The new coverage uses a **command-level** fixture (`testdata/rsyslog_includes.toml`), where the recorded key is the actual `find` command and the output is what a real host returns — so the command construction is tested honestly.

## Tests

`TestRsyslogConf_IncludeExpansion` drives `rsyslog.conf.files` end-to-end against a host with every include shape, asserting:

| Case | Assertion |
|---|---|
| glob outside the conventional `.d` | `/etc/rsyslog.extra/10-site.conf` is reported |
| glob applied to the listing | `notes.txt`, sharing that directory, is not |
| exact include, no metacharacters | `/etc/rsyslog.single.conf` is reported... |
| ...without dragging in the directory | ...and `/etc/other.conf` is not |
| include nested inside a fragment | `/etc/rsyslog.deep/90-deep.conf` is reported |
| include of a missing directory | skipped, walk continues, no error |

It fails on the pre-fix code exactly as the production bug behaves: the `.d` fragment is still present (found by the fallback, not the include) while the non-`.d` fragment is silently missing.

`TestRsyslogIncludeMatches` carries over every case from the deleted `TestGlobToRegex` (`*`, `?`, character classes, regex metacharacters as literals, exact names) plus basename-vs-directory matching and a malformed glob, which matches nothing rather than erroring — mirroring glob(3). `TestResolveRsyslogInclude` is updated for the `(dir, baseGlob)` contract and gains relative-glob, metacharacter-passthrough, and parent-traversal cases.

Full `providers/os/resources` package passes.

## Context

Found while investigating #9104 (`files.find` backend selection on Windows). Independent of that issue and of #9105; no overlap in files.

The underlying `name` split-brain remains: it is a basename glob on the command backends and a full-path regex natively, so **only a literal filename is safe today** — which is what `firefox.go` and `chrome.go` pass, and why they work on local/ssh but would return nothing natively. That is worth reconciling separately, and is a prerequisite for the native-walk option in #9104.
