### PR TITLE
✨ stackit: add typed cross-resource refs and promote volumeBackups to a sub-resource

### DIFF
--- a/providers/stackit/resources/dns.go
+++ b/providers/stackit/resources/dns.go
@@ -179,3 +179,16 @@ func (r *mqlStackitDnsZone) recordSets() ([]any, error) {
 func (r *mqlStackitDnsRecordSet) id() (string, error) {
 	return "stackit.dns.recordSet/" + r.ZoneId.Data + "/" + r.Id.Data, nil
 }
+
+func (r *mqlStackitDnsRecordSet) zone() (*mqlStackitDnsZone, error) {
+	if r.ZoneId.Data == "" {
+		return markNull[mqlStackitDnsZone](&r.Zone)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.dns.zone", map[string]*llx.RawData{
+		"id": llx.StringData(r.ZoneId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitDnsZone), nil
+}

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -233,6 +233,21 @@ func serverRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStac
 	return res.(*mqlStackitServer), nil
 }
 
+// volumeRef resolves a single stackit.volume by its UUID, marking the given
+// field null when the ID is empty.
+func volumeRef(runtime *plugin.Runtime, id string, field *plugin.TValue[*mqlStackitVolume]) (*mqlStackitVolume, error) {
+	if id == "" {
+		return markNull[mqlStackitVolume](field)
+	}
+	res, err := NewResource(runtime, "stackit.volume", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitVolume), nil
+}
+
 // volumeRefs resolves a list of stackit.volume resources from their UUIDs,
 // skipping empty IDs.
 func volumeRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -351,6 +351,19 @@ func (r *mqlStackitVolume) server() (*mqlStackitServer, error) {
 	return res.(*mqlStackitServer), nil
 }
 
+func (r *mqlStackitVolume) sourceSnapshot() (*mqlStackitSnapshot, error) {
+	if r.SourceSnapshotId.Data == "" {
+		return markNull[mqlStackitSnapshot](&r.SourceSnapshot)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.snapshot", map[string]*llx.RawData{
+		"id": llx.StringData(r.SourceSnapshotId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitSnapshot), nil
+}
+
 // ------------------------- snapshots -------------------------
 
 func (r *mqlStackit) snapshots() ([]any, error) {

--- a/providers/stackit/resources/kms.go
+++ b/providers/stackit/resources/kms.go
@@ -72,6 +72,27 @@ func (r *mqlStackitKmsKeyRing) id() (string, error) {
 	return "stackit.kms.keyRing/" + r.Id.Data, nil
 }
 
+func initStackitKmsKeyRing(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := idArg(args, "id")
+	if !ok {
+		return args, nil, nil
+	}
+	c := conn(runtime)
+	client, err := c.KMS()
+	if err != nil {
+		return nil, nil, err
+	}
+	kr, err := client.GetKeyRingExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := buildKmsKeyRing(runtime, kr)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
 func (r *mqlStackitKmsKeyRing) keys() ([]any, error) {
 	c := conn(r.MqlRuntime)
 	client, err := c.KMS()
@@ -119,4 +140,17 @@ func buildKmsKey(runtime *plugin.Runtime, k *kms.Key) (plugin.Resource, error) {
 
 func (r *mqlStackitKmsKey) id() (string, error) {
 	return "stackit.kms.key/" + r.KeyRingId.Data + "/" + r.Id.Data, nil
+}
+
+func (r *mqlStackitKmsKey) keyRing() (*mqlStackitKmsKeyRing, error) {
+	if r.KeyRingId.Data == "" {
+		return markNull[mqlStackitKmsKeyRing](&r.KeyRing)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.kms.keyRing", map[string]*llx.RawData{
+		"id": llx.StringData(r.KeyRingId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitKmsKeyRing), nil
 }

--- a/providers/stackit/resources/serverbackup.go
+++ b/providers/stackit/resources/serverbackup.go
@@ -9,8 +9,16 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlStackitServerBackupInternal struct {
+	// cacheVolumeBackups holds the backup's per-volume entries, captured when
+	// the backup is built so volumeBackups() and volumes() can expose them
+	// without another API call. cacheIdBase is the backup's own cache key,
+	// used to key the volume-backup sub-resources.
+	cacheVolumeBackups []serverbackup.BackupVolumeBackupsInner
+	cacheIdBase        string
+}
 
 // ------------------------- server backups -------------------------
 
@@ -43,17 +51,6 @@ func (r *mqlStackitServer) backups() ([]any, error) {
 }
 
 func buildServerBackup(runtime *plugin.Runtime, serverID string, b *serverbackup.Backup) (plugin.Resource, error) {
-	volumeBackups := []any{}
-	for _, vb := range b.GetVolumeBackups() {
-		volumeBackups = append(volumeBackups, map[string]any{
-			"id":                   vb.GetId(),
-			"volumeId":             vb.GetVolumeId(),
-			"size":                 vb.GetSize(),
-			"status":               string(vb.GetStatus()),
-			"lastRestoredAt":       vb.GetLastRestoredAt(),
-			"lastRestoredVolumeId": vb.GetLastRestoredVolumeId(),
-		})
-	}
 	args := map[string]*llx.RawData{
 		"id":             llx.StringData(b.GetId()),
 		"serverId":       llx.StringData(serverID),
@@ -63,9 +60,15 @@ func buildServerBackup(runtime *plugin.Runtime, serverID string, b *serverbackup
 		"createdAt":      llx.TimeDataPtr(parseRFC3339(b.GetCreatedAt())),
 		"expireAt":       llx.TimeDataPtr(parseRFC3339(b.GetExpireAt())),
 		"lastRestoredAt": llx.TimeDataPtr(parseRFC3339(b.GetLastRestoredAt())),
-		"volumeBackups":  llx.ArrayData(volumeBackups, types.Dict),
 	}
-	return CreateResource(runtime, "stackit.server.backup", args)
+	res, err := CreateResource(runtime, "stackit.server.backup", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlBackup := res.(*mqlStackitServerBackup)
+	mqlBackup.cacheVolumeBackups = b.GetVolumeBackups()
+	mqlBackup.cacheIdBase = "stackit.server.backup/" + serverID + "/" + b.GetId()
+	return res, nil
 }
 
 func (r *mqlStackitServerBackup) id() (string, error) {
@@ -76,20 +79,47 @@ func (r *mqlStackitServerBackup) server() (*mqlStackitServer, error) {
 	return serverRef(r.MqlRuntime, r.ServerId.Data, &r.Server)
 }
 
+// volumeBackups exposes the backup's per-volume entries as typed
+// sub-resources, captured when the backup was built.
+func (r *mqlStackitServerBackup) volumeBackups() ([]any, error) {
+	out := make([]any, 0, len(r.cacheVolumeBackups))
+	for i := range r.cacheVolumeBackups {
+		vb := r.cacheVolumeBackups[i]
+		res, err := CreateResource(r.MqlRuntime, "stackit.server.backup.volumeBackup", map[string]*llx.RawData{
+			"__id":                 llx.StringData(r.cacheIdBase + "/volumeBackup/" + vb.GetId()),
+			"id":                   llx.StringData(vb.GetId()),
+			"volumeId":             llx.StringData(vb.GetVolumeId()),
+			"size":                 llx.IntData(vb.GetSize()),
+			"status":               llx.StringData(string(vb.GetStatus())),
+			"lastRestoredAt":       llx.TimeDataPtr(parseRFC3339(vb.GetLastRestoredAt())),
+			"lastRestoredVolumeId": llx.StringData(vb.GetLastRestoredVolumeId()),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
 // volumes resolves the volumes protected by the backup from the volume IDs
 // carried in its per-volume backup entries.
 func (r *mqlStackitServerBackup) volumes() ([]any, error) {
-	ids := []string{}
-	for _, raw := range r.VolumeBackups.Data {
-		vb, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		if id, ok := vb["volumeId"].(string); ok {
+	ids := make([]string, 0, len(r.cacheVolumeBackups))
+	for i := range r.cacheVolumeBackups {
+		if id := r.cacheVolumeBackups[i].GetVolumeId(); id != "" {
 			ids = append(ids, id)
 		}
 	}
 	return volumeRefs(r.MqlRuntime, ids)
+}
+
+func (r *mqlStackitServerBackupVolumeBackup) volume() (*mqlStackitVolume, error) {
+	return volumeRef(r.MqlRuntime, r.VolumeId.Data, &r.Volume)
+}
+
+func (r *mqlStackitServerBackupVolumeBackup) lastRestoredVolume() (*mqlStackitVolume, error) {
+	return volumeRef(r.MqlRuntime, r.LastRestoredVolumeId.Data, &r.LastRestoredVolume)
 }
 
 // ------------------------- server backup schedules -------------------------

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -218,6 +218,8 @@ private stackit.volume @defaults("id name size status") {
   image() stackit.image
   // Source snapshot UUID (empty if not snapshot-based)
   sourceSnapshotId string
+  // Snapshot the volume was created from (nullable)
+  sourceSnapshot() stackit.snapshot
   // Server the volume is attached to (nullable)
   server() stackit.server
   // Attached server UUID (empty if detached)
@@ -500,10 +502,35 @@ private stackit.server.backup @defaults("id name status size") {
   expireAt time
   // Timestamp of the most recent restore from this backup (unset if never restored)
   lastRestoredAt time
-  // Per-volume backup entries [{id, volumeId, size, status, lastRestoredAt, lastRestoredVolumeId}]
-  volumeBackups []dict
+  // Per-volume backup entries that make up the backup
+  volumeBackups() []stackit.server.backup.volumeBackup
   // Volumes protected by this backup
   volumes() []stackit.volume
+}
+
+// STACKIT server volume backup entry
+//
+// Backup of a single volume that is part of a server backup, keyed by its
+// UUID id. Exposes the size and status of the volume's backup, the volume
+// it protects, and, once a restore has run, the timestamp and the volume
+// the data was restored into.
+private stackit.server.backup.volumeBackup @defaults("id status size") {
+  // Volume backup UUID
+  id string
+  // UUID of the volume this entry backs up
+  volumeId string
+  // Volume this entry backs up
+  volume() stackit.volume
+  // Size of the volume backup in GiB
+  size int
+  // Status of the volume backup
+  status string
+  // Timestamp of the most recent restore from this entry (unset if never restored)
+  lastRestoredAt time
+  // UUID of the volume the data was most recently restored into (empty if never restored)
+  lastRestoredVolumeId string
+  // Volume the data was most recently restored into (nullable)
+  lastRestoredVolume() stackit.volume
 }
 
 // STACKIT server backup schedule
@@ -1121,6 +1148,8 @@ private stackit.dns.recordSet @defaults("name type state") {
   id string
   // Owning zone UUID
   zoneId string
+  // Zone the record set belongs to
+  zone() stackit.dns.zone
   // Record name (FQDN, e.g., `www.example.com.`)
   name string
   // Record type (A, AAAA, CNAME, MX, TXT, NS, SRV, …)
@@ -2049,6 +2078,7 @@ stackit.kms {
 // Examine a single key ring — a logical container that groups keys
 // for IAM and lifecycle purposes. Keyed by its UUID `id`.
 private stackit.kms.keyRing @defaults("id displayName state") {
+  init(id? string)
   // Key ring UUID
   id string
   // User-supplied display name
@@ -2076,6 +2106,8 @@ private stackit.kms.key @defaults("id displayName state purpose") {
   id string
   // Parent key ring UUID
   keyRingId string
+  // Key ring the key belongs to
+  keyRing() stackit.kms.keyRing
   // Display name
   displayName string
   // Description

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -29,6 +29,7 @@ const (
 	ResourceStackitSecurityGroupRule             string = "stackit.securityGroup.rule"
 	ResourceStackitNetworkExposure               string = "stackit.network.exposure"
 	ResourceStackitServerBackup                  string = "stackit.server.backup"
+	ResourceStackitServerBackupVolumeBackup      string = "stackit.server.backup.volumeBackup"
 	ResourceStackitServerBackupSchedule          string = "stackit.server.backupSchedule"
 	ResourceStackitServerUpdate                  string = "stackit.server.update"
 	ResourceStackitServerUpdateSchedule          string = "stackit.server.updateSchedule"
@@ -156,6 +157,10 @@ func init() {
 		"stackit.server.backup": {
 			// to override args, implement: initStackitServerBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createStackitServerBackup,
+		},
+		"stackit.server.backup.volumeBackup": {
+			// to override args, implement: initStackitServerBackupVolumeBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createStackitServerBackupVolumeBackup,
 		},
 		"stackit.server.backupSchedule": {
 			// to override args, implement: initStackitServerBackupSchedule(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -402,7 +407,7 @@ func init() {
 			Create: createStackitKms,
 		},
 		"stackit.kms.keyRing": {
-			// to override args, implement: initStackitKmsKeyRing(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initStackitKmsKeyRing,
 			Create: createStackitKmsKeyRing,
 		},
 		"stackit.kms.key": {
@@ -754,6 +759,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.volume.sourceSnapshotId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetSourceSnapshotId()).ToDataRes(types.String)
 	},
+	"stackit.volume.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetSourceSnapshot()).ToDataRes(types.Resource("stackit.snapshot"))
+	},
 	"stackit.volume.server": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetServer()).ToDataRes(types.Resource("stackit.server"))
 	},
@@ -1055,10 +1063,34 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlStackitServerBackup).GetLastRestoredAt()).ToDataRes(types.Time)
 	},
 	"stackit.server.backup.volumeBackups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitServerBackup).GetVolumeBackups()).ToDataRes(types.Array(types.Dict))
+		return (r.(*mqlStackitServerBackup).GetVolumeBackups()).ToDataRes(types.Array(types.Resource("stackit.server.backup.volumeBackup")))
 	},
 	"stackit.server.backup.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServerBackup).GetVolumes()).ToDataRes(types.Array(types.Resource("stackit.volume")))
+	},
+	"stackit.server.backup.volumeBackup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetId()).ToDataRes(types.String)
+	},
+	"stackit.server.backup.volumeBackup.volumeId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetVolumeId()).ToDataRes(types.String)
+	},
+	"stackit.server.backup.volumeBackup.volume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetVolume()).ToDataRes(types.Resource("stackit.volume"))
+	},
+	"stackit.server.backup.volumeBackup.size": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetSize()).ToDataRes(types.Int)
+	},
+	"stackit.server.backup.volumeBackup.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetStatus()).ToDataRes(types.String)
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetLastRestoredAt()).ToDataRes(types.Time)
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredVolumeId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetLastRestoredVolumeId()).ToDataRes(types.String)
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredVolume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServerBackupVolumeBackup).GetLastRestoredVolume()).ToDataRes(types.Resource("stackit.volume"))
 	},
 	"stackit.server.backupSchedule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServerBackupSchedule).GetId()).ToDataRes(types.Int)
@@ -1641,6 +1673,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.dns.recordSet.zoneId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsRecordSet).GetZoneId()).ToDataRes(types.String)
+	},
+	"stackit.dns.recordSet.zone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitDnsRecordSet).GetZone()).ToDataRes(types.Resource("stackit.dns.zone"))
 	},
 	"stackit.dns.recordSet.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitDnsRecordSet).GetName()).ToDataRes(types.String)
