### PR TITLE
🌟 digitalocean: add size resource + dropletSize() typed refs

### DIFF
--- a/providers/digitalocean/resources/digitalocean.go
+++ b/providers/digitalocean/resources/digitalocean.go
@@ -103,6 +103,9 @@ type mqlDigitaloceanDropletInternal struct {
 	// image caches the godo image embedded in the droplet list response so the
 	// typed baseImage() accessor can build a digitalocean.image without a refetch.
 	image *godo.Image
+	// size caches the godo size embedded in the droplet list response so the
+	// typed dropletSize() accessor can build a digitalocean.size without a refetch.
+	size *godo.Size
 	// cacheVolumeIDs holds the block-storage volume IDs attached to the droplet so
 	// the typed volumes() accessor can resolve them without a refetch.
 	cacheVolumeIDs []string
@@ -233,6 +236,7 @@ func (r *mqlDigitalocean) droplets() ([]interface{}, error) {
 			// snapshots(), and backups() accessors — all without a refetch.
 			mqlDroplet := res.(*mqlDigitaloceanDroplet)
 			mqlDroplet.image = d.Image
+			mqlDroplet.size = d.Size
 			mqlDroplet.cacheVolumeIDs = d.VolumeIDs
 			mqlDroplet.cacheSnapshotIDs = d.SnapshotIDs
 			mqlDroplet.cacheBackupIDs = d.BackupIDs

--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -42,6 +42,8 @@ digitalocean {
   images() []digitalocean.image
   // Droplet and volume snapshots
   snapshots() []digitalocean.snapshot
+  // Droplet size catalog (hardware tiers)
+  sizes() []digitalocean.size
   // Functions namespaces
   functionNamespaces() []digitalocean.function.namespace
   // Load balancers
@@ -151,6 +153,8 @@ digitalocean.droplet @defaults("id name status") {
   region string
   // Size slug (DigitalOcean droplet size identifier, e.g., s-1vcpu-1gb)
   size string
+  // Hardware tier the droplet runs on, resolved from the size slug
+  dropletSize() digitalocean.size
   // Status (new, active, off, archive)
   status string
   // Whether the droplet is locked while an action is in progress
@@ -908,6 +912,8 @@ private digitalocean.kubernetes.nodePool @defaults("id name size") {
   name string
   // Droplet size slug
   size string
+  // Hardware tier the pool's worker nodes run on, resolved from the size slug
+  dropletSize() digitalocean.size
   // Number of nodes
   count int
   // Auto-scale enabled
@@ -1573,6 +1579,41 @@ digitalocean.snapshot @defaults("id name resourceType") {
   tags []string
   // Time the resource was created
   createdAt time
+}
+
+// DigitalOcean Droplet size
+//
+// Hardware tier a Droplet or Kubernetes worker node runs on, selected
+// by its `slug` (for example `s-1vcpu-1gb` or `g-2vcpu-8gb`). Surfaces
+// the allocated `memory`, `vcpus` and `disk`, the `priceMonthly` and
+// `priceHourly` in US dollars, the included outbound `transfer`
+// allowance, `gpuInfo` for GPU tiers, the `regions` where the size can
+// currently be provisioned, and the `available` flag reporting whether
+// it can be provisioned at all. Select a single size by slug, for
+// example `digitalocean.size(slug: "s-1vcpu-1gb")`.
+digitalocean.size @defaults("slug vcpus memory priceMonthly") {
+  // Size slug, for example s-1vcpu-1gb
+  slug string
+  // Memory allocated to the size, in megabytes
+  memory int
+  // Number of virtual CPUs allocated to the size
+  vcpus int
+  // Disk capacity allocated to the size, in gigabytes
+  disk int
+  // Monthly price in US dollars
+  priceMonthly float
+  // Hourly price in US dollars
+  priceHourly float
+  // Included outbound transfer allowance, in terabytes
+  transfer float
+  // Whether the size can currently be provisioned
+  available bool
+  // Region slugs where the size is offered
+  regions []string
+  // Human-readable description of the size
+  description string
+  // GPU details for GPU sizes (count, model, vram); null on non-GPU sizes
+  gpuInfo dict
 }
 
 // DigitalOcean Functions namespace

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -59,6 +59,7 @@ const (
 	ResourceDigitaloceanSpacesBucket                                    string = "digitalocean.spacesBucket"
 	ResourceDigitaloceanImage                                           string = "digitalocean.image"
 	ResourceDigitaloceanSnapshot                                        string = "digitalocean.snapshot"
+	ResourceDigitaloceanSize                                            string = "digitalocean.size"
 	ResourceDigitaloceanFunctionNamespace                               string = "digitalocean.function.namespace"
 	ResourceDigitaloceanFunctionAccessKey                               string = "digitalocean.function.accessKey"
 	ResourceDigitaloceanFunctionAction                                  string = "digitalocean.function.action"
@@ -269,6 +270,10 @@ func init() {
 		"digitalocean.snapshot": {
 			// to override args, implement: initDigitaloceanSnapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createDigitaloceanSnapshot,
+		},
+		"digitalocean.size": {
+			Init:   initDigitaloceanSize,
+			Create: createDigitaloceanSize,
 		},
 		"digitalocean.function.namespace": {
 			// to override args, implement: initDigitaloceanFunctionNamespace(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -506,6 +511,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.snapshots": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitalocean).GetSnapshots()).ToDataRes(types.Array(types.Resource("digitalocean.snapshot")))
 	},
+	"digitalocean.sizes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitalocean).GetSizes()).ToDataRes(types.Array(types.Resource("digitalocean.size")))
+	},
 	"digitalocean.functionNamespaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitalocean).GetFunctionNamespaces()).ToDataRes(types.Array(types.Resource("digitalocean.function.namespace")))
 	},
@@ -634,6 +642,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.droplet.size": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetSize()).ToDataRes(types.String)
+	},
+	"digitalocean.droplet.dropletSize": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetDropletSize()).ToDataRes(types.Resource("digitalocean.size"))
 	},
 	"digitalocean.droplet.status": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetStatus()).ToDataRes(types.String)
@@ -1400,6 +1411,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.kubernetes.nodePool.size": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesNodePool).GetSize()).ToDataRes(types.String)
 	},
