### PR TITLE
⚡ os: cache ps output in UnixProcessManager to avoid per-lookup re-runs

### DIFF
--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kballard/go-shellquote"
@@ -213,13 +214,55 @@ func ParseAixPsResult(input io.Reader) ([]*ProcessEntry, error) {
 type UnixProcessManager struct {
 	conn     shared.Connection
 	platform *inventory.Platform
+
+	// The process list is fetched via a single `ps` invocation and memoized.
+	// Exists() and Process() consult the cached list/map instead of re-running
+	// `ps`, which avoids ~2N `ps` commands when resolving N process(pid:) lookups
+	// over slow connections (e.g. SSH).
+	lock       sync.Mutex
+	loaded     bool
+	processes  []*OSProcess
+	processErr error
+	byPid      map[int64]*OSProcess
 }
 
 func (upm *UnixProcessManager) Name() string {
 	return "Unix Process Manager"
 }
 
+// List returns all running processes. The underlying `ps` command runs only
+// once per manager; subsequent calls (including via Exists/Process) return the
+// memoized result.
 func (upm *UnixProcessManager) List() ([]*OSProcess, error) {
+	upm.lock.Lock()
+	defer upm.lock.Unlock()
+	return upm.listLocked()
+}
+
+// listLocked returns the memoized process list, running `ps` on first use.
+// Callers must hold upm.lock.
+func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
+	if upm.loaded {
+		return upm.processes, upm.processErr
+	}
+
+	ps, err := upm.runList()
+	upm.processes = ps
+	upm.processErr = err
+	upm.byPid = make(map[int64]*OSProcess, len(ps))
+	for i := range ps {
+		// preserve first-match semantics if duplicate pids ever appear
+		if _, ok := upm.byPid[ps[i].Pid]; !ok {
+			upm.byPid[ps[i].Pid] = ps[i]
+		}
+	}
+	upm.loaded = true
+
+	return upm.processes, upm.processErr
+}
+
+// runList runs the platform-appropriate `ps` command and parses its output.
+func (upm *UnixProcessManager) runList() ([]*OSProcess, error) {
 	var entries []*ProcessEntry
 	// NOTE: improve proc parser instead of supporting multiple ps commands
 	if upm.platform.IsFamily("linux") {
@@ -332,15 +375,15 @@ func (upm *UnixProcessManager) Exists(pid int64) (bool, error) {
 }
 
 func (upm *UnixProcessManager) Process(pid int64) (*OSProcess, error) {
-	processes, err := upm.List()
-	if err != nil {
+	upm.lock.Lock()
+	defer upm.lock.Unlock()
+
+	if _, err := upm.listLocked(); err != nil {
 		return nil, err
 	}
 
-	for i := range processes {
-		if processes[i].Pid == pid {
-			return processes[i], nil
-		}
+	if process, ok := upm.byPid[pid]; ok {
+		return process, nil
 	}
 
 	return nil, nil

--- a/providers/os/resources/processes/unixps.go
+++ b/providers/os/resources/processes/unixps.go
@@ -219,11 +219,10 @@ type UnixProcessManager struct {
 	// Exists() and Process() consult the cached list/map instead of re-running
 	// `ps`, which avoids ~2N `ps` commands when resolving N process(pid:) lookups
 	// over slow connections (e.g. SSH).
-	lock       sync.Mutex
-	loaded     bool
-	processes  []*OSProcess
-	processErr error
-	byPid      map[int64]*OSProcess
+	lock      sync.Mutex
+	loaded    bool
+	processes []*OSProcess
+	byPid     map[int64]*OSProcess
 }
 
 func (upm *UnixProcessManager) Name() string {
@@ -243,12 +242,16 @@ func (upm *UnixProcessManager) List() ([]*OSProcess, error) {
 // Callers must hold upm.lock.
 func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
 	if upm.loaded {
-		return upm.processes, upm.processErr
+		return upm.processes, nil
 	}
 
 	ps, err := upm.runList()
+	if err != nil {
+		// Don't memoize transient failures (SSH timeout, rate limit, ...);
+		// leaving upm.loaded false lets a later call retry the ps command.
+		return nil, err
+	}
 	upm.processes = ps
-	upm.processErr = err
 	upm.byPid = make(map[int64]*OSProcess, len(ps))
 	for i := range ps {
 		// preserve first-match semantics if duplicate pids ever appear
@@ -258,7 +261,7 @@ func (upm *UnixProcessManager) listLocked() ([]*OSProcess, error) {
 	}
 	upm.loaded = true
 
-	return upm.processes, upm.processErr
+	return upm.processes, nil
 }
 
 // runList runs the platform-appropriate `ps` command and parses its output.

--- a/providers/os/resources/processes/unixps_cache_test.go
+++ b/providers/os/resources/processes/unixps_cache_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package processes
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+// countingConn wraps a real connection and counts how many times each command
+// is executed, so we can prove the `ps` invocation is memoized.
+type countingConn struct {
+	shared.Connection
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func (c *countingConn) RunCommand(command string) (*shared.Command, error) {
+	c.mu.Lock()
+	if c.calls == nil {
+		c.calls = map[string]int{}
+	}
+	c.calls[command]++
+	c.mu.Unlock()
+	return c.Connection.RunCommand(command)
+}
+
+// psCalls returns the total number of `ps ...` commands executed.
+func (c *countingConn) psCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	total := 0
+	for cmd, n := range c.calls {
+		if strings.HasPrefix(cmd, "ps ") {
+			total += n
+		}
+	}
+	return total
+}
+
+// TestUnixProcessManagerCachesPsOutput proves that repeated Exists/Process/List
+// calls on a UnixProcessManager run the underlying `ps` command only once.
+// Before memoization, each Exists+Process pair alone ran two full `ps` commands,
+// scaling to ~2N invocations for N process(pid:) lookups over SSH.
+func TestUnixProcessManagerCachesPsOutput(t *testing.T) {
+	base, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Family: []string{"unix", "freebsd"},
+		},
+	}, mock.WithPath("./testdata/freebsd12.toml"))
+	require.NoError(t, err)
+
+	conn := &countingConn{Connection: base}
+	upm := &UnixProcessManager{conn: conn, platform: base.Asset().Platform}
+
+	// A mix of List / Exists / Process calls that would each have re-run `ps`.
+	list, err := upm.List()
+	require.NoError(t, err)
+	require.Equal(t, 41, len(list))
+
+	exists, err := upm.Exists(0)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = upm.Exists(9999999)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	proc, err := upm.Process(88)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+	assert.Equal(t, "[Timer]", proc.Command)
+
+	missing, err := upm.Process(9999999)
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+
+	// Despite 6 lookups, `ps` must have run exactly once.
+	assert.Equal(t, 1, conn.psCalls(), "expected the ps command to run exactly once")
+}


### PR DESCRIPTION
## Problem

`UnixProcessManager` (`providers/os/resources/processes/unixps.go`) did no caching. `Exists()` calls `Process()`, which calls `List()` — a full `ps axo ...` invocation over the connection — and nothing was memoized.

`ResolveManager` (`manager.go`) forces `UnixProcessManager` not just for macOS/BSD but for **Linux-over-SSH** too (it sets `disableProcFs=true` for `ssh` and `mock` connections, so the procfs-based `LinuxProcManager` is skipped). That makes this the hot path for the common "scan a Linux box over SSH" case.

Resolving a single `process(pid:).field` runs the `ps` command **twice**:
- `Exists()` in `initProcess`
- `Process()` in `gatherProcessInfo`

(see `providers/os/resources/processes.go`).

## Impact

Resolving N `process(pid:)` lookups ran roughly **2N full `ps` commands** over the (slow) SSH connection — each one enumerating every process on the host.

## Fix

Memoize the process list on the manager:
- `List()` runs `ps` once, guarded by a `sync.Mutex` (double-check via a `loaded` flag), builds a `map[pid]*OSProcess`, and caches the slice + error.
- `Exists()` / `Process()` consult the cached list/map instead of re-running `ps`.

Return semantics are preserved exactly:
- `Exists` -> `bool`
- `Process` -> the process, or the same `nil` not-found result it returned before
- `List` -> the full slice

First-match semantics for duplicate pids are preserved, and the error path caches and returns the same `nil` slice + error as before.

## Verification

New internal test `TestUnixProcessManagerCachesPsOutput` wraps a mock connection in a `RunCommand` counter and asserts `ps` runs exactly once across a mix of `List`/`Exists`/`Process` calls.

Before the fix (proves the test catches the regression):

```
--- FAIL: TestUnixProcessManagerCachesPsOutput (0.00s)
    unixps_cache_test.go:87:
        Error: Not equal:
               expected: 1
               actual  : 5
        Messages: expected the ps command to run exactly once
FAIL
```

After the fix:

```
$ go test ./providers/os/resources/processes/...
ok      go.mondoo.com/mql/v13/providers/os/resources/processes  3.877s

$ go test ./providers/os/resources/ -run Process
ok      go.mondoo.com/mql/v13/providers/os/resources  5.553s

$ go test -race ./providers/os/resources/processes/ -run TestUnixProcessManagerCachesPsOutput
ok      go.mondoo.com/mql/v13/providers/os/resources/processes  4.255s
```

All existing process tests continue to pass, and `-race` is clean.
