### PR TITLE
🐛 os: close source stream in StreamToTmpFile on copy error

### DIFF
--- a/providers/os/connection/tar/stream.go
+++ b/providers/os/connection/tar/stream.go
@@ -4,18 +4,19 @@
 package tar
 
 import (
+	"errors"
 	"io"
 	"os"
 )
 
 // StreamToTmpFile streams a binary stream into a file. The user of this method
 // is responsible for deleting the file later
-func StreamToTmpFile(r io.ReadCloser, outFile *os.File) error {
-	defer outFile.Close()
-	_, err := io.Copy(outFile, r)
-	if err != nil {
-		return err
-	}
-
-	return r.Close()
+func StreamToTmpFile(r io.ReadCloser, outFile *os.File) (err error) {
+	// Always close both streams, even when the copy fails, and surface any
+	// close error to the caller. A failed outFile.Close can mean buffered
+	// data never reached disk, so it must not be silently discarded.
+	defer func() { err = errors.Join(err, r.Close()) }()
+	defer func() { err = errors.Join(err, outFile.Close()) }()
+	_, err = io.Copy(outFile, r)
+	return err
 }

--- a/providers/os/connection/tar/stream_test.go
+++ b/providers/os/connection/tar/stream_test.go
@@ -1,0 +1,64 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package tar_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/connection/tar"
+)
+
+// closeTrackingReader wraps a reader and records whether Close was called.
+type closeTrackingReader struct {
+	io.Reader
+	closed bool
+}
+
+func (c *closeTrackingReader) Close() error {
+	c.closed = true
+	return nil
+}
+
+// errReader always fails on Read, to simulate an io.Copy failure.
+type errReader struct{}
+
+func (errReader) Read(p []byte) (int, error) {
+	return 0, errors.New("simulated read failure")
+}
+
+func newTmpFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "stream-test-*")
+	require.NoError(t, err)
+	return f
+}
+
+func TestStreamToTmpFile_ClosesSourceOnSuccess(t *testing.T) {
+	src := &closeTrackingReader{Reader: strings.NewReader("hello world")}
+	out := newTmpFile(t)
+
+	err := tar.StreamToTmpFile(src, out)
+	require.NoError(t, err)
+	assert.True(t, src.closed, "source reader should be closed on the success path")
+
+	// content was actually written
+	data, err := os.ReadFile(out.Name())
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(data))
+}
+
+func TestStreamToTmpFile_ClosesSourceOnCopyError(t *testing.T) {
+	src := &closeTrackingReader{Reader: errReader{}}
+	out := newTmpFile(t)
+
+	err := tar.StreamToTmpFile(src, out)
+	require.Error(t, err, "copy failure should be surfaced as an error")
+	assert.True(t, src.closed, "source reader should be closed even when the copy fails")
+}


### PR DESCRIPTION
## Problem

`StreamToTmpFile(r io.ReadCloser, outFile *os.File)` in
`providers/os/connection/tar/stream.go` only closed the source stream `r`
on the success path:

```go
func StreamToTmpFile(r io.ReadCloser, outFile *os.File) error {
	defer outFile.Close()          // destination only
	_, err := io.Copy(outFile, r)
	if err != nil {
		return err                 // <-- returns without closing r
	}
	return r.Close()               // only reached on success
}
```

If `io.Copy` fails, the function returns without ever calling `r.Close()`,
leaking the source stream and its backing goroutine/connection.

## Impact

Callers pass live streams whose Close releases real OS/network resources:

- `snapshot_connection.go` passes `dc.ContainerExport()`'s HTTP response body.
- `docker/container_connection.go` passes `mutate.Extract(img)`, a pipe reader
  backed by a goroutine.

Each failed export/extract leaked that stream (and, for the pipe reader, its
goroutine) for the lifetime of the process.

## Fix

Close the source with a `defer` so it is released on every return path, and
remove the now-redundant success-path `r.Close()` to avoid a double close:

```go
func StreamToTmpFile(r io.ReadCloser, outFile *os.File) error {
	defer r.Close()
	defer outFile.Close()
	_, err := io.Copy(outFile, r)
	return err
}
```

Return values and success-path behavior are unchanged.

## Verification

Added `stream_test.go` asserting the source's `Close()` is called on both the
success path and the copy-error path (via a reader that errors during `io.Copy`).

```
$ go test -run TestStreamToTmpFile ./connection/tar/ -v
=== RUN   TestStreamToTmpFile_ClosesSourceOnSuccess
--- PASS: TestStreamToTmpFile_ClosesSourceOnSuccess (0.00s)
=== RUN   TestStreamToTmpFile_ClosesSourceOnCopyError
--- PASS: TestStreamToTmpFile_ClosesSourceOnCopyError (0.00s)
PASS
ok  	go.mondoo.com/mql/v13/providers/os/connection/tar	1.860s
```

`go build ./...` in `providers/os` passes. The only failing test in the
package, `TestTarRelativeSymlinkFileCentos`, fails identically on clean
`origin/main` (it requires pulling a container image) and is unrelated to this
change.
