### PR TITLE
✨ stackit: add volume backups, affinity groups, server service accounts

### DIFF
--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -224,6 +224,26 @@ func (r *mqlStackitServer) securityGroups() ([]any, error) {
 	return out, nil
 }
 
+// serviceAccounts resolves the service accounts attached to the server from
+// the mail addresses carried on the server object.
+func (r *mqlStackitServer) serviceAccounts() ([]any, error) {
+	out := make([]any, 0, len(r.ServiceAccountMails.Data))
+	for _, raw := range r.ServiceAccountMails.Data {
+		mail, ok := raw.(string)
+		if !ok || mail == "" {
+			continue
+		}
+		sa, err := NewResource(r.MqlRuntime, "stackit.serviceAccount", map[string]*llx.RawData{
+			"email": llx.StringData(mail),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sa)
+	}
+	return out, nil
+}
+
 // ------------------------- volumes -------------------------
 
 func (r *mqlStackit) volumes() ([]any, error) {

--- a/providers/stackit/resources/iaas_compute.go
+++ b/providers/stackit/resources/iaas_compute.go
@@ -9,6 +9,14 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+type mqlStackitBackupInternal struct {
+	// cacheVolumeId/cacheSnapshotId hold the backup's source IDs so volume()
+	// and snapshot() can resolve them. They are not exposed as fields because
+	// those accessors already carry the same information.
+	cacheVolumeId   string
+	cacheSnapshotId string
+}
+
 // ------------------------- volume backups -------------------------
 
 func (r *mqlStackit) backups() ([]any, error) {
@@ -47,13 +55,18 @@ func buildBackup(runtime *plugin.Runtime, b *iaas.Backup) (plugin.Resource, erro
 		"size":             llx.IntData(b.GetSize()),
 		"availabilityZone": llx.StringData(b.GetAvailabilityZone()),
 		"encrypted":        llx.BoolData(b.GetEncrypted()),
-		"volumeId":         llx.StringData(b.GetVolumeId()),
-		"snapshotId":       llx.StringData(b.GetSnapshotId()),
 		"createdAt":        llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
 		"updatedAt":        llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
 		"labels":           labelData(b.GetLabels()),
 	}
-	return CreateResource(runtime, "stackit.backup", args)
+	res, err := CreateResource(runtime, "stackit.backup", args)
+	if err != nil {
+		return nil, err
+	}
+	mqlBackup := res.(*mqlStackitBackup)
+	mqlBackup.cacheVolumeId = b.GetVolumeId()
+	mqlBackup.cacheSnapshotId = b.GetSnapshotId()
+	return res, nil
 }
 
 func (r *mqlStackitBackup) id() (string, error) {
@@ -82,15 +95,15 @@ func initStackitBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 }
 
 func (r *mqlStackitBackup) volume() (*mqlStackitVolume, error) {
-	return volumeRef(r.MqlRuntime, r.VolumeId.Data, &r.Volume)
+	return volumeRef(r.MqlRuntime, r.cacheVolumeId, &r.Volume)
 }
 
 func (r *mqlStackitBackup) snapshot() (*mqlStackitSnapshot, error) {
-	if r.SnapshotId.Data == "" {
+	if r.cacheSnapshotId == "" {
 		return markNull[mqlStackitSnapshot](&r.Snapshot)
 	}
 	res, err := NewResource(r.MqlRuntime, "stackit.snapshot", map[string]*llx.RawData{
-		"id": llx.StringData(r.SnapshotId.Data),
+		"id": llx.StringData(r.cacheSnapshotId),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/stackit/resources/iaas_compute.go
+++ b/providers/stackit/resources/iaas_compute.go
@@ -1,0 +1,190 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// ------------------------- volume backups -------------------------
+
+func (r *mqlStackit) backups() ([]any, error) {
+	c := conn(r.MqlRuntime)
+	client, err := c.IaaS()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListBackupsExecute(bgctx(), c.ProjectID(), c.Region())
+	if err != nil {
+		if isAccessDenied(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, _ := resp.GetItemsOk()
+	out := make([]any, 0, len(items))
+	for i := range items {
+		res, err := buildBackup(r.MqlRuntime, &items[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func buildBackup(runtime *plugin.Runtime, b *iaas.Backup) (plugin.Resource, error) {
+	createdAt, ok1 := b.GetCreatedAtOk()
+	updatedAt, ok2 := b.GetUpdatedAtOk()
+	args := map[string]*llx.RawData{
+		"id":               llx.StringData(b.GetId()),
+		"name":             llx.StringData(b.GetName()),
+		"description":      llx.StringData(b.GetDescription()),
+		"status":           llx.StringData(b.GetStatus()),
+		"size":             llx.IntData(b.GetSize()),
+		"availabilityZone": llx.StringData(b.GetAvailabilityZone()),
+		"encrypted":        llx.BoolData(b.GetEncrypted()),
+		"volumeId":         llx.StringData(b.GetVolumeId()),
+		"snapshotId":       llx.StringData(b.GetSnapshotId()),
+		"createdAt":        llx.TimeDataPtr(timeOrNil(createdAt, ok1)),
+		"updatedAt":        llx.TimeDataPtr(timeOrNil(updatedAt, ok2)),
+		"labels":           labelData(b.GetLabels()),
+	}
+	return CreateResource(runtime, "stackit.backup", args)
+}
+
+func (r *mqlStackitBackup) id() (string, error) {
+	return "stackit.backup/" + r.Id.Data, nil
+}
+
+func initStackitBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := idArg(args, "id")
+	if !ok {
+		return args, nil, nil
+	}
+	c := conn(runtime)
+	client, err := c.IaaS()
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := client.GetBackupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := buildBackup(runtime, b)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+func (r *mqlStackitBackup) volume() (*mqlStackitVolume, error) {
+	return volumeRef(r.MqlRuntime, r.VolumeId.Data, &r.Volume)
+}
+
+func (r *mqlStackitBackup) snapshot() (*mqlStackitSnapshot, error) {
+	if r.SnapshotId.Data == "" {
+		return markNull[mqlStackitSnapshot](&r.Snapshot)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.snapshot", map[string]*llx.RawData{
+		"id": llx.StringData(r.SnapshotId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitSnapshot), nil
+}
+
+type mqlStackitAffinityGroupInternal struct {
+	// cacheMemberIds holds the member server UUIDs, captured when the group is
+	// built so servers() can resolve them. It is not exposed as a field
+	// because servers() already carries the same information.
+	cacheMemberIds []string
+}
+
+// ------------------------- affinity groups -------------------------
+
+func (r *mqlStackit) affinityGroups() ([]any, error) {
+	c := conn(r.MqlRuntime)
+	client, err := c.IaaS()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.ListAffinityGroupsExecute(bgctx(), c.ProjectID(), c.Region())
+	if err != nil {
+		if isAccessDenied(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+	items, _ := resp.GetItemsOk()
+	out := make([]any, 0, len(items))
+	for i := range items {
+		res, err := buildAffinityGroup(r.MqlRuntime, &items[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func buildAffinityGroup(runtime *plugin.Runtime, ag *iaas.AffinityGroup) (plugin.Resource, error) {
+	args := map[string]*llx.RawData{
+		"id":     llx.StringData(ag.GetId()),
+		"name":   llx.StringData(ag.GetName()),
+		"policy": llx.StringData(ag.GetPolicy()),
+	}
+	res, err := CreateResource(runtime, "stackit.affinityGroup", args)
+	if err != nil {
+		return nil, err
+	}
+	res.(*mqlStackitAffinityGroup).cacheMemberIds = ag.GetMembers()
+	return res, nil
+}
+
+func (r *mqlStackitAffinityGroup) id() (string, error) {
+	return "stackit.affinityGroup/" + r.Id.Data, nil
+}
+
+func initStackitAffinityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, ok := idArg(args, "id")
+	if !ok {
+		return args, nil, nil
+	}
+	c := conn(runtime)
+	client, err := c.IaaS()
+	if err != nil {
+		return nil, nil, err
+	}
+	ag, err := client.GetAffinityGroupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := buildAffinityGroup(runtime, ag)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+// servers resolves the affinity group's member servers from their UUIDs.
+func (r *mqlStackitAffinityGroup) servers() ([]any, error) {
+	out := make([]any, 0, len(r.cacheMemberIds))
+	for _, id := range r.cacheMemberIds {
+		if id == "" {
+			continue
+		}
+		res, err := NewResource(r.MqlRuntime, "stackit.server", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -31,6 +31,10 @@ stackit {
   volumes() []stackit.volume
   // Volume snapshots
   snapshots() []stackit.snapshot
+  // Volume backups
+  backups() []stackit.backup
+  // Server affinity and anti-affinity placement groups
+  affinityGroups() []stackit.affinityGroup
   // VM images
   images() []stackit.image
   // Project networks
@@ -168,8 +172,14 @@ private stackit.server @defaults("id name status machineType") {
   exposure() stackit.network.exposure
   // Service account mail addresses attached to the server
   serviceAccountMails []string
-  // Network interfaces: [{nicId, ipv4, ipv6, mac, networkId, securityGroups, allowedAddresses}]
-  nics []dict
+  // Service accounts attached to the server
+  serviceAccounts() []stackit.serviceAccount
+  // Network interface summaries
+  //
+  // Deprecated in favor of networkInterfaces, which exposes each interface
+  // as a resource with network and security-group references. Each entry
+  // has {nicId, ipv4, ipv6, mac, networkId, securityGroups, allowedAddresses}.
+  nics @maturity("deprecated") []dict
   // Network interfaces attached to the server
   networkInterfaces() []stackit.nic
   // Point-in-time backups taken from the server by the Server Backup service
@@ -265,6 +275,63 @@ private stackit.snapshot @defaults("id name status") {
   updatedAt time
   // User-defined labels
   labels map[string]string
+}
+
+// STACKIT volume backup
+//
+// Backup of a volume in the project, keyed by its UUID id. Exposes the
+// status, size, availability zone, encryption flag, the source volume and
+// snapshot, and timestamps. This is the compute-service backup resource;
+// backups managed by the Server Backup service are reached through a
+// server's backups instead.
+private stackit.backup @defaults("id name status size") {
+  init(id? string)
+  // Backup UUID
+  id string
+  // Backup name
+  name string
+  // Description
+  description string
+  // Backup status
+  status string
+  // Size in GiB
+  size int
+  // Availability zone
+  availabilityZone string
+  // Whether the backup is encrypted at rest
+  encrypted bool
+  // Source volume UUID (empty if not volume-based)
+  volumeId string
+  // Source volume (nullable)
+  volume() stackit.volume
+  // Source snapshot UUID (empty if not snapshot-based)
+  snapshotId string
+  // Source snapshot (nullable)
+  snapshot() stackit.snapshot
+  // Creation timestamp
+  createdAt time
+  // Last update timestamp
+  updatedAt time
+  // User-defined labels
+  labels map[string]string
+}
+
+// STACKIT affinity group
+//
+// Server placement group that keeps its member servers on the same
+// underlying host (affinity) or spreads them across different hosts
+// (anti-affinity). The group is keyed by its UUID id and exposes the
+// placement policy and the member servers.
+private stackit.affinityGroup @defaults("id name policy") {
+  init(id? string)
+  // Affinity group UUID
+  id string
+  // Group name
+  name string
+  // Placement policy (for example hard-affinity, soft-affinity, hard-anti-affinity, soft-anti-affinity)
+  policy string
+  // Member servers
+  servers() []stackit.server
 }
 
 // STACKIT compute image

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -170,8 +170,11 @@ private stackit.server @defaults("id name status machineType") {
   securityGroups() []stackit.securityGroup
   // Internet-exposure breakdown (public IP combined with security group ingress)
   exposure() stackit.network.exposure
-  // Service account mail addresses attached to the server
-  serviceAccountMails []string
+  // Service account mail addresses
+  //
+  // Deprecated in favor of serviceAccounts, which resolves each mail to a
+  // resource exposing the service account's email and project.
+  serviceAccountMails @maturity("deprecated") []string
   // Service accounts attached to the server
   serviceAccounts() []stackit.serviceAccount
   // Network interface summaries
@@ -300,13 +303,9 @@ private stackit.backup @defaults("id name status size") {
   availabilityZone string
   // Whether the backup is encrypted at rest
   encrypted bool
-  // Source volume UUID (empty if not volume-based)
-  volumeId string
-  // Source volume (nullable)
+  // Source volume the backup was taken from (nullable)
   volume() stackit.volume
-  // Source snapshot UUID (empty if not snapshot-based)
-  snapshotId string
-  // Source snapshot (nullable)
+  // Source snapshot the backup was taken from (nullable)
   snapshot() stackit.snapshot
   // Creation timestamp
   createdAt time

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -21,6 +21,8 @@ const (
 	ResourceStackitServer                        string = "stackit.server"
 	ResourceStackitVolume                        string = "stackit.volume"
 	ResourceStackitSnapshot                      string = "stackit.snapshot"
+	ResourceStackitBackup                        string = "stackit.backup"
+	ResourceStackitAffinityGroup                 string = "stackit.affinityGroup"
 	ResourceStackitImage                         string = "stackit.image"
 	ResourceStackitNetwork                       string = "stackit.network"
 	ResourceStackitNic                           string = "stackit.nic"
@@ -125,6 +127,14 @@ func init() {
 		"stackit.snapshot": {
 			Init:   initStackitSnapshot,
 			Create: createStackitSnapshot,
+		},
+		"stackit.backup": {
+			Init:   initStackitBackup,
+			Create: createStackitBackup,
+		},
+		"stackit.affinityGroup": {
+			Init:   initStackitAffinityGroup,
+			Create: createStackitAffinityGroup,
 		},
 		"stackit.image": {
 			Init:   initStackitImage,
@@ -528,6 +538,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.snapshots": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackit).GetSnapshots()).ToDataRes(types.Array(types.Resource("stackit.snapshot")))
 	},
+	"stackit.backups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackit).GetBackups()).ToDataRes(types.Array(types.Resource("stackit.backup")))
+	},
+	"stackit.affinityGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackit).GetAffinityGroups()).ToDataRes(types.Array(types.Resource("stackit.affinityGroup")))
+	},
 	"stackit.images": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackit).GetImages()).ToDataRes(types.Array(types.Resource("stackit.image")))
 	},
@@ -699,6 +715,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.server.serviceAccountMails": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetServiceAccountMails()).ToDataRes(types.Array(types.String))
 	},
+	"stackit.server.serviceAccounts": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitServer).GetServiceAccounts()).ToDataRes(types.Array(types.Resource("stackit.serviceAccount")))
+	},
 	"stackit.server.nics": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitServer).GetNics()).ToDataRes(types.Array(types.Dict))
 	},
@@ -815,6 +834,60 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.snapshot.labels": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSnapshot).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"stackit.backup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetId()).ToDataRes(types.String)
+	},
+	"stackit.backup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetName()).ToDataRes(types.String)
+	},
+	"stackit.backup.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetDescription()).ToDataRes(types.String)
+	},
+	"stackit.backup.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetStatus()).ToDataRes(types.String)
+	},
+	"stackit.backup.size": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetSize()).ToDataRes(types.Int)
+	},
+	"stackit.backup.availabilityZone": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetAvailabilityZone()).ToDataRes(types.String)
+	},
+	"stackit.backup.encrypted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetEncrypted()).ToDataRes(types.Bool)
+	},
+	"stackit.backup.volumeId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetVolumeId()).ToDataRes(types.String)
+	},
+	"stackit.backup.volume": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetVolume()).ToDataRes(types.Resource("stackit.volume"))
+	},
+	"stackit.backup.snapshotId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetSnapshotId()).ToDataRes(types.String)
+	},
+	"stackit.backup.snapshot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetSnapshot()).ToDataRes(types.Resource("stackit.snapshot"))
+	},
+	"stackit.backup.createdAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetCreatedAt()).ToDataRes(types.Time)
+	},
+	"stackit.backup.updatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetUpdatedAt()).ToDataRes(types.Time)
+	},
+	"stackit.backup.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitBackup).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"stackit.affinityGroup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitAffinityGroup).GetId()).ToDataRes(types.String)
+	},
+	"stackit.affinityGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitAffinityGroup).GetName()).ToDataRes(types.String)
+	},
+	"stackit.affinityGroup.policy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitAffinityGroup).GetPolicy()).ToDataRes(types.String)
+	},
+	"stackit.affinityGroup.servers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitAffinityGroup).GetServers()).ToDataRes(types.Array(types.Resource("stackit.server")))
 	},
 	"stackit.image.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitImage).GetId()).ToDataRes(types.String)
