### PR TITLE
✨ stackit: add Object Storage credentials groups and access keys

### DIFF
--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -19,6 +19,13 @@ type mqlStackitObjectStorageBucketInternal struct {
 	retentionLock    sync.Mutex
 }
 
+type mqlStackitObjectStorageAccessKeyInternal struct {
+	// cacheCredentialsGroupId holds the owning group's UUID so the lazy
+	// credentialsGroup() reference can resolve it. It is not exposed as a
+	// field because credentialsGroup() already carries the same value.
+	cacheCredentialsGroupId string
+}
+
 func (r *mqlStackitObjectStorage) buckets() ([]any, error) {
 	c := conn(r.MqlRuntime)
 	client, err := c.ObjectStorage()
@@ -220,30 +227,32 @@ func (r *mqlStackitObjectStorageCredentialsGroup) accessKeys() ([]any, error) {
 	keys, _ := resp.GetAccessKeysOk()
 	out := make([]any, 0, len(keys))
 	for i := range keys {
+		keyID := keys[i].GetKeyId()
+		// Synthetic cache key: the access key ID is unique within a group, so
+		// project + group + key keeps instances distinct. It mirrors the
+		// project-qualified form used by credentialsGroup.id().
+		accessKeyID := "stackit.objectStorage.accessKey/" + c.ProjectID() + "/" + r.Id.Data + "/" + keyID
 		res, err := CreateResource(r.MqlRuntime, "stackit.objectStorage.accessKey", map[string]*llx.RawData{
-			"keyId":              llx.StringData(keys[i].GetKeyId()),
-			"credentialsGroupId": llx.StringData(r.Id.Data),
-			"displayName":        llx.StringData(keys[i].GetDisplayName()),
-			"expires":            llx.TimeDataPtr(parseRFC3339(keys[i].GetExpires())),
+			"__id":        llx.StringData(accessKeyID),
+			"keyId":       llx.StringData(keyID),
+			"displayName": llx.StringData(keys[i].GetDisplayName()),
+			"expires":     llx.TimeDataPtr(parseRFC3339(keys[i].GetExpires())),
 		})
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlStackitObjectStorageAccessKey).cacheCredentialsGroupId = r.Id.Data
 		out = append(out, res)
 	}
 	return out, nil
 }
 
