### PR TITLE
🐛 azure: fix policyAssignments pagination, mysql ssl error-handling, nil-derefs, elasticPoolName

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -140,6 +140,11 @@ func (a *mqlAzureSubscriptionAksService) clusters() ([]any, error) {
 			return nil, err
 		}
 		for _, entry := range page.Value {
+			// Normalize a nil Properties to an empty struct so the many early
+			// accesses below are nil-safe; the later blocks already guard it.
+			if entry.Properties == nil {
+				entry.Properties = &clusters.ManagedClusterProperties{}
+			}
 			storageProfile, err := convert.JsonToDict(entry.Properties.StorageProfile)
 			if err != nil {
 				return nil, err

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -48,34 +48,57 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(conn.subscriptionId))
 	urlPath = runtime.JoinPaths(conn.host, urlPath)
-	client := http.Client{}
-	req, err := http.NewRequest("GET", urlPath, nil)
+
+	// Build the first request URL with the api-version query parameter. The
+	// service returns a fully-formed absolute nextLink for subsequent pages, so
+	// we only need to assemble the query on the initial request.
+	firstURL, err := url.Parse(urlPath)
 	if err != nil {
 		return PolicyAssignments{}, err
 	}
-	q := req.URL.Query()
+	q := firstURL.Query()
 	q.Set("api-version", "2022-06-01")
-	req.URL.RawQuery = q.Encode()
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+	firstURL.RawQuery = q.Encode()
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return PolicyAssignments{}, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return PolicyAssignments{}, errors.New("failed to fetch policy assignments from " + urlPath + ": " + resp.Status)
-	}
-
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return PolicyAssignments{}, err
-	}
+	client := http.Client{}
 	result := PolicyAssignments{}
