### PR TITLE
🐛 azure: fix roles/advisor/keyvault nil-deref panics

### DIFF
--- a/providers/azure/resources/advisor.go
+++ b/providers/azure/resources/advisor.go
@@ -59,25 +59,35 @@ func (a *mqlAzureSubscriptionAdvisorService) recommendations() ([]any, error) {
 			return nil, err
 		}
 		for _, r := range page.Value {
+			if r == nil {
+				continue
+			}
 			props, err := convert.JsonToDict(r.Properties)
 			if err != nil {
 				return nil, err
+			}
+			// Properties is a nullable pointer dereferenced throughout the
+			// arg map; normalize to an empty struct to avoid a panic on a
+			// null-properties recommendation (mirrors newMqlRoleAssignment).
+			recProps := r.Properties
+			if recProps == nil {
+				recProps = &advisor.RecommendationProperties{}
 			}
 			args := map[string]*llx.RawData{
 				"id":                   llx.StringDataPtr(r.ID),
 				"name":                 llx.StringDataPtr(r.Name),
 				"type":                 llx.StringDataPtr(r.Type),
-				"category":             llx.StringDataPtr((*string)(r.Properties.Category)),
-				"impact":               llx.StringDataPtr((*string)(r.Properties.Impact)),
-				"risk":                 llx.StringDataPtr((*string)(r.Properties.Risk)),
+				"category":             llx.StringDataPtr((*string)(recProps.Category)),
+				"impact":               llx.StringDataPtr((*string)(recProps.Impact)),
+				"risk":                 llx.StringDataPtr((*string)(recProps.Risk)),
 				"properties":           llx.DictData(props),
-				"impactedResourceType": llx.StringDataPtr(r.Properties.ImpactedField),
-				"impactedResource":     llx.StringDataPtr(r.Properties.ImpactedValue),
+				"impactedResourceType": llx.StringDataPtr(recProps.ImpactedField),
+				"impactedResource":     llx.StringDataPtr(recProps.ImpactedValue),
 			}
-			if r.Properties.ShortDescription != nil {
+			if recProps.ShortDescription != nil {
 				// the 'Description' field in the API response is always empty, use the short description instead
-				args["description"] = llx.StringDataPtr(r.Properties.ShortDescription.Problem)
-				args["remediation"] = llx.StringDataPtr(r.Properties.ShortDescription.Solution)
+				args["description"] = llx.StringDataPtr(recProps.ShortDescription.Problem)
+				args["remediation"] = llx.StringDataPtr(recProps.ShortDescription.Solution)
 			}
 			mqlRecomm, err := CreateResource(a.MqlRuntime, "azure.subscription.advisorService.recommendation", args)
 			if err != nil {

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -163,9 +163,19 @@ func (a *mqlAzureSubscriptionAuthorizationService) roles() ([]any, error) {
 			return nil, err
 		}
 		for _, roleDef := range page.Value {
-			roleType := convert.ToValue(roleDef.Properties.RoleType)
+			if roleDef == nil {
+				continue
+			}
+			// Properties is a nullable pointer that is dereferenced throughout
+			// the loop body; normalize to an empty struct to avoid a panic
+			// (mirrors newMqlRoleAssignment below).
+			props := roleDef.Properties
+			if props == nil {
+				props = &authorization.RoleDefinitionProperties{}
+			}
+			roleType := convert.ToValue(props.RoleType)
 			scopes := []any{}
-			for _, s := range roleDef.Properties.AssignableScopes {
+			for _, s := range props.AssignableScopes {
 				if s != nil {
 					scopes = append(scopes, *s)
 				}
@@ -174,8 +184,8 @@ func (a *mqlAzureSubscriptionAuthorizationService) roles() ([]any, error) {
 				map[string]*llx.RawData{
 					"__id":        llx.StringDataPtr(roleDef.ID),
 					"id":          llx.StringDataPtr(roleDef.ID),
-					"name":        llx.StringDataPtr(roleDef.Properties.RoleName),
-					"description": llx.StringDataPtr(roleDef.Properties.Description),
+					"name":        llx.StringDataPtr(props.RoleName),
+					"description": llx.StringDataPtr(props.Description),
 					"type":        llx.StringData(roleType),
 					"scopes":      llx.ArrayData(scopes, types.String),
 				})
@@ -183,7 +193,7 @@ func (a *mqlAzureSubscriptionAuthorizationService) roles() ([]any, error) {
 				return nil, err
 			}
 			mqlRole := mqlRoleDefinition.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition)
-			mqlRole.cachePermissions = roleDef.Properties.Permissions
+			mqlRole.cachePermissions = props.Permissions
 			res = append(res, mqlRole)
 		}
 	}

--- a/providers/azure/resources/keyvault.go
+++ b/providers/azure/resources/keyvault.go
@@ -32,6 +32,17 @@ import (
 
 var keyvaultidRegex = regexp.MustCompile(`^(https:\/\/([^\/]*)\.(?:vault|managedhsm)\.azure\.net)\/(certificates|secrets|keys)\/([^\/]*)(?:\/([^\/]*)){0,1}$`)
 
+// isKeyRotateAction reports whether a key rotation policy lifetime action is a
+// "Rotate" action. Both the action wrapper and its inner Type are nullable
+// pointers, so both are guarded to avoid a nil dereference. Per the Key Vault
+// SDK the action value is compared case-insensitively.
+func isKeyRotateAction(action *azkeys.LifetimeActionType) bool {
+	if action == nil || action.Type == nil {
+		return false
+	}
+	return strings.EqualFold(string(*action.Type), string(azkeys.KeyRotationPolicyActionRotate))
+}
+
 type keyvaultid struct {
 	BaseUrl string
 	Vault   string
@@ -427,7 +438,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceVault) autorotation() ([]any, error)
 					return nil
 				}
 				for _, action := range policyResp.LifetimeActions {
-					if action.Action != nil && string(*action.Action.Type) == "Rotate" {
+					if isKeyRotateAction(action.Action) {
 						mu.Lock()
 						enabledByKid[kid] = true
 						mu.Unlock()
@@ -995,7 +1006,7 @@ func (a *mqlAzureSubscriptionKeyVaultServiceKey) rotationPolicy() (*mqlAzureSubs
 			}
 			lifetimeActions = append(lifetimeActions, actionDict)
 
-			if action.Action != nil && string(*action.Action.Type) == "Rotate" {
+			if isKeyRotateAction(action.Action) {
 				rotationEnabled = true
 			}
 		}

--- a/providers/azure/resources/keyvault_test.go
+++ b/providers/azure/resources/keyvault_test.go
@@ -6,9 +6,28 @@ package resources
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsKeyRotateAction(t *testing.T) {
+	action := func(t string) *azkeys.LifetimeActionType {
+		v := azkeys.KeyRotationPolicyAction(t)
+		return &azkeys.LifetimeActionType{Type: &v}
+	}
+
+	// nil wrapper -> false (guards a nil action.Action)
+	assert.False(t, isKeyRotateAction(nil))
+	// non-nil wrapper with a nil Type -> false
+	assert.False(t, isKeyRotateAction(&azkeys.LifetimeActionType{}))
+	// exact "Rotate" -> true
+	assert.True(t, isKeyRotateAction(action("Rotate")))
+	// different casing -> true (the SDK compares case-insensitively)
+	assert.True(t, isKeyRotateAction(action("rotate")))
+	// other action ("Notify") -> false
+	assert.False(t, isKeyRotateAction(action("Notify")))
+}
 
 type azureIdTestCase struct {
 	url      string


### PR DESCRIPTION
## Summary
Three Tier-1 Azure fixes — all nil-deref panics that crash the scan from a field-resolver goroutine.

- **iam `roles()`**: guard nil `roleDef` and normalize a nil `roleDef.Properties` to an empty struct (mirrors the sibling `newMqlRoleAssignment`).
- **advisor `recommendations()`**: guard nil `r` and normalize a nil `r.Properties` before the property derefs.
- **keyvault**: extract `isKeyRotateAction`, which guards the nullable action wrapper and its nil inner `.Type` and compares case-insensitively against the SDK `KeyRotationPolicyActionRotate` constant. Applied at both rotation call sites.

## Tests
`isKeyRotateAction` unit test (nil wrapper, nil type, "Rotate", "rotate", other).

Go-only; no schema/codegen/version changes.