-func (r *mqlStackitObjectStorageAccessKey) id() (string, error) {
-	return "stackit.objectStorage.accessKey/" + r.CredentialsGroupId.Data + "/" + r.KeyId.Data, nil
-}
-
 func (r *mqlStackitObjectStorageAccessKey) credentialsGroup() (*mqlStackitObjectStorageCredentialsGroup, error) {
-	if r.CredentialsGroupId.Data == "" {
+	if r.cacheCredentialsGroupId == "" {
 		return markNull[mqlStackitObjectStorageCredentialsGroup](&r.CredentialsGroup)
 	}
 	res, err := NewResource(r.MqlRuntime, "stackit.objectStorage.credentialsGroup", map[string]*llx.RawData{
-		"id": llx.StringData(r.CredentialsGroupId.Data),
+		"id": llx.StringData(r.cacheCredentialsGroupId),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
@@ -132,4 +133,120 @@ func (r *mqlStackitObjectStorageBucket) defaultRetentionDays() (int64, error) {
 func (r *mqlStackitObjectStorageBucket) defaultRetentionMode() (string, error) {
 	_, mode, err := r.fetchDefaultRetention()
 	return mode, err
+}
+
+// ------------------------- credentials groups & access keys -------------------------
+
+func (r *mqlStackitObjectStorage) credentialsGroups() ([]any, error) {
+	c := conn(r.MqlRuntime)
+	client, err := c.ObjectStorage()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListCredentialsGroupsExecute(bgctx(), c.ProjectID(), c.Region())
+	if err != nil {
+		// A 404 means the project is not onboarded to Object Storage; treat it
+		// as no credentials groups.
+		if isAccessDenied(err) || isNotFound(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	groups, _ := resp.GetCredentialsGroupsOk()
+	out := make([]any, 0, len(groups))
+	for i := range groups {
+		res, err := CreateResource(r.MqlRuntime, "stackit.objectStorage.credentialsGroup", map[string]*llx.RawData{
+			"id":          llx.StringData(groups[i].GetCredentialsGroupId()),
+			"displayName": llx.StringData(groups[i].GetDisplayName()),
+			"urn":         llx.StringData(groups[i].GetUrn()),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func (r *mqlStackitObjectStorageCredentialsGroup) id() (string, error) {
+	return "stackit.objectStorage.credentialsGroup/" + conn(r.MqlRuntime).ProjectID() + "/" + r.Id.Data, nil
+}
+
+// initStackitObjectStorageCredentialsGroup resolves a credentials group by ID,
+// used when navigating to it from an access key.
+func initStackitObjectStorageCredentialsGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := idArg(args, "id")
+	if !ok {
+		return args, nil, nil
+	}
+	c := conn(runtime)
+	client, err := c.ObjectStorage()
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := client.GetCredentialsGroupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	g, ok := resp.GetCredentialsGroupOk()
+	if !ok {
+		return nil, nil, fmt.Errorf("stackit object storage credentials group %q not found", id)
+	}
+	res, err := CreateResource(runtime, "stackit.objectStorage.credentialsGroup", map[string]*llx.RawData{
+		"id":          llx.StringData(g.GetCredentialsGroupId()),
+		"displayName": llx.StringData(g.GetDisplayName()),
+		"urn":         llx.StringData(g.GetUrn()),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+func (r *mqlStackitObjectStorageCredentialsGroup) accessKeys() ([]any, error) {
+	c := conn(r.MqlRuntime)
+	client, err := c.ObjectStorage()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListAccessKeys(bgctx(), c.ProjectID(), c.Region()).
+		CredentialsGroup(r.Id.Data).Execute()
+	if err != nil {
+		if isAccessDenied(err) || isNotFound(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	keys, _ := resp.GetAccessKeysOk()
+	out := make([]any, 0, len(keys))
+	for i := range keys {
+		res, err := CreateResource(r.MqlRuntime, "stackit.objectStorage.accessKey", map[string]*llx.RawData{
+			"keyId":              llx.StringData(keys[i].GetKeyId()),
+			"credentialsGroupId": llx.StringData(r.Id.Data),
+			"displayName":        llx.StringData(keys[i].GetDisplayName()),
+			"expires":            llx.TimeDataPtr(parseRFC3339(keys[i].GetExpires())),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func (r *mqlStackitObjectStorageAccessKey) id() (string, error) {
+	return "stackit.objectStorage.accessKey/" + r.CredentialsGroupId.Data + "/" + r.KeyId.Data, nil
+}
+
+func (r *mqlStackitObjectStorageAccessKey) credentialsGroup() (*mqlStackitObjectStorageCredentialsGroup, error) {
+	if r.CredentialsGroupId.Data == "" {
+		return markNull[mqlStackitObjectStorageCredentialsGroup](&r.CredentialsGroup)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.objectStorage.credentialsGroup", map[string]*llx.RawData{
+		"id": llx.StringData(r.CredentialsGroupId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitObjectStorageCredentialsGroup), nil
 }

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -843,8 +843,6 @@ private stackit.objectStorage.credentialsGroup @defaults("id displayName") {
 private stackit.objectStorage.accessKey @defaults("keyId displayName expires") {
   // Access key ID
   keyId string
-  // Owning credentials group UUID
-  credentialsGroupId string
   // Credentials group the key belongs to
   credentialsGroup() stackit.objectStorage.credentialsGroup
   // Display name

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -813,6 +813,44 @@ private stackit.ske.cluster.nodePool @defaults("name machineType minimum maximum
 stackit.objectStorage {
   // Object Storage buckets
   buckets() []stackit.objectStorage.bucket
+  // S3 credentials groups holding access keys
+  credentialsGroups() []stackit.objectStorage.credentialsGroup
+}
+
+// STACKIT Object Storage credentials group
+//
+// Group of S3-compatible access keys for a project's Object Storage. The
+// group is keyed by its UUID id and exposes the display name, the URN
+// that identifies the group, and the access keys it contains.
+private stackit.objectStorage.credentialsGroup @defaults("id displayName") {
+  init(id? string)
+  // Credentials group UUID
+  id string
+  // Display name
+  displayName string
+  // URN identifying the credentials group
+  urn string
+  // Access keys belonging to the group
+  accessKeys() []stackit.objectStorage.accessKey
+}
+
+// STACKIT Object Storage access key
+//
+// S3-compatible access key belonging to a credentials group. The key is
+// keyed by its keyId and exposes the display name, the expiry timestamp
+// (unset for keys that never expire), and the credentials group the key
+// belongs to.
+private stackit.objectStorage.accessKey @defaults("keyId displayName expires") {
+  // Access key ID
+  keyId string
+  // Owning credentials group UUID
+  credentialsGroupId string
+  // Credentials group the key belongs to
+  credentialsGroup() stackit.objectStorage.credentialsGroup
+  // Display name
+  displayName string
+  // Expiry timestamp (unset for keys that never expire)
+  expires time
 }
 
 // STACKIT Object Storage bucket

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -16,77 +16,79 @@ import (
 
 // The MQL type names exposed as public consts for ease of reference.
 const (
-	ResourceStackit                           string = "stackit"
-	ResourceStackitProject                    string = "stackit.project"
-	ResourceStackitServer                     string = "stackit.server"
-	ResourceStackitVolume                     string = "stackit.volume"
-	ResourceStackitSnapshot                   string = "stackit.snapshot"
-	ResourceStackitImage                      string = "stackit.image"
-	ResourceStackitNetwork                    string = "stackit.network"
-	ResourceStackitNic                        string = "stackit.nic"
-	ResourceStackitPublicIp                   string = "stackit.publicIp"
-	ResourceStackitSecurityGroup              string = "stackit.securityGroup"
-	ResourceStackitSecurityGroupRule          string = "stackit.securityGroup.rule"
-	ResourceStackitNetworkExposure            string = "stackit.network.exposure"
-	ResourceStackitServerBackup               string = "stackit.server.backup"
-	ResourceStackitServerBackupSchedule       string = "stackit.server.backupSchedule"
-	ResourceStackitServerUpdate               string = "stackit.server.update"
-	ResourceStackitServerUpdateSchedule       string = "stackit.server.updateSchedule"
-	ResourceStackitKeyPair                    string = "stackit.keyPair"
-	ResourceStackitLoadBalancer               string = "stackit.loadBalancer"
-	ResourceStackitLoadBalancerListener       string = "stackit.loadBalancer.listener"
-	ResourceStackitLoadBalancerTargetPool     string = "stackit.loadBalancer.targetPool"
-	ResourceStackitSke                        string = "stackit.ske"
-	ResourceStackitSkeCluster                 string = "stackit.ske.cluster"
-	ResourceStackitSkeClusterNodePool         string = "stackit.ske.cluster.nodePool"
-	ResourceStackitObjectStorage              string = "stackit.objectStorage"
-	ResourceStackitObjectStorageBucket        string = "stackit.objectStorage.bucket"
-	ResourceStackitSfs                        string = "stackit.sfs"
-	ResourceStackitSfsResourcePool            string = "stackit.sfs.resourcePool"
-	ResourceStackitSfsShare                   string = "stackit.sfs.share"
-	ResourceStackitSfsExportPolicy            string = "stackit.sfs.exportPolicy"
-	ResourceStackitSfsExportPolicyRule        string = "stackit.sfs.exportPolicy.rule"
-	ResourceStackitSfsSnapshot                string = "stackit.sfs.snapshot"
-	ResourceStackitDns                        string = "stackit.dns"
-	ResourceStackitDnsZone                    string = "stackit.dns.zone"
-	ResourceStackitDnsRecordSet               string = "stackit.dns.recordSet"
-	ResourceStackitPostgresFlex               string = "stackit.postgresFlex"
-	ResourceStackitPostgresFlexInstance       string = "stackit.postgresFlex.instance"
-	ResourceStackitMongoDbFlex                string = "stackit.mongoDbFlex"
-	ResourceStackitMongoDbFlexInstance        string = "stackit.mongoDbFlex.instance"
-	ResourceStackitSqlServerFlex              string = "stackit.sqlServerFlex"
-	ResourceStackitSqlServerFlexInstance      string = "stackit.sqlServerFlex.instance"
-	ResourceStackitOpenSearch                 string = "stackit.openSearch"
-	ResourceStackitOpenSearchInstance         string = "stackit.openSearch.instance"
-	ResourceStackitMariaDb                    string = "stackit.mariaDb"
-	ResourceStackitMariaDbInstance            string = "stackit.mariaDb.instance"
-	ResourceStackitRedis                      string = "stackit.redis"
-	ResourceStackitRedisInstance              string = "stackit.redis.instance"
-	ResourceStackitRabbitMq                   string = "stackit.rabbitMq"
-	ResourceStackitRabbitMqInstance           string = "stackit.rabbitMq.instance"
-	ResourceStackitLogMe                      string = "stackit.logMe"
-	ResourceStackitLogMeInstance              string = "stackit.logMe.instance"
-	ResourceStackitSecretsManager             string = "stackit.secretsManager"
-	ResourceStackitSecretsManagerInstance     string = "stackit.secretsManager.instance"
-	ResourceStackitObservability              string = "stackit.observability"
-	ResourceStackitObservabilityInstance      string = "stackit.observability.instance"
-	ResourceStackitTelemetry                  string = "stackit.telemetry"
-	ResourceStackitTelemetryRouter            string = "stackit.telemetry.router"
-	ResourceStackitTelemetryRouterDestination string = "stackit.telemetry.router.destination"
-	ResourceStackitTelemetryRouterAccessToken string = "stackit.telemetry.router.accessToken"
-	ResourceStackitTelemetryLink              string = "stackit.telemetry.link"
-	ResourceStackitModelServing               string = "stackit.modelServing"
-	ResourceStackitModelServingToken          string = "stackit.modelServing.token"
-	ResourceStackitModelServingModel          string = "stackit.modelServing.model"
-	ResourceStackitServiceAccount             string = "stackit.serviceAccount"
-	ResourceStackitCertificate                string = "stackit.certificate"
-	ResourceStackitAlbLoadBalancer            string = "stackit.alb.loadBalancer"
-	ResourceStackitKms                        string = "stackit.kms"
-	ResourceStackitKmsKeyRing                 string = "stackit.kms.keyRing"
-	ResourceStackitKmsKey                     string = "stackit.kms.key"
-	ResourceStackitIam                        string = "stackit.iam"
-	ResourceStackitIamMember                  string = "stackit.iam.member"
-	ResourceStackitIamRole                    string = "stackit.iam.role"
+	ResourceStackit                              string = "stackit"
+	ResourceStackitProject                       string = "stackit.project"
+	ResourceStackitServer                        string = "stackit.server"
+	ResourceStackitVolume                        string = "stackit.volume"
+	ResourceStackitSnapshot                      string = "stackit.snapshot"
+	ResourceStackitImage                         string = "stackit.image"
+	ResourceStackitNetwork                       string = "stackit.network"
+	ResourceStackitNic                           string = "stackit.nic"
+	ResourceStackitPublicIp                      string = "stackit.publicIp"
+	ResourceStackitSecurityGroup                 string = "stackit.securityGroup"
+	ResourceStackitSecurityGroupRule             string = "stackit.securityGroup.rule"
+	ResourceStackitNetworkExposure               string = "stackit.network.exposure"
+	ResourceStackitServerBackup                  string = "stackit.server.backup"
+	ResourceStackitServerBackupSchedule          string = "stackit.server.backupSchedule"
+	ResourceStackitServerUpdate                  string = "stackit.server.update"
+	ResourceStackitServerUpdateSchedule          string = "stackit.server.updateSchedule"
+	ResourceStackitKeyPair                       string = "stackit.keyPair"
+	ResourceStackitLoadBalancer                  string = "stackit.loadBalancer"
+	ResourceStackitLoadBalancerListener          string = "stackit.loadBalancer.listener"
+	ResourceStackitLoadBalancerTargetPool        string = "stackit.loadBalancer.targetPool"
+	ResourceStackitSke                           string = "stackit.ske"
+	ResourceStackitSkeCluster                    string = "stackit.ske.cluster"
+	ResourceStackitSkeClusterNodePool            string = "stackit.ske.cluster.nodePool"
+	ResourceStackitObjectStorage                 string = "stackit.objectStorage"
+	ResourceStackitObjectStorageCredentialsGroup string = "stackit.objectStorage.credentialsGroup"
+	ResourceStackitObjectStorageAccessKey        string = "stackit.objectStorage.accessKey"
+	ResourceStackitObjectStorageBucket           string = "stackit.objectStorage.bucket"
+	ResourceStackitSfs                           string = "stackit.sfs"
+	ResourceStackitSfsResourcePool               string = "stackit.sfs.resourcePool"
+	ResourceStackitSfsShare                      string = "stackit.sfs.share"
+	ResourceStackitSfsExportPolicy               string = "stackit.sfs.exportPolicy"
+	ResourceStackitSfsExportPolicyRule           string = "stackit.sfs.exportPolicy.rule"
+	ResourceStackitSfsSnapshot                   string = "stackit.sfs.snapshot"
+	ResourceStackitDns                           string = "stackit.dns"
+	ResourceStackitDnsZone                       string = "stackit.dns.zone"
+	ResourceStackitDnsRecordSet                  string = "stackit.dns.recordSet"
+	ResourceStackitPostgresFlex                  string = "stackit.postgresFlex"
+	ResourceStackitPostgresFlexInstance          string = "stackit.postgresFlex.instance"
+	ResourceStackitMongoDbFlex                   string = "stackit.mongoDbFlex"
+	ResourceStackitMongoDbFlexInstance           string = "stackit.mongoDbFlex.instance"
+	ResourceStackitSqlServerFlex                 string = "stackit.sqlServerFlex"
+	ResourceStackitSqlServerFlexInstance         string = "stackit.sqlServerFlex.instance"
+	ResourceStackitOpenSearch                    string = "stackit.openSearch"
+	ResourceStackitOpenSearchInstance            string = "stackit.openSearch.instance"
+	ResourceStackitMariaDb                       string = "stackit.mariaDb"
+	ResourceStackitMariaDbInstance               string = "stackit.mariaDb.instance"
+	ResourceStackitRedis                         string = "stackit.redis"
+	ResourceStackitRedisInstance                 string = "stackit.redis.instance"
+	ResourceStackitRabbitMq                      string = "stackit.rabbitMq"
+	ResourceStackitRabbitMqInstance              string = "stackit.rabbitMq.instance"
+	ResourceStackitLogMe                         string = "stackit.logMe"
+	ResourceStackitLogMeInstance                 string = "stackit.logMe.instance"
+	ResourceStackitSecretsManager                string = "stackit.secretsManager"
+	ResourceStackitSecretsManagerInstance        string = "stackit.secretsManager.instance"
+	ResourceStackitObservability                 string = "stackit.observability"
+	ResourceStackitObservabilityInstance         string = "stackit.observability.instance"
+	ResourceStackitTelemetry                     string = "stackit.telemetry"
+	ResourceStackitTelemetryRouter               string = "stackit.telemetry.router"
+	ResourceStackitTelemetryRouterDestination    string = "stackit.telemetry.router.destination"
+	ResourceStackitTelemetryRouterAccessToken    string = "stackit.telemetry.router.accessToken"
+	ResourceStackitTelemetryLink                 string = "stackit.telemetry.link"
+	ResourceStackitModelServing                  string = "stackit.modelServing"
+	ResourceStackitModelServingToken             string = "stackit.modelServing.token"
+	ResourceStackitModelServingModel             string = "stackit.modelServing.model"
+	ResourceStackitServiceAccount                string = "stackit.serviceAccount"
+	ResourceStackitCertificate                   string = "stackit.certificate"
+	ResourceStackitAlbLoadBalancer               string = "stackit.alb.loadBalancer"
+	ResourceStackitKms                           string = "stackit.kms"
+	ResourceStackitKmsKeyRing                    string = "stackit.kms.keyRing"
+	ResourceStackitKmsKey                        string = "stackit.kms.key"
+	ResourceStackitIam                           string = "stackit.iam"
+	ResourceStackitIamMember                     string = "stackit.iam.member"
+	ResourceStackitIamRole                       string = "stackit.iam.role"
 )
 
 var resourceFactories map[string]plugin.ResourceFactory
@@ -188,6 +190,14 @@ func init() {
 		"stackit.objectStorage": {
 			// to override args, implement: initStackitObjectStorage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createStackitObjectStorage,
+		},
+		"stackit.objectStorage.credentialsGroup": {
+			Init:   initStackitObjectStorageCredentialsGroup,
+			Create: createStackitObjectStorageCredentialsGroup,
+		},
+		"stackit.objectStorage.accessKey": {
+			// to override args, implement: initStackitObjectStorageAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createStackitObjectStorageAccessKey,
 		},
 		"stackit.objectStorage.bucket": {
 			Init:   initStackitObjectStorageBucket,
@@ -1302,6 +1312,36 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.objectStorage.buckets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitObjectStorage).GetBuckets()).ToDataRes(types.Array(types.Resource("stackit.objectStorage.bucket")))
+	},
+	"stackit.objectStorage.credentialsGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorage).GetCredentialsGroups()).ToDataRes(types.Array(types.Resource("stackit.objectStorage.credentialsGroup")))
+	},
+	"stackit.objectStorage.credentialsGroup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageCredentialsGroup).GetId()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.credentialsGroup.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageCredentialsGroup).GetDisplayName()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.credentialsGroup.urn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageCredentialsGroup).GetUrn()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.credentialsGroup.accessKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageCredentialsGroup).GetAccessKeys()).ToDataRes(types.Array(types.Resource("stackit.objectStorage.accessKey")))
+	},
+	"stackit.objectStorage.accessKey.keyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageAccessKey).GetKeyId()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.accessKey.credentialsGroupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageAccessKey).GetCredentialsGroupId()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.accessKey.credentialsGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageAccessKey).GetCredentialsGroup()).ToDataRes(types.Resource("stackit.objectStorage.credentialsGroup"))
+	},
+	"stackit.objectStorage.accessKey.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageAccessKey).GetDisplayName()).ToDataRes(types.String)
+	},
+	"stackit.objectStorage.accessKey.expires": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitObjectStorageAccessKey).GetExpires()).ToDataRes(types.Time)
 	},
 	"stackit.objectStorage.bucket.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitObjectStorageBucket).GetName()).ToDataRes(types.String)
@@ -3551,6 +3591,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.objectStorage.buckets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitObjectStorage).Buckets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.credentialsGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorage).CredentialsGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.credentialsGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageCredentialsGroup).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.objectStorage.credentialsGroup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageCredentialsGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.credentialsGroup.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageCredentialsGroup).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.credentialsGroup.urn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageCredentialsGroup).Urn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.credentialsGroup.accessKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageCredentialsGroup).AccessKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.accessKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.objectStorage.accessKey.keyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.accessKey.credentialsGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).CredentialsGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.accessKey.credentialsGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).CredentialsGroup, ok = plugin.RawToTValue[*mqlStackitObjectStorageCredentialsGroup](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.accessKey.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.objectStorage.accessKey.expires": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitObjectStorageAccessKey).Expires, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"stackit.objectStorage.bucket.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8267,7 +8355,8 @@ type mqlStackitObjectStorage struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlStackitObjectStorageInternal it will be used here
-	Buckets plugin.TValue[[]any]
+	Buckets           plugin.TValue[[]any]
+	CredentialsGroups plugin.TValue[[]any]
 }
 
 // createStackitObjectStorage creates a new instance of this resource
@@ -8321,6 +8410,179 @@ func (c *mqlStackitObjectStorage) GetBuckets() *plugin.TValue[[]any] {
 
 		return c.buckets()
 	})
+}
+
+func (c *mqlStackitObjectStorage) GetCredentialsGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.CredentialsGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.objectStorage", c.__id, "credentialsGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.credentialsGroups()
+	})
+}
+
+// mqlStackitObjectStorageCredentialsGroup for the stackit.objectStorage.credentialsGroup resource
+type mqlStackitObjectStorageCredentialsGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlStackitObjectStorageCredentialsGroupInternal it will be used here
+	Id          plugin.TValue[string]
+	DisplayName plugin.TValue[string]
+	Urn         plugin.TValue[string]
+	AccessKeys  plugin.TValue[[]any]
+}
+
+// createStackitObjectStorageCredentialsGroup creates a new instance of this resource
+func createStackitObjectStorageCredentialsGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitObjectStorageCredentialsGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.objectStorage.credentialsGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) MqlName() string {
+	return "stackit.objectStorage.credentialsGroup"
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) GetUrn() *plugin.TValue[string] {
+	return &c.Urn
+}
+
+func (c *mqlStackitObjectStorageCredentialsGroup) GetAccessKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AccessKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.objectStorage.credentialsGroup", c.__id, "accessKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.accessKeys()
+	})
+}
+
+// mqlStackitObjectStorageAccessKey for the stackit.objectStorage.accessKey resource
+type mqlStackitObjectStorageAccessKey struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlStackitObjectStorageAccessKeyInternal it will be used here
+	KeyId              plugin.TValue[string]
+	CredentialsGroupId plugin.TValue[string]
+	CredentialsGroup   plugin.TValue[*mqlStackitObjectStorageCredentialsGroup]
+	DisplayName        plugin.TValue[string]
+	Expires            plugin.TValue[*time.Time]
+}
+
+// createStackitObjectStorageAccessKey creates a new instance of this resource
+func createStackitObjectStorageAccessKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitObjectStorageAccessKey{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.objectStorage.accessKey", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitObjectStorageAccessKey) MqlName() string {
+	return "stackit.objectStorage.accessKey"
+}
+
+func (c *mqlStackitObjectStorageAccessKey) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitObjectStorageAccessKey) GetKeyId() *plugin.TValue[string] {
+	return &c.KeyId
+}
+
+func (c *mqlStackitObjectStorageAccessKey) GetCredentialsGroupId() *plugin.TValue[string] {
+	return &c.CredentialsGroupId
+}
+
+func (c *mqlStackitObjectStorageAccessKey) GetCredentialsGroup() *plugin.TValue[*mqlStackitObjectStorageCredentialsGroup] {
+	return plugin.GetOrCompute[*mqlStackitObjectStorageCredentialsGroup](&c.CredentialsGroup, func() (*mqlStackitObjectStorageCredentialsGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.objectStorage.accessKey", c.__id, "credentialsGroup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitObjectStorageCredentialsGroup), nil
+			}
+		}
+
+		return c.credentialsGroup()
+	})
+}
+
+func (c *mqlStackitObjectStorageAccessKey) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlStackitObjectStorageAccessKey) GetExpires() *plugin.TValue[*time.Time] {
+	return &c.Expires
 }
 
 // mqlStackitObjectStorageBucket for the stackit.objectStorage.bucket resource

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -1331,9 +1331,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.objectStorage.accessKey.keyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitObjectStorageAccessKey).GetKeyId()).ToDataRes(types.String)
 	},
