### PR TITLE
⚡ os: skip redundant /proc stat for pids already enumerated

### DIFF
--- a/providers/os/resources/processes/linuxproc.go
+++ b/providers/os/resources/processes/linuxproc.go
@@ -61,15 +61,12 @@ func (lpm *LinuxProcManager) List() ([]*OSProcess, error) {
 }
 
 // processInfo gathers cmdline, status for a process without socket inodes.
+//
+// It does not verify that the pid still exists: callers that enumerate pids
+// from /proc (List) already know the directory exists, so re-stating it here
+// would be a redundant syscall per process. The single-pid entry point
+// (Process) checks existence itself before calling in.
 func (lpm *LinuxProcManager) processInfo(pid int64, pidPath string) (*OSProcess, error) {
-	exists, err := lpm.Exists(pid)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, errors.New("process " + strconv.FormatInt(pid, 10) + " does not exist: " + pidPath)
-	}
-
 	cmdlinef, err := lpm.conn.FileSystem().Open(filepath.Join(pidPath, "cmdline"))
 	if err != nil {
 		return nil, err
@@ -122,6 +119,18 @@ func (lpm *LinuxProcManager) Exists(pid int64) (bool, error) {
 
 func (lpm *LinuxProcManager) Process(pid int64) (*OSProcess, error) {
 	pidPath := filepath.Join("/proc", strconv.FormatInt(pid, 10))
+
+	// The caller supplies an arbitrary pid that may not exist, so verify it
+	// before reading. List() skips this check because its pids come straight
+	// from the /proc enumeration.
+	exists, err := lpm.Exists(pid)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errors.New("process " + strconv.FormatInt(pid, 10) + " does not exist: " + pidPath)
+	}
+
 	proc, err := lpm.processInfo(pid, pidPath)
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/processes/linuxproc_internal_test.go
+++ b/providers/os/resources/processes/linuxproc_internal_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+// fakeProcConn is a minimal shared.Connection backed by an afero filesystem so
+// we can exercise LinuxProcManager against a synthetic /proc tree.
+type fakeProcConn struct {
+	fs afero.Fs
+}
+
+func (c *fakeProcConn) ID() uint32                                 { return 0 }
+func (c *fakeProcConn) ParentID() uint32                           { return 0 }
+func (c *fakeProcConn) RunCommand(string) (*shared.Command, error) { return nil, nil }
+func (c *fakeProcConn) FileInfo(string) (shared.FileInfoDetails, error) {
+	return shared.FileInfoDetails{}, nil
+}
+func (c *fakeProcConn) FileSystem() afero.Fs              { return c.fs }
+func (c *fakeProcConn) Name() string                      { return "fake" }
+func (c *fakeProcConn) Type() shared.ConnectionType       { return "fake" }
+func (c *fakeProcConn) Asset() *inventory.Asset           { return &inventory.Asset{} }
+func (c *fakeProcConn) UpdateAsset(*inventory.Asset)      {}
+func (c *fakeProcConn) Capabilities() shared.Capabilities { return shared.Capability_File }
+
+func writeProcEntry(t *testing.T, fs afero.Fs, pid, name string) {
+	t.Helper()
+	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/cmdline", []byte(name+"\x00"), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/proc/"+pid+"/status", []byte("Name:\t"+name+"\nState:\tS (sleeping)\nPid:\t"+pid+"\n"), 0o644))
+}
+
+func newLinuxProcManager(t *testing.T) *LinuxProcManager {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/proc", 0o755))
+	writeProcEntry(t, fs, "1", "init")
+	writeProcEntry(t, fs, "42", "bash")
+	writeProcEntry(t, fs, "1337", "nginx")
+	return &LinuxProcManager{conn: &fakeProcConn{fs: fs}}
+}
+
+// List() must return every pid it enumerated from /proc.
+func TestLinuxProcManager_ListReturnsAllPids(t *testing.T) {
+	lpm := newLinuxProcManager(t)
+
+	procs, err := lpm.List()
+	require.NoError(t, err)
+	require.Len(t, procs, 3)
+
+	pids := map[int64]bool{}
+	for _, p := range procs {
+		pids[p.Pid] = true
+	}
+	require.True(t, pids[1])
+	require.True(t, pids[42])
+	require.True(t, pids[1337])
+}
+
+// Process(pid) for a pid that does not exist must still report not-found,
+// even though List() no longer re-stats enumerated pids.
+func TestLinuxProcManager_ProcessNonexistentErrors(t *testing.T) {
+	lpm := newLinuxProcManager(t)
+
+	_, err := lpm.Process(999999)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+}
+
+// Process(pid) for an existing pid must succeed and return its data.
+func TestLinuxProcManager_ProcessExistingSucceeds(t *testing.T) {
+	lpm := newLinuxProcManager(t)
+
+	proc, err := lpm.Process(42)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), proc.Pid)
+	require.Equal(t, "bash", proc.Command)
+}


### PR DESCRIPTION
## Problem

`LinuxProcManager.List()` enumerates process ids by reading `Readdirnames("/proc")`, then calls `processInfo` for each pid. The first thing `processInfo` did was `lpm.Exists(pid)` — an afero stat of `/proc/<pid>` that the directory enumeration had *just* returned. Every listed pid was therefore stat'd a second time for no reason.

## Impact

One redundant `stat` syscall per process on every process listing. On an 800-process host that is 800 wasted syscalls per query. The local and docker-fs connection backends both resolve to this manager, so this hits common `processes` queries.

## Fix

Move the existence check out of the shared `processInfo` helper and into the single-pid `Process(pid)` entry point, where the caller supplies an arbitrary pid that may not exist and the check is still needed. The `List()` path no longer re-stats pids it already enumerated. `Process(pid)` keeps its exact prior not-found behavior (same error message for a pid that does not exist).

## Verification

- `go test ./providers/os/resources/processes/...` passes.
- `go test ./providers/os/resources/ -run Process` passes.
- Added focused tests (`linuxproc_internal_test.go`) driving `LinuxProcManager` over a synthetic in-memory `/proc`:
  - `List()` returns every enumerated pid.
  - `Process(nonexistentPid)` still errors with "does not exist".
  - `Process(existingPid)` succeeds and returns the process data.
