### PR TITLE
🐛 os: fix rsyslog != severity selectors and mid-path include globs

### DIFF
--- a/providers/os/resources/rsyslog.go
+++ b/providers/os/resources/rsyslog.go
@@ -313,6 +313,9 @@ func (s *mqlRsyslogConf) files(path string) ([]any, error) {
 	return out, nil
 }
 
+// reRsyslogGlob detects filepath glob meta-characters in a path segment.
+var reRsyslogGlob = regexp.MustCompile(`[*?\[]`)
+
 // expandIncludePattern resolves a single include pattern (relative to
 // parentDir if not absolute) into the list of files it matches, using
 // files.find against the asset's filesystem.
@@ -323,15 +326,87 @@ func (s *mqlRsyslogConf) files(path string) ([]any, error) {
 // compiles it as a regex matched against the whole path. Matching locally
 // keeps rsyslog's own glob(3) semantics identical on every connection type.
 //
-// depth=1 restricts the search to the immediate directory, matching
-// rsyslog's own glob(3) semantics: `$IncludeConfig /etc/rsyslog.d/*.conf`
-// does not pick up `/etc/rsyslog.d/nested/extra.conf`.
+// A glob may appear in any path segment, not just the basename: rsyslog
+// expands `$IncludeConfig /etc/rsyslog.d/*/out.conf` by matching every
+// immediate subdirectory in turn. The directory portion is resolved
+// segment-by-segment (`resolveIncludeDirs`) so a mid-path glob fans out to
+// the set of concrete directories it names; the basename glob is then
+// matched against the files in each. Each glob segment consumes exactly one
+// level, matching rsyslog's own glob(3) semantics: a `*` does not descend
+// past a single directory boundary.
 func (s *mqlRsyslogConf) expandIncludePattern(parentDir, pattern string) ([]string, error) {
 	dir, baseGlob := resolveRsyslogInclude(parentDir, pattern)
 
+	dirs, err := s.resolveIncludeDirs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, d := range dirs {
+		files, err := s.findChildren(d, "file")
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range files {
+			if rsyslogIncludeMatches(baseGlob, p) {
+				paths = append(paths, p)
+			}
+		}
+	}
+	return paths, nil
+}
+
+// resolveIncludeDirs turns an absolute directory path that may contain glob
+// segments into the concrete directories it names. Non-glob segments are
+// appended literally (no listing, so a plain directory path collapses to a
+// single result without any filesystem access); a glob segment lists the
+// immediate subdirectories of each current path and keeps the ones whose
+// name matches. Paths naming a directory that doesn't exist simply drop out,
+// mirroring glob(3)'s "no match" behaviour.
+func (s *mqlRsyslogConf) resolveIncludeDirs(dir string) ([]string, error) {
+	paths := []string{"/"}
+	for _, seg := range strings.Split(dir, "/") {
+		if seg == "" {
+			continue
+		}
+		if !reRsyslogGlob.MatchString(seg) {
+			for i := range paths {
+				paths[i] = filepath.Join(paths[i], seg)
+			}
+			continue
+		}
+
+		var next []string
+		for _, p := range paths {
+			subdirs, err := s.findChildren(p, "directory")
+			if err != nil {
+				return nil, err
+			}
+			for _, sd := range subdirs {
+				// `find -maxdepth 1 -type d` also lists the search root
+				// itself; only its children are candidates for the segment.
+				if filepath.Clean(sd) == filepath.Clean(p) {
+					continue
+				}
+				if rsyslogIncludeMatches(seg, sd) {
+					next = append(next, sd)
+				}
+			}
+		}
+		paths = next
+	}
+	return paths, nil
+}
+
+// findChildren lists the immediate children of `dir` of the given find type
+// ("file" or "directory") via files.find with depth=1, returning their
+// paths. A missing directory yields an empty list rather than an error,
+// matching how the command backends report an absent search root.
+func (s *mqlRsyslogConf) findChildren(dir, typ string) ([]string, error) {
 	o, err := CreateResource(s.MqlRuntime, "files.find", map[string]*llx.RawData{
 		"from":  llx.StringData(dir),
-		"type":  llx.StringData("file"),
+		"type":  llx.StringData(typ),
 		"depth": llx.IntData(1),
 	})
 	if err != nil {
@@ -343,18 +418,13 @@ func (s *mqlRsyslogConf) expandIncludePattern(parentDir, pattern string) ([]stri
 		return nil, list.Error
 	}
 
-	paths := make([]string, 0, len(list.Data))
+	out := make([]string, 0, len(list.Data))
 	for _, item := range list.Data {
-		mf, ok := item.(*mqlFile)
-		if !ok {
-			continue
+		if mf, ok := item.(*mqlFile); ok {
+			out = append(out, mf.Path.Data)
 		}
-		if !rsyslogIncludeMatches(baseGlob, mf.Path.Data) {
-			continue
-		}
-		paths = append(paths, mf.Path.Data)
 	}
-	return paths, nil
+	return out, nil
 }
 
 func (s *mqlRsyslogConf) content(files []any) (string, error) {

--- a/providers/os/resources/rsyslog_include_internal_test.go
+++ b/providers/os/resources/rsyslog_include_internal_test.go
@@ -20,8 +20,15 @@ import (
 // and returns the paths it reports.
 func rsyslogFixtureFiles(t *testing.T) []string {
 	t.Helper()
+	return rsyslogFixtureFilesFrom(t, "testdata/rsyslog_includes.toml")
+}
 
-	fixturePath, err := filepath.Abs("testdata/rsyslog_includes.toml")
+// rsyslogFixtureFilesFrom resolves rsyslog.conf.files against an arbitrary
+// mock fixture and returns the file paths it reports.
+func rsyslogFixtureFilesFrom(t *testing.T, fixture string) []string {
+	t.Helper()
+
+	fixturePath, err := filepath.Abs(fixture)
 	require.NoError(t, err)
 
 	asset := &inventory.Asset{
@@ -95,6 +102,27 @@ func TestRsyslogConf_IncludeExpansion(t *testing.T) {
 			assert.NotContains(t, p, "rsyslog.absent")
 		}
 		assert.Contains(t, paths, "/etc/rsyslog.conf")
+	})
+}
+
+// A wildcard in a non-terminal path segment (`/etc/rsyslog.apps/*/out.conf`)
+// must fan out across every matching subdirectory. Previously the middle glob
+// was handed to the directory search verbatim and matched nothing, so no
+// fragment was ever included.
+func TestRsyslogConf_MidPathIncludeGlob(t *testing.T) {
+	paths := rsyslogFixtureFilesFrom(t, "testdata/rsyslog_midpath_include.toml")
+
+	t.Run("expands the wildcard across every subdirectory", func(t *testing.T) {
+		assert.ElementsMatch(t, []string{
+			"/etc/rsyslog.conf",
+			"/etc/rsyslog.apps/web/out.conf",
+			"/etc/rsyslog.apps/db/out.conf",
+		}, paths)
+	})
+
+	t.Run("applies the basename glob inside each matched subdirectory", func(t *testing.T) {
+		assert.NotContains(t, paths, "/etc/rsyslog.apps/web/other.conf",
+			"other.conf shares the directory but does not match out.conf")
 	})
 }
 

--- a/providers/os/resources/rsyslog_parse.go
+++ b/providers/os/resources/rsyslog_parse.go
@@ -176,13 +176,23 @@ var rsyslogModernStmt = regexp.MustCompile(`^(module|input|action|global)\s*\((.
 // The regex is intentionally permissive on the selector half (anything
 // that isn't whitespace until the target) so audits get a typed entry
 // even for forms we don't otherwise model — the rule's `facilities`/
-// `severities` arrays simply reflect what we could parse.
-var rsyslogSelector = regexp.MustCompile(`^([!*A-Za-z0-9_,;.\-]+)\s+(\S.*)$`)
+// `severities` arrays simply reflect what we could parse. `=` is part of
+// the class so severity comparison prefixes (`=info`, `!=info`) don't cut
+// the selector short before the target token.
+var rsyslogSelector = regexp.MustCompile(`^([!*=A-Za-z0-9_,;.\-]+)\s+(\S.*)$`)
 
 // rsyslogFacilitySeverity matches a single "facility.severity" pair where
 // each side may be a list (comma-separated) or `*`. Used inside the
 // per-selector loop, after splitting on `;`.
-var rsyslogFacilitySeverity = regexp.MustCompile(`^([!*A-Za-z0-9_,\-]+)\.([!=]?[*A-Za-z0-9]+)$`)
+//
+// The severity may carry an optional comparison prefix: `=` (exactly this
+// severity), `!` (all except this severity), or `!=` (negate-exact). The
+// `!?=?` prefix accepts “, `=`, `!`, and `!=` — but not the invalid `=!`
+// ordering — so selectors like `mail.info`, `mail.=info`, `mail.!info`, and
+// `mail.!=info` all parse. The prefix is preserved verbatim in the captured
+// severity token; downstream inspection only special-cases the `.none`
+// negation, which is unaffected by these prefixes.
+var rsyslogFacilitySeverity = regexp.MustCompile(`^([!*A-Za-z0-9_,\-]+)\.(!?=?[*A-Za-z0-9]+)$`)
 
 // kvRegexp matches a single key="value" / key='value' / key=bareword pair
 // inside a coalesced modern statement's argument list. `.` is permitted in

--- a/providers/os/resources/rsyslog_parse_test.go
+++ b/providers/os/resources/rsyslog_parse_test.go
@@ -434,6 +434,43 @@ auth,authpriv.none /var/log/quieted
 	assert.Equal(t, ":omusrmsg:*", rules[6].target)
 }
 
+func TestParseRsyslogFile_SeverityPrefixes(t *testing.T) {
+	// rsyslog severity selectors accept `=` (exactly), `!` (all except), and
+	// `!=` (negate-exact) prefixes. Each must still produce a rule entry with
+	// the prefix preserved on the severity token — previously the `!=` form
+	// was dropped entirely, yielding zero rules with no error.
+	content := `mail.info /var/log/mail.log
+mail.=info /var/log/mail.exact.log
+mail.!info /var/log/mail.notinfo.log
+mail.!=info /var/log/mail.notexact.log
+`
+	got := parseRsyslogFile("/etc/rsyslog.conf", content)
+
+	var rules []rsyslogEntry
+	for _, e := range got {
+		if e.kind == rsyslogKindRule {
+			rules = append(rules, e)
+		}
+	}
+	require.Len(t, rules, 4, "each severity prefix form must yield exactly one rule")
+
+	assert.Equal(t, []string{"mail"}, rules[0].facilities)
+	assert.Equal(t, []string{"info"}, rules[0].severities)
+	assert.Equal(t, "/var/log/mail.log", rules[0].target)
+
+	assert.Equal(t, []string{"=info"}, rules[1].severities)
+	assert.Equal(t, "/var/log/mail.exact.log", rules[1].target)
+	assert.False(t, rules[1].negate)
+
+	assert.Equal(t, []string{"!info"}, rules[2].severities)
+	assert.Equal(t, "/var/log/mail.notinfo.log", rules[2].target)
+	assert.False(t, rules[2].negate)
+
+	assert.Equal(t, []string{"!=info"}, rules[3].severities)
+	assert.Equal(t, "/var/log/mail.notexact.log", rules[3].target)
+	assert.False(t, rules[3].negate)
+}
+
 func TestParseRsyslogFile_SourceAttribution(t *testing.T) {
 	// Every emitted entry must carry the file path we passed in. That's
 	// how the typed accessors point findings at the originating fragment

--- a/providers/os/resources/testdata/rsyslog_midpath_include.toml
+++ b/providers/os/resources/testdata/rsyslog_midpath_include.toml
@@ -1,0 +1,56 @@
+# A Linux host whose main rsyslog.conf pulls in fragments via an include glob
+# that carries a wildcard in a NON-terminal path segment:
+#
+#   $IncludeConfig /etc/rsyslog.apps/*/out.conf
+#
+# rsyslog expands this by matching every immediate subdirectory of
+# /etc/rsyslog.apps and then the `out.conf` basename inside each. The include
+# lives outside the conventional /etc/rsyslog.d, so the legacy `.d` fallback
+# cannot mask a broken mid-path expansion.
+#
+# Recorded `find` output mirrors what a real host returns for each command:
+# the directory listing includes the search root itself (which the expander
+# must skip), and one app directory holds an `other.conf` that does not match
+# the `out.conf` basename.
+
+[files."/etc/rsyslog.conf"]
+path = "/etc/rsyslog.conf"
+content = """$ModLoad imuxsock
+
+# Per-application fragments, one directory each, wildcard in the middle.
+$IncludeConfig /etc/rsyslog.apps/*/out.conf
+"""
+
+[files."/etc/rsyslog.apps/web/out.conf"]
+path = "/etc/rsyslog.apps/web/out.conf"
+content = """local0.* /var/log/web.log
+"""
+
+# Shares the web directory but does not match the `out.conf` basename glob.
+[files."/etc/rsyslog.apps/web/other.conf"]
+path = "/etc/rsyslog.apps/web/other.conf"
+content = """local0.* /var/log/web.other.log
+"""
+
+[files."/etc/rsyslog.apps/db/out.conf"]
+path = "/etc/rsyslog.apps/db/out.conf"
+content = """local1.* /var/log/db.log
+"""
+
+# Mid-path glob: list the immediate subdirectories of the wildcard's parent.
+# The search root itself (/etc/rsyslog.apps) is present and must be skipped.
+[commands."find -L \"/etc/rsyslog.apps\" -xdev -type d -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.apps
+/etc/rsyslog.apps/web
+/etc/rsyslog.apps/db
+"""
+
+# Terminal basename glob: list the files inside each matched subdirectory.
+[commands."find -L \"/etc/rsyslog.apps/web\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.apps/web/out.conf
+/etc/rsyslog.apps/web/other.conf
+"""
+
+[commands."find -L \"/etc/rsyslog.apps/db\" -xdev -type f -perm -0 -maxdepth 1"]
+stdout = """/etc/rsyslog.apps/db/out.conf
+"""


### PR DESCRIPTION
## Problem

Two independent bugs in the os provider's rsyslog config parser.

**Bug A (#13) — negated-exact severity selectors are silently dropped.**
rsyslog severity selectors support comparison prefixes: `=info` (exactly this
severity), `!info` (all except), and `!=info` (negate-exact). The parser's
severity sub-pattern only allowed a *single* optional `!` or `=`
(`[!=]?[*A-Za-z0-9]+`), so `mail.!=info` failed to match — `!` was consumed
and the remaining `=info` had no matching class. On top of that, the outer
selector regex's character class (`[!*A-Za-z0-9_,;.\-]+`) had no `=` at all,
so `mail.=info` never reached the target token. In both cases the selector
matched nothing, the rule was skipped near the `m == nil; continue` guard, and
the query returned zero `rsyslog.rule` entries with no error.

**Bug B (#14) — include globs in a non-terminal path segment expand to
nothing.** `expandIncludePattern` split a pattern into
`dir = filepath.Dir(pattern)` and `baseGlob = filepath.Base(pattern)`, ran
`files.find` against `dir`, and only glob-matched the basename. A glob in a
non-terminal segment — e.g. `$IncludeConfig /etc/rsyslog.d/*/out.conf` — was
handed to the directory search verbatim (`/etc/rsyslog.d/*` as a literal
directory), matched no directory, and pulled in no fragments.

## Impact

- Configs using `!=`/`=` severity comparisons produced no rules for those
  lines, so any audit over `rsyslog.conf.rules` missed them entirely.
- Any include whose wildcard sat in a directory segment (per-application or
  per-host fragment layouts) contributed no files, so their modules, inputs,
  actions, and rules were invisible to MQL.

Both failures were silent — no error, just missing data.

## Fix

**Bug A.** The severity sub-pattern now accepts an optional `=`, `!`, or `!=`
comparison prefix (`!?=?[*A-Za-z0-9]+`, which matches ``, `=`, `!`, and `!=`
but rejects the invalid `=!` ordering), and `=` was added to the outer
selector regex's character class so the comparison form reaches the target.
The prefix is preserved verbatim on the captured severity token; the only
downstream inspection special-cases the `.none` negation, which these prefixes
don't affect.

**Bug B.** The directory portion of an include pattern is now resolved
segment by segment (`resolveIncludeDirs`), mirroring the segment-walk
apache2/nginx/squid use for their own include globs: literal segments are
appended without any filesystem access, and a glob segment lists the immediate
subdirectories of each current path (via `files.find` type=directory,
skipping the search root itself) and keeps the matches. The basename glob is
then matched against the files in each resolved directory. The common
basename-only case (`/etc/rsyslog.d/*.conf`) performs no directory listings
and issues the exact same single `files.find` as before, so its behaviour is
unchanged.

Each glob segment consumes exactly one directory level, matching rsyslog's
own glob(3) semantics (a `*` does not descend past a single boundary).

## Verification

New regression tests (each fails before the fix, passes after):

- `TestParseRsyslogFile_SeverityPrefixes` — `mail.info`, `mail.=info`,
  `mail.!info`, and `mail.!=info` each yield exactly one rule with the prefix
  preserved on the severity token.
- `TestRsyslogConf_MidPathIncludeGlob` — `/etc/rsyslog.apps/*/out.conf` fans
  out across `web/` and `db/` subdirectories, applies the `out.conf` basename
  glob inside each, and skips a non-matching `other.conf`. Backed by a new
  mock fixture (`testdata/rsyslog_midpath_include.toml`) placed outside the
  conventional `.d` directory so the legacy fallback can't mask the result.

```
$ go test ./resources/ -run Rsyslog -count=1
ok  	go.mondoo.com/mql/v13/providers/os/resources	5.163s
```

```
--- PASS: TestRsyslogConf_IncludeExpansion (0.00s)
--- PASS: TestRsyslogConf_MidPathIncludeGlob (0.00s)
--- PASS: TestRsyslogIncludeMatches (0.00s)
--- PASS: TestParseRsyslogFile_SeverityPrefixes (0.00s)
--- PASS: TestParseRsyslogFile_Rules (0.00s)
PASS
ok  	go.mondoo.com/mql/v13/providers/os/resources	5.444s
```