-	"stackit.objectStorage.accessKey.credentialsGroupId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitObjectStorageAccessKey).GetCredentialsGroupId()).ToDataRes(types.String)
-	},
 	"stackit.objectStorage.accessKey.credentialsGroup": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitObjectStorageAccessKey).GetCredentialsGroup()).ToDataRes(types.Resource("stackit.objectStorage.credentialsGroup"))
 	},
@@ -3623,10 +3620,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.objectStorage.accessKey.keyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitObjectStorageAccessKey).KeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"stackit.objectStorage.accessKey.credentialsGroupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlStackitObjectStorageAccessKey).CredentialsGroupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"stackit.objectStorage.accessKey.credentialsGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8508,12 +8501,11 @@ func (c *mqlStackitObjectStorageCredentialsGroup) GetAccessKeys() *plugin.TValue
 type mqlStackitObjectStorageAccessKey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitObjectStorageAccessKeyInternal it will be used here
-	KeyId              plugin.TValue[string]
-	CredentialsGroupId plugin.TValue[string]
-	CredentialsGroup   plugin.TValue[*mqlStackitObjectStorageCredentialsGroup]
-	DisplayName        plugin.TValue[string]
-	Expires            plugin.TValue[*time.Time]
+	mqlStackitObjectStorageAccessKeyInternal
+	KeyId            plugin.TValue[string]
+	CredentialsGroup plugin.TValue[*mqlStackitObjectStorageCredentialsGroup]
+	DisplayName      plugin.TValue[string]
+	Expires          plugin.TValue[*time.Time]
 }
 
 // createStackitObjectStorageAccessKey creates a new instance of this resource