+	"digitalocean.kubernetes.nodePool.dropletSize": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanKubernetesNodePool).GetDropletSize()).ToDataRes(types.Resource("digitalocean.size"))
+	},
 	"digitalocean.kubernetes.nodePool.count": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanKubernetesNodePool).GetCount()).ToDataRes(types.Int)
 	},
@@ -2029,6 +2043,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"digitalocean.snapshot.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanSnapshot).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"digitalocean.size.slug": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetSlug()).ToDataRes(types.String)
+	},
+	"digitalocean.size.memory": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetMemory()).ToDataRes(types.Int)
+	},
+	"digitalocean.size.vcpus": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetVcpus()).ToDataRes(types.Int)
+	},
+	"digitalocean.size.disk": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetDisk()).ToDataRes(types.Int)
+	},
+	"digitalocean.size.priceMonthly": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetPriceMonthly()).ToDataRes(types.Float)
+	},
+	"digitalocean.size.priceHourly": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetPriceHourly()).ToDataRes(types.Float)
+	},
+	"digitalocean.size.transfer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetTransfer()).ToDataRes(types.Float)
+	},
+	"digitalocean.size.available": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetAvailable()).ToDataRes(types.Bool)
+	},
+	"digitalocean.size.regions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetRegions()).ToDataRes(types.Array(types.String))
+	},
+	"digitalocean.size.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetDescription()).ToDataRes(types.String)
+	},
+	"digitalocean.size.gpuInfo": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanSize).GetGpuInfo()).ToDataRes(types.Dict)
 	},
 	"digitalocean.function.namespace.uuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanFunctionNamespace).GetUuid()).ToDataRes(types.String)
