### PR TITLE
🐛 os: close docker exec hijacked connection to prevent fd leak

### DIFF
--- a/providers/os/connection/docker/command.go
+++ b/providers/os/connection/docker/command.go
@@ -43,6 +43,10 @@ func (c *Command) Exec(command string) (*shared.Command, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The moby SDK requires the caller to close the hijacked response, which
+	// closes the underlying net.Conn to the docker daemon. Without this every
+	// command run against a running container leaks a socket/goroutine.
+	defer resp.Close()
 
 	// TODO: transformHijack breaks for long stdout, but not if we read stdout/stderr in upfront
 	content, err := io.ReadAll(resp.Reader)


### PR DESCRIPTION
## Problem

`Command.Exec` in `providers/os/connection/docker/command.go` attaches to a
container exec session through the moby SDK's `Client.ExecAttach`. That call
returns an `ExecAttachResult` embedding a `HijackedResponse`, which wraps the
underlying `net.Conn` to the docker daemon. The code read the output via
`io.ReadAll(resp.Reader)` but never called `Close()` on the hijacked response.

The moby SDK explicitly documents that the caller must close the hijacked
connection (`Close()` closes the underlying `net.Conn`).

## Impact

Every command executed against a running docker container leaked a socket and
associated goroutine to the docker daemon. A scan runs many commands per
container, so over a scan these leaks accumulate and can lead to
file-descriptor exhaustion on long-running or multi-container scans.

## Fix

Add a `defer resp.Close()` immediately after the `ExecAttach` error check so
the hijacked connection is closed on all return paths (including the early
returns from the `io.ReadAll` and `ExecInspect` error checks). The read logic
and return values are unchanged. This implements the moby SDK's documented
`Close()` contract.

## Verification

This path requires a live docker daemon, so a true unit test for the leak is
not feasible here. Verified:

- `go build ./providers/os/connection/docker/...` succeeds.
- `go test ./providers/os/connection/docker/...` passes (tests that require a
  running docker daemon are skipped in this environment, which is expected).
- `gofmt -w` applied to the changed file.
