### PR TITLE
🐛 aws: fix init husks, cloudwatch kmsKey null-state, and S3 wrong-region calls

### DIFF
--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -1662,8 +1662,11 @@ func initAwsBatchComputeEnvironment(runtime *plugin.Runtime, args map[string]*ll
 	if err != nil {
 		return nil, nil, err
 	}
+	// Returning (args, nil, nil) here would let the runtime create a resource
+	// whose fields are all unset, which surfaces as malformed nil data when
+	// those fields are queried.
 	if len(resp.ComputeEnvironments) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.batch.computeEnvironment with arn %q not found", arnStr)
 	}
 	ce := resp.ComputeEnvironments[0]
 
@@ -1730,8 +1733,11 @@ func initAwsBatchSchedulingPolicy(runtime *plugin.Runtime, args map[string]*llx.
 	if err != nil {
 		return nil, nil, err
 	}
+	// Returning (args, nil, nil) here would let the runtime create a resource
+	// whose fields are all unset, which surfaces as malformed nil data when
+	// those fields are queried.
 	if len(resp.SchedulingPolicies) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.batch.schedulingPolicy with arn %q not found", arnStr)
 	}
 	sp := resp.SchedulingPolicies[0]
 

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -814,6 +814,14 @@ func (a *mqlAwsCloudwatchLoggroup) tags() (map[string]any, error) {
 }
 
 func (a *mqlAwsCloudwatchLoggroup) kmsKey() (*mqlAwsKmsKey, error) {
+	// Return the key resolved at creation time when present; only mark the field
+	// null (with an explicit state) when no key was set — e.g. the cross-account
+	// placeholder path that never populates kmsKey. Unconditionally nulling here
+	// would drop the KMS key on log groups that actually have one.
+	if a.KmsKey.Data == nil {
+		a.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	return a.KmsKey.Data, nil
 }
 

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -3157,12 +3157,12 @@ func initAwsEc2Internetgateway(runtime *plugin.Runtime, args map[string]*llx.Raw
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("access denied fetching aws.ec2.internetGateway with id %q in region %s", igwID, region)
 		}
 		return nil, nil, err
 	}
 	if len(resp.InternetGateways) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.ec2.internetGateway with id %q not found", igwID)
 	}
 	res, err := newMqlAwsEc2Internetgateway(runtime, region, conn, resp.InternetGateways[0])
 	if err != nil {
@@ -3277,12 +3277,12 @@ func initAwsEc2Transitgateway(runtime *plugin.Runtime, args map[string]*llx.RawD
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("access denied fetching aws.ec2.transitGateway with id %q in region %s", tgwID, region)
 		}
 		return nil, nil, err
 	}
 	if len(resp.TransitGateways) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.ec2.transitGateway with id %q not found", tgwID)
 	}
 	res, err := newMqlAwsEc2Transitgateway(runtime, region, resp.TransitGateways[0])
 	if err != nil {
@@ -3831,12 +3831,12 @@ func initAwsEc2EgressOnlyInternetGateway(runtime *plugin.Runtime, args map[strin
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("access denied fetching aws.ec2.egressOnlyInternetGateway with id %q in region %s", eigwID, region)
 		}
 		return nil, nil, err
 	}
 	if len(resp.EgressOnlyInternetGateways) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.ec2.egressOnlyInternetGateway with id %q not found", eigwID)
 	}
 	res, err := newMqlAwsEc2EgressOnlyInternetGateway(runtime, region, conn, resp.EgressOnlyInternetGateways[0])
 	if err != nil {

--- a/providers/aws/resources/aws_ec2_ipam.go
+++ b/providers/aws/resources/aws_ec2_ipam.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -169,12 +170,12 @@ func initAwsEc2Ipam(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	resp, err := svc.DescribeIpams(ctx, &ec2.DescribeIpamsInput{IpamIds: []string{id}})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("access denied fetching aws.ec2.ipam with id %q in region %s", id, region)
 		}
 		return nil, nil, err
 	}
 	if len(resp.Ipams) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.ec2.ipam with id %q not found", id)
 	}
 
 	mqlIpam, err := newMqlAwsEc2Ipam(runtime, region, &resp.Ipams[0])

