### PR TITLE
✨ providers: report subprocess exit status and peak RSS in crash diagnostics

### DIFF
--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -346,7 +346,6 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			Logger: pluginLogger,
 			Stderr: crashLog,
 		})
-		procTracker.track(client, pluginCmd)
 
 		// Connect via RPC
 		rpcClient, err := client.Client()
@@ -362,6 +361,12 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			client.Kill()
 			return nil, nil, errors.Wrap(err, "failed to call "+pluginName+" plugin")
 		}
+
+		// Track only after the handshake succeeds: a failed reconnect
+		// attempt must not re-point the tracker away from the previous
+		// (crashed) subprocess, whose exit disposition is what crash
+		// diagnostics still need to report.
+		procTracker.track(client, pluginCmd)
 
 		return raw.(pp.ProviderPlugin), client, nil
 	}

--- a/providers/coordinator.go
+++ b/providers/coordinator.go
@@ -324,6 +324,11 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	// restarts triggered by RestartableProvider.Reconnect().
 	crashLog := newCrashLogBuffer(logger.LogOutputWriter, defaultCrashLogLines)
 
+	// procTracker follows the current plugin subprocess (across restarts) so
+	// crash diagnostics can report how it died: exit code vs. signal
+	// (SIGKILL with empty stderr ≈ OOM killer) and peak RSS.
+	procTracker := &processTracker{}
+
 	connectFunc := func() (pp.ProviderPlugin, *plugin.Client, error) {
 		pluginCmd := exec.Command(provider.binPath(), []string{"run_as_plugin", "--log-level", zerolog.GlobalLevel().String()}...)
 
@@ -341,6 +346,7 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 			Logger: pluginLogger,
 			Stderr: crashLog,
 		})
+		procTracker.track(client, pluginCmd)
 
 		// Connect via RPC
 		rpcClient, err := client.Client()
@@ -373,6 +379,7 @@ func (c *coordinator) unsafeStartProvider(id string, update UpdateProvidersConfi
 	}
 	res.Version = provider.Version
 	res.crashLog = crashLog
+	res.proc = procTracker
 	c.runningByID[res.ID] = res
 
 	return res, nil

--- a/providers/exit_status.go
+++ b/providers/exit_status.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"github.com/hashicorp/go-plugin"
+)
+
+// processTracker pairs the plugin subprocess command with the go-plugin
+// client supervising it, so crash diagnostics can read the subprocess's exit
+// disposition (exit code vs. signal, peak RSS) after it dies.
+//
+// go-plugin's exit-watcher goroutine calls cmd.Wait() — which populates
+// exec.Cmd.ProcessState — and only afterwards marks Client.Exited() under the
+// client's mutex. Reading ProcessState is therefore only safe once Exited()
+// reports true for the client that owns this exact cmd; exitState enforces
+// that pairing. The tracker is updated in lock-step by the coordinator's
+// connect function, including across RestartableProvider restarts.
+type processTracker struct {
+	lock   sync.Mutex
+	client *plugin.Client
+	cmd    *exec.Cmd
+}
+
+func (t *processTracker) track(client *plugin.Client, cmd *exec.Cmd) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.client = client
+	t.cmd = cmd
+}
+
+// exitState returns the exit state of the tracked plugin subprocess, or nil
+// while it is still running (or if nothing is tracked). A non-nil result is
+// safe to read: Exited() == true means go-plugin's Wait on this cmd returned.
+func (t *processTracker) exitState() *os.ProcessState {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.client == nil || t.cmd == nil {
+		return nil
+	}
+	if !t.client.Exited() {
+		return nil
+	}
+	return t.cmd.ProcessState
+}
+
+// formatExitStatus renders a process's exit disposition for the crash
+// diagnostics meta block: "code:<n>" for a regular exit, "signal:<SIG>" when
+// the process was killed by a signal (e.g. "signal:SIGKILL", the typical OOM
+// killer fingerprint), or "unknown" if the state carries neither.
+func formatExitStatus(ps *os.ProcessState) string {
+	if ps == nil {
+		return "unknown"
+	}
+	if ws, ok := ps.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return "signal:" + signalName(ws.Signal())
+	}
+	if code := ps.ExitCode(); code >= 0 {
+		return "code:" + strconv.Itoa(code)
+	}
+	return "unknown"
+}

