### PR TITLE
🐛 os: fix binary version scanner dropping/truncating versions on short reads

### DIFF
--- a/providers/os/resources/apache2.go
+++ b/providers/os/resources/apache2.go
@@ -92,42 +92,73 @@ func scanBinaryForTag(fs *afero.Afero, path string, tag []byte) string {
 	}
 	defer f.Close()
 
-	const chunkSize = 64 * 1024
 	// Overlap must be at least len(tag) + max version length to avoid
 	// missing a match that spans two chunks.
-	overlap := len(tag) + 20
+	return scanReaderForTag(f, tag, len(tag)+20, isApacheVersionByte)
+}
+
+// isApacheVersionByte reports whether b belongs to an Apache/nginx style
+// dot-separated numeric version (e.g. "2.4.62").
+func isApacheVersionByte(b byte) bool {
+	return b == '.' || (b >= '0' && b <= '9')
+}
+
+// scanReaderForTag streams r in chunks, looking for tag followed by a run of
+// version bytes (as classified by isVersionByte). It is the reader-based core
+// shared by the binary version scanners; the caller owns opening/closing the
+// underlying file. `overlap` is the number of trailing bytes retained between
+// chunks so a match spanning a chunk boundary isn't missed.
+func scanReaderForTag(r io.Reader, tag []byte, overlap int, isVersionByte func(byte) bool) string {
+	const chunkSize = 64 * 1024
 	buf := make([]byte, chunkSize+overlap)
 	carry := 0
 
 	for {
-		n, err := f.Read(buf[carry:])
-		if n == 0 && err != nil {
-			break
-		}
+		n, err := r.Read(buf[carry:])
 		active := buf[:carry+n]
 
 		idx := bytes.Index(active, tag)
 		if idx >= 0 {
 			start := idx + len(tag)
 			end := start
-			for end < len(active) && (active[end] == '.' || (active[end] >= '0' && active[end] <= '9')) {
+			for end < len(active) && isVersionByte(active[end]) {
 				end++
 			}
 			if end > start {
+				// If the version run reaches the end of the current buffer
+				// and more data may still follow (err == nil), the literal
+				// might continue into the next chunk. Carry the tag and the
+				// partial run forward and keep reading rather than returning
+				// a truncated version (e.g. "2.4.6" instead of "2.4.62").
+				// The len(active)-idx guard ensures carrying from the tag
+				// frees room in the buffer for the next read (avoiding an
+				// infinite loop when a run fills the whole buffer).
+				if end == len(active) && err == nil && len(active)-idx < len(buf) {
+					copy(buf, active[idx:])
+					carry = len(active) - idx
+					continue
+				}
 				return string(active[start:end])
 			}
 		}
 
-		// Keep the last `overlap` bytes so a tag spanning chunks isn't missed.
+		// Stop once the reader is drained. `active` was already scanned
+		// above, so any tail carried from a previous iteration has had its
+		// final chance to match.
+		if err != nil {
+			break
+		}
+
+		// Keep the last `overlap` bytes so a tag spanning chunks isn't
+		// missed. On a short read (len(active) <= overlap) retain the whole
+		// buffer instead of discarding it, so a tag split across two short
+		// reads is still found.
 		if len(active) > overlap {
 			copy(buf, active[len(active)-overlap:])
 			carry = overlap
 		} else {
-			carry = 0
-		}
-
-		if err != nil {
-			break
+			copy(buf, active)
+			carry = len(active)
 		}
 	}
 	return ""

--- a/providers/os/resources/nginx_test.go
+++ b/providers/os/resources/nginx_test.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"io"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -220,6 +221,80 @@ func TestScanBinaryForTagNginx(t *testing.T) {
 		data := append(prefix, []byte("nginx/1.25.3\x00")...)
 		afs := writeBinary(t, data)
 		assert.Equal(t, "1.25.3", scanBinaryForTag(afs, "/usr/sbin/nginx", tag))
+	})
+
+	t.Run("version literal at exact chunkSize+overlap boundary", func(t *testing.T) {
+		// Position the version so its numeric run reaches exactly the end of
+		// the first full buffer read (chunkSize+overlap) while more file data
+		// remains. The trailing digit ("2") lands in the next chunk. Without
+		// the fix the scanner returns a truncated "1.25.6" instead of the
+		// full "1.25.62".
+		const chunkSize = 64 * 1024
+		overlap := len(tag) + 20
+		bufLen := chunkSize + overlap
+		head := append([]byte("nginx/"), []byte("1.25.6")...) // ends at bufLen
+		prefix := make([]byte, bufLen-len(head))
+		data := append(prefix, head...)
+		data = append(data, []byte("2\x00trailing")...)
+		afs := writeBinary(t, data)
+		assert.Equal(t, "1.25.62", scanBinaryForTag(afs, "/usr/sbin/nginx", tag))
+	})
+}
+
+// chunkReader returns at most max bytes per Read, letting tests exercise the
+// short-read paths of scanReaderForTag (a tag or version literal split across
+// multiple Reads).
+type chunkReader struct {
+	data []byte
+	pos  int
+	max  int
+}
+
+func (c *chunkReader) Read(p []byte) (int, error) {
+	if c.pos >= len(c.data) {
+		return 0, io.EOF
+	}
+	n := len(c.data) - c.pos
+	if n > c.max {
+		n = c.max
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	copy(p, c.data[c.pos:c.pos+n])
+	c.pos += n
+	return n, nil
+}
+
+func TestScanReaderForTagShortReads(t *testing.T) {
+	tag := []byte("nginx/")
+	overlap := len(tag) + 20
+
+	t.Run("tag split across two short reads", func(t *testing.T) {
+		// Three bytes per Read forces the "nginx/" tag itself to span
+		// several reads. The pre-fix short-read handling discarded the
+		// unmatched tail (carry = 0), missing the tag entirely.
+		data := []byte("\x00\x00nginx/1.25.3\x00")
+		r := &chunkReader{data: data, max: 3}
+		assert.Equal(t, "1.25.3", scanReaderForTag(r, tag, overlap, isApacheVersionByte))
+	})
+
+	t.Run("version literal split across short reads", func(t *testing.T) {
+		// Small reads make the numeric run reach the buffer end mid-version
+		// while more data remains. The pre-fix return-on-boundary truncated
+		// this to "1.25.6".
+		data := []byte("nginx/1.25.62\x00")
+		r := &chunkReader{data: data, max: 4}
+		assert.Equal(t, "1.25.62", scanReaderForTag(r, tag, overlap, isApacheVersionByte))
+	})
+
+	t.Run("version ends exactly at final EOF read", func(t *testing.T) {
+		// The version literal runs to the very end of the data with no
+		// trailing terminator, so the final bytes arrive on the read that
+		// also reports io.EOF.
+		data := []byte("nginx/1.25.62")
+		r := &chunkReader{data: data, max: 4}
+		assert.Equal(t, "1.25.62", scanReaderForTag(r, tag, overlap, isApacheVersionByte))
 	})
 }
 

--- a/providers/os/resources/squid.go
+++ b/providers/os/resources/squid.go
@@ -4,7 +4,6 @@
 package resources
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -91,60 +90,23 @@ func scanBinaryForSquidVersion(fs *afero.Afero, path string) string {
 	}
 	defer f.Close()
 
-	const chunkSize = 64 * 1024
 	tag := squidVersionTag
-	overlap := len(tag) + 32
-	buf := make([]byte, chunkSize+overlap)
-	carry := 0
+	return scanReaderForTag(f, tag, len(tag)+32, isSquidVersionByte)
+}
 