@@ -8527,12 +8519,7 @@ func createStackitObjectStorageAccessKey(runtime *plugin.Runtime, args map[strin
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("stackit.objectStorage.accessKey", res.__id)
@@ -8555,10 +8542,6 @@ func (c *mqlStackitObjectStorageAccessKey) MqlID() string {
 
 func (c *mqlStackitObjectStorageAccessKey) GetKeyId() *plugin.TValue[string] {
 	return &c.KeyId
-}
-
-func (c *mqlStackitObjectStorageAccessKey) GetCredentialsGroupId() *plugin.TValue[string] {
-	return &c.CredentialsGroupId
 }
 
 func (c *mqlStackitObjectStorageAccessKey) GetCredentialsGroup() *plugin.TValue[*mqlStackitObjectStorageCredentialsGroup] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -274,7 +274,6 @@ stackit.nic.status 13.4.2
 stackit.objectStorage 13.0.0
 stackit.objectStorage.accessKey 13.4.2
 stackit.objectStorage.accessKey.credentialsGroup 13.4.2
-stackit.objectStorage.accessKey.credentialsGroupId 13.4.2
 stackit.objectStorage.accessKey.displayName 13.4.2
 stackit.objectStorage.accessKey.expires 13.4.2
 stackit.objectStorage.accessKey.keyId 13.4.2

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -272,6 +272,12 @@ stackit.nic.securityGroupIds 13.4.2
 stackit.nic.securityGroups 13.4.2
 stackit.nic.status 13.4.2
 stackit.objectStorage 13.0.0
+stackit.objectStorage.accessKey 13.4.2
+stackit.objectStorage.accessKey.credentialsGroup 13.4.2
+stackit.objectStorage.accessKey.credentialsGroupId 13.4.2
+stackit.objectStorage.accessKey.displayName 13.4.2
+stackit.objectStorage.accessKey.expires 13.4.2
+stackit.objectStorage.accessKey.keyId 13.4.2
 stackit.objectStorage.bucket 13.0.0
 stackit.objectStorage.bucket.defaultRetentionDays 13.0.1
 stackit.objectStorage.bucket.defaultRetentionMode 13.0.1
@@ -281,6 +287,12 @@ stackit.objectStorage.bucket.region 13.0.0
 stackit.objectStorage.bucket.urlPathStyle 13.0.0
 stackit.objectStorage.bucket.urlVirtualHostedStyle 13.0.0
 stackit.objectStorage.buckets 13.0.0
+stackit.objectStorage.credentialsGroup 13.4.2
+stackit.objectStorage.credentialsGroup.accessKeys 13.4.2
+stackit.objectStorage.credentialsGroup.displayName 13.4.2
+stackit.objectStorage.credentialsGroup.id 13.4.2
+stackit.objectStorage.credentialsGroup.urn 13.4.2
+stackit.objectStorage.credentialsGroups 13.4.2
 stackit.observability 13.0.0
 stackit.observability.instance 13.0.0
 stackit.observability.instance.dashboardUrl 13.0.0


### PR DESCRIPTION
## What

Models the S3-compatible credentials that grant programmatic access to STACKIT Object Storage, so they can be inventoried and audited for expiry. Follows up on the network/server-lifecycle expansion (#9138) with the same typed cross-resource priority.

- `stackit.objectStorage.credentialsGroups()` lists the project's S3 credentials groups (`id`, `displayName`, `urn`).
- `credentialsGroup.accessKeys()` lists the access keys in a group (`keyId`, `displayName`, `expires`), filtered server-side by the group id.
- `accessKey.credentialsGroup()` resolves the owning group; an `init` on the group fetches it by id via `GetCredentialsGroup` so the reverse reference populates fully instead of leaving a bare husk.

The `expires` timestamp (unset for keys that never expire) makes it straightforward to flag long-lived or never-expiring keys.

## Example queries
```
stackit.objectStorage.credentialsGroups { displayName accessKeys { keyId expires } }

// never-expiring access keys
stackit.objectStorage.credentialsGroups.accessKeys.where(expires == null)
```

## Testing
Codegen + compile + `go vet` + provider unit tests pass. Live cloud verification is deferred to a batch provider-verification run.

New `.lr.versions` entries are at `13.4.2`; provider `Version` is left untouched for the release flow. No new SDK dependency (the objectstorage SDK was already imported).
