### PR TITLE
🎉 os-13.35.3

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.35.2",
+	Version: "13.35.3",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.35.3)
- 🐛 os: single CIM query + cache for Windows hypervisor detection (#9113)
- 🐛 os: fix rsyslog $IncludeConfig expansion matching nothing (#9108)