@@ -2437,6 +2472,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.kms.key.keyRingId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitKmsKey).GetKeyRingId()).ToDataRes(types.String)
 	},
+	"stackit.kms.key.keyRing": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitKmsKey).GetKeyRing()).ToDataRes(types.Resource("stackit.kms.keyRing"))
+	},
 	"stackit.kms.key.displayName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitKmsKey).GetDisplayName()).ToDataRes(types.String)
 	},
@@ -2949,6 +2987,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitVolume).SourceSnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"stackit.volume.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).SourceSnapshot, ok = plugin.RawToTValue[*mqlStackitSnapshot](v.Value, v.Error)
+		return
+	},
 	"stackit.volume.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitVolume).Server, ok = plugin.RawToTValue[*mqlStackitServer](v.Value, v.Error)
 		return
@@ -3391,6 +3433,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.server.backup.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServerBackup).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.server.backup.volumeBackup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.volumeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).VolumeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.volume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).Volume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.size": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).Size, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).LastRestoredAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredVolumeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).LastRestoredVolumeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.server.backup.volumeBackup.lastRestoredVolume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServerBackupVolumeBackup).LastRestoredVolume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
 		return
 	},
 	"stackit.server.backupSchedule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -4259,6 +4337,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.dns.recordSet.zoneId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitDnsRecordSet).ZoneId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.dns.recordSet.zone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitDnsRecordSet).Zone, ok = plugin.RawToTValue[*mqlStackitDnsZone](v.Value, v.Error)
 		return
 	},
 	"stackit.dns.recordSet.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5479,6 +5561,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.kms.key.keyRingId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitKmsKey).KeyRingId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.kms.key.keyRing": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitKmsKey).KeyRing, ok = plugin.RawToTValue[*mqlStackitKmsKeyRing](v.Value, v.Error)
 		return
 	},
 	"stackit.kms.key.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -6762,6 +6848,7 @@ type mqlStackitVolume struct {
 	ImageId              plugin.TValue[string]
 	Image                plugin.TValue[*mqlStackitImage]
 	SourceSnapshotId     plugin.TValue[string]