--- a/providers/exit_status.go
+++ b/providers/exit_status.go
@@ -36,19 +36,22 @@ func (t *processTracker) track(client *plugin.Client, cmd *exec.Cmd) {
 	t.cmd = cmd
 }
 
-// exitState returns the exit state of the tracked plugin subprocess, or nil
-// while it is still running (or if nothing is tracked). A non-nil result is
-// safe to read: Exited() == true means go-plugin's Wait on this cmd returned.
-func (t *processTracker) exitState() *os.ProcessState {
+// exitInfo reports whether the tracked plugin subprocess has been reaped
+// and, if so, its exit state. Exited() == true means go-plugin's Wait on
+// this exact cmd returned, so reading ProcessState is race-free. The tracker
+// is the single source of truth for crash diagnostics: unlike
+// RestartableProvider's client accessor, its lock is only ever held for a
+// field copy, so this never blocks behind an in-flight Reconnect.
+func (t *processTracker) exitInfo() (bool, *os.ProcessState) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	if t.client == nil || t.cmd == nil {
-		return nil
+		return false, nil
 	}
 	if !t.client.Exited() {
-		return nil
+		return false, nil
 	}
-	return t.cmd.ProcessState
+	return true, t.cmd.ProcessState
 }
 
 // formatExitStatus renders a process's exit disposition for the crash
@@ -59,6 +62,8 @@ func formatExitStatus(ps *os.ProcessState) string {
 	if ps == nil {
 		return "unknown"
 	}
+	// syscall.WaitStatus exists on every port, including Windows, where
+	// Signaled() is hardwired to false and we fall through to ExitCode().
 	if ws, ok := ps.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
 		return "signal:" + signalName(ws.Signal())
 	}

--- a/providers/exit_status_unix.go
+++ b/providers/exit_status_unix.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build unix
+
+package providers
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// signalName returns the conventional "SIGKILL"-style name for a signal,
+// falling back to Go's prose rendering ("killed") for unnamed signals.
+func signalName(sig syscall.Signal) string {
+	if name := unix.SignalName(unix.Signal(sig)); name != "" {
+		return name
+	}
+	return sig.String()
+}
+
+// maxRSSBytes returns the process's peak resident set size in bytes, or 0 if
+// unavailable. Reported unit-free in bytes so downstream log aggregation can
+// consume the value without unit parsing.
+func maxRSSBytes(ps *os.ProcessState) int64 {
+	if ps == nil {
+		return 0
+	}
+	ru, ok := ps.SysUsage().(*syscall.Rusage)
+	if !ok || ru == nil {
+		return 0
+	}
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		// macOS reports ru_maxrss in bytes
+		return int64(ru.Maxrss)
+	default:
+		// Linux and the BSDs report ru_maxrss in kilobytes
+		return int64(ru.Maxrss) * 1024
+	}
+}

--- a/providers/exit_status_unix_test.go
+++ b/providers/exit_status_unix_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build unix
+
+package providers
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatExitStatus_ExitCode(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 2")
+	_ = cmd.Run()
+	require.NotNil(t, cmd.ProcessState)
+	assert.Equal(t, "code:2", formatExitStatus(cmd.ProcessState))
+}
+
+func TestFormatExitStatus_CleanExit(t *testing.T) {
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	assert.Equal(t, "code:0", formatExitStatus(cmd.ProcessState))
+}
+
+func TestFormatExitStatus_Signal(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Process.Kill()) // SIGKILL, same as the OOM killer
+	_ = cmd.Wait()
+	require.NotNil(t, cmd.ProcessState)
+	assert.Equal(t, "signal:SIGKILL", formatExitStatus(cmd.ProcessState))
+}
+
+func TestFormatExitStatus_Nil(t *testing.T) {
+	assert.Equal(t, "unknown", formatExitStatus(nil))
+}
+
+func TestMaxRSSBytes(t *testing.T) {
+	cmd := exec.Command("true")
+	require.NoError(t, cmd.Run())
+	assert.Greater(t, maxRSSBytes(cmd.ProcessState), int64(0))
+	assert.Zero(t, maxRSSBytes(nil))
+}
+
+func TestProcessTracker_NoSubprocess(t *testing.T) {
+	// Untracked (builtin providers, tests): no state, no panic.
+	tracker := &processTracker{}
+	assert.Nil(t, tracker.exitState())
+
+	var p *RunningProvider = &RunningProvider{}
+	assert.Nil(t, p.exitState())
+}

