### PR TITLE
🐛 gcp: fix scan-crash panic, subnetwork husk, and DNS zone lookup

### DIFF
--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -567,6 +567,7 @@ func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
 				})
 				if err != nil {
 					log.Error().Err(err).Send()
+					continue
 				}
 				mqlS.(*mqlGcpProjectCloudRunServiceService).cacheEncryptionKey = s.GetTemplate().GetEncryptionKey()
 				mux.Lock()

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -441,29 +441,43 @@ func getNetworkByUrl(networkUrl string, runtime *plugin.Runtime) (*mqlGcpProject
 	return res.(*mqlGcpProjectComputeServiceNetwork), nil
 }
 
-func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComputeServiceSubnetwork, error) {
-	// A reference to a subnetwork is not mandatory for this resource
+// parseSubnetworkURL extracts the project, region, and name from a compute
+// subnetwork self-link. It accepts both the www.googleapis.com and
+// compute.googleapis.com hosts. ok is false when the URL is empty or is not a
+// recognized subnetwork reference.
+func parseSubnetworkURL(subnetUrl string) (project, region, name string, ok bool) {
 	if subnetUrl == "" {
-		return nil, nil
+		return "", "", "", false
 	}
-
 	// Format is https://www.googleapis.com/compute/v1/projects/project1/regions/us-central1/subnetworks/subnet-1
 	// or https://compute.googleapis.com/compute/v1/projects/project1/regions/us-central1/subnetworks/subnet-1
 	params := strings.TrimPrefix(subnetUrl, "https://www.googleapis.com/compute/v1/")
 	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
 	parts := strings.Split(params, "/")
 	if len(parts) < 6 || parts[0] != "projects" || parts[2] != "regions" || parts[4] != "subnetworks" {
+		return "", "", "", false
+	}
+	return parts[1], parts[3], parts[5], true
+}
+
+func getSubnetworkByUrl(subnetUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComputeServiceSubnetwork, error) {
+	// A reference to a subnetwork is not mandatory for this resource
+	if subnetUrl == "" {
+		return nil, nil
+	}
+
+	project, region, name, ok := parseSubnetworkURL(subnetUrl)
+	if !ok {
 		return nil, fmt.Errorf("unrecognized subnetwork reference: %q", subnetUrl)
 	}
-	resId := resourceId{Project: parts[1], Region: parts[3], Name: parts[5]}
 	// regionUrl is the full URL up to and including the region segment
-	regionUrl := "https://www.googleapis.com/compute/v1/projects/" + resId.Project + "/regions/" + resId.Region
+	regionUrl := "https://www.googleapis.com/compute/v1/projects/" + project + "/regions/" + region
 
 	// Use NewResource so initGcpProjectComputeServiceSubnetwork runs and
 	// populates every field instead of leaving the resource partially set.
 	res, err := NewResource(runtime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
-		"name":      llx.StringData(resId.Name),
-		"projectId": llx.StringData(resId.Project),
+		"name":      llx.StringData(name),
+		"projectId": llx.StringData(project),
 		"regionUrl": llx.StringData(regionUrl),
 	})
 	if err != nil {

--- a/providers/gcp/resources/common_test.go
+++ b/providers/gcp/resources/common_test.go
@@ -35,3 +35,32 @@ func TestRegionNameFromRegionUrl(t *testing.T) {
 	assert.Equal(t, "europe-west1", RegionNameFromRegionUrl("europe-west1"))
 	assert.Equal(t, "", RegionNameFromRegionUrl(""))
 }
+
+func TestParseSubnetworkURL(t *testing.T) {
+	t.Run("www.googleapis.com host", func(t *testing.T) {
+		project, region, name, ok := parseSubnetworkURL("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/subnet-1")
+		require.True(t, ok)
+		assert.Equal(t, "my-project", project)
+		assert.Equal(t, "us-central1", region)
+		assert.Equal(t, "subnet-1", name)
+	})
+	t.Run("compute.googleapis.com host", func(t *testing.T) {
+		project, region, name, ok := parseSubnetworkURL("https://compute.googleapis.com/compute/v1/projects/my-project/regions/europe-west1/subnetworks/subnet-2")
+		require.True(t, ok)
+		assert.Equal(t, "my-project", project)
+		assert.Equal(t, "europe-west1", region)
+		assert.Equal(t, "subnet-2", name)
+	})
+	t.Run("empty url", func(t *testing.T) {
+		_, _, _, ok := parseSubnetworkURL("")
+		assert.False(t, ok)
+	})
+	t.Run("malformed / too short does not panic", func(t *testing.T) {
+		_, _, _, ok := parseSubnetworkURL("https://www.googleapis.com/compute/v1/projects/my-project")
+		assert.False(t, ok)
+	})
+	t.Run("wrong resource kind", func(t *testing.T) {
+		_, _, _, ok := parseSubnetworkURL("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/disks/disk-1")
+		assert.False(t, ok)
+	})
+}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1936,26 +1936,17 @@ func (g *mqlGcpProjectComputeServiceNetwork) subnetworks() ([]any, error) {
 		return nil, g.SubnetworkUrls.Error
 	}
 	subnetUrls := g.SubnetworkUrls.Data
-	type resourceId struct {
-		Project string
-		Region  string
-		Name    string
-	}
 	subnets := make([]any, 0, len(subnetUrls))
 	for _, subnetUrl := range subnetUrls {
-		// Format is https://www.googleapis.com/compute/v1/projects/project1regions/us-central1/subnetworks/subnet-1
-		params := strings.TrimPrefix(subnetUrl.(string), "https://www.googleapis.com/compute/v1/")
-		parts := strings.Split(params, "/")
-		resId := resourceId{Project: parts[1], Region: parts[3], Name: parts[5]}
-		regionUrl := strings.SplitN(subnetUrl.(string), "/subnetworks", 2)
-
-		subnet, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
-			"name":      llx.StringData(resId.Name),
-			"projectId": llx.StringData(resId.Project),
-			"regionUrl": llx.StringData(regionUrl[0]),
-		})
+		// Resolve through the shared helper so it uses NewResource and the
+		// subnetwork init populates every field (and a stable __id) instead of
+		// leaving a partially-set husk that collides in the resource cache.
+		subnet, err := getSubnetworkByUrl(subnetUrl.(string), g.MqlRuntime)
 		if err != nil {
 			return nil, err
+		}
+		if subnet == nil {
+			continue
 		}
 		subnets = append(subnets, subnet)
 	}

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -50,19 +50,21 @@ func initGcpProjectDnsServiceManagedzone(runtime *plugin.Runtime, args map[strin
 		return nil, nil, managedzones.Error
 	}
 
-	// Find the matching managed zone
+	// Find the matching managed zone. The asset identifier / lookup key is the
+	// zone name (getAssetIdentifier stores it in args["name"]), not the numeric
+	// zone id — so match on the name field.
 	for _, mz := range managedzones.Data {
 		managedzone := mz.(*mqlGcpProjectDnsServiceManagedzone)
-		id := managedzone.GetId()
-		if id.Error != nil {
-			return nil, nil, id.Error
+		name := managedzone.GetName()
+		if name.Error != nil {
+			return nil, nil, name.Error
 		}
 		projectId := managedzone.GetProjectId()
 		if projectId.Error != nil {
 			return nil, nil, projectId.Error
 		}
 
-		if id.Data == args["name"].Value && projectId.Data == args["projectId"].Value {
+		if name.Data == args["name"].Value && projectId.Data == args["projectId"].Value {
 			return args, managedzone, nil
 		}
 	}


### PR DESCRIPTION
## Summary
Three Tier-1 GCP fixes from a provider logic-error audit — one scan-crash, two data-correctness.

- **cloudrun**: skip a Cloud Run service whose `CreateResource` fails instead of type-asserting the nil resource. The assertion ran in a per-region goroutine, so the panic was unrecoverable and crashed the entire scan.
- **compute**: resolve `network.subnetworks()` through `getSubnetworkByUrl` (`NewResource`) so the subnetwork init populates every field and a stable `__id`, instead of the partially-set husk `CreateResource` produced. All subnets of a network shared one empty `__id` (collapsing to a single cached instance) and any unset field surfaced as `no type information`.
- **dns**: match managed zones on the zone name (the lookup key stored in `args["name"]`) instead of the numeric zone id, which never equals the name — so `managedzone(name:)` and discovered-zone scans always returned "not found".

## Tests
Extracts `parseSubnetworkURL` as a pure helper with unit tests (both hosts, malformed/short, wrong resource kind).

Go-only; no schema/codegen/version changes.
