### PR TITLE
🐛 gcp: fix monitoring/dataproc/pubsub/functions correctness bugs

### DIFF
--- a/providers/gcp/resources/cloud_functions_v2.go
+++ b/providers/gcp/resources/cloud_functions_v2.go
@@ -52,6 +52,12 @@ func (g *mqlGcpProject) cloudFunctionsV2() ([]any, error) {
 			break
 		}
 		if err != nil {
+			// Gracefully skip when the Cloud Functions API is disabled or access
+			// is denied (matches the gRPC-based sibling resources), instead of
+			// failing the whole query with a hard error.
+			if isGRPCSkippable(err) {
+				break
+			}
 			return nil, err
 		}
 
@@ -463,16 +469,12 @@ func (g *mqlGcpProjectCloudFunctionV2EventTrigger) serviceAccount() (*mqlGcpProj
 }
 
 func (g *mqlGcpProjectCloudFunctionV2EventTrigger) topic() (*mqlGcpProjectPubsubServiceTopic, error) {
-	topicName := g.cachePubsubTopic
-	if topicName == "" {
-		g.Topic.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
-		"name": llx.StringData(topicName),
-	})
+	ref, err := resolvePubsubTopicRef(g.MqlRuntime, g.cachePubsubTopic, "")
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+	if ref == nil {
+		g.Topic.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
 }

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -285,18 +285,14 @@ type mqlGcpProjectCloudBuildServiceTriggerPubsubConfigInternal struct {
 }
 
 func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) pubsubTopic() (*mqlGcpProjectPubsubServiceTopic, error) {
-	topic := g.cacheTopic
-	if topic == "" {
-		g.PubsubTopic.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
-		"name": llx.StringData(topic),
-	})
+	ref, err := resolvePubsubTopicRef(g.MqlRuntime, g.cacheTopic, "")
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+	if ref == nil {
+		g.PubsubTopic.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
 }
 
 func (g *mqlGcpProjectCloudBuildServiceTriggerPubsubConfig) serviceAccount() (*mqlGcpProjectIamServiceServiceAccount, error) {

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -321,6 +321,32 @@ func parseProjectFromPath(fullPath string) string {
 	return ""
 }
 
+// resolvePubsubTopicRef resolves a Pub/Sub topic reference to the typed
+// gcp.project.pubsubService.topic resource. The reference is typically a full
+// "projects/{project}/topics/{topic}" path; both the project and the short
+// topic name are pulled from it (fallbackProjectId is used only when the path
+// carries no project segment). Both are required: the topic init matches on the
+// short name and needs the project to build its parent service, so passing the
+// full path as the name (or omitting the project) leaves the ref unresolved.
+// Returns nil when the reference is empty.
+func resolvePubsubTopicRef(runtime *plugin.Runtime, topicRef, fallbackProjectId string) (*mqlGcpProjectPubsubServiceTopic, error) {
+	if topicRef == "" {
+		return nil, nil
+	}
+	projectId := fallbackProjectId
+	if p := parseProjectFromPath(topicRef); p != "" {
+		projectId = p
+	}
+	res, err := NewResource(runtime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
+		"name":      llx.StringData(parseResourceName(topicRef)),
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+}
+
 // parseLocationFromPath extracts the location/region from a GCP resource path.
 // The path format is: projects/{project}/locations/{location}/...
 // Returns "global" if no location segment is found.

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -452,10 +452,14 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 									TruststorePasswordUri:            c.Config.SecurityConfig.KerberosConfig.TruststorePasswordUri,
 									TruststoreUri:                    c.Config.SecurityConfig.KerberosConfig.TruststoreUri,
 								}
-								mqlSecurityCfg, err = convert.JsonToDict(cfg)
-								if err != nil {
-									log.Error().Err(err).Send()
-								}
+							}
+							// Serialize the whole security config, not just the Kerberos
+							// branch: a cluster with only IdentityConfig set (workforce
+							// identity federation without Kerberos) must still surface its
+							// security config instead of a null.
+							mqlSecurityCfg, err = convert.JsonToDict(cfg)
+							if err != nil {
+								log.Error().Err(err).Send()
 							}
 						}
 

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -1432,18 +1432,14 @@ type mqlGcpProjectGkeServiceClusterNotificationConfigInternal struct {
 }
 
 func (g *mqlGcpProjectGkeServiceClusterNotificationConfig) topic() (*mqlGcpProjectPubsubServiceTopic, error) {
-	topicName := g.cacheTopic
-	if topicName == "" {
-		g.Topic.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
-	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
-		"name": llx.StringData(topicName),
-	})
+	ref, err := resolvePubsubTopicRef(g.MqlRuntime, g.cacheTopic, "")
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectPubsubServiceTopic), nil
+	if ref == nil {
+		g.Topic.State = plugin.StateIsNull | plugin.StateIsSet
+	}
+	return ref, nil
 }
 
 func (g *mqlGcpProjectGkeServiceCluster) loggingEnabled() (bool, error) {

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -256,7 +256,7 @@ func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 			"labels":                  llx.MapData(convert.MapToInterfaceMap(p.UserLabels), types.String),
 			"conditions":              llx.ArrayData(mqlConditions, types.Dict),
 			"combiner":                llx.StringData(p.Combiner.String()),
-			"enabled":                 llx.BoolData(p.Enabled.Value),
+			"enabled":                 llx.BoolData(p.Enabled.GetValue()),
 			"validity":                llx.DictData(mqlValidity),
 			"notificationChannelUrls": llx.ArrayData(convert.SliceAnyToInterface(p.NotificationChannels), types.String),
 			"created":                 mutationRecordTime(p.CreationRecord),

--- a/providers/gcp/resources/pubsub_test.go
+++ b/providers/gcp/resources/pubsub_test.go
@@ -124,3 +124,19 @@ func TestSubscriptionStateToString(t *testing.T) {
 		})
 	}
 }