@@ -3257,6 +3304,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitalocean).Snapshots, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"digitalocean.sizes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitalocean).Sizes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"digitalocean.functionNamespaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitalocean).FunctionNamespaces, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -3435,6 +3486,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.droplet.size": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDroplet).Size, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.dropletSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).DropletSize, ok = plugin.RawToTValue[*mqlDigitaloceanSize](v.Value, v.Error)
 		return
 	},
 	"digitalocean.droplet.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4533,6 +4588,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDigitaloceanKubernetesNodePool).Size, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"digitalocean.kubernetes.nodePool.dropletSize": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanKubernetesNodePool).DropletSize, ok = plugin.RawToTValue[*mqlDigitaloceanSize](v.Value, v.Error)
+		return
+	},
 	"digitalocean.kubernetes.nodePool.count": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanKubernetesNodePool).Count, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
@@ -5455,6 +5514,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.snapshot.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanSnapshot).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).__id, ok = v.Value.(string)
+		return
+	},
+	"digitalocean.size.slug": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Slug, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.memory": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Memory, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.vcpus": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Vcpus, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.disk": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Disk, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.priceMonthly": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).PriceMonthly, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.priceHourly": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).PriceHourly, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.transfer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Transfer, ok = plugin.RawToTValue[float64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.available": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Available, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.regions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Regions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.size.gpuInfo": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanSize).GpuInfo, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"digitalocean.function.namespace.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7185,6 +7292,7 @@ type mqlDigitalocean struct {
 	Volumes               plugin.TValue[[]any]
 	Images                plugin.TValue[[]any]
 	Snapshots             plugin.TValue[[]any]
+	Sizes                 plugin.TValue[[]any]
 	FunctionNamespaces    plugin.TValue[[]any]
 	LoadBalancers         plugin.TValue[[]any]
 	Vpcs                  plugin.TValue[[]any]
@@ -7423,6 +7531,22 @@ func (c *mqlDigitalocean) GetSnapshots() *plugin.TValue[[]any] {
 		}
 
 		return c.snapshots()
+	})
+}
+
+func (c *mqlDigitalocean) GetSizes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Sizes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean", c.__id, "sizes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.sizes()
 	})
 }
 
@@ -7948,6 +8072,7 @@ type mqlDigitaloceanDroplet struct {
 	Disk                  plugin.TValue[int64]
 	Region                plugin.TValue[string]
 	Size                  plugin.TValue[string]
+	DropletSize           plugin.TValue[*mqlDigitaloceanSize]
 	Status                plugin.TValue[string]
 	Locked                plugin.TValue[bool]
 	CreatedAt             plugin.TValue[*time.Time]
@@ -8036,6 +8161,22 @@ func (c *mqlDigitaloceanDroplet) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanDroplet) GetSize() *plugin.TValue[string] {
 	return &c.Size
+}
+
+func (c *mqlDigitaloceanDroplet) GetDropletSize() *plugin.TValue[*mqlDigitaloceanSize] {
+	return plugin.GetOrCompute[*mqlDigitaloceanSize](&c.DropletSize, func() (*mqlDigitaloceanSize, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.droplet", c.__id, "dropletSize")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanSize), nil
+			}
+		}
+
+		return c.dropletSize()
+	})
 }
 
 func (c *mqlDigitaloceanDroplet) GetStatus() *plugin.TValue[string] {
@@ -10516,19 +10657,20 @@ type mqlDigitaloceanKubernetesNodePool struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDigitaloceanKubernetesNodePoolInternal
-	Id        plugin.TValue[string]
-	ClusterId plugin.TValue[string]
-	Cluster   plugin.TValue[*mqlDigitaloceanKubernetesCluster]
-	Name      plugin.TValue[string]
-	Size      plugin.TValue[string]
-	Count     plugin.TValue[int64]
-	AutoScale plugin.TValue[bool]
-	MinNodes  plugin.TValue[int64]
-	MaxNodes  plugin.TValue[int64]
-	Tags      plugin.TValue[[]any]
-	Labels    plugin.TValue[any]
-	Taints    plugin.TValue[[]any]
-	Nodes     plugin.TValue[[]any]
+	Id          plugin.TValue[string]
+	ClusterId   plugin.TValue[string]
+	Cluster     plugin.TValue[*mqlDigitaloceanKubernetesCluster]
+	Name        plugin.TValue[string]
+	Size        plugin.TValue[string]
+	DropletSize plugin.TValue[*mqlDigitaloceanSize]
+	Count       plugin.TValue[int64]
+	AutoScale   plugin.TValue[bool]
+	MinNodes    plugin.TValue[int64]
+	MaxNodes    plugin.TValue[int64]
+	Tags        plugin.TValue[[]any]
+	Labels      plugin.TValue[any]
+	Taints      plugin.TValue[[]any]
+	Nodes       plugin.TValue[[]any]
 }
 
 // createDigitaloceanKubernetesNodePool creates a new instance of this resource