--- a/providers/aws/resources/aws_ec2_placement.go
+++ b/providers/aws/resources/aws_ec2_placement.go
@@ -211,12 +211,12 @@ func initAwsEc2CapacityReservation(runtime *plugin.Runtime, args map[string]*llx
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("cannot fetch aws.ec2.capacityReservation with id %q in region %s: %w", id, region, err)
 		}
 		return nil, nil, err
 	}
 	if len(resp.CapacityReservations) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.ec2.capacityReservation with id %q not found", id)
 	}
 	mqlCr, err := buildCapacityReservationResource(runtime, region, conn.AccountId(), resp.CapacityReservations[0])
 	if err != nil {

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -975,15 +975,18 @@ func (a *mqlAwsS3Bucket) logging() (map[string]any, error) {
 
 func (a *mqlAwsS3Bucket) versioning() (map[string]any, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketname := a.Name.Data
-	location := a.Location.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.S3(location)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	versioning, err := svc.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
@@ -1030,8 +1033,15 @@ func (a *mqlAwsS3Bucket) fetchReplicationConfig() (*s3types.ReplicationConfigura
 		return nil, nil
 	}
 	a.replicationOnce.Do(func() {
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.replicationErr = err
+			return
+		}
+		if !ok {
+			return
+		}
 		bucketname := a.Name.Data
-		region := a.Location.Data
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		svc := conn.S3(region)
 		ctx := context.Background()
@@ -1057,8 +1067,15 @@ func (a *mqlAwsS3Bucket) fetchEncryptionConfig() (*s3types.ServerSideEncryptionC
 		return nil, nil
 	}
 	a.encryptionOnce.Do(func() {
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.encryptionErr = err
+			return
+		}
+		if !ok {
+			return
+		}
 		bucketname := a.Name.Data
-		region := a.Location.Data
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		svc := conn.S3(region)
 		ctx := context.Background()
@@ -1218,10 +1235,18 @@ func (a *mqlAwsS3Bucket) kmsKey() (*mqlAwsKmsKey, error) {
 		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
 		map[string]*llx.RawData{
 			"arn":    llx.StringData(keyRef),
-			"region": llx.StringData(a.Location.Data),
+			"region": llx.StringData(region),
 		})
 	if err != nil {
 		return nil, err
@@ -1277,11 +1302,14 @@ func (a *mqlAwsS3BucketMetricsConfiguration) id() (string, error) {
 
 func (a *mqlAwsS3Bucket) metricsConfigurations() ([]any, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketName := a.Name.Data
-	region := a.Location.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.S3(region)
 	ctx := context.Background()
@@ -1332,8 +1360,15 @@ func (a *mqlAwsS3Bucket) fetchObjectLockConfig() (*s3types.ObjectLockConfigurati
 		return nil, nil
 	}
 	a.objectLockOnce.Do(func() {
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.objectLockErr = err
+			return
+		}
+		if !ok {
+			return
+		}
 		bucketname := a.Name.Data
-		region := a.Location.Data
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		svc := conn.S3(region)
 		ctx := context.Background()
@@ -1393,12 +1428,15 @@ func (a *mqlAwsS3Bucket) staticWebsiteHosting() (map[string]any, error) {
 
 func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		a.Website.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
 	bucketname := a.Name.Data
-	region := a.Location.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
@@ -1530,8 +1568,15 @@ func (a *mqlAwsS3BucketPolicy) statements() ([]any, error) {
 
 func (a *mqlAwsS3Bucket) fetchLifecycleConfig() ([]s3types.LifecycleRule, error) {
 	a.lifecycleOnce.Do(func() {
+		region, ok, err := a.bucketRegion()
+		if err != nil {
+			a.lifecycleErr = err
+			return
+		}
+		if !ok {
+			return
+		}
 		bucketname := a.Name.Data
-		region := a.Location.Data
 		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 		svc := conn.S3(region)
 		ctx := context.Background()
@@ -1646,11 +1691,14 @@ func (a *mqlAwsS3BucketLifecycleRule) id() (string, error) {
 
 func (a *mqlAwsS3Bucket) notificationConfiguration() (any, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketname := a.Name.Data
-	region := a.Location.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.S3(region)
@@ -1700,11 +1748,14 @@ func (a *mqlAwsS3Bucket) notificationConfiguration() (any, error) {
 
 func (a *mqlAwsS3Bucket) eventNotifications() ([]any, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketname := a.Name.Data
-	region := a.Location.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.S3(region)
@@ -1800,12 +1851,16 @@ func (a *mqlAwsS3BucketEventNotification) topic() (*mqlAwsSnsTopic, error) {
 }
 
 func (a *mqlAwsS3Bucket) intelligentTieringConfigurations() ([]any, error) {
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketName := a.Name.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.S3(a.Location.Data)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	res := []any{}
@@ -1837,12 +1892,16 @@ func (a *mqlAwsS3Bucket) intelligentTieringConfigurations() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) inventoryConfigurations() ([]any, error) {
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketName := a.Name.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.S3(a.Location.Data)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	res := []any{}
@@ -1874,12 +1933,16 @@ func (a *mqlAwsS3Bucket) inventoryConfigurations() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) analyticsConfigurations() ([]any, error) {
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	bucketName := a.Name.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.S3(a.Location.Data)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	res := []any{}
@@ -1911,12 +1974,16 @@ func (a *mqlAwsS3Bucket) analyticsConfigurations() ([]any, error) {
 }
 
 func (a *mqlAwsS3Bucket) requestPayment() (string, error) {
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
 		return "", nil
 	}
 	bucketName := a.Name.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.S3(a.Location.Data)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	resp, err := svc.GetBucketRequestPayment(ctx, &s3.GetBucketRequestPaymentInput{Bucket: &bucketName})
@@ -1930,12 +1997,16 @@ func (a *mqlAwsS3Bucket) requestPayment() (string, error) {
 }
 
 func (a *mqlAwsS3Bucket) transferAcceleration() (string, error) {
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
 		return "", nil
 	}
 	bucketName := a.Name.Data
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	svc := conn.S3(a.Location.Data)
+	svc := conn.S3(region)
 	ctx := context.Background()
 
 	resp, err := svc.GetBucketAccelerateConfiguration(ctx, &s3.GetBucketAccelerateConfigurationInput{Bucket: &bucketName})
@@ -1950,11 +2021,14 @@ func (a *mqlAwsS3Bucket) transferAcceleration() (string, error) {
 
 func (a *mqlAwsS3Bucket) ownershipControls() (string, error) {
 	// Placeholder buckets (e.g., cross-account references) can't be queried
-	if !a.Exists.Data {
+	region, ok, err := a.bucketRegion()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
 		return "", nil
 	}
 	bucketname := a.Name.Data
-	region := a.Location.Data
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	svc := conn.S3(region)

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -396,7 +396,7 @@ func initAwsVpcNatgateway(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, err
 	}
 	if len(resp.NatGateways) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.vpc.natgateway with id %q not found", natID)
 	}
 	mqlNat, err := newMqlAwsVpcNatgateway(runtime, region, resp.NatGateways[0])
 	if err != nil {
@@ -791,12 +791,12 @@ func initAwsVpcPeeringConnection(runtime *plugin.Runtime, args map[string]*llx.R
 	})
 	if err != nil {
 		if Is400AccessDeniedError(err) {
-			return args, nil, nil
+			return nil, nil, fmt.Errorf("access denied fetching aws.vpc.peeringConnection with id %q in region %s", pcxID, region)
 		}
 		return nil, nil, err
 	}
 	if len(resp.VpcPeeringConnections) == 0 {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("aws.vpc.peeringConnection with id %q not found", pcxID)
 	}
 	res, err := newMqlAwsVpcPeeringConnection(runtime, region, resp.VpcPeeringConnections[0])
 	if err != nil {


### PR DESCRIPTION
## Summary
AWS Tier-2 correctness fixes from the provider logic-error audit.

- **init husks → not-found errors** (batch computeEnvironment/schedulingPolicy; ec2 internet/transit/egress-only gateways; vpc natgateway/peeringConnection; ec2 capacityReservation; ipam): a targeted Describe-by-id that returned nothing (or access-denied) returned `args, nil, nil`, letting the runtime build a blank husk that surfaces client-side as `no type information`. Converted those concrete-id-miss branches to not-found/access-denied errors (mirrors `initAwsEc2ManagedPrefixList`). The early "args already complete" fast-path and the genuine "no id supplied → bare resource" paths are unchanged.
- **cloudwatch `loggroup.kmsKey()`**: set `StateIsSet | StateIsNull` before returning nil (mirrors `logAnomalyDetector.kmsKey`), fixing null-coercion on the cross-account placeholder path.
- **s3**: ~15 region-aware accessors read raw `a.Location.Data`; a bucket reached lazily by name has empty Location, so the request hits the default region and 301s for any out-of-region bucket. Swapped to the region-aware `bucketRegion()` resolver (which also handles placeholder/cross-account buckets via its `ok` return).

## Deferred
DynamoDB `id` field is always empty, but a proper fix needs a schema change (`id string` → `id() string`) or a per-table `DescribeTable` N+1, so it's out of scope for this Go-only change.

Go-only; no schema/codegen/version changes.