@@ -2667,6 +2740,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackit).Snapshots, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"stackit.backups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackit).Backups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.affinityGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackit).AffinityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"stackit.images": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackit).Images, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -2903,6 +2984,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitServer).ServiceAccountMails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"stackit.server.serviceAccounts": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitServer).ServiceAccounts, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"stackit.server.nics": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitServer).Nics, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -3065,6 +3150,86 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.snapshot.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSnapshot).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.backup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.size": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Size, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.availabilityZone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).AvailabilityZone, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.encrypted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.volumeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).VolumeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.volume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Volume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.snapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).SnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.snapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Snapshot, ok = plugin.RawToTValue[*mqlStackitSnapshot](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.updatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).UpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"stackit.backup.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitBackup).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"stackit.affinityGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitAffinityGroup).__id, ok = v.Value.(string)
+		return
+	},
+	"stackit.affinityGroup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitAffinityGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.affinityGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitAffinityGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.affinityGroup.policy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitAffinityGroup).Policy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.affinityGroup.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitAffinityGroup).Servers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"stackit.image.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5837,6 +6002,8 @@ type mqlStackit struct {
 	Servers          plugin.TValue[[]any]
 	Volumes          plugin.TValue[[]any]
 	Snapshots        plugin.TValue[[]any]
+	Backups          plugin.TValue[[]any]
+	AffinityGroups   plugin.TValue[[]any]
 	Images           plugin.TValue[[]any]
 	Networks         plugin.TValue[[]any]
 	PublicIps        plugin.TValue[[]any]
@@ -5972,6 +6139,38 @@ func (c *mqlStackit) GetSnapshots() *plugin.TValue[[]any] {
 		}
 
 		return c.snapshots()
+	})
+}
+
+func (c *mqlStackit) GetBackups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Backups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit", c.__id, "backups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.backups()
+	})
+}
+
+func (c *mqlStackit) GetAffinityGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AffinityGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit", c.__id, "affinityGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.affinityGroups()
 	})
 }
 