@@ -10598,6 +10740,22 @@ func (c *mqlDigitaloceanKubernetesNodePool) GetName() *plugin.TValue[string] {
 
 func (c *mqlDigitaloceanKubernetesNodePool) GetSize() *plugin.TValue[string] {
 	return &c.Size
+}
+
+func (c *mqlDigitaloceanKubernetesNodePool) GetDropletSize() *plugin.TValue[*mqlDigitaloceanSize] {
+	return plugin.GetOrCompute[*mqlDigitaloceanSize](&c.DropletSize, func() (*mqlDigitaloceanSize, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("digitalocean.kubernetes.nodePool", c.__id, "dropletSize")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDigitaloceanSize), nil
+			}
+		}
+
+		return c.dropletSize()
+	})
 }
 
 func (c *mqlDigitaloceanKubernetesNodePool) GetCount() *plugin.TValue[int64] {
@@ -12820,6 +12978,105 @@ func (c *mqlDigitaloceanSnapshot) GetTags() *plugin.TValue[[]any] {
 
 func (c *mqlDigitaloceanSnapshot) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
+}
+
+// mqlDigitaloceanSize for the digitalocean.size resource
+type mqlDigitaloceanSize struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlDigitaloceanSizeInternal it will be used here
+	Slug         plugin.TValue[string]
+	Memory       plugin.TValue[int64]
+	Vcpus        plugin.TValue[int64]
+	Disk         plugin.TValue[int64]
+	PriceMonthly plugin.TValue[float64]
+	PriceHourly  plugin.TValue[float64]
+	Transfer     plugin.TValue[float64]
+	Available    plugin.TValue[bool]
+	Regions      plugin.TValue[[]any]
+	Description  plugin.TValue[string]
+	GpuInfo      plugin.TValue[any]
+}
+
+// createDigitaloceanSize creates a new instance of this resource
+func createDigitaloceanSize(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlDigitaloceanSize{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("digitalocean.size", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlDigitaloceanSize) MqlName() string {
+	return "digitalocean.size"
+}
+
+func (c *mqlDigitaloceanSize) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlDigitaloceanSize) GetSlug() *plugin.TValue[string] {
+	return &c.Slug
+}
+
+func (c *mqlDigitaloceanSize) GetMemory() *plugin.TValue[int64] {
+	return &c.Memory
+}
+
+func (c *mqlDigitaloceanSize) GetVcpus() *plugin.TValue[int64] {
+	return &c.Vcpus
+}
+
+func (c *mqlDigitaloceanSize) GetDisk() *plugin.TValue[int64] {
+	return &c.Disk
+}
+
+func (c *mqlDigitaloceanSize) GetPriceMonthly() *plugin.TValue[float64] {
+	return &c.PriceMonthly
+}
+
+func (c *mqlDigitaloceanSize) GetPriceHourly() *plugin.TValue[float64] {
+	return &c.PriceHourly
+}
+
+func (c *mqlDigitaloceanSize) GetTransfer() *plugin.TValue[float64] {
+	return &c.Transfer
+}
+
+func (c *mqlDigitaloceanSize) GetAvailable() *plugin.TValue[bool] {
+	return &c.Available
+}
+
+func (c *mqlDigitaloceanSize) GetRegions() *plugin.TValue[[]any] {
+	return &c.Regions
+}
+
+func (c *mqlDigitaloceanSize) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlDigitaloceanSize) GetGpuInfo() *plugin.TValue[any] {
+	return &c.GpuInfo
 }
 
 // mqlDigitaloceanFunctionNamespace for the digitalocean.function.namespace resource

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -222,6 +222,7 @@ digitalocean.droplet.backupsEnabled 13.0.1
 digitalocean.droplet.baseImage 13.1.7
 digitalocean.droplet.createdAt 13.0.1
 digitalocean.droplet.disk 13.0.1
