### PR TITLE
🐛 os: fix lsof IPv6 established-connection host/port parsing

### DIFF
--- a/providers/os/resources/lsof/lsof.go
+++ b/providers/os/resources/lsof/lsof.go
@@ -114,7 +114,7 @@ type FileDescriptor struct {
 }
 
 // n127.0.0.1:3000->127.0.0.1:54335
-var networkNameRegexp = regexp.MustCompile(`(.*):(.*)->(.*):(.*)`)
+// or, for IPv6, n[fe80::1]:8080->[fe80::2]:9090
 
 // local and remote Internet addresses of a network file
 func (f *FileDescriptor) NetworkFile() (string, int64, string, int64, error) {
@@ -126,22 +126,26 @@ func (f *FileDescriptor) NetworkFile() (string, int64, string, int64, error) {
 	}
 
 	if strings.Contains(f.Name, "->") {
-		matches := networkNameRegexp.FindStringSubmatch(f.Name)
-		if len(matches) != 5 {
+		// An established connection is "<local>-><remote>". Splitting on
+		// "->" and parsing each endpoint with net.SplitHostPort correctly
+		// handles bracketed IPv6 addresses (e.g. "[fe80::1]:8080"), whose
+		// embedded colons would otherwise confuse a naive host:port split.
+		local, remote, ok := strings.Cut(f.Name, "->")
+		if !ok {
 			return "", 0, "", 0, errors.New("network name not supported: " + f.Name)
 		}
 
-		localPort, err := strconv.Atoi(matches[2])
+		localHost, localPort, err := splitHostPort(local)
 		if err != nil {
 			return "", 0, "", 0, errors.New("network name not supported: " + f.Name)
 		}
 
-		remotePort, err := strconv.Atoi(matches[4])
+		remoteHost, remotePort, err := splitHostPort(remote)
 		if err != nil {
 			return "", 0, "", 0, errors.New("network name not supported: " + f.Name)
 		}
 
-		return matches[1], int64(localPort), matches[3], int64(remotePort), nil
+		return localHost, localPort, remoteHost, remotePort, nil
 	}
 
 	// loop-back address [::1]:17223 or *:56863
@@ -159,6 +163,27 @@ func (f *FileDescriptor) NetworkFile() (string, int64, string, int64, error) {
 	}
 
 	return host, int64(localPort), "", 0, nil
+}
+
+// splitHostPort separates a single "host:port" endpoint into its host and
+// numeric port. It relies on net.SplitHostPort so bracketed IPv6 literals
+// like "[fe80::1]:8080" are parsed correctly. A "*" port (wildcard) maps to 0.
+func splitHostPort(endpoint string) (string, int64, error) {
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if port == "*" {
+		return host, 0, nil
+	}
+
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return host, int64(p), nil
 }
 
 // maps lsof state to tcp states

--- a/providers/os/resources/lsof/lsof.go
+++ b/providers/os/resources/lsof/lsof.go
@@ -149,20 +149,12 @@ func (f *FileDescriptor) NetworkFile() (string, int64, string, int64, error) {
 	}
 
 	// loop-back address [::1]:17223 or *:56863
-	host, port, err := net.SplitHostPort(f.Name)
+	host, localPort, err := splitHostPort(f.Name)
 	if err != nil {
 		return "", 0, "", 0, errors.Wrapf(err, "network name not supported: %s", f.Name)
 	}
 
-	localPort := 0
-	if port != "*" {
-		localPort, err = strconv.Atoi(port)
-		if err != nil {
-			return "", 0, "", 0, errors.New("network name not supported: " + f.Name)
-		}
-	}
-
-	return host, int64(localPort), "", 0, nil
+	return host, localPort, "", 0, nil
 }
 
 // splitHostPort separates a single "host:port" endpoint into its host and

--- a/providers/os/resources/lsof/lsof_test.go
+++ b/providers/os/resources/lsof/lsof_test.go
@@ -168,6 +168,61 @@ func TestParseLsofMalformedTcpField(t *testing.T) {
 	})
 }
 
