### PR TITLE
🐎 os: fix windows.rdp load() data race reporting insecure config as secure

### DIFF
--- a/providers/os/resources/windows_rdp.go
+++ b/providers/os/resources/windows_rdp.go
@@ -80,9 +80,6 @@ func (r *mqlWindowsRdp) readRdpKey(path string) (map[string]int64, error) {
 // load reads the policy and effective registry keys exactly once and caches
 // them so every field shares a single set of registry reads.
 func (r *mqlWindowsRdp) load() error {
-	if r.loaded {
-		return nil
-	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	if r.loaded || r.loadErr != nil {


### PR DESCRIPTION
## Problem

`(*mqlWindowsRdp).load()` in `providers/os/resources/windows_rdp.go` had an unlocked fast path:

```go
func (r *mqlWindowsRdp) load() error {
	if r.loaded {   // unlocked read of a plain bool
		return nil
	}
	r.lock.Lock()
	...
}
```

`loaded` is a plain `bool`, and `windows.rdp` field accessors call `load()` from parallel executor goroutines. Reading `loaded` outside the lock is a data race.

## Impact

This is not just a benign flag race. Because there is no happens-before edge established by the unlocked read, a goroutine can observe `loaded == true` while the writes to the cached registry maps (`r.policy`, `r.policyClient`, `r.winSta`, `r.tsRoot`) are not yet visible. Those maps then read as `nil`, and `resolveRdpValue` falls through to the **secure Windows defaults**.

The result is a security-relevant false negative: an insecure RDP configuration (for example NLA disabled, or Remote Desktop connections allowed) can be reported as secure.

## Fix

Remove the pre-lock `if r.loaded { return nil }` block so `load()` takes `r.lock` first, exactly like its siblings `windows_defender.go`, `windows_smartscreen.go`, and `chrome.go`, all of which `Lock()` immediately with no unlocked fast path.

The existing post-lock guard already provides correct caching:

```go
if r.loaded || r.loadErr != nil {
	return r.loadErr
}
```

When `loaded && loadErr == nil` this returns `nil`, so cached results are still served without re-reading the registry, now with proper synchronization on both the flag and the map writes.

## Verification

- `go test -race ./providers/os/resources/ -run Rdp` passes.
- Change is a 3-line deletion; no schema, no provider version bump.