+digitalocean.droplet.dropletSize 13.13.2
 digitalocean.droplet.exposure 13.7.1
 digitalocean.droplet.features 13.0.1
 digitalocean.droplet.firewalls 13.0.2
@@ -655,6 +656,7 @@ digitalocean.kubernetes.nodePool.autoScale 13.0.1
 digitalocean.kubernetes.nodePool.cluster 13.4.2
 digitalocean.kubernetes.nodePool.clusterId 13.0.1
 digitalocean.kubernetes.nodePool.count 13.0.1
+digitalocean.kubernetes.nodePool.dropletSize 13.13.2
 digitalocean.kubernetes.nodePool.id 13.0.1
 digitalocean.kubernetes.nodePool.labels 13.0.1
 digitalocean.kubernetes.nodePool.maxNodes 13.0.1
@@ -852,6 +854,19 @@ digitalocean.securityScan.findings 13.4.2
 digitalocean.securityScan.id 13.4.2
 digitalocean.securityScan.status 13.4.2
 digitalocean.securityScans 13.4.2
+digitalocean.size 13.13.2
+digitalocean.size.available 13.13.2
+digitalocean.size.description 13.13.2
+digitalocean.size.disk 13.13.2
+digitalocean.size.gpuInfo 13.13.2
+digitalocean.size.memory 13.13.2
+digitalocean.size.priceHourly 13.13.2
+digitalocean.size.priceMonthly 13.13.2
+digitalocean.size.regions 13.13.2
+digitalocean.size.slug 13.13.2
+digitalocean.size.transfer 13.13.2
+digitalocean.size.vcpus 13.13.2
+digitalocean.sizes 13.13.2
 digitalocean.snapshot 13.1.7
 digitalocean.snapshot.createdAt 13.1.7
 digitalocean.snapshot.droplet 13.10.2

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -70,6 +70,10 @@ type mqlDigitaloceanInternal struct {
 	partnerAttachmentIndexOnce sync.Once
 	partnerAttachmentIndex     map[string]*mqlDigitaloceanPartnerAttachment
 	partnerAttachmentIndexErr  error
+
+	sizeIndexOnce sync.Once
+	sizeIndex     map[string]*mqlDigitaloceanSize
+	sizeIndexErr  error
 }
 
 // partnerAttachmentByID resolves a partner attachment by its ID from the