+	SourceSnapshot       plugin.TValue[*mqlStackitSnapshot]
 	Server               plugin.TValue[*mqlStackitServer]
 	ServerId             plugin.TValue[string]
 	Encrypted            plugin.TValue[bool]
@@ -6863,6 +6950,22 @@ func (c *mqlStackitVolume) GetImage() *plugin.TValue[*mqlStackitImage] {
 
 func (c *mqlStackitVolume) GetSourceSnapshotId() *plugin.TValue[string] {
 	return &c.SourceSnapshotId
+}
+
+func (c *mqlStackitVolume) GetSourceSnapshot() *plugin.TValue[*mqlStackitSnapshot] {
+	return plugin.GetOrCompute[*mqlStackitSnapshot](&c.SourceSnapshot, func() (*mqlStackitSnapshot, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "sourceSnapshot")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitSnapshot), nil
+			}
+		}
+
+		return c.sourceSnapshot()
+	})
 }
 
 func (c *mqlStackitVolume) GetServer() *plugin.TValue[*mqlStackitServer] {
@@ -7735,7 +7838,7 @@ func (c *mqlStackitNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] 
 type mqlStackitServerBackup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitServerBackupInternal it will be used here
+	mqlStackitServerBackupInternal
 	Id             plugin.TValue[string]
 	ServerId       plugin.TValue[string]
 	Server         plugin.TValue[*mqlStackitServer]
@@ -7835,7 +7938,19 @@ func (c *mqlStackitServerBackup) GetLastRestoredAt() *plugin.TValue[*time.Time] 
 }
 
 func (c *mqlStackitServerBackup) GetVolumeBackups() *plugin.TValue[[]any] {
-	return &c.VolumeBackups
+	return plugin.GetOrCompute[[]any](&c.VolumeBackups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server.backup", c.__id, "volumeBackups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.volumeBackups()
+	})
 }
 
 func (c *mqlStackitServerBackup) GetVolumes() *plugin.TValue[[]any] {
@@ -7851,6 +7966,109 @@ func (c *mqlStackitServerBackup) GetVolumes() *plugin.TValue[[]any] {
 		}
 
 		return c.volumes()
+	})
+}
+
+// mqlStackitServerBackupVolumeBackup for the stackit.server.backup.volumeBackup resource
+type mqlStackitServerBackupVolumeBackup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlStackitServerBackupVolumeBackupInternal it will be used here
+	Id                   plugin.TValue[string]
+	VolumeId             plugin.TValue[string]
+	Volume               plugin.TValue[*mqlStackitVolume]
+	Size                 plugin.TValue[int64]
+	Status               plugin.TValue[string]
+	LastRestoredAt       plugin.TValue[*time.Time]
+	LastRestoredVolumeId plugin.TValue[string]
+	LastRestoredVolume   plugin.TValue[*mqlStackitVolume]
+}
+
+// createStackitServerBackupVolumeBackup creates a new instance of this resource
+func createStackitServerBackupVolumeBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitServerBackupVolumeBackup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.server.backup.volumeBackup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) MqlName() string {
+	return "stackit.server.backup.volumeBackup"
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetVolumeId() *plugin.TValue[string] {
+	return &c.VolumeId
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetVolume() *plugin.TValue[*mqlStackitVolume] {
+	return plugin.GetOrCompute[*mqlStackitVolume](&c.Volume, func() (*mqlStackitVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server.backup.volumeBackup", c.__id, "volume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitVolume), nil
+			}
+		}
+
+		return c.volume()
+	})
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetSize() *plugin.TValue[int64] {
+	return &c.Size
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetLastRestoredAt() *plugin.TValue[*time.Time] {
+	return &c.LastRestoredAt
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetLastRestoredVolumeId() *plugin.TValue[string] {
+	return &c.LastRestoredVolumeId
+}
+
+func (c *mqlStackitServerBackupVolumeBackup) GetLastRestoredVolume() *plugin.TValue[*mqlStackitVolume] {
+	return plugin.GetOrCompute[*mqlStackitVolume](&c.LastRestoredVolume, func() (*mqlStackitVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server.backup.volumeBackup", c.__id, "lastRestoredVolume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitVolume), nil
+			}
+		}
+
+		return c.lastRestoredVolume()
 	})
 }
 
