### PR TITLE
🐛 os: skip malformed PAM lines instead of aborting the whole parse

### DIFF
--- a/providers/os/resources/pam.go
+++ b/providers/os/resources/pam.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/checksums"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -561,7 +562,11 @@ func (s *mqlPamConf) entries(files []any) (map[string]any, error) {
 
 			entry, err := pam.ParseLine(line)
 			if err != nil {
-				return nil, err
+				// A single malformed line must not abort parsing of the whole
+				// PAM configuration. Log it and continue with the rest, like
+				// the other config parsers in this package do.
+				log.Warn().Err(err).Str("path", filePath).Int("line", i+1).Msg("skipping malformed PAM line")
+				continue
 			}
 
 			// empty lines parse as empty object

--- a/providers/os/resources/pam_internal_test.go
+++ b/providers/os/resources/pam_internal_test.go
@@ -221,6 +221,34 @@ func TestPamConfSingleFile(t *testing.T) {
 	assert.Equal(t, "", wheel.Params.Data["use_uid"])
 }
 
+func TestPamConfSkipsMalformedLine(t *testing.T) {
+	// A single malformed line (too few fields for pam.ParseLine to accept)
+	// must not abort parsing of the whole configuration. The bad line is
+	// skipped and the valid entries around it are still returned, matching how
+	// the other config parsers in this package (modprobe, rsyslog) behave.
+	content := strings.Join([]string{
+		"su auth required pam_env.so",
+		"su auth required", // malformed: only two fields after the service column
+		"su account required pam_permit.so",
+		"",
+	}, "\n")
+	rt := newPamRuntimeWithFiles(t, map[string]string{"/etc/pam.conf": content})
+
+	pam := &mqlPamConf{MqlRuntime: rt}
+	entries := pam.GetEntries()
+	require.NoError(t, entries.Error, "malformed line must not fail the whole parse")
+
+	suList, ok := entries.Data["su"].([]any)
+	require.True(t, ok, "expected entries for service 'su'")
+	require.Len(t, suList, 2, "the two valid lines survive; the malformed one is skipped")
+
+	modules := []string{
+		suList[0].(*mqlPamConfServiceEntry).Module.Data,
+		suList[1].(*mqlPamConfServiceEntry).Module.Data,
+	}
+	assert.ElementsMatch(t, []string{"pam_env.so", "pam_permit.so"}, modules)
+}
+
 func TestPamConfServiceEntryParams(t *testing.T) {
 	se := &mqlPamConfServiceEntry{}
 


### PR DESCRIPTION
## Problem

In `pam.conf.entries` (`providers/os/resources/pam.go`), a single malformed line aborted the entire parse:

```go
entry, err := pam.ParseLine(line)
if err != nil {
    return nil, err
}
```

`pam.ParseLine` returns an error for any line with fewer than three fields (that isn't an `@include`) or an unclosed `[ ]` control. Because the loop returned on the first such error, one bad line in **any** `/etc/pam.d/*` file (or the legacy `/etc/pam.conf`) discarded every entry already parsed and failed the whole `pam.entries` result.

## Impact

`pam.services` and `pam.modules` both derive from `pam.entries`, so the failure cascaded: a single stray/truncated line anywhere in the PAM configuration made all PAM audits error out instead of reporting the valid, parseable entries. The other config parsers in this package (`modprobe`, `rsyslog`) already skip bad lines and continue.

## Fix

On a `ParseLine` error, log a warning that includes the file path and line number, then `continue` to the next line instead of returning the error. `pam.ParseLine` itself is unchanged.

```go
entry, err := pam.ParseLine(line)
if err != nil {
    log.Warn().Err(err).Str("path", filePath).Int("line", i+1).Msg("skipping malformed PAM line")
    continue
}
```

Uses the `github.com/rs/zerolog/log` logger already used across this package.

## Verification

Added `TestPamConfSkipsMalformedLine`, which parses a PAM file containing one malformed line between two valid entries and asserts the two valid entries come back with no error. It fails before the change (returns `invalid pam entry: auth required`) and passes after.

```
$ go test ./providers/os/resources/ -run 'Pam' -count=1
ok  	go.mondoo.com/mql/v13/providers/os/resources	3.861s

$ go test ./providers/os/resources/pam/... -count=1
ok  	go.mondoo.com/mql/v13/providers/os/resources/pam	1.692s

$ go test ./providers/os/resources/ -run 'TestPamConfSkipsMalformedLine' -count=1 -v
=== RUN   TestPamConfSkipsMalformedLine
WRN skipping malformed PAM line error="invalid pam entry: auth required" line=2 path=/etc/pam.conf
--- PASS: TestPamConfSkipsMalformedLine (0.00s)
PASS
```
