### PR TITLE
✨ azure: discover Cognitive Services (AI Services) accounts as assets

### DIFF
--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -59,6 +59,7 @@ Examples run in the Azure CLI:
 				resources.DiscoverySecurityGroups,
 				resources.DiscoveryCosmosDb,
 				resources.DiscoveryVirtualNetworks,
+				resources.DiscoveryCognitiveServices,
 			},
 			Flags: []plugin.Flag{
 				{
@@ -163,8 +164,9 @@ Examples run in the Azure CLI:
 										"other":           nil,
 									},
 								},
-								"keyvault": nil,
-								"cosmosdb": nil,
+								"keyvault":          nil,
+								"cosmosdb":          nil,
+								"cognitiveservices": nil,
 							},
 						},
 					},

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -2190,7 +2190,7 @@ func init() {
 			Create: createAzureSubscriptionCognitiveServicesService,
 		},
 		"azure.subscription.cognitiveServicesService.account": {
-			// to override args, implement: initAzureSubscriptionCognitiveServicesServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionCognitiveServicesServiceAccount,
 			Create: createAzureSubscriptionCognitiveServicesServiceAccount,
 		},
 		"azure.subscription.cognitiveServicesService.account.deployment": {

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -40,6 +40,59 @@ func (a *mqlAzureSubscriptionCognitiveServicesService) id() (string, error) {
 	return "azure.subscription.cognitiveServicesService/" + a.SubscriptionId.Data, nil
 }
 
+// initAzureSubscriptionCognitiveServicesServiceAccount resolves a single AI
+// Services (Cognitive Services) account. When called without arguments it falls
+// back to the discovered asset's platform id (see getAssetIdentifier), so an
+// azure-cognitiveservices-account asset resolves to its backing account instead
+// of an empty husk.
+func initAzureSubscriptionCognitiveServicesServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if ids := getAssetIdentifier(runtime); ids != nil {
+			args["id"] = llx.StringData(ids.id)
+		}
+	}
+
+	if args["id"] == nil {
+		return nil, nil, errors.New("id required to fetch azure cognitive services account")
+	}
+
+	conn, ok := runtime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	id := args["id"].Value.(string)
+	resourceID, err := ParseResourceID(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	accountName, err := resourceID.Component("accounts")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := armcognitiveservices.NewAccountsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	account, err := client.Get(context.Background(), resourceID.ResourceGroup, accountName, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	res, err := cognitiveServicesAccountToMql(runtime, &account.Account)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, res, nil
+}
+
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) id() (string, error) {
 	return a.Id.Data, nil
 }

--- a/providers/azure/resources/discovery.go
+++ b/providers/azure/resources/discovery.go
@@ -61,6 +61,7 @@ const (
 	DiscoveryApplicationGateways     = "application-gateways"
 	DiscoveryFirewalls               = "firewalls"
 	DiscoveryContainerApps           = "container-apps"
+	DiscoveryCognitiveServices       = "cognitiveservices-accounts"
 )
 
 // Auto includes all API resources except storage containers (which require
@@ -108,6 +109,7 @@ var AllAPIResources = []string{
 	DiscoveryApplicationGateways,
 	DiscoveryFirewalls,
 	DiscoveryContainerApps,
+	DiscoveryCognitiveServices,
 }
 
 // genericDiscoverySpec maps an ARM resource type to the discovery metadata
@@ -168,6 +170,7 @@ var genericDiscoverySpecs = []genericDiscoverySpec{
 	{armType: "Microsoft.Synapse/workspaces", discoveryTarget: DiscoverySynapseWorkspaces, service: "synapse", objectType: "workspace"},
 	{armType: "Microsoft.DataFactory/factories", discoveryTarget: DiscoveryDataFactories, service: "datafactory", objectType: "factory"},
 	{armType: "Microsoft.App/containerApps", discoveryTarget: DiscoveryContainerApps, service: "containerapps", objectType: "app"},
+	{armType: "Microsoft.CognitiveServices/accounts", discoveryTarget: DiscoveryCognitiveServices, service: "cognitiveservices", objectType: "account"},
 }
 
 type azureObject struct {
@@ -751,6 +754,10 @@ func getTitleFamily(azureObject azureObject) (azureObjectPlatformInfo, error) {
 	case "datafactory":
 		if azureObject.objectType == "factory" {
 			return azureObjectPlatformInfo{title: "Azure Data Factory", platform: "azure-datafactory"}, nil
+		}
+	case "cognitiveservices":
+		if azureObject.objectType == "account" {
+			return azureObjectPlatformInfo{title: "Azure AI Services Account", platform: "azure-cognitiveservices-account"}, nil
 		}
 	}
 	return azureObjectPlatformInfo{}, fmt.Errorf("missing runtime info for azure object service %s type %s", azureObject.service, azureObject.objectType)

--- a/providers/azure/resources/platforms.go
+++ b/providers/azure/resources/platforms.go
@@ -40,6 +40,7 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "azure-recovery-services-vault", Title: "Azure Recovery Services Vault", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
 	{Name: "azure-synapse-workspace", Title: "Azure Synapse Analytics Workspace", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
 	{Name: "azure-datafactory", Title: "Azure Data Factory", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
+	{Name: "azure-cognitiveservices-account", Title: "Azure AI Services Account", Kind: []string{"azure-object"}, Runtime: []string{"azure"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)


### PR DESCRIPTION
## What

Exposes Azure AI Services (Cognitive Services) accounts as first-class discovered assets. Each `Microsoft.CognitiveServices/accounts` resource now surfaces under the new `azure-cognitiveservices-account` platform, so it can be discovered during a subscription scan and scanned directly on its own.

The `azure.subscription.cognitiveServicesService.account` resource (and its rich child tree: deployments, projects, connections, RAI policies, network ACLs, CMK) already existed — this PR adds the discovery + platform + init plumbing that was missing to make an account a standalone asset.

## Changes

- **Discovery target** `cognitiveservices-accounts` added to `discovery.go`: a `genericDiscoverySpec` for `Microsoft.CognitiveServices/accounts` (discovered via a single `armresources` list call per subscription, like the other generic-path services), plus the `getTitleFamily` → platform mapping.
- **Platform** `azure-cognitiveservices-account` ("Azure AI Services Account") registered in the platform catalog; target exposed on the connector's discovery list and added to the subscription asset-URL tree.
- **Init** `initAzureSubscriptionCognitiveServicesServiceAccount`: when connected directly to a discovered account (args come in via the asset's platform id, not explicit args), it resolves the ARM id through `getAssetIdentifier` and does a direct `AccountsClient.Get`, reusing the existing `cognitiveServicesAccountToMql` mapper. Without this an `azure-cognitiveservices-account` asset would render as an empty husk.

## Testing

- `go build ./...` in `providers/azure` passes.
- Codegen (`mqlr generate`) regenerated cleanly; the only `azure.lr.go` change is the `Init:` binding flipping on for the account resource. No `.lr.versions` churn (no new schema fields).
- Live discovery verification deferred to the batched provider-verification run.