-	versionByte := func(b byte) bool {
-		if b >= '0' && b <= '9' {
-			return true
-		}
-		if b >= 'a' && b <= 'z' {
-			return true
-		}
-		if b >= 'A' && b <= 'Z' {
-			return true
-		}
-		return b == '.' || b == '-' || b == '_' || b == '+'
+// isSquidVersionByte reports whether b belongs to a Squid version literal,
+// whose alphabet is wider than the numeric Apache form (e.g. "5.7-rc1").
+func isSquidVersionByte(b byte) bool {
+	if b >= '0' && b <= '9' {
+		return true
 	}
-
-	for {
-		n, err := f.Read(buf[carry:])
-		if n == 0 && err != nil {
-			break
-		}
-		active := buf[:carry+n]
-
-		idx := bytes.Index(active, tag)
-		if idx >= 0 {
-			start := idx + len(tag)
-			end := start
-			for end < len(active) && versionByte(active[end]) {
-				end++
-			}
-			if end > start {
-				return string(active[start:end])
-			}
-		}
-
-		if len(active) > overlap {
-			copy(buf, active[len(active)-overlap:])
-			carry = overlap
-		} else {
-			// Carry the whole active buffer forward — if the version
-			// tag straddles the boundary of a short final read, this
-			// keeps the prefix bytes available for the next iteration.
-			// `active` aliases `buf[:carry+n]`, so no copy is needed.
-			carry = len(active)
-		}
-
-		if err != nil {
-			break
-		}
+	if b >= 'a' && b <= 'z' {
+		return true
 	}
-	return ""
+	if b >= 'A' && b <= 'Z' {
+		return true
+	}
+	return b == '.' || b == '-' || b == '_' || b == '+'
 }
 
 type mqlSquidConfInternal struct {


### PR DESCRIPTION
## Problem

`scanBinaryForTag` in `providers/os/resources/apache2.go` — used by both the
`apache2` and `nginx` version resources to pull the embedded `Apache/x.y.z` /
`nginx/x.y.z` string out of the server binary — mishandled `Read` calls that
return fewer bytes than requested (short reads, common on remote SSH/streamed
filesystems):

1. **Dropped tail on short reads.** When `len(active) <= overlap`, the loop set
   `carry = 0`, discarding the unmatched bytes. A version tag split across two
   short reads was therefore never matched. (The sibling
   `scanBinaryForSquidVersion` in `squid.go` had already been fixed for this.)
2. **Truncated version on the boundary.** When the tag was found near the end of
   the buffer, the numeric run was read only up to `len(active)` and returned
   immediately. A version literal that straddled the chunk/overlap boundary was
   cut short — e.g. `2.4.6` instead of `2.4.62`.

## Impact

`apache2.version` and `nginx.version` could return an empty or truncated version
string depending on where the version literal happened to land relative to the
64 KiB read boundary. Truncated versions silently skew any policy that compares
the reported version against a fixed floor.

## Fix

- Refactored the scanning loop into a reader-based core, `scanReaderForTag`,
  that operates on an `io.Reader` (the `fs.Open`/`defer Close` wrapper is
  retained). This also makes the short-read paths unit-testable.
- On a short read the whole buffer is now carried forward (`carry = len(active)`)
  instead of being discarded.
- When a version run reaches the end of the buffer while more data may still
  follow (`err == nil`), the tag and partial run are carried forward and reading
  continues before returning, so boundary-straddling literals are returned in
  full. A `len(active)-idx` guard prevents an infinite loop if a run ever fills
  the whole buffer.
- `scanBinaryForSquidVersion` now shares the same core (via an
  `isSquidVersionByte` classifier), so it picks up the truncation-on-return fix
  as well.

Normal full-read behavior and all existing return values are preserved.

## Verification

`nginx_test.go` gains a reader-based `chunkReader` and cases that force (1) the
tag split across short reads and (2) the version literal at the exact
`chunkSize+overlap` boundary. Each case fails before the fix and passes after.

```
$ go test ./providers/os/resources/ -run 'Nginx|Apache|Squid'
ok  	go.mondoo.com/mql/v13/providers/os/resources	1.175s
```

New/updated subtests:

```
--- PASS: TestScanBinaryForTagNginx
    --- PASS: TestScanBinaryForTagNginx/version_literal_at_exact_chunkSize+overlap_boundary
--- PASS: TestScanReaderForTagShortReads
    --- PASS: TestScanReaderForTagShortReads/tag_split_across_two_short_reads
    --- PASS: TestScanReaderForTagShortReads/version_literal_split_across_short_reads
    --- PASS: TestScanReaderForTagShortReads/version_ends_exactly_at_final_EOF_read
```

Confirmed the new cases fail against the pre-fix logic (returning `""` /
`1.25.6`) and pass with the fix in place.
