### PR TITLE
🐛 os: fix sshd relative Include glob dropping first path segment

### DIFF
--- a/providers/os/resources/sshd.go
+++ b/providers/os/resources/sshd.go
@@ -111,6 +111,15 @@ func matchBlocks2Resources(m sshd.MatchBlocks, runtime *plugin.Runtime, ownerID 
 var reGlob = regexp.MustCompile(`.*\*.*`)
 
 func (s *mqlSshdConfig) expandGlob(glob string) ([]string, error) {
+	conn := s.MqlRuntime.Connection.(shared.Connection)
+	afs := &afero.Afero{Fs: conn.FileSystem()}
+	return expandSshdGlob(afs, glob)
+}
+
+// expandSshdGlob expands an sshd_config Include glob against afs. Relative
+// patterns are resolved from /etc/ssh, matching sshd_config(5):
+// https://man7.org/linux/man-pages/man5/sshd_config.5.html
+func expandSshdGlob(afs *afero.Afero, glob string) ([]string, error) {
 	if !reGlob.MatchString(glob) {
 		if !filepath.IsAbs(glob) {
 			glob = filepath.Join("/etc/ssh", glob)
@@ -121,17 +130,21 @@ func (s *mqlSshdConfig) expandGlob(glob string) ([]string, error) {
 	var paths []string
 	segments := strings.Split(glob, "/")
 	if segments[0] == "" {
+		// Absolute pattern: the leading segment is the empty string before the
+		// root "/", so start at root and consume the remaining segments.
 		paths = []string{"/"}
+		segments = segments[1:]
 	} else {
-		// https://man7.org/linux/man-pages/man5/sshd_config.5.html
-		// Relative files are always expanded from `/ssh`
+		// Relative pattern: sshd expands it from /etc/ssh. Every segment is a
+		// real path component here, so all of them must be consumed below.
 		paths = []string{"/etc/ssh"}
 	}
 
-	conn := s.MqlRuntime.Connection.(shared.Connection)
-	afs := &afero.Afero{Fs: conn.FileSystem()}
+	for _, segment := range segments {
+		if segment == "" {
+			continue
+		}
 
-	for _, segment := range segments[1:] {
 		if !reGlob.MatchString(segment) {
 			for i := range paths {
 				paths[i] = filepath.Join(paths[i], segment)

--- a/providers/os/resources/sshd_glob_internal_test.go
+++ b/providers/os/resources/sshd_glob_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandSshdGlob(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	files := []string{
+		"/etc/ssh/sshd_config",
+		"/etc/ssh/decoy.conf",
+		"/etc/ssh/sshd_config.d/10-a.conf",
+		"/etc/ssh/sshd_config.d/20-b.conf",
+		"/etc/ssh/sshd_config.d/nested/deep.conf",
+	}
+	for _, f := range files {
+		require.NoError(t, afero.WriteFile(fs, f, []byte("Port 22\n"), 0o644))
+	}
+	afs := &afero.Afero{Fs: fs}
+
+	tests := []struct {
+		name string
+		glob string
+		want []string
+	}{
+		{
+			name: "non-glob absolute path is returned as-is",
+			glob: "/etc/ssh/sshd_config",
+			want: []string{"/etc/ssh/sshd_config"},
+		},
+		{
+			name: "non-glob relative path resolves from /etc/ssh",
+			glob: "sshd_config",
+			want: []string{"/etc/ssh/sshd_config"},
+		},
+		{
+			name: "absolute glob in a subdirectory",
+			glob: "/etc/ssh/sshd_config.d/*.conf",
+			want: []string{"/etc/ssh/sshd_config.d/10-a.conf", "/etc/ssh/sshd_config.d/20-b.conf"},
+		},
+		{
+			// Regression: a relative Include glob with a subdirectory must not
+			// drop the subdirectory segment and glob one level too shallow.
+			name: "relative glob in a subdirectory",
+			glob: "sshd_config.d/*.conf",
+			want: []string{"/etc/ssh/sshd_config.d/10-a.conf", "/etc/ssh/sshd_config.d/20-b.conf"},
+		},
+		{
+			// Regression: a single-segment relative glob must expand within
+			// /etc/ssh, not return the directory itself.
+			name: "relative single-segment glob",
+			glob: "*.conf",
+			want: []string{"/etc/ssh/decoy.conf"},
+		},
+		{
+			name: "glob does not descend into subdirectories",
+			glob: "/etc/ssh/*.conf",
+			want: []string{"/etc/ssh/decoy.conf"},
+		},
+		{
+			name: "glob against a missing directory yields no matches",
+			glob: "/etc/does-not-exist/*.conf",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandSshdGlob(afs, tt.glob)
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`sshd.config`'s `expandGlob` resolved **relative** `Include` globs against the wrong directory.

Per [`sshd_config(5)`](https://man7.org/linux/man-pages/man5/sshd_config.5.html), a relative `Include` pattern is expanded from `/etc/ssh`. The glob expander split the pattern on `/` and then iterated `segments[1:]` unconditionally. That is only correct for **absolute** patterns, where `strings.Split("/a/b", "/")` yields a leading empty `""` segment that should be skipped. For a **relative** pattern, `segments[0]` is a real path component — and it was silently dropped:

| Include pattern | Expanded to (before) | Correct |
|---|---|---|
| `sshd_config.d/*.conf` | `/etc/ssh/*.conf` (subdir dropped) | `/etc/ssh/sshd_config.d/*.conf` |
| `*.conf` | `["/etc/ssh"]` (never expanded) | `/etc/ssh/*.conf` |
| `/etc/ssh/sshd_config.d/*.conf` | correct | correct |

## Impact

An sshd hardening audit could **miss `Include`'d drop-in configs** — e.g. a `sshd_config.d` fragment setting `PermitRootLogin yes` or weak `Ciphers`/`MACs` — which is a security false-negative. It could also wrongly pull in unrelated files sitting directly in `/etc/ssh`. Most distro defaults ship an *absolute* `Include /etc/ssh/sshd_config.d/*.conf` (unaffected), but relative includes are valid and used.

## Fix

- The relative branch now consumes **all** segments; the absolute branch still skips the empty leading segment.
- Empty segments (trailing/double slashes) are skipped defensively.
- Logic extracted into a pure `expandSshdGlob(afs, glob)` helper so it can be unit-tested without a live connection.
- Added `TestExpandSshdGlob` covering absolute, relative-subdir, and single-segment relative globs, plus non-glob and missing-directory cases. **The function previously had no test coverage at all.**

## Verification

```
go test ./providers/os/resources/ -run 'TestExpandSshdGlob|TestResource_SSHD|TestSshdConfig'
ok  	go.mondoo.com/mql/v13/providers/os/resources
```

Verified against an in-memory filesystem: before the fix, `sshd_config.d/*.conf` matched a decoy in `/etc/ssh` and missed the real drop-ins; after, all three backend cases resolve correctly.