+func TestNetworkFileEstablished(t *testing.T) {
+	// Established connections are "<local>-><remote>". IPv6 endpoints are
+	// bracketed and contain colons, so the local/remote host and port must be
+	// split on "->" and parsed per-endpoint rather than with a naive
+	// host:port regex.
+	cases := []struct {
+		name       string
+		fdName     string
+		localHost  string
+		localPort  int64
+		remoteHost string
+		remotePort int64
+	}{
+		{
+			name:       "ipv4",
+			fdName:     "10.184.10.188:64647->76.76.21.61:443",
+			localHost:  "10.184.10.188",
+			localPort:  64647,
+			remoteHost: "76.76.21.61",
+			remotePort: 443,
+		},
+		{
+			name:       "ipv6",
+			fdName:     "[fe80::1]:8080->[fe80::2]:9090",
+			localHost:  "fe80::1",
+			localPort:  8080,
+			remoteHost: "fe80::2",
+			remotePort: 9090,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fd := FileDescriptor{Name: tc.fdName}
+			localHost, localPort, remoteHost, remotePort, err := fd.NetworkFile()
+			require.NoError(t, err)
+			assert.Equal(t, tc.localHost, localHost)
+			assert.Equal(t, tc.localPort, localPort)
+			assert.Equal(t, tc.remoteHost, remoteHost)
+			assert.Equal(t, tc.remotePort, remotePort)
+		})
+	}
+}
+
+func TestNetworkFileListening(t *testing.T) {
+	// The listening branch (no "->") must keep working for bracketed IPv6.
+	fd := FileDescriptor{Name: "[::1]:17223"}
+	host, port, remoteHost, remotePort, err := fd.NetworkFile()
+	require.NoError(t, err)
+	assert.Equal(t, "::1", host)
+	assert.Equal(t, int64(17223), port)
+	assert.Equal(t, "", remoteHost)
+	assert.Equal(t, int64(0), remotePort)
+}
+
 func TestParseEmpty(t *testing.T) {
 	processes, err := Parse(strings.NewReader(""))
 	if err != nil {


### PR DESCRIPTION
## Problem

`lsof`'s `NetworkFile()` parses an established connection's name — of the form
`<local-host>:<local-port>-><remote-host>:<remote-port>` — with a greedy regex:

```go
var networkNameRegexp = regexp.MustCompile(`(.*):(.*)->(.*):(.*)`)
```

For IPv4 this works, but IPv6 endpoints are bracketed and contain colons inside
the address (e.g. `[fe80::1]:8080->[fe80::2]:9090`). The greedy `(.*):(.*)`
grabs the colons *inside* the bracketed address, so the host and port split at
the wrong boundary — the host keeps its brackets and the port is mis-parsed.

The listening branch (names without `->`) was already correct because it uses
`net.SplitHostPort`; only the established `->` branch used the naive regex.

## Impact

For any TCP connection whose local or remote endpoint is IPv6, the local/remote
host and port returned by `NetworkFile()` were wrong. This feeds the `mql`
`processes`/socket surface, so IPv6 connection host/port data was incorrect
while IPv4 connections were unaffected.

## Fix

Split the established name on `->` into its two endpoint strings, then parse
each endpoint with `net.SplitHostPort` — the same bracket-aware helper the
listening branch already relied on. A small `splitHostPort` helper wraps
`net.SplitHostPort` + numeric port parsing (mapping a `*` wildcard port to 0).
IPv4 behavior and the existing field assignments are unchanged; the now-unused
regex is removed.

## Verification

Added `TestNetworkFileEstablished` (table-driven, IPv4 + IPv6 cases) and
`TestNetworkFileListening` (IPv6 loop-back). The IPv6 established case fails
against the old regex (host comes back as `[fe80::1]` instead of `fe80::1`) and
passes with the fix; IPv4 passes both.

```
$ go test ./providers/os/resources/lsof/...
ok  	go.mondoo.com/mql/v13/providers/os/resources/lsof	4.658s
```

```
=== RUN   TestNetworkFileEstablished
=== RUN   TestNetworkFileEstablished/ipv4
=== RUN   TestNetworkFileEstablished/ipv6
--- PASS: TestNetworkFileEstablished (0.00s)
=== RUN   TestNetworkFileListening
--- PASS: TestNetworkFileListening (0.00s)
PASS
ok  	go.mondoo.com/mql/v13/providers/os/resources/lsof
```
