### PR TITLE
🎉 os-13.35.2

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.35.1",
+	Version: "13.35.2",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.35.2)
- 🧹 Migrate browser/editor resources onto shared targetUserHomes helper (#9103)
- 🐛 Evaluate AI-agent skills for all users, not just one (#9102)
- ⚡ os: skip Firefox addon search for browsers that aren't installed (#9105)