@@ -10056,6 +10274,7 @@ type mqlStackitDnsRecordSet struct {
 	// optional: if you define mqlStackitDnsRecordSetInternal it will be used here
 	Id                 plugin.TValue[string]
 	ZoneId             plugin.TValue[string]
+	Zone               plugin.TValue[*mqlStackitDnsZone]
 	Name               plugin.TValue[string]
 	Type               plugin.TValue[string]
 	Ttl                plugin.TValue[int64]
@@ -10111,6 +10330,22 @@ func (c *mqlStackitDnsRecordSet) GetId() *plugin.TValue[string] {
 
 func (c *mqlStackitDnsRecordSet) GetZoneId() *plugin.TValue[string] {
 	return &c.ZoneId
+}
+
+func (c *mqlStackitDnsRecordSet) GetZone() *plugin.TValue[*mqlStackitDnsZone] {
+	return plugin.GetOrCompute[*mqlStackitDnsZone](&c.Zone, func() (*mqlStackitDnsZone, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.dns.recordSet", c.__id, "zone")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitDnsZone), nil
+			}
+		}
+
+		return c.zone()
+	})
 }
 
 func (c *mqlStackitDnsRecordSet) GetName() *plugin.TValue[string] {
@@ -13502,6 +13737,7 @@ type mqlStackitKmsKey struct {
 	// optional: if you define mqlStackitKmsKeyInternal it will be used here
 	Id           plugin.TValue[string]
 	KeyRingId    plugin.TValue[string]
+	KeyRing      plugin.TValue[*mqlStackitKmsKeyRing]
 	DisplayName  plugin.TValue[string]
 	Description  plugin.TValue[string]
 	Purpose      plugin.TValue[string]
@@ -13557,6 +13793,22 @@ func (c *mqlStackitKmsKey) GetId() *plugin.TValue[string] {
 
 func (c *mqlStackitKmsKey) GetKeyRingId() *plugin.TValue[string] {
 	return &c.KeyRingId
+}
+
+func (c *mqlStackitKmsKey) GetKeyRing() *plugin.TValue[*mqlStackitKmsKeyRing] {
+	return plugin.GetOrCompute[*mqlStackitKmsKeyRing](&c.KeyRing, func() (*mqlStackitKmsKeyRing, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.kms.key", c.__id, "keyRing")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitKmsKeyRing), nil
+			}
+		}
+
+		return c.keyRing()
+	})
 }
 
 func (c *mqlStackitKmsKey) GetDisplayName() *plugin.TValue[string] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -91,6 +91,7 @@ stackit.dns.recordSet.state 13.0.0
 stackit.dns.recordSet.ttl 13.0.0
 stackit.dns.recordSet.type 13.0.0
 stackit.dns.recordSet.updateFinishedAt 13.0.0
+stackit.dns.recordSet.zone 13.4.2
 stackit.dns.recordSet.zoneId 13.0.0
 stackit.dns.zone 13.0.0
 stackit.dns.zone.acl 13.0.0
@@ -160,6 +161,7 @@ stackit.kms.key.description 13.0.1
 stackit.kms.key.displayName 13.0.1
 stackit.kms.key.id 13.0.1
 stackit.kms.key.importOnly 13.0.1
+stackit.kms.key.keyRing 13.4.2
 stackit.kms.key.keyRingId 13.0.1
 stackit.kms.key.protection 13.0.1
 stackit.kms.key.purpose 13.0.1
@@ -463,6 +465,15 @@ stackit.server.backup.server 13.4.2
 stackit.server.backup.serverId 13.4.2
 stackit.server.backup.size 13.4.2
 stackit.server.backup.status 13.4.2
+stackit.server.backup.volumeBackup 13.4.2
+stackit.server.backup.volumeBackup.id 13.4.2
+stackit.server.backup.volumeBackup.lastRestoredAt 13.4.2
+stackit.server.backup.volumeBackup.lastRestoredVolume 13.4.2
+stackit.server.backup.volumeBackup.lastRestoredVolumeId 13.4.2
+stackit.server.backup.volumeBackup.size 13.4.2
+stackit.server.backup.volumeBackup.status 13.4.2
+stackit.server.backup.volumeBackup.volume 13.4.2
+stackit.server.backup.volumeBackup.volumeId 13.4.2
 stackit.server.backup.volumeBackups 13.4.2
 stackit.server.backup.volumes 13.4.2
 stackit.server.backupSchedule 13.4.2
@@ -715,6 +726,7 @@ stackit.volume.performanceClass 13.0.0
 stackit.volume.server 13.0.0
 stackit.volume.serverId 13.0.0
 stackit.volume.size 13.0.0
+stackit.volume.sourceSnapshot 13.4.2
 stackit.volume.sourceSnapshotId 13.0.0
 stackit.volume.status 13.0.0
 stackit.volume.updatedAt 13.0.0


### PR DESCRIPTION
## What

Fills in missing typed cross-resource references between existing `stackit` resources, and replaces an opaque `[]dict` with a proper sub-resource.

### Typed references (raw `*Id` fields kept; typed accessors added alongside, matching the provider's existing idiom)
- `volume.sourceSnapshot()` → `stackit.snapshot`
- `dns.recordSet.zone()` → `stackit.dns.zone`
- `kms.key.keyRing()` → `stackit.kms.keyRing` — also adds an `init` on the key ring (via `GetKeyRing`) so the reference hydrates fully instead of leaving a bare husk.

### Sub-resource: `server.backup.volumeBackups`
Previously `[]dict`; now a typed `stackit.server.backup.volumeBackup` collection with `id`, `volumeId`, `size`, `status`, `lastRestoredAt`, `lastRestoredVolumeId`, plus `volume()` and `lastRestoredVolume()` typed edges. The per-volume entries are cached on the backup, so the accessor makes no extra API call. This field only shipped at the **unreleased 13.4.2**, so replacing it is not a breaking change.

## Example queries
```
stackit.volumes { name sourceSnapshot { name createdAt } }
stackit.dns.zones.recordSets { name zone { dnsName } }
stackit.kms.keys { displayName keyRing { displayName state } }
stackit.servers.backups.volumeBackups { status volume { name size } }
```

## Not added
`volume.encryptionKey()` — the volume carries only the bare KEK key id, but resolving a `stackit.kms.key` needs its key ring as well (`GetKey` requires both), so a clean typed reference isn't possible from the volume alone.

## Testing
Codegen + compile + `go vet` + provider unit tests pass. Live cloud verification is deferred to a batch provider-verification run. New `.lr.versions` entries at `13.4.2`; no version bump. No new SDK dependency.