+
+// TestPubsubTopicRefPathParsing covers the project + short-name extraction that
+// resolvePubsubTopicRef relies on to resolve a typed pubsub topic from a full
+// "projects/{project}/topics/{topic}" reference. The cross-reference bug it
+// guards against passed the full path as the topic name and dropped the
+// project, so the topic init (which matches on the short name and needs the
+// project to build its parent service) never resolved the reference.
+func TestPubsubTopicRefPathParsing(t *testing.T) {
+	const ref = "projects/my-project/topics/my-topic"
+	assert.Equal(t, "my-project", parseProjectFromPath(ref))
+	assert.Equal(t, "my-topic", parseResourceName(ref))
+
+	// a bare topic name carries no project segment
+	assert.Equal(t, "", parseProjectFromPath("my-topic"))
+	assert.Equal(t, "my-topic", parseResourceName("my-topic"))
+}


### PR DESCRIPTION
## Summary
GCP Tier-2 correctness fixes from the provider logic-error audit.

- **monitoring**: read `alertPolicy.enabled` via `BoolValue.GetValue()` so a nil `Enabled` wrapper no longer panics `alertPolicies()`.
- **dataproc**: serialize the whole cluster `SecurityConfig`, not just the Kerberos branch — a cluster with only `IdentityConfig` set (workforce identity federation without Kerberos) now surfaces `config.security` instead of null.
- **pubsub cross-references**: resolve topics through a shared `resolvePubsubTopicRef` helper that passes the short topic name plus the project parsed from the full path. GKE `notificationConfig`, Cloud Functions v2 `eventTrigger`, and Cloud Build `pubsubConfig` previously passed the full `projects/P/topics/T` path as the name and dropped the project, so the reference never resolved.
- **cloudFunctionsV2**: skip a disabled/denied Cloud Functions API via `isGRPCSkippable` instead of failing the whole query (matches the v1 accessor and the other gRPC-based resources).

## Tests
Unit test for the topic-path parsing the pubsub fix relies on.

Go-only; no schema/codegen/version changes.