@@ -6540,6 +6739,7 @@ type mqlStackitServer struct {
 	SecurityGroups      plugin.TValue[[]any]
 	Exposure            plugin.TValue[*mqlStackitNetworkExposure]
 	ServiceAccountMails plugin.TValue[[]any]
+	ServiceAccounts     plugin.TValue[[]any]
 	Nics                plugin.TValue[[]any]
 	NetworkInterfaces   plugin.TValue[[]any]
 	Backups             plugin.TValue[[]any]
@@ -6734,6 +6934,22 @@ func (c *mqlStackitServer) GetExposure() *plugin.TValue[*mqlStackitNetworkExposu
 
 func (c *mqlStackitServer) GetServiceAccountMails() *plugin.TValue[[]any] {
 	return &c.ServiceAccountMails
+}
+
+func (c *mqlStackitServer) GetServiceAccounts() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ServiceAccounts, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.server", c.__id, "serviceAccounts")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.serviceAccounts()
+	})
 }
 
 func (c *mqlStackitServer) GetNics() *plugin.TValue[[]any] {
@@ -7116,6 +7332,220 @@ func (c *mqlStackitSnapshot) GetUpdatedAt() *plugin.TValue[*time.Time] {
 
 func (c *mqlStackitSnapshot) GetLabels() *plugin.TValue[map[string]any] {
 	return &c.Labels
+}
+
+// mqlStackitBackup for the stackit.backup resource
+type mqlStackitBackup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlStackitBackupInternal it will be used here
+	Id               plugin.TValue[string]
+	Name             plugin.TValue[string]
+	Description      plugin.TValue[string]
+	Status           plugin.TValue[string]
+	Size             plugin.TValue[int64]
+	AvailabilityZone plugin.TValue[string]
+	Encrypted        plugin.TValue[bool]
+	VolumeId         plugin.TValue[string]
+	Volume           plugin.TValue[*mqlStackitVolume]
+	SnapshotId       plugin.TValue[string]
+	Snapshot         plugin.TValue[*mqlStackitSnapshot]
+	CreatedAt        plugin.TValue[*time.Time]
+	UpdatedAt        plugin.TValue[*time.Time]
+	Labels           plugin.TValue[map[string]any]
+}
+
+// createStackitBackup creates a new instance of this resource
+func createStackitBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitBackup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.backup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitBackup) MqlName() string {
+	return "stackit.backup"
+}
+
+func (c *mqlStackitBackup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitBackup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlStackitBackup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlStackitBackup) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlStackitBackup) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlStackitBackup) GetSize() *plugin.TValue[int64] {
+	return &c.Size
+}
+
+func (c *mqlStackitBackup) GetAvailabilityZone() *plugin.TValue[string] {
+	return &c.AvailabilityZone
+}
+
+func (c *mqlStackitBackup) GetEncrypted() *plugin.TValue[bool] {
+	return &c.Encrypted
+}
+
+func (c *mqlStackitBackup) GetVolumeId() *plugin.TValue[string] {
+	return &c.VolumeId
+}
+
+func (c *mqlStackitBackup) GetVolume() *plugin.TValue[*mqlStackitVolume] {
+	return plugin.GetOrCompute[*mqlStackitVolume](&c.Volume, func() (*mqlStackitVolume, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.backup", c.__id, "volume")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitVolume), nil
+			}
+		}
+
+		return c.volume()
+	})
+}
+
+func (c *mqlStackitBackup) GetSnapshotId() *plugin.TValue[string] {
+	return &c.SnapshotId
+}
+
+func (c *mqlStackitBackup) GetSnapshot() *plugin.TValue[*mqlStackitSnapshot] {
+	return plugin.GetOrCompute[*mqlStackitSnapshot](&c.Snapshot, func() (*mqlStackitSnapshot, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.backup", c.__id, "snapshot")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitSnapshot), nil
+			}
+		}
+
+		return c.snapshot()
+	})
+}
+
+func (c *mqlStackitBackup) GetCreatedAt() *plugin.TValue[*time.Time] {
+	return &c.CreatedAt
+}
+
+func (c *mqlStackitBackup) GetUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.UpdatedAt
+}
+
+func (c *mqlStackitBackup) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
+}
+
+// mqlStackitAffinityGroup for the stackit.affinityGroup resource
+type mqlStackitAffinityGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlStackitAffinityGroupInternal
+	Id      plugin.TValue[string]
+	Name    plugin.TValue[string]
+	Policy  plugin.TValue[string]
+	Servers plugin.TValue[[]any]
+}
+
+// createStackitAffinityGroup creates a new instance of this resource
+func createStackitAffinityGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlStackitAffinityGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("stackit.affinityGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlStackitAffinityGroup) MqlName() string {
+	return "stackit.affinityGroup"
+}
+
+func (c *mqlStackitAffinityGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlStackitAffinityGroup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlStackitAffinityGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlStackitAffinityGroup) GetPolicy() *plugin.TValue[string] {
+	return &c.Policy
+}
+
+func (c *mqlStackitAffinityGroup) GetServers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Servers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.affinityGroup", c.__id, "servers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.servers()
+	})
 }
 
 // mqlStackitImage for the stackit.image resource

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -856,14 +856,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.backup.encrypted": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitBackup).GetEncrypted()).ToDataRes(types.Bool)
 	},