-	err = json.Unmarshal(raw, &result)
-	return result, err
+	nextURL := firstURL.String()
+	for nextURL != "" {
+		req, err := http.NewRequestWithContext(ctx, "GET", nextURL, nil)
+		if err != nil {
+			return PolicyAssignments{}, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return PolicyAssignments{}, err
+		}
+
+		if resp.StatusCode != 200 {
+			resp.Body.Close()
+			return PolicyAssignments{}, errors.New("failed to fetch policy assignments from " + nextURL + ": " + resp.Status)
+		}
+
+		raw, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return PolicyAssignments{}, err
+		}
+
+		page := PolicyAssignments{}
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return PolicyAssignments{}, err
+		}
+		result.PolicyAssignments = append(result.PolicyAssignments, page.PolicyAssignments...)
+
+		if page.NextLink == nil {
+			break
+		}
+		nextURL = *page.NextLink
+	}
+	return result, nil
 }
 
 func getServerVulnAssessmentSettings(ctx context.Context, conn armSecurityConn) (ServerVulnerabilityAssessmentsSettingsList, error) {
@@ -155,6 +178,7 @@ type PolicyAssignment struct {
 
 type PolicyAssignments struct {
 	PolicyAssignments []PolicyAssignment `json:"value"`
+	NextLink          *string            `json:"nextLink"`
 }
 
 type ServerVulnerabilityAssessmentsSettings struct {

--- a/providers/azure/resources/armsecurity.go
+++ b/providers/azure/resources/armsecurity.go
@@ -41,10 +41,6 @@ func getArmSecurityConnection(ctx context.Context, conn *connection.AzureConnect
 }
 
 func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssignments, error) {
-	token, err := conn.GetToken()
-	if err != nil {
-		return PolicyAssignments{}, err
-	}
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(conn.subscriptionId))
 	urlPath = runtime.JoinPaths(conn.host, urlPath)
@@ -64,6 +60,13 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 	result := PolicyAssignments{}
 	nextURL := firstURL.String()
 	for nextURL != "" {
+		// Fetch the token per page so a long pagination run over many policy
+		// assignments doesn't fail on an expired bearer token; the credential
+		// caches and only refreshes when the token is near expiry.
+		token, err := conn.GetToken()
+		if err != nil {
+			return PolicyAssignments{}, err
+		}
 		req, err := http.NewRequestWithContext(ctx, "GET", nextURL, nil)
 		if err != nil {
 			return PolicyAssignments{}, err
@@ -93,7 +96,7 @@ func getPolicyAssignments(ctx context.Context, conn armSecurityConn) (PolicyAssi
 		}
 		result.PolicyAssignments = append(result.PolicyAssignments, page.PolicyAssignments...)
 
-		if page.NextLink == nil {
+		if page.NextLink == nil || *page.NextLink == "" {
 			break
 		}
 		nextURL = *page.NextLink

--- a/providers/azure/resources/iam.go
+++ b/providers/azure/resources/iam.go
@@ -351,9 +351,15 @@ func (a *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) role() (*mqlAzu
 	if err != nil {
 		return nil, err
 	}
-	mqlResource := r.(*mqlAzureSubscription)
-	iamResource := mqlResource.GetIam().Data
-	roles := iamResource.GetRoles().Data
+	iam := r.(*mqlAzureSubscription).GetIam()
+	if iam.Error != nil {
+		return nil, iam.Error
+	}
+	rolesVal := iam.Data.GetRoles()
+	if rolesVal.Error != nil {
+		return nil, rolesVal.Error
+	}
+	roles := rolesVal.Data
 	for i := range roles {
 		role := roles[i].(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition)
 		if role.__id == a.roleDefinitionId {

--- a/providers/azure/resources/mysql.go
+++ b/providers/azure/resources/mysql.go
@@ -6,8 +6,10 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -302,8 +304,15 @@ func (a *mqlAzureSubscriptionMySqlServiceFlexibleServer) sslEnforcement() (bool,
 
 	resp, err := dbConfClient.Get(ctx, resourceID.ResourceGroup, server, "require_secure_transport", nil)
 	if err != nil {
-		// Default to true as MySQL flexible servers enforce SSL by default
-		return true, nil
+		// Only tolerate access-denied / not-found: swallowing every error would
+		// report a transient/permission failure as SSL enforced, masking the real
+		// state of a security-relevant setting. MySQL flexible servers enforce SSL
+		// by default, so on those two cases we fall back to that default.
+		var rerr *azcore.ResponseError
+		if errors.As(err, &rerr) && (rerr.StatusCode == http.StatusForbidden || rerr.StatusCode == http.StatusNotFound) {
+			return true, nil
+		}
+		return false, err
 	}
 
 	if resp.Properties != nil && resp.Properties.Value != nil {

--- a/providers/azure/resources/resource_groups.go
+++ b/providers/azure/resources/resource_groups.go
@@ -37,6 +37,10 @@ func (a *mqlAzureSubscription) resourceGroups() ([]any, error) {
 			return nil, err
 		}
 		for _, rg := range page.Value {
+			var provisioningState *string
+			if rg.Properties != nil {
+				provisioningState = rg.Properties.ProvisioningState
+			}
 			mqlAzure, err := CreateResource(a.MqlRuntime, "azure.subscription.resourcegroup",
 				map[string]*llx.RawData{
 					"id":                llx.StringDataPtr(rg.ID),
@@ -44,7 +48,7 @@ func (a *mqlAzureSubscription) resourceGroups() ([]any, error) {
 					"location":          llx.StringDataPtr(rg.Location),
 					"tags":              llx.MapData(convert.PtrMapStrToInterface(rg.Tags), types.String),
 					"type":              llx.StringDataPtr(rg.Type),
-					"provisioningState": llx.StringDataPtr(rg.Properties.ProvisioningState),
+					"provisioningState": llx.StringDataPtr(provisioningState),
 					"managedBy":         llx.StringDataPtr(rg.ManagedBy),
 				},
 			)

--- a/providers/azure/resources/sql.go
+++ b/providers/azure/resources/sql.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,6 +22,22 @@ import (
 
 	sql "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 )
+
+// elasticPoolNameFromID extracts the elastic pool name (the last path segment)
+// from a full ARM elastic pool resource ID, e.g.
+// "/subscriptions/.../elasticPools/mypool" -> "mypool". It is nil-safe: a nil
+// input yields a nil result so the field stays null rather than carrying the
+// raw ARM ID, which would break equality filters on the pool name.
+func elasticPoolNameFromID(id *string) *string {
+	if id == nil {
+		return nil
+	}
+	name := *id
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return &name
+}
 
 type mqlAzureSubscriptionSqlServiceServerInternal struct {
 	encryptionProtectorOnce sync.Once
@@ -298,7 +315,7 @@ func (a *mqlAzureSubscriptionSqlServiceServer) databases() ([]any, error) {
 				"requestedServiceObjectiveName": llx.StringDataPtr(entry.Properties.RequestedServiceObjectiveName),
 				"serviceLevelObjective":         llx.StringDataPtr(entry.Properties.CurrentServiceObjectiveName),
 				"status":                        llx.StringDataPtr((*string)(entry.Properties.Status)),
-				"elasticPoolName":               llx.StringDataPtr(entry.Properties.ElasticPoolID),
+				"elasticPoolName":               llx.StringDataPtr(elasticPoolNameFromID(entry.Properties.ElasticPoolID)),
 				"defaultSecondaryLocation":      llx.StringDataPtr(entry.Properties.DefaultSecondaryLocation),
 				"failoverGroupId":               llx.StringDataPtr(entry.Properties.FailoverGroupID),
 				"readScale":                     llx.StringDataPtr((*string)(entry.Properties.ReadScale)),

--- a/providers/azure/resources/sql_test.go
+++ b/providers/azure/resources/sql_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestElasticPoolNameFromID(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		assert.Nil(t, elasticPoolNameFromID(nil))
+	})
+	t.Run("full ARM id returns last segment", func(t *testing.T) {
+		id := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Sql/servers/srv/elasticPools/mypool"
+		got := elasticPoolNameFromID(&id)
+		assert.NotNil(t, got)
+		assert.Equal(t, "mypool", *got)
+	})
+	t.Run("bare name returns itself", func(t *testing.T) {
+		id := "mypool"
+		got := elasticPoolNameFromID(&id)
+		assert.NotNil(t, got)
+		assert.Equal(t, "mypool", *got)
+	})
+	t.Run("empty string returns empty", func(t *testing.T) {
+		id := ""
+		got := elasticPoolNameFromID(&id)
+		assert.NotNil(t, got)
+		assert.Equal(t, "", *got)
+	})
+	t.Run("trailing slash returns empty last segment", func(t *testing.T) {
+		id := "/subscriptions/sub/elasticPools/"
+		got := elasticPoolNameFromID(&id)
+		assert.NotNil(t, got)
+		assert.Equal(t, "", *got)
+	})
+}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -1297,6 +1297,9 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscr
 		args["httpLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.HTTPLoggingEnabled)
 		args["detailedErrorLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.DetailedErrorLoggingEnabled)
 		args["autoHealEnabled"] = llx.BoolDataPtr(configuration.Properties.AutoHealEnabled)
+		if configuration.Properties.MinTLSCipherSuite != nil {
+			args["minTlsCipherSuite"] = llx.StringData(string(*configuration.Properties.MinTLSCipherSuite))
+		}
 		if configuration.Properties.ScmMinTLSVersion != nil {
 			args["scmMinTlsVersion"] = llx.StringData(string(*configuration.Properties.ScmMinTLSVersion))
 		}


### PR DESCRIPTION
## Summary
Azure Tier-2 correctness fixes from the provider logic-error audit.

- **armsecurity**: `getPolicyAssignments` read only the first page of `Microsoft.Authorization/policyAssignments`; added `nextLink` pagination. Prevents `cloud_defender` false-negatives (a secured subscription reported as unprotected) when the qualifying assignment spills past page 1.
- **mysql**: `sslEnforcement()` swallowed every config-Get error and returned `true` (secure), masking transient/permission failures; now tolerates only 403/404 and re-raises other errors (mirrors `azureAdOnlyAuthentication`).
- **aks / resource_groups**: guard nullable `Properties` before the early derefs.
- **iam `role()`**: check `.Error` on `GetIam()`/`GetRoles()` instead of nil-deref on a denied listing.
- **sql**: `elasticPoolName` carried the full ARM ID; now the last path segment via a nil-safe helper. Field name/type unchanged.
- **web**: appslot `configuration()` now maps `minTlsCipherSuite` (previously always null on deployment slots).

## Tests
`elasticPoolNameFromID` unit test.

Go-only; no schema/codegen/version changes.