--- a/providers/digitalocean/resources/digitalocean_sizes.go
+++ b/providers/digitalocean/resources/digitalocean_sizes.go
@@ -1,0 +1,182 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// --- Sizes (droplet size catalog) ---
+
+// newMqlDigitaloceanSize builds a digitalocean.size resource from a godo size.
+// It is shared by the sizes() catalog collection and the droplet/nodePool
+// dropletSize() accessors.
+func newMqlDigitaloceanSize(runtime *plugin.Runtime, size godo.Size) (*mqlDigitaloceanSize, error) {
+	regions := make([]interface{}, len(size.Regions))
+	for i, rg := range size.Regions {
+		regions[i] = rg
+	}
+
+	var gpuInfo interface{}
+	if size.GPUInfo != nil {
+		gi := map[string]interface{}{
+			"count": int64(size.GPUInfo.Count),
+			"model": size.GPUInfo.Model,
+		}
+		if size.GPUInfo.VRAM != nil {
+			gi["vram"] = map[string]interface{}{
+				"amount": int64(size.GPUInfo.VRAM.Amount),
+				"unit":   size.GPUInfo.VRAM.Unit,
+			}
+		}
+		gpuInfo = gi
+	}
+
+	res, err := CreateResource(runtime, "digitalocean.size", map[string]*llx.RawData{
+		"slug":         llx.StringData(size.Slug),
+		"memory":       llx.IntData(int64(size.Memory)),
+		"vcpus":        llx.IntData(int64(size.Vcpus)),
+		"disk":         llx.IntData(int64(size.Disk)),
+		"priceMonthly": llx.FloatData(size.PriceMonthly),
+		"priceHourly":  llx.FloatData(size.PriceHourly),
+		"transfer":     llx.FloatData(size.Transfer),
+		"available":    llx.BoolData(size.Available),
+		"regions":      llx.ArrayData(regions, "\x02"),
+		"description":  llx.StringData(size.Description),
+		"gpuInfo":      llx.DictData(gpuInfo),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDigitaloceanSize), nil
+}
+
+// sizes lists the DigitalOcean droplet size catalog — the hardware tiers a
+// droplet or Kubernetes worker node can run on.
+func (r *mqlDigitalocean) sizes() ([]interface{}, error) {
+	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+	client := conn.Client()
+
+	var all []interface{}
+	opt := &godo.ListOptions{PerPage: 200}
+	for {
+		sizes, resp, err := client.Sizes.List(context.Background(), opt)
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range sizes {
+			res, err := newMqlDigitaloceanSize(r.MqlRuntime, s)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, res)
+		}
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+		opt.Page = page + 1
+	}
+	return all, nil
+}
+
+func (r *mqlDigitaloceanSize) id() (string, error) {
+	return "digitalocean.size/" + r.Slug.Data, nil
+}
+
+// sizeBySlug resolves a size by its slug from the account-wide catalog,
+// caching the index so repeated node-pool lookups do not re-list the catalog.
+func (r *mqlDigitalocean) sizeBySlug(slug string) (*mqlDigitaloceanSize, error) {
+	r.sizeIndexOnce.Do(func() {
+		sizes := r.GetSizes()
+		if sizes.Error != nil {
+			r.sizeIndexErr = sizes.Error
+			return
+		}
+		idx := make(map[string]*mqlDigitaloceanSize, len(sizes.Data))
+		for _, s := range sizes.Data {
+			ms := s.(*mqlDigitaloceanSize)
+			idx[ms.Slug.Data] = ms
+		}
+		r.sizeIndex = idx
+	})
+	if r.sizeIndexErr != nil {
+		return nil, r.sizeIndexErr
+	}
+	return r.sizeIndex[slug], nil
+}
+
+// initDigitaloceanSize resolves a size requested by slug (for example
+// digitalocean.size(slug: "s-1vcpu-1gb")) against the catalog. Fully-populated
+// args from the sizes() collection take the fast path.
+func initDigitaloceanSize(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	slugRaw, ok := args["slug"]
+	if !ok {
+		return nil, nil, errors.New("digitalocean.size requires a slug")
+	}
+	slug, ok := slugRaw.Value.(string)
+	if !ok || slug == "" {
+		return nil, nil, errors.New("digitalocean.size slug must be a non-empty string")
+	}
+
+	parent, err := parentDigitalocean(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	size, err := parent.sizeBySlug(slug)
+	if err != nil {
+		return nil, nil, err
+	}
+	if size == nil {
+		return nil, nil, fmt.Errorf("digitalocean.size with slug %q not found", slug)
+	}
+	return nil, size, nil
+}
+
+// dropletSize resolves the droplet's hardware tier to a typed digitalocean.size.
+// The godo size is embedded in the droplet list response, so no refetch happens.
+func (r *mqlDigitaloceanDroplet) dropletSize() (*mqlDigitaloceanSize, error) {
+	if r.size == nil || r.size.Slug == "" {
+		r.DropletSize.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return newMqlDigitaloceanSize(r.MqlRuntime, *r.size)
+}
+
+// dropletSize resolves the node pool's droplet hardware tier to a typed
+// digitalocean.size. The pool carries only the size slug, so it is resolved
+// against the account-wide catalog (cached after the first lookup).
+func (r *mqlDigitaloceanKubernetesNodePool) dropletSize() (*mqlDigitaloceanSize, error) {
+	if r.Size.Data == "" {
+		r.DropletSize.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	size, err := parent.sizeBySlug(r.Size.Data)
+	if err != nil {
+		return nil, err
+	}
+	if size == nil {
+		r.DropletSize.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return size, nil
+}


### PR DESCRIPTION
## What

Adds a new `digitalocean.size` resource — the DigitalOcean Droplet size catalog — and wires it into the resources that reference a size slug via a new `dropletSize()` typed accessor.

The size resource is the join target that makes Droplet/node **cost and capacity** data traversable in MQL. On its own a size catalog is low value; the point is `dropletSize()` on `digitalocean.droplet` and `digitalocean.kubernetes.nodePool`, which turn a bare slug string into a resource you can traverse.

### New resource

`digitalocean.size` — keyed by `slug` (the natural query key), exposing:

`slug`, `memory`, `vcpus`, `disk`, `priceMonthly`, `priceHourly`, `transfer`, `available`, `regions`, `description`, `gpuInfo` (dict: count / model / vram).

Listed via `digitalocean.sizes`, selectable by slug, e.g. `digitalocean.size(slug: "s-1vcpu-1gb")`.

### New typed accessors

- `digitalocean.droplet.dropletSize() digitalocean.size`
- `digitalocean.kubernetes.nodePool.dropletSize() digitalocean.size`

The raw `size` slug fields are left untouched (the slug is a legitimate query key), so this is purely additive.

## Why

`droplet.size` and `nodePool.size` were bare slug strings — a Droplet knew it was `s-1vcpu-1gb` but couldn't tell you what that costs or whether it has a GPU. This also closes a coverage asymmetry: the Hetzner provider already models `hetzner.serverType` (the equivalent hardware-tier catalog), DigitalOcean did not.

Queries this newly enables:

```mql
// Every droplet's monthly bill, no second lookup
digitalocean.droplets { name size dropletSize.priceMonthly }

// GPU droplets, with GPU details
digitalocean.droplets.where( dropletSize.gpuInfo != null )
  { name dropletSize.gpuInfo }

// Node pools on a size that's been retired in their region
digitalocean.kubernetesClusters.nodePools.where( dropletSize.available == false )
```

## Implementation notes

- **Two feeders, one resource type.** The Droplet list response embeds the full godo size object, so `droplet.dropletSize` builds directly from cache with no extra API call (mirroring the existing `baseImage()` accessor). A node pool carries only the slug, so it resolves against the account-wide catalog through a `sync.Once`-cached slug index on the parent `digitalocean` resource — the same idiom as the existing `*Index` caches. Because entries are cache-keyed by slug, a Droplet-built size is reused when a node pool later asks for the same slug.
- **`gpuInfo` is a `dict`, not a sub-resource** — a small heterogeneous struct with no stable ID and no nested typed ref, so per the sub-resource bar it stays a dict on the parent.
- `initDigitaloceanSize` resolves direct `digitalocean.size(slug: ...)` queries against the catalog and returns a not-found error for unknown slugs.
- New `.lr.versions` entries are all at `13.13.2` (next patch after the provider's current `13.13.1`).

## Verification

- `make providers/build/digitalocean` — builds clean
- `go build ./...` + `go test ./resources/...` — pass
- codegen regenerated (`mqlr generate`), doc-comment structure validated, gofmt run

⚠️ **Not** exercised against live DigitalOcean infrastructure — no DO token was available in the dev environment. The static path (schema, codegen, compile, generated getter types) is fully validated; the two runtime resolution paths have not been proven against real account data. Worth a live smoke test (`digitalocean.sizes`, `droplet.dropletSize.priceMonthly`, a GPU-size `gpuInfo` check) before merge.