--- a/providers/exit_status_unix_test.go
+++ b/providers/exit_status_unix_test.go
@@ -8,6 +8,7 @@ package providers
 import (
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,10 +48,36 @@ func TestMaxRSSBytes(t *testing.T) {
 }
 
 func TestProcessTracker_NoSubprocess(t *testing.T) {
-	// Untracked (builtin providers, tests): no state, no panic.
+	// Untracked (builtin providers, tests): no state, no panic, no wait.
 	tracker := &processTracker{}
-	assert.Nil(t, tracker.exitState())
+	exited, ps := tracker.exitInfo()
+	assert.False(t, exited)
+	assert.Nil(t, ps)
 
 	p := &RunningProvider{}
-	assert.Nil(t, p.exitState())
+	exited, ps = p.awaitExit(time.Second)
+	assert.False(t, exited)
+	assert.Nil(t, ps)
+}
+
+func TestAwaitExit_GraceIsMemoized(t *testing.T) {
+	// A tracker whose subprocess never exits: the first awaitExit pays the
+	// grace period, subsequent calls must return immediately.
+	cmd := exec.Command("sleep", "30")
+	require.NoError(t, cmd.Start())
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	p := &RunningProvider{proc: &processTracker{}}
+	p.proc.track(nil, cmd) // nil client → exitInfo always reports running
+	_, _ = p.awaitExit(30 * time.Millisecond)
+	require.True(t, p.exitGraceExpired.Load())
+
+	start := time.Now()
+	exited, ps := p.awaitExit(30 * time.Millisecond)
+	assert.False(t, exited)
+	assert.Nil(t, ps)
+	assert.Less(t, time.Since(start), 25*time.Millisecond)
 }

--- a/providers/exit_status_unix_test.go
+++ b/providers/exit_status_unix_test.go
@@ -51,6 +51,6 @@ func TestProcessTracker_NoSubprocess(t *testing.T) {
 	tracker := &processTracker{}
 	assert.Nil(t, tracker.exitState())
 
-	var p *RunningProvider = &RunningProvider{}
+	p := &RunningProvider{}
 	assert.Nil(t, p.exitState())
 }

--- a/providers/exit_status_windows.go
+++ b/providers/exit_status_windows.go
@@ -1,0 +1,23 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package providers
+
+import (
+	"os"
+	"syscall"
+)
+
+// signalName falls back to Go's rendering; Windows processes are never
+// signal-killed in the POSIX sense, so this path is effectively unused there.
+func signalName(sig syscall.Signal) string {
+	return sig.String()
+}
+
+// maxRSSBytes is unavailable on Windows: syscall.Rusage there only carries
+// process times, not memory counters.
+func maxRSSBytes(ps *os.ProcessState) int64 {
+	return 0
+}

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-plugin"
@@ -382,6 +383,16 @@ type RunningProvider struct {
 	// exit disposition (exit code vs. signal, peak RSS) after it dies. Nil
 	// for builtin providers and providers constructed without a subprocess.
 	proc *processTracker
+	// exitGraceExpired memoizes that awaitExit already waited a full grace
+	// period without the subprocess exiting, so subsequent crash-diagnostic
+	// builds don't each re-pay the wait for a hung-but-alive provider.
+	// Reset on successful reconnect.
+	exitGraceExpired atomic.Bool
+	// killedSelf records that we sent the kill signal to the subprocess
+	// ourselves (shutdown, heartbeat-triggered or otherwise). It lets crash
+	// diagnostics distinguish our own SIGKILL from an external one — the
+	// latter, with an empty stderr tail, is the OOM-killer fingerprint.
+	killedSelf atomic.Bool
 	// provider errors which are evaluated and printed during shutdown of the provider
 	err          error
 	lock         sync.Mutex
@@ -499,6 +510,8 @@ func (p *RunningProvider) Reconnect() error {
 		}
 		p.isClosed = false
 		p.isShutdown = false
+		p.exitGraceExpired.Store(false)
+		p.killedSelf.Store(false)
 		hbCtx, hbCancelFunc := context.WithCancel(context.Background())
 		if p.hbCancelFunc != nil {
 			p.hbCancelFunc()
@@ -537,6 +550,7 @@ func (p *RunningProvider) Shutdown() error {
 		if rp, ok := p.Plugin.(*RestartableProvider); ok {
 			c := rp.Client()
 			if c != nil {
+				p.killedSelf.Store(true)
 				c.Kill()
 			}
 		}
@@ -557,54 +571,55 @@ func (p *RunningProvider) KillClient() {
 	if rp, ok := p.Plugin.(*RestartableProvider); ok {
 		c := rp.Client()
 		if c != nil {
+			p.killedSelf.Store(true)
 			c.Kill()
 		}
 	}
 }
 
-// hasExited reports whether the underlying plugin subprocess has exited.
-// Returns false if we have no client handle (e.g. for builtin providers).
-func (p *RunningProvider) hasExited() bool {
-	if rp, ok := p.Plugin.(*RestartableProvider); ok {
-		c := rp.Client()
-		if c != nil {
-			return c.Exited()
-		}
-	}
-	return false
-}
-
-// exitState returns the subprocess's exit state once it has died, or nil
-// while it is still running or when no subprocess is tracked (builtin
-// providers, tests). See processTracker.exitState for the safety contract.
-func (p *RunningProvider) exitState() *os.ProcessState {
-	if p.proc == nil {
-		return nil
-	}
-	return p.proc.exitState()
+// wasKilledLocally reports whether we sent the subprocess its kill signal
+// ourselves, so crash diagnostics don't misread our own SIGKILL as the
+// OOM killer's.
+func (p *RunningProvider) wasKilledLocally() bool {
+	return p.killedSelf.Load()
 }
 
 // awaitExit waits up to grace for the plugin subprocess to be reaped,
-// reporting whether it exited. An in-flight RPC fails the instant the
-// child's socket dies — usually before go-plugin's exit-watcher goroutine
-// has waited on the process — so crash diagnostics built immediately would
-// see "still running" and miss the exit disposition. Reaping a dead direct
-// child settles within milliseconds; the grace bound only matters for the
-// true-hang case, where the process really is still running.
-// Returns immediately when no subprocess is tracked.
-func (p *RunningProvider) awaitExit(grace time.Duration) bool {
+// reporting whether it exited and, if so, its exit state. An in-flight RPC
+// fails the instant the child's socket dies — usually before go-plugin's
+// exit-watcher goroutine has waited on the process — so crash diagnostics
+// built immediately would see "still running" and miss the exit
+// disposition. Reaping a dead direct child settles within milliseconds; the
+// grace bound only matters for the true-hang case, where the process really
+// is still running.
+//
+// It reads exclusively from the process tracker: consulting the
+// RestartableProvider's client here would block on its lock, which
+// Reconnect() holds for the full duration of re-establishing every tracked
+// connection. The wait is also memoized — handlePluginError builds
+// diagnostics once per failed RPC, and a hung-but-alive provider must stall
+// the first of them at most, not every one.
+// Returns immediately when no subprocess is tracked (builtin providers).
+func (p *RunningProvider) awaitExit(grace time.Duration) (bool, *os.ProcessState) {
 	if p.proc == nil {
-		return p.hasExited()
+		return false, nil
+	}
+	if exited, ps := p.proc.exitInfo(); exited {
+		return true, ps
+	}
+	if p.exitGraceExpired.Load() {
+		return false, nil
 	}
 	deadline := time.Now().Add(grace)
 	for {
-		if p.hasExited() {
-			return true
+		time.Sleep(25 * time.Millisecond)
+		if exited, ps := p.proc.exitInfo(); exited {
+			return true, ps
 		}
 		if time.Now().After(deadline) {
-			return false
+			p.exitGraceExpired.Store(true)
+			return false, nil
 		}
-		time.Sleep(25 * time.Millisecond)
 	}
 }
 

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -377,6 +378,10 @@ type RunningProvider struct {
 	// we can include the most recent stderr (typically a runtime fatal or
 	// panic stack trace) in the error attached to Runtime.CriticalErrors.
 	crashLog *crashLogBuffer
+	// proc tracks the plugin subprocess so crash diagnostics can report its
+	// exit disposition (exit code vs. signal, peak RSS) after it dies. Nil
+	// for builtin providers and providers constructed without a subprocess.
+	proc *processTracker
 	// provider errors which are evaluated and printed during shutdown of the provider
 	err          error
 	lock         sync.Mutex
@@ -567,6 +572,40 @@ func (p *RunningProvider) hasExited() bool {
 		}
 	}
 	return false
+}
+
+// exitState returns the subprocess's exit state once it has died, or nil
+// while it is still running or when no subprocess is tracked (builtin
+// providers, tests). See processTracker.exitState for the safety contract.
+func (p *RunningProvider) exitState() *os.ProcessState {
+	if p.proc == nil {
+		return nil
+	}
+	return p.proc.exitState()
+}
+
+// awaitExit waits up to grace for the plugin subprocess to be reaped,
+// reporting whether it exited. An in-flight RPC fails the instant the
+// child's socket dies — usually before go-plugin's exit-watcher goroutine
+// has waited on the process — so crash diagnostics built immediately would
+// see "still running" and miss the exit disposition. Reaping a dead direct
+// child settles within milliseconds; the grace bound only matters for the
+// true-hang case, where the process really is still running.
+// Returns immediately when no subprocess is tracked.
+func (p *RunningProvider) awaitExit(grace time.Duration) bool {
+	if p.proc == nil {
+		return p.hasExited()
+	}
+	deadline := time.Now().Add(grace)
+	for {
+		if p.hasExited() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 // uptime reports how long the provider has been running. Zero if startedAt

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -652,9 +652,10 @@ func (r *Runtime) handlePluginError(err error, provider *ConnectedProvider, reso
 
 // buildCrashDiagnostics returns a multi-line suffix to append to a crash error
 // with whatever extra context we have about the dead/dying provider:
-// version, uptime, whether the subprocess actually exited, whether the
-// shutdown was triggered by a heartbeat probe, and the most recent stderr
-// (panic/fatal trace if one was captured).
+// version, uptime, whether the subprocess actually exited (and if so, its
+// exit code or killing signal plus peak RSS), whether the shutdown was
+// triggered by a heartbeat probe, and the most recent stderr (panic/fatal
+// trace if one was captured).
 //
 // Returns "" when there's nothing useful to report, so the message stays
 // compact for cases where the optional context is unavailable (mostly tests
@@ -671,8 +672,17 @@ func buildCrashDiagnostics(p *RunningProvider) string {
 	if up := p.uptime(); up > 0 {
 		meta = append(meta, "uptime="+up.Round(time.Millisecond).String())
 	}
-	if p.hasExited() {
+	if p.awaitExit(2 * time.Second) {
 		meta = append(meta, "subprocess=exited")
+		// Exit disposition separates the silent-death causes: a SIGKILL with
+		// empty stderr is near-certainly the OOM killer, a regular exit code
+		// points at the plugin terminating itself. Peak RSS (bytes)
+		// corroborates the OOM classification without host access.
+		ps := p.exitState()
+		meta = append(meta, "exit="+formatExitStatus(ps))
+		if rss := maxRSSBytes(ps); rss > 0 {
+			meta = append(meta, "max_rss="+strconv.FormatInt(rss, 10))
+		}
 	} else if p.startedAt.IsZero() {
 		// builtin/in-process — no subprocess to report on
 	} else {

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -672,13 +672,13 @@ func buildCrashDiagnostics(p *RunningProvider) string {
 	if up := p.uptime(); up > 0 {
 		meta = append(meta, "uptime="+up.Round(time.Millisecond).String())
 	}
-	if p.awaitExit(2 * time.Second) {
+	if exited, ps := p.awaitExit(2 * time.Second); exited {
 		meta = append(meta, "subprocess=exited")
 		// Exit disposition separates the silent-death causes: a SIGKILL with
-		// empty stderr is near-certainly the OOM killer, a regular exit code
-		// points at the plugin terminating itself. Peak RSS (bytes)
-		// corroborates the OOM classification without host access.
-		ps := p.exitState()
+		// empty stderr and no trigger= flag is near-certainly the OOM
+		// killer, a regular exit code points at the plugin terminating
+		// itself. Peak RSS (bytes) corroborates the OOM classification
+		// without host access.
 		meta = append(meta, "exit="+formatExitStatus(ps))
 		if rss := maxRSSBytes(ps); rss > 0 {
 			meta = append(meta, "max_rss="+strconv.FormatInt(rss, 10))
@@ -690,6 +690,10 @@ func buildCrashDiagnostics(p *RunningProvider) string {
 	}
 	if p.hadHeartbeatFailure() {
 		meta = append(meta, "trigger=heartbeat-timeout")
+	} else if p.wasKilledLocally() {
+		// We sent the kill signal ourselves (shutdown race) — without this
+		// flag, our own SIGKILL would wear the OOM killer's fingerprint.
+		meta = append(meta, "trigger=local-kill")
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
References #9109

## Problem

When a provider plugin subprocess dies silently — no panic, empty stderr tail, variable uptime — the crash diagnostics cannot distinguish an OOM kill from a hang. The runtime only tracks a boolean exit state (`Client.Exited()`), so the dominant real-world crash shape is unattributable and misleads triage toward per-field bugs.

## Change

Capture the subprocess's exit disposition and surface it in the existing `[version=… uptime=… subprocess=… trigger=…]` meta block:

- **`exit=signal:SIGKILL` / `exit=code:N` / `exit=unknown`** — a SIGKILL with an empty stderr tail is near-certainly the OOM killer; a heartbeat timeout on a still-running process is a hang.
- **`max_rss=<bytes>`** — peak resident set size from the child's `wait4` rusage, corroborating the OOM classification without needing `dmesg` on the host. Emitted as raw bytes so fleet-side aggregation can consume the value without unit parsing.

### How, without an upstream go-plugin change

We own the `*exec.Cmd` we hand to `plugin.NewClient`, and go-plugin's exit-watcher goroutine calls `cmd.Wait()` (which populates `ProcessState`) **before** marking `Client.Exited()` under its mutex — so reading `ProcessState` once `Exited()` reports true is race-free. A small `processTracker` pairs each cmd with the exact client that reaps it, staying consistent across `RestartableProvider` restarts.

### Reaper race

An in-flight RPC fails with `Unavailable: EOF` the instant the socket dies, typically before go-plugin has reaped the child — diagnostics built immediately reported `subprocess=running` for a process that was already dead. `buildCrashDiagnostics` now waits up to 2s (`awaitExit`) for the reaper; a dead direct child settles within milliseconds, so the bound only delays the true-hang case (already a fatal path).

## Verification

Unit tests for the exit-status formatting (`code:N`, `signal:SIGKILL`, nil handling, max RSS) plus end-to-end against a live `os` provider:

SIGKILL mid-query (OOM shape):
```
the 'os' provider crashed (resource=command, field=stdout): rpc error: code = Unavailable desc = error reading from server: EOF
[version=13.35.2 uptime=5.203s subprocess=exited exit=signal:SIGKILL max_rss=55984128]
```

SIGSTOP then kill (heartbeat-timeout shape from the issue):
```
[version=13.35.2 uptime=17.949s subprocess=exited exit=signal:SIGKILL max_rss=56328192 trigger=heartbeat-timeout]
```

Cross-compiles clean for linux/windows; `go test ./providers/` passes; Windows reports `exit=code:N` and omits `max_rss` (rusage there carries no memory counters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)