-	"stackit.backup.volumeId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitBackup).GetVolumeId()).ToDataRes(types.String)
-	},
 	"stackit.backup.volume": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitBackup).GetVolume()).ToDataRes(types.Resource("stackit.volume"))
-	},
-	"stackit.backup.snapshotId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlStackitBackup).GetSnapshotId()).ToDataRes(types.String)
 	},
 	"stackit.backup.snapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitBackup).GetSnapshot()).ToDataRes(types.Resource("stackit.snapshot"))
@@ -3184,16 +3178,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitBackup).Encrypted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
-	"stackit.backup.volumeId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlStackitBackup).VolumeId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"stackit.backup.volume": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitBackup).Volume, ok = plugin.RawToTValue[*mqlStackitVolume](v.Value, v.Error)
-		return
-	},
-	"stackit.backup.snapshotId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlStackitBackup).SnapshotId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"stackit.backup.snapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7338,7 +7324,7 @@ func (c *mqlStackitSnapshot) GetLabels() *plugin.TValue[map[string]any] {
 type mqlStackitBackup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlStackitBackupInternal it will be used here
+	mqlStackitBackupInternal
 	Id               plugin.TValue[string]
 	Name             plugin.TValue[string]
 	Description      plugin.TValue[string]
@@ -7346,9 +7332,7 @@ type mqlStackitBackup struct {
 	Size             plugin.TValue[int64]
 	AvailabilityZone plugin.TValue[string]
 	Encrypted        plugin.TValue[bool]
-	VolumeId         plugin.TValue[string]
 	Volume           plugin.TValue[*mqlStackitVolume]
-	SnapshotId       plugin.TValue[string]
 	Snapshot         plugin.TValue[*mqlStackitSnapshot]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
@@ -7420,10 +7404,6 @@ func (c *mqlStackitBackup) GetEncrypted() *plugin.TValue[bool] {
 	return &c.Encrypted
 }
 
-func (c *mqlStackitBackup) GetVolumeId() *plugin.TValue[string] {
-	return &c.VolumeId
-}
-
 func (c *mqlStackitBackup) GetVolume() *plugin.TValue[*mqlStackitVolume] {
 	return plugin.GetOrCompute[*mqlStackitVolume](&c.Volume, func() (*mqlStackitVolume, error) {
 		if c.MqlRuntime.HasRecording {
@@ -7438,10 +7418,6 @@ func (c *mqlStackitBackup) GetVolume() *plugin.TValue[*mqlStackitVolume] {
 
 		return c.volume()
 	})
-}
-
-func (c *mqlStackitBackup) GetSnapshotId() *plugin.TValue[string] {
-	return &c.SnapshotId
 }
 
 func (c *mqlStackitBackup) GetSnapshot() *plugin.TValue[*mqlStackitSnapshot] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 stackit 13.0.0
+stackit.affinityGroup 13.4.2
+stackit.affinityGroup.id 13.4.2
+stackit.affinityGroup.name 13.4.2
+stackit.affinityGroup.policy 13.4.2
+stackit.affinityGroup.servers 13.4.2
+stackit.affinityGroups 13.4.2
 stackit.alb.customRule 13.4.2
 stackit.alb.customRule.action 13.4.2
 stackit.alb.customRule.conditions 13.4.2
@@ -57,6 +63,22 @@ stackit.alb.waf.managedRuleSetName 13.4.2
 stackit.alb.waf.name 13.4.2
 stackit.albLoadBalancers 13.0.1
 stackit.albWafs 13.4.2
+stackit.backup 13.4.2
+stackit.backup.availabilityZone 13.4.2
+stackit.backup.createdAt 13.4.2
+stackit.backup.description 13.4.2
+stackit.backup.encrypted 13.4.2
+stackit.backup.id 13.4.2
+stackit.backup.labels 13.4.2
+stackit.backup.name 13.4.2
+stackit.backup.size 13.4.2
+stackit.backup.snapshot 13.4.2
+stackit.backup.snapshotId 13.4.2
+stackit.backup.status 13.4.2
+stackit.backup.updatedAt 13.4.2
+stackit.backup.volume 13.4.2
+stackit.backup.volumeId 13.4.2
+stackit.backups 13.4.2
 stackit.certificate 13.0.1
 stackit.certificate.dnsNames 13.4.2
 stackit.certificate.extendedKeyUsage 13.4.2
@@ -508,6 +530,7 @@ stackit.server.powerStatus 13.0.0
 stackit.server.securityGroupIds 13.0.0
 stackit.server.securityGroups 13.0.0
 stackit.server.serviceAccountMails 13.0.0
+stackit.server.serviceAccounts 13.4.2
 stackit.server.status 13.0.0
 stackit.server.update 13.4.2
 stackit.server.update.endDate 13.4.2

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -73,11 +73,9 @@ stackit.backup.labels 13.4.2
 stackit.backup.name 13.4.2
 stackit.backup.size 13.4.2
 stackit.backup.snapshot 13.4.2
-stackit.backup.snapshotId 13.4.2
 stackit.backup.status 13.4.2
 stackit.backup.updatedAt 13.4.2
 stackit.backup.volume 13.4.2
-stackit.backup.volumeId 13.4.2
 stackit.backups 13.4.2
 stackit.certificate 13.0.1
 stackit.certificate.dnsNames 13.4.2


### PR DESCRIPTION
## What

Extends the `stackit` compute surface with three IaaS resources (no new SDK dependency), favoring typed cross-resource references.

- **`stackit.backups()`** → `stackit.backup` (volume backups) with `volume()` and `snapshot()` typed references. This is the compute-service backup resource, distinct from the Server Backup *service* reached via a server's `backups`; the doc-comment calls out the difference.
- **`stackit.affinityGroups()`** → `stackit.affinityGroup` with `policy` and `servers()` resolving the member servers. The member server IDs are cached internally and exposed only through `servers()` — no redundant raw `*Ids` field.
- **`stackit.server.serviceAccounts()`** resolves the server's attached service-account mails to `stackit.serviceAccount` resources (reuses the mails already on the server object, so no extra API call for them).
- **Deprecates `server.nics []dict`** in favor of the typed `networkInterfaces()` added earlier (`@maturity("deprecated")`, version unchanged).

## Example queries
```
stackit.backups { name status volume { name } snapshot { name } }
stackit.affinityGroups { name policy servers { name availabilityZone } }
stackit.servers { name serviceAccounts { email } }
```

## Testing
Codegen + compile + `go vet` + provider unit tests pass. Live cloud verification is deferred to a batch provider-verification run. New `.lr.versions` entries at `13.4.2`; no version bump; no new SDK dependency.
