### PR TITLE
🐛 aws: fix serverCertificates nesting, NAT address __id collision, delegatedService panic

### DIFF
--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -445,8 +445,18 @@ func (a *mqlAwsOrganizationDelegatedAdministrator) delegatedServices() ([]any, e
 	return res, nil
 }
 
+// delegatedServiceCacheKey builds a stable cache key for a delegated service.
+// DelegationEnabledDate is optional, so guard against a nil time pointer to avoid
+// dereferencing nil (which would panic in a field-resolver goroutine).
+func delegatedServiceCacheKey(servicePrincipal string, date *time.Time) string {
+	if date == nil {
+		return servicePrincipal
+	}
+	return servicePrincipal + "/" + date.String()
+}
+
 func (a *mqlAwsOrganizationDelegatedService) id() (string, error) {
-	return a.ServicePrincipal.Data + "/" + a.DelegationEnabledDate.Data.String(), nil
+	return delegatedServiceCacheKey(a.ServicePrincipal.Data, a.DelegationEnabledDate.Data), nil
 }
 
 func (a *mqlAwsAccount) paths() ([]any, error) {

--- a/providers/aws/resources/aws_account_test.go
+++ b/providers/aws/resources/aws_account_test.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelegatedServiceCacheKey(t *testing.T) {
+	date := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	t.Run("with date", func(t *testing.T) {
+		assert.Equal(t,
+			"config.amazonaws.com/"+date.String(),
+			delegatedServiceCacheKey("config.amazonaws.com", &date),
+		)
+	})
+
+	t.Run("nil date does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			assert.Equal(t,
+				"config.amazonaws.com",
+				delegatedServiceCacheKey("config.amazonaws.com", nil),
+			)
+		})
+	})
+}

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -68,7 +68,7 @@ func (a *mqlAwsIam) serverCertificates() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			res = append(res, certs)
+			res = append(res, certs...)
 		}
 	}
 	return res, nil

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -218,8 +218,16 @@ func (a *mqlAwsVpc) ipv6CidrBlockAssociations() ([]any, error) {
 	return res, nil
 }
 
+// natgatewayAddressCacheKey builds a stable, unique cache key for a NAT gateway
+// address. Private NAT gateways have no AllocationId, so the allocation ID alone
+// collapses every private address onto the same key; the ENI plus private IP are
+// always present and uniquely identify the address.
+func natgatewayAddressCacheKey(networkInterfaceId, privateIp string) string {
+	return networkInterfaceId + "/" + privateIp
+}
+
 func (a *mqlAwsVpcNatgatewayAddress) id() (string, error) {
-	return a.AllocationId.Data, nil
+	return natgatewayAddressCacheKey(a.NetworkInterfaceId.Data, a.PrivateIp.Data), nil
 }
 
 func (a *mqlAwsVpcNatgateway) id() (string, error) {

--- a/providers/aws/resources/aws_vpc_test.go
+++ b/providers/aws/resources/aws_vpc_test.go
@@ -622,3 +622,12 @@ func TestRouteNextHopNullState(t *testing.T) {
 		assert.True(t, route.PeeringConnection.IsSet())
 	})
 }
+
+func TestNatgatewayAddressCacheKey(t *testing.T) {
+	// two private NAT gateway addresses without an AllocationId must not collide
+	a := natgatewayAddressCacheKey("eni-0a1b2c3d", "10.0.0.5")
+	b := natgatewayAddressCacheKey("eni-4e5f6a7b", "10.0.0.6")
+	assert.Equal(t, "eni-0a1b2c3d/10.0.0.5", a)
+	assert.Equal(t, "eni-4e5f6a7b/10.0.0.6", b)
+	assert.NotEqual(t, a, b)
+}


### PR DESCRIPTION
## Summary
Three Tier-1 AWS fixes — one malformed-data, one wrong-data, one latent scan-crash.

- **iam `serverCertificates()`**: `append(res, certs...)` instead of `append(res, certs)` so paginated dict slices are spread rather than nested as `[[dict]]` sub-arrays.
- **vpc NAT gateway address `id()`**: key on the ENI + private IP (always present) instead of `AllocationId`. Private NAT gateways have no AllocationId, so every private address collapsed onto one empty cache key and `CreateResource` returned the first for all of them.
- **account `delegatedService.id()`**: guard the nullable `DelegationEnabledDate` before `.String()`. A nil enable-date dereferenced nil in a field-resolver goroutine, crashing the whole scan; the resource has no explicit `__id` so `id()` is always called.

## Tests
`natgatewayAddressCacheKey` and `delegatedServiceCacheKey` (incl. the nil-date case) unit tests.

Go-only; no schema/codegen/version changes.
