### PR TITLE
✨ aws: discover SageMaker domains and models as assets

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -101,6 +101,8 @@ Notes:
 				resources.DiscoverySagemakerNotebookInstances,
 				resources.DiscoverySagemakerProcessingJobs,
 				resources.DiscoverySagemakerTrainingJobs,
+				resources.DiscoverySagemakerDomains,
+				resources.DiscoverySagemakerModels,
 				resources.DiscoverySecretsManagerSecrets,
 				resources.DiscoverySecurityGroups,
 				resources.DiscoverySSMInstances,

--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -91,6 +91,10 @@ func getServiceName(platformName string) string {
 		return "sagemaker"
 	case "aws-sagemaker-trainingjob":
 		return "sagemaker"
+	case "aws-sagemaker-domain":
+		return "sagemaker"
+	case "aws-sagemaker-model":
+		return "sagemaker"
 	case "aws-ec2-instance":
 		return "ec2"
 	case "aws-ssm-instance":

--- a/providers/aws/connection/platforms.go
+++ b/providers/aws/connection/platforms.go
@@ -37,6 +37,8 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "aws-sagemaker-notebookinstance", Title: "AWS SageMaker Notebook Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-sagemaker-processingjob", Title: "AWS SageMaker Processing Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-sagemaker-trainingjob", Title: "AWS SageMaker Training Job", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sagemaker-domain", Title: "AWS SageMaker Domain", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sagemaker-model", Title: "AWS SageMaker Model", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-ec2-instance", Title: "AWS EC2 Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-ssm-instance", Title: "AWS SSM Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-ecr-image", Title: "AWS ECR Image", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -2009,6 +2009,12 @@ func initAwsSagemakerDomain(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 
+	if len(args) == 0 {
+		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+			args["arn"] = llx.StringData(assetArn)
+		}
+	}
+
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch sagemaker domain")
 	}

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -70,6 +70,11 @@ func initAwsSagemakerModel(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if len(args) > 2 {
 		return args, nil, nil
 	}
+	if len(args) == 0 {
+		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+			args["arn"] = llx.StringData(assetArn)
+		}
+	}
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to resolve sagemaker model")
 	}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -59,6 +59,8 @@ const (
 	DiscoverySagemakerNotebookInstances  = "sagemaker-notebookinstances"
 	DiscoverySagemakerProcessingJobs     = "sagemaker-processingjobs"
 	DiscoverySagemakerTrainingJobs       = "sagemaker-trainingjobs"
+	DiscoverySagemakerDomains            = "sagemaker-domains"
+	DiscoverySagemakerModels             = "sagemaker-models"
 	DiscoverySecretsManagerSecrets       = "secretsmanager-secrets"
 	DiscoveryElasticacheClusters         = "elasticache-clusters"
 	DiscoveryCloudfrontDistributions     = "cloudfront-distributions"
@@ -112,6 +114,8 @@ var AllAPIResources = []string{
 	DiscoverySagemakerNotebookInstances,
 	DiscoverySagemakerProcessingJobs,
 	DiscoverySagemakerTrainingJobs,
+	DiscoverySagemakerDomains,
+	DiscoverySagemakerModels,
 	DiscoverySecretsManagerSecrets,
 	DiscoveryElasticacheClusters,
 	DiscoveryCloudfrontDistributions,
@@ -1281,6 +1285,58 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 				awsObject: awsObject{
 					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
 					id: f.Name.Data, service: "sagemaker", objectType: "trainingjob",
+				},
+			}
+			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))
+		}
+	case DiscoverySagemakerDomains:
+		res, err := NewResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+
+		sm := res.(*mqlAwsSagemaker)
+
+		domains := sm.GetDomains()
+		if domains == nil {
+			return assetList, nil
+		}
+
+		for i := range domains.Data {
+			f := domains.Data[i].(*mqlAwsSagemakerDomain)
+
+			tags := mapStringInterfaceToStringString(f.GetTags().Data)
+			m := mqlObject{
+				name: f.Name.Data, labels: tags,
+				awsObject: awsObject{
+					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
+					id: f.Name.Data, service: "sagemaker", objectType: "domain",
+				},
+			}
+			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))
+		}
+	case DiscoverySagemakerModels:
+		res, err := NewResource(runtime, "aws.sagemaker", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+
+		sm := res.(*mqlAwsSagemaker)
+
+		models := sm.GetModels()
+		if models == nil {
+			return assetList, nil
+		}
+
+		for i := range models.Data {
+			f := models.Data[i].(*mqlAwsSagemakerModel)
+
+			tags := mapStringInterfaceToStringString(f.GetTags().Data)
+			m := mqlObject{
+				name: f.Name.Data, labels: tags,
+				awsObject: awsObject{
+					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
+					id: f.Name.Data, service: "sagemaker", objectType: "model",
 				},
 			}
 			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -202,6 +202,10 @@ func getPlatformName(awsObject awsObject) string {
 			return "aws-sagemaker-processingjob"
 		case "trainingjob":
 			return "aws-sagemaker-trainingjob"
+		case "domain":
+			return "aws-sagemaker-domain"
+		case "model":
+			return "aws-sagemaker-model"
 		}
 	case "secretsmanager":
 		if awsObject.objectType == "secret" {


### PR DESCRIPTION
## What

Exposes AWS SageMaker **domains** and **models** as first-class discovered assets, under the new `aws-sagemaker-domain` and `aws-sagemaker-model` platforms. Each is now enumerated during an account scan and can be scanned directly on its own, matching the existing SageMaker notebook-instance / processing-job / training-job discovery.

The `aws.sagemaker.domain` and `aws.sagemaker.model` resources (and their `init` functions) already existed — this PR adds the discovery + platform plumbing that was missing, plus the small init fix needed for direct-connect resolution.

## Changes

- **Discovery targets** `sagemaker-domains` and `sagemaker-models` added to `discovery.go` (constants + `AllAPIResources` + `discover()` cases). The cases reuse the existing `aws.sagemaker` `GetDomains()` / `GetModels()` listers — no new API calls.
- **Platforms** `aws-sagemaker-domain` ("AWS SageMaker Domain") and `aws-sagemaker-model` ("AWS SageMaker Model") registered in the connection platform catalog; both mapped to the `sagemaker` service in `getServiceName`, and both object types added to the `sagemaker` branch of `getPlatformName`.
- **Connector** discovery list extended with the two new targets.
- **Init fix**: `initAwsSagemakerDomain` and `initAwsSagemakerModel` now inject the ARN from the connected asset's platform id via `getAssetIdentifier` when called with no args (the direct-connect discovery path), matching `initAwsSagemakerNotebookinstance`. Without this a discovered domain/model asset would fail with "arn required".

## Testing

- `go build ./...` in `providers/aws` passes.
- No codegen or `.lr` changes (resources + inits already existed); `aws.permissions.json` unchanged (discovery reuses existing listers).
- Live discovery verification deferred to the batched provider-verification run.
