### PR TITLE
📄 aws: enrich resource and field documentation across services

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -30,15 +30,17 @@ aws @defaults("account.id") {
 
 // AWS account
 //
-// Examine identification, aliases, contacts, and organization metadata for
-// the AWS account being inspected. Surfaces the account ID and aliases, the
-// associated `organization` (when the account is part of AWS Organizations),
-// the primary `contactInformation` and the alternate `securityContact`,
-// `billingContact`, and `operationsContact` entries, the per-region opt-in
-// status (`regionOptInStatus`), and the organization-managed lifecycle fields
-// (`name`, `email`, `state`, `joinedMethod`, `joinedTimestamp`) that are
-// available only when the caller is the management account or a delegated
-// administrator.
+// Identification, aliases, contacts, and organization metadata for the AWS
+// account being inspected. Covers the account ID and aliases, the associated
+// organization membership (when the account belongs to AWS Organizations),
+// the primary contactInformation, the alternate securityContact,
+// billingContact, and operationsContact entries, and the per-region opt-in
+// status. Use it to audit account ownership, contact hygiene (a missing
+// security contact means AWS has no one to reach on abuse or compromise), and
+// organization placement. The organization-managed lifecycle fields (name,
+// email, state, joinedMethod, joinedTimestamp) resolve only when the calling
+// identity is the organization's management account or a delegated
+// administrator, and are otherwise empty.
 aws.account @defaults("id aliases.first organization.id") {
   // Account ID
   id string
@@ -54,6 +56,10 @@ aws.account @defaults("id aliases.first organization.id") {
   tags() map[string]string
 
   // Primary contact information for the account
+  //
+  // Keys: addressLine1, addressLine2, addressLine3, city, companyName,
+  // countryCode, districtOrCounty, fullName, phoneNumber, postalCode,
+  // stateOrRegion, and websiteUrl.
   contactInformation() dict
 
   // All alternate contacts configured for the account
@@ -128,12 +134,12 @@ private aws.account.alternateContact @defaults("contactType name emailAddress") 
 
 // AWS Billing
 //
-// Examine the AWS account's billing posture: month-to-date and recent
-// historical spend (from AWS Cost Explorer), service-level breakdowns,
+// Spend and budget posture for the AWS account: month-to-date and recent
+// historical cost (from AWS Cost Explorer), service-level breakdowns,
 // forecasts for the current month, and the inventory of configured
 // AWS Budgets. Cost Explorer must be enabled in the account; if not,
 // cost fields return zero. Each Cost Explorer API call is billed by
-// AWS at $0.01, so cost-related fields are fetched lazily and cached.
+// AWS at $0.01, so cost queries carry a small per-call charge.
 aws.billing @defaults("monthToDateCost currency budgets.length") {
   // Currency the account is billed in (e.g., USD)
   currency() string
@@ -157,10 +163,13 @@ aws.billing @defaults("monthToDateCost currency budgets.length") {
 
 // AWS Budget
 //
-// Examine a single AWS Budgets entry. The `name` field selects the budget
-// (unique per account), e.g. `aws.billing.budgets.where(name == "monthly-cap")`.
-// Surfaces the budget's type, time unit, limit, actual and forecasted
-// spend, cost filters, and the configured notifications and subscribers.
+// Single AWS Budgets entry defining a cost or usage ceiling and the
+// alerts raised when spend approaches it. The `name` field selects the
+// budget (unique per account), e.g. `aws.billing.budgets.where(name == "monthly-cap")`.
+// Exposes the budget's type, time unit, limit, actual and forecasted
+// spend, cost filters, and the configured notifications and subscribers,
+// so you can audit whether spending guardrails are in place and who is
+// notified when they trip.
 private aws.billing.budget @defaults("name budgetType budgetLimit actualSpend") {
   // Budget name (unique within an account)
   name string
@@ -200,12 +209,15 @@ private aws.billing.budget @defaults("name budgetType budgetLimit actualSpend") 
 
 // AWS Organizations organization
 //
-// Examine the AWS Organizations entity that the account belongs to.
-// Surfaces the organization ID and ARN, the master (management) account
-// identifiers and email, the configured feature set
-// (`ALL` vs `CONSOLIDATED_BILLING`), the member `accounts` (when available
-// to the caller), the `delegatedAdministrators` registered for the org,
-// and the `organizationalUnits` that make up the org tree.
+// AWS Organizations entity that the account belongs to, the billing and
+// governance root for a set of member accounts. The `featureSet` field
+// (`ALL` vs `CONSOLIDATED_BILLING`) determines whether organization-wide
+// controls such as service control policies apply or the org is limited to
+// consolidated billing. Member accounts, delegated administrators, service
+// control policies, and the organizational-unit tree let you audit account
+// membership and the guardrails that constrain every member account. Access
+// to member accounts, delegated administrators, and policies depends on the
+// calling account's permissions in the organization.
 aws.organization @defaults("id masterAccountEmail") {
   // ARN of the organization
   arn string
@@ -231,12 +243,12 @@ aws.organization @defaults("id masterAccountEmail") {
 
 // AWS Organizations service control policy
 //
-// Examine a service control policy (SCP) and the maximum permissions it
-// defines for the accounts, organizational units, and roots it is attached
-// to. The parsed statements expose the allowed or denied actions and the
-// conditions that bound them, so you can audit the organization-wide
-// guardrails that constrain every member account. The policy is selected by
-// its id, for example p-0123456789abcdef.
+// Service control policy (SCP) and the maximum permissions it defines for
+// the accounts, organizational units, and roots it is attached to. The
+// parsed statements expose the allowed or denied actions and the conditions
+// that bound them, so you can audit the organization-wide guardrails that
+// constrain every member account. The policy is selected by its id, for
+// example p-0123456789abcdef.
 private aws.organization.serviceControlPolicy @defaults("name id") {
   // Unique identifier of the policy
   id string
@@ -302,12 +314,13 @@ private aws.organization.organizationalUnit @defaults("id name path") {
 
 // Amazon Virtual Private Cloud (VPC)
 //
-// Examine a VPC along with its subnets, route tables, internet/NAT gateways,
-// flow logs, peering connections, service endpoints, and VPN gateways.
-// Use the `id` field as the selection key — for example
-// `aws.vpc(id: "vpc-0a1b2c3d")`. Each row reports the IPv4 CIDR block, state,
-// default-VPC flag, instance tenancy, region, internet-gateway block mode,
-// tags, and the typed sub-resources for each component of the VPC topology.
+// Isolated virtual network in an AWS account, the boundary that contains
+// subnets, route tables, internet and NAT gateways, flow logs, peering
+// connections, service endpoints, and VPN gateways. The `id` field selects
+// the VPC, for example `aws.vpc(id: "vpc-0a1b2c3d")`. Query it to audit the
+// network topology and its exposure: the IPv4 CIDR ranges, default-VPC
+// status, instance tenancy, internet-gateway block mode, DNS resolution
+// settings, and encryption-in-transit controls.
 aws.vpc @defaults("id isDefault cidrBlock region") {
   // ARN of the VPC
   arn string
@@ -371,9 +384,19 @@ aws.vpc @defaults("id isDefault cidrBlock region") {
   enableDnsSupport() bool
   // Whether instances launched in the VPC get public DNS hostnames
   enableDnsHostnames() bool
-  // IPv4 CIDR block associations for the VPC (primary and secondary)
+  // IPv4 CIDR block associations for the VPC
+  //
+  // The primary and any secondary IPv4 ranges attached to the VPC. Each
+  // entry has `AssociationId`, `CidrBlock`, and `CidrBlockState` (a nested
+  // `State`/`StatusMessage` pair, where `State` is associating, associated,
+  // disassociating, disassociated, failing, or failed).
   cidrBlockAssociations() []dict
   // IPv6 CIDR block associations for the VPC
+  //
+  // Each entry has `AssociationId`, `Ipv6CidrBlock`, `Ipv6CidrBlockState`
+  // (a nested `State`/`StatusMessage` pair), `Ipv6Pool`, `NetworkBorderGroup`,
+  // `IpSource` (amazon, byoip, or none), and `Ipv6AddressAttribute` (public
+  // or private).
   ipv6CidrBlockAssociations() []dict
   // CloudFormation stack that manages this VPC, if any
   cloudformationStack() aws.cloudformation.stack
@@ -535,6 +558,9 @@ private aws.vpc.routetable.association @defaults("routeTableAssociationId gatewa
   // Unique ID of the association
   routeTableAssociationId string
   // Association state
+  //
+  // Keys are `State` (associating, associated, disassociating, disassociated,
+  // or failed) and `StatusMessage` (detail when the association failed).
   associationsState dict
   // Unique ID of the associated gateway
   gatewayId string
@@ -625,6 +651,10 @@ private aws.vpc.endpoint @defaults("id type region") {
   // Network interfaces for the endpoint (interface endpoints only)
   networkInterfaces() []aws.ec2.networkinterface
   // DNS entries for the endpoint
+  //
+  // Regional and zonal DNS names that resolve to the endpoint. Each entry has
+  // `dnsName` (the hostname) and `hostedZoneId` (the Route 53 hosted zone the
+  // name lives in).
   dnsEntries []dict
   // Tags on the endpoint
   tags map[string]string
@@ -691,6 +721,9 @@ private aws.vpc.vpnGateway @defaults("id state") {
   // Availability zone for the virtual private gateway
   availabilityZone string
   // VPC attachments for the virtual private gateway
+  //
+  // VPCs the gateway is attached to. Each entry has `VpcId` and `State`
+  // (attaching, attached, detaching, or detached).
   attachments []dict
   // Tags on the virtual private gateway
   tags map[string]string
@@ -700,13 +733,13 @@ private aws.vpc.vpnGateway @defaults("id state") {
 
 // AWS WAF v2
 //
-// Use the WAF v2 namespace to enumerate web application firewall building
-// blocks attached to ALBs, API Gateway stages, AppSync APIs, and CloudFront
-// distributions. Iterate `acls()` for web ACLs (each carrying its rules,
-// default action, and logging configuration), `ruleGroups()` for reusable
-// rule groups, `ipSets()` for IP-set match references, and
-// `regexPatternSets()` for shared regex pattern sets. The `scope` field
-// records whether resources are CloudFront-scoped (global) or REGIONAL.
+// Web application firewall building blocks that protect ALBs, API Gateway
+// stages, AppSync APIs, and CloudFront distributions. The acls field lists
+// web ACLs (each carrying its rules, default action, and logging
+// configuration), ruleGroups lists reusable rule groups, ipSets lists IP-set
+// match references, and regexPatternSets lists shared regex pattern sets. The
+// scope field records whether resources are CloudFront-scoped (global) or
+// REGIONAL.
 aws.waf {
   // List of WAF ACLs
   acls() []aws.waf.acl
@@ -721,6 +754,14 @@ aws.waf {
 }
 
 // Amazon WAF v2 ACL
+//
+// Web ACL that inspects requests to a protected resource and allows, blocks,
+// or counts them according to its rules. The rules field carries the ordered
+// match statements and their actions, loggingConfiguration exposes where
+// matched requests are logged and which fields are redacted, and
+// associatedResources and associatedLoadBalancers show what the ACL protects.
+// scope is REGIONAL for ALB, API Gateway, and AppSync targets or CLOUDFRONT
+// for global distributions.
 private aws.waf.acl @defaults("name") {
   // ARN of the ACL
   arn string
@@ -750,6 +791,10 @@ private aws.waf.acl @defaults("name") {
 }
 
 // Amazon WAF v2 RuleGroup
+//
+// Reusable collection of WAF rules that web ACLs reference so the same match
+// logic can protect multiple resources. The rules field lists the contained
+// match statements and their actions. scope is REGIONAL or CLOUDFRONT.
 private aws.waf.rulegroup @defaults("name") {
   // ARN of the rulegroup
   arn string
@@ -994,7 +1039,7 @@ private aws.waf.rule.fieldtomatch @defaults("target") {
   ruleName string
   // ID of the statement
   statementID string
-  // Whether to match the HTTP method: GET or POST
+  // Whether the rule inspects the HTTP request method
   method bool
   // Whether to match the URI path
   uriPath bool
@@ -1002,21 +1047,21 @@ private aws.waf.rule.fieldtomatch @defaults("target") {
   queryString bool
   // Whether to match all query arguments
   allQueryArguments bool
-  // Whether to match the body (match if not null)
+  // Request body inspection settings, present when the rule inspects the body
   body aws.waf.rule.fieldtomatch.body
-  // Whether to match the cookie (match if not null)
+  // Cookie inspection settings, present when the rule inspects cookies
   cookie aws.waf.rule.fieldtomatch.cookie
-  // Whether to match the single header (match if not null)
+  // Single named header inspection settings, present when the rule inspects one header
   singleHeader aws.waf.rule.fieldtomatch.singleheader
-  // Whether to match the header order (match if not null)
+  // Header-order inspection settings, present when the rule inspects header order
   headerOrder aws.waf.rule.fieldtomatch.headerorder
-  // Whether to match the header (match if not null)
+  // Header inspection settings, present when the rule inspects headers
   headers aws.waf.rule.fieldtomatch.headers
-  // Whether to match the JA3 fingerprint (match if not null)
+  // JA3 TLS fingerprint inspection settings, present when the rule inspects the JA3 fingerprint
   ja3Fingerprint aws.waf.rule.fieldtomatch.ja3fingerprint
-  // Whether to match the JSON body (match if not null)
+  // JSON request-body inspection settings, present when the rule inspects the JSON body
   jsonBody aws.waf.rule.fieldtomatch.jsonbody
-  // Whether to match the single query argument of the field (match if not null)
+  // Single named query-argument inspection settings, present when the rule inspects one query argument
   singleQueryArgument aws.waf.rule.fieldtomatch.singlequeryargument
 }
 
@@ -1161,6 +1206,11 @@ private aws.waf.rule.statement.sqlimatchstatement {
 
 
 // Amazon WAF IP set (defining IP Ranges)
+//
+// Named set of IP address ranges that WAF rules reference to allow or block
+// traffic by source address. The addresses field lists the CIDR ranges and
+// addressType reports whether they are IPV4 or IPV6. scope is REGIONAL or
+// CLOUDFRONT.
 private aws.waf.ipset @defaults("name") {
   // ARN of the IP set
   arn string
@@ -1172,13 +1222,17 @@ private aws.waf.ipset @defaults("name") {
   name string
   // Description of the IP set
   description string
-  // Address type: ipv4 or ipv6
+  // Address type: IPV4 or IPV6
   addressType() string
-  // List of IP addresses
+  // List of IP address ranges in CIDR notation
   addresses() dict
 }
 
 // Amazon WAF regex pattern set
+//
+// Named set of regular expressions that WAF rules reference to match request
+// components against a shared pattern library. The regularExpressions field
+// lists the patterns. scope is REGIONAL or CLOUDFRONT.
 private aws.waf.regexPatternSet @defaults("name") {
   // ARN of the regex pattern set
   arn string
@@ -1208,14 +1262,14 @@ private aws.waf.acl.loggingConfiguration @defaults("arn") {
 
 // AWS Network Firewall
 //
-// Use the Network Firewall namespace to enumerate VPC-level firewall
-// deployments and the policy building blocks they reference. Iterate
-// `firewalls()` for each deployed firewall (with its associated VPC,
-// subnets, logging configuration, and attached policy), `policies()` for
-// firewall policies that compose stateless and stateful rule groups,
-// `ruleGroups()` for reusable Suricata-compatible or stateless rule groups,
-// and `tlsInspectionConfigurations()` for the configurations that drive
-// SSL/TLS decryption performed by the firewall.
+// VPC-level managed firewall deployments and the policy building blocks
+// they reference. `firewalls` lists each deployed firewall with its
+// associated VPC, subnets, logging configuration, and attached policy.
+// `policies` lists firewall policies that compose stateless and stateful
+// rule groups. `ruleGroups` lists reusable Suricata-compatible or
+// stateless rule groups. `tlsInspectionConfigurations` lists the
+// configurations that drive the SSL/TLS decryption performed by the
+// firewall.
 aws.networkfirewall @defaults("firewalls") {
   // List of Network Firewall firewalls
   firewalls() []aws.networkfirewall.firewall
@@ -1251,7 +1305,11 @@ private aws.networkfirewall.firewall @defaults("arn name region") {
   firewallPolicyArn string
   // Firewall policy associated with this firewall
   policy() aws.networkfirewall.policy
-  // Subnet mappings for the firewall
+  // Subnet mappings for the firewall endpoints
+  //
+  // One entry per firewall endpoint, each with `subnetId` (the subnet the
+  // endpoint is placed in) and `ipAddressType` (DUALSTACK, IPV4, or IPV6).
+  // See `subnets` for the resolved subnet resources.
   subnetMappings []dict
   // KMS encryption type for firewall resources (AWS_OWNED_KMS_KEY or CUSTOMER_KMS)
   encryptionType string
@@ -1266,8 +1324,19 @@ private aws.networkfirewall.firewall @defaults("arn name region") {
   // Configuration sync state summary across all Availability Zones (IN_SYNC, PENDING, CAPACITY_CONSTRAINED)
   configurationSyncStateSummary() string
   // Per-Availability-Zone sync states for the firewall endpoints
+  //
+  // One entry per Availability Zone, each with `availabilityZone`,
+  // `subnetId`, `endpointId`, `status`, and `statusMessage` for the endpoint
+  // attachment, plus a `config` map keyed by configuration object ARN whose
+  // values carry `syncStatus` and `updateToken`.
   syncStates() []dict
   // Logging destinations configured on the firewall (one entry per log type)
+  //
+  // Each entry carries `logType` (ALERT, FLOW, or TLS), `logDestinationType`
+  // (S3, CloudWatchLogs, or KinesisDataFirehose), and a `logDestination` map
+  // whose keys depend on the destination type (`bucketName`/`prefix` for S3,
+  // `logGroup` for CloudWatch Logs, or `deliveryStream` for Kinesis Data
+  // Firehose).
   loggingDestinations() []dict
   // Logging configuration for the firewall
   //
@@ -1312,24 +1381,45 @@ private aws.networkfirewall.policy @defaults("arn name region") {
   // Stateless default actions for fragmented packets
   statelessFragmentDefaultActions []string
   // Custom stateless actions usable by name in the policy's default actions
+  //
+  // Each entry has `actionName` (the name referenced from stateless default
+  // actions) and `actionDefinition`, which holds a `publishMetricAction`
+  // with the CloudWatch dimensions to publish when the action fires.
   statelessCustomActions []dict
   // Stateless rule group references
+  //
+  // Each entry has `resourceArn` (the referenced rule group) and `priority`
+  // (its evaluation order). See `statelessRuleGroups` for the resolved rule
+  // group resources.
   statelessRuleGroupReferences []dict
   // Stateless rule groups referenced by the policy
   statelessRuleGroups() []aws.networkfirewall.rulegroup
   // Stateful default actions
   statefulDefaultActions []string
   // Stateful rule group references
+  //
+  // Each entry has `resourceArn` (the referenced rule group), an optional
+  // `priority` (used with STRICT_ORDER evaluation), and an optional
+  // `override` whose `action` can put the group into alert-only mode. See
+  // `statefulRuleGroups` for the resolved rule group resources.
   statefulRuleGroupReferences []dict
   // Stateful rule groups referenced by the policy
   statefulRuleGroups() []aws.networkfirewall.rulegroup
   // Stateful engine options
+  //
+  // Carries `ruleOrder` (DEFAULT_ACTION_ORDER or STRICT_ORDER),
+  // `streamExceptionPolicy` (DROP, CONTINUE, or REJECT), and `flowTimeouts`
+  // with `tcpIdleTimeoutSeconds`. Also surfaced individually as
+  // `statefulEngineRuleOrder` and `statefulEngineStreamExceptionPolicy`.
   statefulEngineOptions dict
   // Order in which stateful rules are evaluated (DEFAULT_ACTION_ORDER or STRICT_ORDER)
   statefulEngineRuleOrder string
   // Behavior when a network connection breaks midstream (DROP, CONTINUE, REJECT)
   statefulEngineStreamExceptionPolicy string
   // Suricata HOME_NET overrides and other policy-level rule variables
+  //
+  // Each entry has `name` (the variable name, such as HOME_NET) and
+  // `definition`, the list of CIDR ranges bound to it.
   policyVariables []dict
   // ARN of the TLS inspection configuration associated with the policy
   tlsInspectionConfigurationArn string
@@ -1372,16 +1462,33 @@ private aws.networkfirewall.rulegroup @defaults("arn name region") {
   // Status of the rule group (ACTIVE, DELETING, ERROR)
   ruleGroupStatus string
   // Rules definition
+  //
+  // The full rule group definition: `rulesSource` (a `rulesString` of
+  // Suricata-compatible rules, `statefulRules`, or
+  // `statelessRulesAndCustomActions`), along with `ruleVariables`,
+  // `referenceSets`, and `statefulRuleOptions`. See `rulesString` for the
+  // raw Suricata body of a stateful rule group.
   rules dict
   // Raw Suricata-compatible rule body for stateful rule groups
   rulesString string
   // Reference sets used by the rule group's rules
+  //
+  // One entry per IP set reference, each with `name` (the variable the
+  // reference is bound to) and `referenceArn` (the referenced resource, such
+  // as a prefix list).
   referenceSets []dict
   // Rule variables (IP sets and port sets) usable in the rule group's rules
+  //
+  // One entry per variable, each with `name`, `kind` (ipSet or portSet), and
+  // `definition`, the list of CIDR ranges or ports bound to the variable.
   ruleVariables []dict
   // Order in which the rule group's stateful rules are evaluated (DEFAULT_ACTION_ORDER or STRICT_ORDER)
   statefulRuleOrder string
   // Metadata about the managed rule group this rule group was copied from
+  //
+  // Present for rule groups derived from an AWS managed rule group. Each
+  // entry has `sourceArn` (the managed rule group) and `sourceUpdateToken`
+  // (the version it was copied from).
   sourceMetadata []dict
   // KMS encryption type for the rule group (AWS_OWNED_KMS_KEY or CUSTOMER_KMS)
   encryptionType string
@@ -1393,12 +1500,12 @@ private aws.networkfirewall.rulegroup @defaults("arn name region") {
 
 // AWS Network Firewall TLS inspection configuration
 //
-// Examine the SSL/TLS decryption settings that a firewall policy can attach
-// to perform deep inspection on TLS traffic. Each configuration carries one
-// or more `serverCertificateConfigurations` entries, each of which combines
-// the inbound `serverCertificates` (ACM-managed) and an outbound
+// SSL/TLS decryption settings that a firewall policy can attach to perform
+// deep inspection on TLS traffic. Each configuration carries one or more
+// `serverCertificateConfigurations` entries, each of which combines the
+// inbound `serverCertificates` (ACM-managed) and an outbound
 // `certificateAuthorityArn` (an imported CA in ACM) with `scopes` that
-// describe the traffic to decrypt. `encryptionType` and `kmsKey()` describe
+// describe the traffic to decrypt. `encryptionType` and `kmsKey` describe
 // how the configuration itself is encrypted at rest.
 private aws.networkfirewall.tlsInspectionConfiguration @defaults("arn name region") {
   // ARN of the TLS inspection configuration
@@ -1450,12 +1557,12 @@ private aws.networkfirewall.tlsInspectionConfiguration @defaults("arn name regio
 
 // AWS Elastic File System (EFS)
 //
-// Use the EFS namespace to enumerate elastic file systems across all
-// configured regions. Iterate `filesystems()` for each EFS file system —
-// every entry surfaces encryption settings, performance and throughput modes,
-// lifecycle and replication configurations, mount targets, and access points
-// for queries about NFS file shares used by EC2, ECS, Lambda, and on-premises
-// clients.
+// Elastic file systems across all configured regions. Each file system
+// surfaces encryption settings, performance and throughput modes,
+// lifecycle and replication configurations, mount targets, and access
+// points, letting you audit the NFS file shares used by EC2, ECS, Lambda,
+// and on-premises clients. The filesystems field lists every EFS file
+// system in the account.
 aws.efs @defaults("filesystems") {
   // List of file systems managed by the service
   filesystems() []aws.efs.filesystem
@@ -1476,6 +1583,10 @@ private aws.efs.filesystem @defaults("name id region") {
   // KMS key used for encryption of the file system
   kmsKey() aws.kms.key
   // Backup policy for the file system
+  //
+  // Dict with a `BackupPolicy` object whose `Status` reports the automatic
+  // backup state, one of ENABLED, ENABLING, DISABLED, or DISABLING. Null
+  // when the file system has no backup policy configured.
   backupPolicy() dict
   // Region in which the file system exists
   region string
@@ -1525,6 +1636,10 @@ private aws.efs.filesystem @defaults("name id region") {
   // Replication configuration for the file system (null if not replicated)
   replicationConfiguration() aws.efs.filesystem.replicationConfiguration
   // File system protection configuration
+  //
+  // Dict with a `replicationOverwriteProtection` key reporting whether the
+  // file system is guarded against being overwritten by an incoming
+  // replication, one of ENABLED, DISABLED, or REPLICATING.
   fileSystemProtection() dict
 }
 
@@ -1632,7 +1747,12 @@ private aws.efs.accessPoint @defaults("accessPointId name") {
   name string
   // POSIX user identity (uid, gid, secondaryGids)
   posixUser dict
-  // Root directory configuration (path, creationInfo)
+  // Root directory configuration
+  //
+  // Dict with `path` (the directory within the file system exposed to NFS
+  // clients through this access point) and `creationInfo`, an object with
+  // `ownerUid`, `ownerGid`, and `permissions` that EFS applies when it
+  // creates the root directory.
   rootDirectory dict
   // Access point state
   lifecycleState string
@@ -1644,11 +1764,13 @@ private aws.efs.accessPoint @defaults("accessPointId name") {
 
 // AWS FSx
 //
-// Use the FSx namespace to enumerate managed file systems and the building
-// blocks around them. Iterate `fileSystems()` for Lustre, Windows File
-// Server, ONTAP, and OpenZFS file systems, `volumes()` for ONTAP and OpenZFS
-// volumes, `backups()` for backup snapshots, and `caches()` for Amazon File
-// Cache instances used to bridge on-premises and cloud storage.
+// Amazon FSx managed file systems and the building blocks around them. The
+// fileSystems collection covers Lustre, Windows File Server, ONTAP, and
+// OpenZFS file systems, volumes covers ONTAP and OpenZFS volumes, backups
+// covers backup snapshots, and caches covers Amazon File Cache instances
+// used to bridge on-premises and cloud storage. Query this namespace to
+// inventory storage footprint, encryption posture, and network placement
+// across every FSx deployment in the account.
 aws.fsx @defaults("fileSystems") {
   // List of FSx file systems
   fileSystems() []aws.fsx.filesystem
@@ -1678,19 +1800,19 @@ private aws.fsx.filesystem @defaults("id type region") {
   encrypted() bool
   // KMS key ID used for encryption
   //
-  // Deprecated in favor of `kmsKey()`.
+  // Deprecated in favor of `kmsKey`.
   kmsKeyId @maturity("deprecated") string
   // KMS key used for encryption
   kmsKey() aws.kms.key
   // VPC ID where the file system resides
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of `vpc`.
   vpcId @maturity("deprecated") string
   // VPC where the file system resides
   vpc() aws.vpc
   // Subnet IDs for the file system
   //
-  // Deprecated in favor of `subnets()`.
+  // Deprecated in favor of `subnets`.
   subnetIds @maturity("deprecated") []string
   // Subnets for the file system
   subnets() []aws.vpc.subnet
@@ -1716,19 +1838,28 @@ private aws.fsx.cache @defaults("id lifecycle") {
   storageCapacity int
   // VPC ID where the cache resides
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of `vpc`.
   vpcId @maturity("deprecated") string
   // VPC where the cache resides
   vpc() aws.vpc
   // Subnet IDs for the cache
   //
-  // Deprecated in favor of `subnets()`.
+  // Deprecated in favor of `subnets`.
   subnetIds @maturity("deprecated") []string
   // Subnets for the cache
   subnets() []aws.vpc.subnet
-  // Lustre-specific configuration
+  // Lustre cache configuration
+  //
+  // Keys include DeploymentType (only CACHE_1), MountName used when
+  // mounting the cache, PerUnitStorageThroughput in MB/s per TiB of
+  // storage, WeeklyMaintenanceStartTime formatted d:HH:MM in UTC,
+  // MetadataConfiguration for the Lustre metadata storage volume, and
+  // LogConfiguration for CloudWatch Logs.
   lustreConfiguration dict
   // S3 data repository associations
+  //
+  // Each entry carries an id key holding the data repository association
+  // ID that links the cache to its backing S3 bucket.
   dataRepositoryAssociations []dict
   // Region where the cache exists
   region string
@@ -1754,7 +1885,7 @@ private aws.fsx.backup @defaults("backupId type lifecycle") {
   fileSystemType string
   // KMS key ID used for encryption
   //
-  // Deprecated in favor of `kmsKey()`.
+  // Deprecated in favor of `kmsKey`.
   kmsKeyId @maturity("deprecated") string
   // KMS key used for encryption
   kmsKey() aws.kms.key
@@ -1826,12 +1957,13 @@ private aws.fsx.volume @defaults("id name lifecycle region") {
 
 // AWS Key Management Service (KMS)
 //
-// Use the KMS namespace to enumerate customer-managed and AWS-managed keys
-// across all enabled regions. Iterate `keys()` for every KMS key in the
-// account — each entry surfaces aliases, key state and origin, key spec,
-// rotation status, key policy, and the grants attached to the key, which is
-// the data needed to audit which principals can encrypt and decrypt
-// account-encrypted resources.
+// Customer-managed and AWS-managed encryption keys across all enabled
+// regions. The `keys` field surfaces every KMS key in the account, each
+// with its aliases, key state and origin, key spec, rotation status, key
+// policy, and attached grants, the data needed to audit which principals
+// can encrypt and decrypt account-encrypted resources. The `grants` and
+// `customKeyStores` fields cover account-wide grant and custom-key-store
+// posture.
 aws.kms @defaults("keys") {
   // List of all customer master keys (CMKs) in the caller's AWS account across all regions
   keys() []aws.kms.key
@@ -1844,6 +1976,13 @@ aws.kms @defaults("keys") {
 }
 
 // AWS Key Management Service (KMS) key
+//
+// Single KMS key (customer master key), including its aliases, key state,
+// origin, and key spec, its rotation configuration, its key policy and
+// parsed policy statements, and the grants attached to it. The `isPublic`
+// and `externalAccessFindings` fields flag keys whose policy allows access
+// from outside the account, and `encryptedVolumes` links the key to the
+// EBS volumes it protects.
 private aws.kms.key @defaults("id region aliases metadata.Description") {
   // Unique identifier for the key
   id string
@@ -1853,7 +1992,9 @@ private aws.kms.key @defaults("id region aliases metadata.Description") {
   region string
   // Whether key rotation is enabled
   keyRotationEnabled() bool
-  // Metadata for the key
+  // Raw key metadata as returned by the KMS DescribeKey API
+  //
+  // JSON form of the KeyMetadata structure, with keys such as `KeyId`, `Arn`, `Description`, `KeyState`, `KeyUsage`, `KeySpec`, `Origin`, `KeyManager`, `CreationDate`, `Enabled`, `MultiRegion`, and `CustomKeyStoreId`. Most values are also exposed as dedicated fields (`keyState`, `keyUsage`, `keySpec`, `origin`, `keyManager`, `description`); prefer those for audits and use this dict for values without a dedicated accessor.
   metadata() dict
   // Tags for the KMS key
   tags() map[string]string
@@ -1971,13 +2112,12 @@ private aws.kms.grant @defaults("grantId name granteePrincipal") {
 
 // Multi-region configuration of a KMS key
 //
-// Examine the primary/replica role of a multi-region key and the typed
-// references to its primary and replica keys. The `multiRegionKeyType`
-// field is PRIMARY for the primary key and REPLICA for replicas. The
-// `primaryKey()` accessor resolves the primary across regions and
-// `replicaKeys()` resolves every replica; both return null/empty when the
-// referenced keys are not accessible to the caller (cross-region or
-// permission boundary).
+// Primary and replica structure of a multi-region key. The
+// `multiRegionKeyType` field is PRIMARY for the primary key and REPLICA
+// for replicas. The `primaryKey` accessor resolves the primary across
+// regions and `replicaKeys` resolves every replica; both return
+// null/empty when the referenced keys are not accessible to the caller
+// (cross-region or permission boundary).
 private aws.kms.key.multiRegionConfiguration @defaults("multiRegionKeyType") {
   // Whether the key is the PRIMARY or a REPLICA in its multi-region key set
   multiRegionKeyType string
@@ -1995,14 +2135,14 @@ private aws.kms.key.multiRegionConfiguration @defaults("multiRegionKeyType") {
 
 // KMS custom key store
 //
-// Examine custom key stores registered with AWS KMS. A custom key store
-// is either backed by an AWS CloudHSM cluster (`AWS_CLOUDHSM`) or by an
-// external key manager reached through an external key store proxy
-// (`EXTERNAL_KEY_STORE`). The `customKeyStoreId` selects an individual
-// store, and the `connectionState`, `connectionErrorCode`,
-// `cloudHsmClusterId`, and `xksProxyConfiguration` fields surface what
-// is needed to audit which keys live outside KMS itself and whether the
-// backing store is currently reachable.
+// Custom key store registered with AWS KMS, either backed by an AWS
+// CloudHSM cluster (`AWS_CLOUDHSM`) or by an external key manager reached
+// through an external key store proxy (`EXTERNAL_KEY_STORE`). The
+// `customKeyStoreId` selects an individual store, and the
+// `connectionState`, `connectionErrorCode`, `cloudHsmClusterId`, and
+// `xksProxyConfiguration` fields surface what is needed to audit which
+// keys live outside KMS itself and whether the backing store is currently
+// reachable.
 private aws.kms.customKeyStore @defaults("customKeyStoreName customKeyStoreType connectionState region") {
   // Unique identifier for the custom key store
   customKeyStoreId string
@@ -2035,15 +2175,14 @@ private aws.kms.customKeyStore @defaults("customKeyStoreName customKeyStoreType 
 
 // AWS Identity and Access Management (IAM)
 //
-// Use the IAM namespace to enumerate identities, permissions, and credential
-// posture for the account. Iterate `users()`, `roles()`, `groups()`,
-// `policies()`, `instanceProfiles()`, `samlProviders()`, `oidcProviders()`,
-// and `virtualMfaDevices()` for the principals and trust providers in the
-// account, and `serverCertificates()` for IAM-stored certs. Read
-// `credentialReport()` for the per-user password and access-key history,
-// `accountSummary()` for account-wide totals, `accountPasswordPolicy()` for
-// the password complexity rules, and `accountAlias()` for the account alias
-// when one is set.
+// Identity, permission, and credential posture for the account. The users,
+// roles, groups, and policies collections cover the principals and their
+// attached permissions, while instanceProfiles, samlProviders,
+// oidcProviders, and virtualMfaDevices cover trust providers and MFA
+// enrollment, and serverCertificates lists IAM-stored certificates. The
+// credentialReport gives per-user password and access-key history,
+// accountSummary the account-wide totals, passwordPolicy the password
+// complexity rules, and accountAlias the account alias when one is set.
 aws.iam {
   // List of IAM users in the account
   users() []aws.iam.user
@@ -2065,10 +2204,20 @@ aws.iam {
   // Account password policy
   passwordPolicy() aws.iam.passwordPolicy
   // IAM account summary
+  //
+  // Account-wide totals and quotas from the IAM account summary, keyed by
+  // summary name. Representative keys include AccountMFAEnabled (1 when the
+  // root user has MFA enabled), Users, Groups, Roles, Policies, MFADevices,
+  // and per-entity quotas such as AccessKeysPerUserQuota and UsersQuota. All
+  // values are integers.
   accountSummary() map[string]int
   // List of virtual mfs devices associated with the account
   virtualMfaDevices() []aws.iam.virtualmfadevice
-  // List of server certificates stored in IAM
+  // Server certificates stored in IAM
+  //
+  // Each entry has the shape `{Arn, Path, ServerCertificateId,
+  // ServerCertificateName, Expiration, UploadDate}`. Expiration is the
+  // certificate expiry date and UploadDate is when it was uploaded to IAM.
   serverCertificates() []dict
   // List of IAM instance profiles in the account
   instanceProfiles() []aws.iam.instanceProfile
@@ -2082,9 +2231,9 @@ aws.iam {
 
 // AWS IAM account password policy
 //
-// Examine the password complexity rules enforced on IAM user passwords for the
-// account. The `exists` field reports whether a policy is configured at all;
-// when no policy is set every other field is null. The remaining fields cover
+// Password complexity rules enforced on IAM user passwords for the account.
+// The exists field reports whether a policy is configured at all; when no
+// policy is set every other field is null. The remaining fields cover
 // length, character-class requirements, reuse prevention, and expiration.
 private aws.iam.passwordPolicy @defaults("exists minimumPasswordLength") {
   // Whether an account password policy is configured
@@ -2187,6 +2336,13 @@ private aws.iam.usercredentialreportentry @defaults("arn") {
 }
 
 // AWS IAM user
+//
+// IAM user identity in the account, covering its inline and managed
+// policies, group memberships, access keys, MFA devices, login profile, and
+// permissions boundary. These fields support auditing long-lived
+// credentials, over-privileged principals, missing MFA, and unrotated or
+// unused access keys. The user is selected by name, for example
+// aws.iam.user(name: "alice").
 private aws.iam.user @defaults("arn name createdAt") {
   // ARN of the IAM user
   arn string
@@ -2221,7 +2377,10 @@ private aws.iam.user @defaults("arn name createdAt") {
   loginProfile() aws.iam.loginProfile
   // Path to the user
   path string
-  // List of MFA devices (virtual and hardware) assigned to the user
+  // MFA devices (virtual and hardware) assigned to the user
+  //
+  // Each entry has the shape `{SerialNumber, EnableDate, UserName}`. For a
+  // virtual MFA device the SerialNumber is the device ARN.
   mfaDevices() []dict
   // Managed policy that sets the permissions boundary for the user, if one is set
   permissionsBoundary() aws.iam.policy
@@ -2229,11 +2388,11 @@ private aws.iam.user @defaults("arn name createdAt") {
 
 // IAM user access key
 //
-// Examine an access key belonging to an IAM user, including its activation
-// status and when it was last used. The createdAt and lastUsedDate fields
-// support auditing for unrotated keys (CIS access-key rotation) and unused
-// active keys that should be deactivated. The key is selected by its
-// accessKeyId, for example AKIAIOSFODNN7EXAMPLE.
+// Access key belonging to an IAM user, including its activation status and
+// when it was last used. The createdAt and lastUsedDate fields support
+// auditing for unrotated keys (CIS access-key rotation) and unused active
+// keys that should be deactivated. The key is selected by its accessKeyId,
+// for example AKIAIOSFODNN7EXAMPLE.
 private aws.iam.user.accessKey @defaults("accessKeyId status lastUsedDate") {
   // Access key ID
   accessKeyId string
@@ -2277,9 +2436,9 @@ private aws.iam.loginProfile @defaults("createdAt") {
 
 // Statement from an IAM or resource-based policy
 //
-// Examine a single statement parsed from a policy document. Each statement
-// pairs an effect (Allow or Deny) with the actions, resources, principals,
-// and conditions it covers, so you can audit wildcard actions, anonymous or
+// Single statement parsed from a policy document. Each statement pairs an
+// effect (Allow or Deny) with the actions, resources, principals, and
+// conditions it covers, so you can audit wildcard actions, anonymous or
 // cross-account principals, and missing condition keys without parsing the
 // raw JSON yourself. The same statement shape is reused across IAM policies,
 // role trust policies, and resource-based policies on KMS keys, S3 buckets,
@@ -2315,6 +2474,13 @@ private aws.iam.policyStatement @defaults("effect") {
 }
 
 // AWS IAM policy
+//
+// Managed IAM policy in the account, either AWS-managed or customer-managed,
+// including its versions, the default version's parsed statements, and the
+// users, roles, and groups it is attached to. The hasWildcardAllow field
+// flags policies whose default version grants wildcard actions or resources,
+// and scope distinguishes AWS-managed from local (customer-managed)
+// policies.
 private aws.iam.policy @defaults("arn name") {
   // ARN of the policy
   arn string
@@ -2362,7 +2528,10 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion createdAt") {
   versionId string
   // Whether this version is the policy default version
   isDefaultVersion bool
-  // JSON statements for this policy version
+  // Policy document for this version
+  //
+  // Raw policy JSON for this version. See statements for the parsed
+  // statement form.
   document() dict
   // Parsed statements for this policy version
   statements() []aws.iam.policyStatement
@@ -2371,6 +2540,14 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion createdAt") {
 }
 
 // AWS IAM role
+//
+// IAM role in the account, including its trust policy, attached and inline
+// permission policies, permissions boundary, and last-used activity. The
+// assumableByPublic and assumableByExternalAccounts fields flag trust
+// relationships that let outside principals assume the role, and
+// externalAccessFindings surfaces IAM Access Analyzer results for the role.
+// The role is selected by ARN or name, for example
+// aws.iam.role(name: "my-role").
 private aws.iam.role @defaults("arn name") {
   // ARN of the role
   arn string
@@ -2385,6 +2562,9 @@ private aws.iam.role @defaults("arn name") {
   // Time when the role was created
   createdAt time
   // Policy document that grants an entity permission to assume the role
+  //
+  // Raw trust policy JSON. See assumeRolePolicyStatements for the parsed
+  // statement form.
   assumeRolePolicyDocument dict
   // Parsed statements from the role trust policy
   assumeRolePolicyStatements() []aws.iam.policyStatement
@@ -2419,6 +2599,11 @@ private aws.iam.role @defaults("arn name") {
 }
 
 // AWS IAM group
+//
+// IAM group in the account, including the usernames of its members and the
+// inline and managed policies that grant those members permissions. The
+// group is selected by ARN or name, for example
+// aws.iam.group(name: "admins").
 private aws.iam.group @defaults("arn name") {
   // ARN of the group
   arn string
@@ -2482,12 +2667,11 @@ private aws.iam.oidcProvider @defaults("arn url") {
 
 // AWS IAM Access Analyzer
 //
-// Use the Access Analyzer namespace to enumerate analyzers and their
-// findings about external or unintended access to account resources.
-// Iterate `analyzers()` for every configured analyzer (account or
-// organization scope) across all enabled regions, `findings()` for the
-// active findings produced by those analyzers, and `archivedFindings()`
-// for findings that have been resolved or suppressed.
+// Analyzers and their findings about external or unintended access to
+// account resources. The analyzers collection lists every configured
+// analyzer (account or organization scope) across all enabled regions,
+// findings holds the active findings produced by those analyzers, and
+// archivedFindings holds findings that have been resolved or suppressed.
 aws.iam.accessAnalyzer @defaults("analyzers") {
   // List of `aws.iam.accessAnalyzer.analyzer` objects for all AWS IAM Access Analyzers configured within the account
   analyzers() []aws.iam.accessAnalyzer.analyzer
@@ -2497,7 +2681,7 @@ aws.iam.accessAnalyzer @defaults("analyzers") {
   archivedFindings() []aws.iam.accessAnalyzer.finding
 }
 
-// AWS IAM Access Analyzer resource (provides an object representing an individual AWS IAM Access Analyzer configuration)
+// AWS IAM Access Analyzer configuration
 private aws.iam.accessAnalyzer.analyzer @defaults("name type region status") {
   // ARN for the analyzer
   arn string
@@ -2549,12 +2733,11 @@ private aws.iam.accessAnalyzer.finding @defaults("resourceType region type statu
 
 // Amazon Personalize
 //
-// Use the Personalize namespace to enumerate real-time recommendation
-// infrastructure across all enabled regions: dataset groups and their
-// datasets, trained solutions and the campaigns that serve them, domain
-// recommenders, event trackers, filters, and dataset schemas. Iterate the
-// collection that matches what you want to audit, then traverse each row for
-// encryption keys, IAM service roles, and inference exposure.
+// Real-time recommendation infrastructure across all enabled regions: dataset
+// groups and their datasets, trained solutions and the campaigns that serve
+// them, domain recommenders, event trackers, filters, and dataset schemas.
+// Each row exposes encryption keys, IAM service roles, and inference exposure
+// for auditing the recommendation pipeline.
 aws.personalize {
   // Dataset groups in all enabled regions
   datasetGroups() []aws.personalize.datasetGroup
@@ -2773,15 +2956,14 @@ private aws.personalize.schema @defaults("name domain") {
 
 // Amazon SageMaker
 //
-// Use the SageMaker namespace to enumerate the building blocks of an
+// Managed machine-learning platform covering the building blocks of a
 // SageMaker workspace across all enabled regions: training and processing
 // jobs, models and inference endpoints, notebook instances, Studio domains
 // and user profiles, pipelines, feature groups, model packages, monitoring
 // schedules and data/model-quality job definitions, experiments and trials,
-// HyperPod clusters, AutoML and labeling jobs, and lineage entities. Iterate
-// the collection accessor that matches the workload you want to audit, then
-// traverse each row for IAM role bindings, KMS encryption, network isolation,
-// and lifecycle state.
+// HyperPod clusters, AutoML and labeling jobs, and lineage entities. Each
+// collection accessor lists one workload type, and every row exposes its IAM
+// role bindings, KMS encryption, network isolation, and lifecycle state.
 aws.sagemaker {
   // List of SageMaker endpoints
   endpoints() []aws.sagemaker.endpoint
@@ -2951,7 +3133,12 @@ private aws.sagemaker.endpoint @defaults("arn name") {
   arn string
   // Name of the endpoint
   name string
-  // Configuration information for the endpoint
+  // Raw endpoint configuration
+  //
+  // Complete configuration attached to this endpoint, including production
+  // variants, data-capture settings, the KMS key, and any async-inference
+  // configuration. The endpointConfigName, productionVariants, and
+  // dataCaptureConfig fields expose the same data in structured form.
   config() dict
   // Region where the endpoint exists
   region string
@@ -3047,7 +3234,7 @@ private aws.sagemaker.model @defaults("arn name") {
   primaryContainer() dict
   // Raw VPC configuration dict
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of the vpc field.
   vpcConfig() @maturity("deprecated") dict
   // VPC associated with this model
   vpc() aws.vpc
@@ -3115,7 +3302,7 @@ private aws.sagemaker.trainingjob @defaults("arn name status") {
   billableTimeInSeconds() int
   // Raw VPC configuration dict
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of the vpc field.
   vpcConfig() @maturity("deprecated") dict
   // VPC associated with this training job
   vpc() aws.vpc
@@ -3232,7 +3419,7 @@ private aws.sagemaker.processingjob @defaults("arn name status") {
   enableInterContainerTrafficEncryption() bool
   // Raw VPC configuration dict
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of the vpc field.
   vpcConfig() @maturity("deprecated") dict
   // VPC associated with this processing job
   vpc() aws.vpc
@@ -3889,12 +4076,12 @@ private aws.sagemaker.monitoringJobDefinition.networkConfig {
 
 // AWS SageMaker monitoring job definition
 //
-// Iterate every monitoring job definition in the account regardless of kind —
-// data quality, model quality, model bias, and model explainability — when an
-// audit applies the same check across all of them. The `type` field reports
-// which kind each entry is, and `networkConfig` exposes the network-isolation
-// and inter-container traffic-encryption settings. Use the kind-specific
-// collections such as `dataQualityJobDefinitions` for the full per-kind detail.
+// Monitoring job definition of any kind (data quality, model quality, model
+// bias, or model explainability), collected together for audits that apply
+// the same check across all of them. The `type` field reports which kind each
+// entry is, and `networkConfig` exposes the network-isolation and
+// inter-container traffic-encryption settings. The kind-specific collections
+// such as `dataQualityJobDefinitions` carry the full per-kind detail.
 private aws.sagemaker.monitoringJobDefinition @defaults("arn name type") {
   // ARN of the job definition
   arn string
@@ -4814,7 +5001,7 @@ private aws.sagemaker.flowDefinition @defaults("arn name status") {
 private aws.sagemaker.artifact @defaults("arn name artifactType") {
   // ARN of the artifact
   arn string
-  // Name of the artifact (may be empty — artifacts are primarily identified by ARN/URI)
+  // Name of the artifact (may be empty; artifacts are primarily identified by ARN or URI)
   name string
   // Type of the artifact (Model, DataSet, Image, etc.)
   artifactType string
@@ -5010,16 +5197,16 @@ private aws.sagemaker.lineageGroup @defaults("arn name") {
 
 // Amazon Simple Email Service (SES)
 //
-// Use the SES namespace to audit the email-sending posture of an account
-// across all enabled regions. Iterate `identities()` for every verified
-// sending identity (domain or email address) — each row surfaces its
-// verification status, DKIM signing configuration, custom MAIL FROM domain,
-// and feedback-forwarding setting, the controls that determine whether mail
-// the account sends can be authenticated and trusted by recipients. Iterate
-// `configurationSets()` for every configuration set that can be applied to a
-// send — each row surfaces the minimum TLS policy enforced on delivery,
-// whether sending and reputation tracking are enabled, the open/click
-// tracking redirect domain, and which suppression-list reasons are active.
+// Email-sending posture of an account across all enabled regions. The
+// `identities` collection covers every verified sending identity (domain or
+// email address), surfacing its verification status, DKIM signing
+// configuration, custom MAIL FROM domain, and feedback-forwarding setting,
+// the controls that determine whether mail the account sends can be
+// authenticated and trusted by recipients. The `configurationSets`
+// collection covers every reusable group of send-time rules, surfacing the
+// minimum TLS policy enforced on delivery, whether sending and reputation
+// tracking are enabled, the open/click tracking redirect domain, and which
+// suppression-list reasons are active.
 aws.ses {
   // List of SES email identities (verified domains and email addresses)
   identities() []aws.ses.identity
@@ -5029,14 +5216,13 @@ aws.ses {
 
 // SES email identity
 //
-// Examine a verified sending identity — a domain, managed domain, or
-// individual email address — and the authentication controls attached to it.
-// Each identity is keyed by its ARN — for example
+// Verified sending identity: a domain, managed domain, or individual email
+// address, and the authentication controls attached to it. Each identity is
+// keyed by its ARN, for example
 // `aws.ses.identity(arn: "arn:aws:ses:us-east-1:123456789012:identity/example.com")`.
-// The `name`, `identityType`, `verificationStatus`, and `verifiedForSending`
-// fields come from the identity listing; the DKIM signing configuration,
-// custom MAIL FROM domain, feedback-forwarding setting, authorization
-// policies, and tags are read from the identity's full record.
+// The DKIM signing configuration, custom MAIL FROM domain, feedback-forwarding
+// setting, and authorization policies together determine whether mail sent
+// from this identity can be authenticated and trusted by recipients.
 private aws.ses.identity @defaults("name identityType verificationStatus verifiedForSending region") {
   // ARN of the identity
   arn string
@@ -5076,11 +5262,11 @@ private aws.ses.identity @defaults("name identityType verificationStatus verifie
 
 // SES configuration set
 //
-// Examine a configuration set — the reusable group of rules that can be
-// applied when sending email. Each configuration set is keyed by its ARN — for
-// example `aws.ses.configurationSet(arn: "arn:aws:ses:us-east-1:123456789012:configuration-set/my-config-set")`,
-// and can also be looked up by `name` — and exposes the minimum TLS policy
-// enforced on delivery, whether sending and reputation metrics are enabled, the
+// Reusable group of rules that can be applied when sending email. Each
+// configuration set is keyed by its ARN, for example
+// `aws.ses.configurationSet(arn: "arn:aws:ses:us-east-1:123456789012:configuration-set/my-config-set")`,
+// and can also be looked up by `name`. Exposes the minimum TLS policy enforced
+// on delivery, whether sending and reputation metrics are enabled, the
 // open/click tracking redirect domain and its HTTPS policy, and which
 // suppression-list reasons (bounces, complaints) are active.
 private aws.ses.configurationSet @defaults("name region") {
@@ -5110,18 +5296,25 @@ private aws.ses.configurationSet @defaults("name region") {
 
 // Amazon Simple Notification Service (SNS)
 //
-// Use the SNS namespace to enumerate publish/subscribe messaging topics
-// across all enabled regions. Iterate `topics()` for every SNS topic — each
-// row surfaces topic attributes, the access policy, KMS encryption key, FIFO
-// configuration, content-based deduplication, X-Ray tracing settings, the
-// data protection policy, the delivery policy, and the subscriptions
-// attached to the topic.
+// Publish/subscribe messaging topics across all enabled regions. Each
+// topic in `topics` carries its access policy, KMS encryption key, FIFO
+// settings, data protection policy, and attached subscriptions, so you can
+// audit which topics are publicly accessible, unencrypted, or delivering
+// to unconfirmed or cross-account endpoints.
 aws.sns {
   // List of SNS topics
   topics() []aws.sns.topic
 }
 
-// AWS Simple Notification Service (SNS) topic
+// Amazon SNS topic
+//
+// Publish/subscribe messaging topic identified by its `arn`. The topic
+// exposes its resource access policy and parsed policy statements, a
+// derived `isPublic` flag, the KMS key used for server-side encryption,
+// FIFO and content-based deduplication settings, the data protection
+// policy, and the subscriptions delivering its messages. Use it to find
+// topics that allow public or cross-account publishing or that lack
+// encryption at rest.
 private aws.sns.topic @defaults("arn") {
   // SNS topic ARN
   arn string
@@ -5129,7 +5322,14 @@ private aws.sns.topic @defaults("arn") {
   region string
   // List of subscriptions associated with the topic ARN
   subscriptions() []aws.sns.subscription
-  // Attributes for the SNS topic, including KMS ID if any
+  // Raw topic attribute map
+  //
+  // The complete set of topic attributes as returned by SNS, including
+  // Policy, Owner, DisplayName, KmsMasterKeyId, FifoTopic,
+  // ContentBasedDeduplication, SignatureVersion, TracingConfig,
+  // EffectiveDeliveryPolicy, and the SubscriptionsConfirmed,
+  // SubscriptionsPending, and SubscriptionsDeleted counts. Most values are
+  // also surfaced as dedicated fields on this resource.
   attributes() dict
   // Tags for the topic
   tags() map[string]string
@@ -5139,7 +5339,12 @@ private aws.sns.topic @defaults("arn") {
   owner() string
   // KMS master key used for server-side encryption
   kmsMasterKey() aws.kms.key
-  // Access policy for the topic (parsed JSON)
+  // Topic access policy
+  //
+  // Resource-based access policy controlling who may publish to or
+  // subscribe to the topic, parsed from JSON into the Version, Id, and
+  // Statement keys. See `policyStatements` for the individual statements
+  // and `isPublic` for whether any statement grants public access.
   policy() dict
   // Parsed statements from the topic access policy
   policyStatements() []aws.iam.policyStatement
@@ -5151,17 +5356,40 @@ private aws.sns.topic @defaults("arn") {
   fifoTopic() bool
   // Whether content-based deduplication is enabled (FIFO topics only)
   contentBasedDeduplication() bool
-  // Data protection policy for the topic (parsed JSON)
+  // Data protection policy
+  //
+  // Policy that inspects, de-identifies, or blocks sensitive data in
+  // messages published to the topic, parsed from JSON. Top-level keys are
+  // Name, Description, Version, and Statement, where each statement carries
+  // DataDirection, DataIdentifier, and an Operation such as Audit,
+  // Deidentify, or Deny.
   dataProtectionPolicy() dict
-  // AWS X-Ray tracing configuration for the topic
+  // Active tracing configuration for X-Ray
+  //
+  // Either PassThrough (only messages that already carry a trace header
+  // are traced) or Active (SNS generates a trace header for every
+  // published message).
   tracingConfig() string
-  // Delivery policy for HTTP/S subscriptions at the topic level (parsed JSON)
+  // Topic-level delivery policy
+  //
+  // Retry and throttle settings applied to HTTP/S subscriptions of the
+  // topic, parsed from JSON. The http key holds defaultHealthyRetryPolicy
+  // (numRetries, minDelayTarget, maxDelayTarget, backoffFunction),
+  // disableSubscriptionOverrides, and defaultThrottlePolicy
+  // (maxReceivesPerSecond).
   deliveryPolicy() dict
   // Display name used for SMS or email subscriptions
   displayName() string
 }
 
-// AWS Simple Notification Service (SNS) subscription
+// Amazon SNS subscription
+//
+// Endpoint subscribed to an SNS topic, identified by its `arn`. The
+// subscription records its protocol and destination endpoint, whether the
+// confirmation was authenticated, its message filter policy and scope, raw
+// message delivery, and any dead-letter redrive policy. Use it to find
+// unconfirmed subscriptions, cross-account endpoints, or topics delivering
+// to unexpected destinations.
 private aws.sns.subscription @defaults("arn") {
   // ARN of the subscription
   arn string
@@ -5175,19 +5403,41 @@ private aws.sns.subscription @defaults("arn") {
   topic() aws.sns.topic
   // Region of the subscription
   region string
-  // All subscription attributes
+  // Raw subscription attribute map
+  //
+  // The complete set of subscription attributes as returned by SNS,
+  // including SubscriptionArn, TopicArn, Protocol, Endpoint, Owner,
+  // ConfirmationWasAuthenticated, PendingConfirmation, RawMessageDelivery,
+  // FilterPolicy, FilterPolicyScope, RedrivePolicy, and DeliveryPolicy.
+  // Most values are also surfaced as dedicated fields on this resource.
   attributes() dict
   // Whether raw message delivery is enabled (no SNS metadata wrapper)
   rawMessageDelivery() bool
-  // Filter policy for message filtering
+  // Message filter policy
+  //
+  // Policy that limits which messages reach the subscription, parsed from
+  // JSON. Keys are message attribute names (or message body fields, per
+  // `filterPolicyScope`) and values are arrays of accepted values or
+  // matching operators such as prefix, anything-but, or numeric ranges.
+  // Empty when the subscription receives every message.
   filterPolicy() dict
   // Scope of the filter policy: MessageAttributes or MessageBody
   filterPolicyScope() string
-  // Dead-letter queue configuration
+  // Dead-letter queue redrive policy
+  //
+  // Configuration directing undeliverable messages to an SQS dead-letter
+  // queue, parsed from JSON. The deadLetterTargetArn key holds the ARN of
+  // the target queue. Empty when no dead-letter queue is configured.
   redrivePolicy() dict
   // Whether the subscription confirmation was authenticated
   confirmationWasAuthenticated() bool
-  // Delivery policy for retries
+  // Subscription delivery policy
+  //
+  // Retry and throttle settings for delivering messages to the
+  // subscription endpoint, parsed from JSON. Includes healthyRetryPolicy
+  // (numRetries, minDelayTarget, maxDelayTarget, backoffFunction),
+  // sicklyRetryPolicy, throttlePolicy (maxReceivesPerSecond), and
+  // guaranteed.
   deliveryPolicy() dict
   // Whether the subscription is confirmed
   pendingConfirmation() bool
@@ -5195,18 +5445,24 @@ private aws.sns.subscription @defaults("arn") {
 
 // Amazon Elasticsearch Service (legacy)
 //
-// Use the Elasticsearch namespace to enumerate the legacy Amazon
-// Elasticsearch Service domains in the account. Iterate `domains()` for each
-// domain and read its endpoint, engine version, encryption-at-rest and
-// node-to-node settings, HTTPS enforcement, TLS policy, and audit-log
-// configuration. New deployments live under the OpenSearch namespace
-// (`aws.opensearch`).
+// Legacy Amazon Elasticsearch Service domains in the account, reached
+// through `domains`. Each domain exposes its endpoint, engine version,
+// encryption-at-rest and node-to-node encryption settings, HTTPS
+// enforcement, TLS security policy, and audit-log configuration, so search
+// clusters can be audited for public exposure and weak transport security.
+// New deployments live under the OpenSearch namespace (`aws.opensearch`).
 aws.es {
   // List of Elasticsearch domains
   domains() []aws.es.domain
 }
 
 // Amazon Elasticsearch service domain
+//
+// A single legacy Elasticsearch domain, covering its cluster topology,
+// storage, encryption, network placement, access policy, and log-publishing
+// configuration. Reveals whether the domain enforces HTTPS, encrypts data
+// at rest and node-to-node, is confined to a VPC, and whether its access
+// policy leaves it reachable from the public internet (see `isPublic`).
 private aws.es.domain @defaults("arn name") {
   // ARN for the Elasticsearch domain
   arn string
@@ -5220,7 +5476,11 @@ private aws.es.domain @defaults("arn name") {
   name string
   // Endpoint used to submit index and search requests
   endpoint string
-  // VPC and internal endpoints used to submit index and search requests
+  // Endpoints used to submit index and search requests
+  //
+  // Keyed by endpoint type (for example `vpc` for a VPC-deployed domain),
+  // with the resolvable hostname as the value. See `endpoint` for the single
+  // primary endpoint of a public domain.
   endpoints map[string]string
   // Region where the domain exists
   region string
@@ -5392,17 +5652,26 @@ private aws.es.domain @defaults("arn name") {
 
 // Amazon OpenSearch Service
 //
-// Use the OpenSearch namespace to enumerate managed OpenSearch and legacy
-// Elasticsearch (OpenSearch-compatible) domains in the account. Iterate
-// `domains()` for each domain and traverse its endpoint, engine version,
-// encryption-at-rest, node-to-node encryption, HTTPS enforcement, TLS
-// security policy, and audit-log configuration.
+// Managed OpenSearch and legacy Elasticsearch (OpenSearch-compatible)
+// domains in the account. The `domains` field enumerates every domain so
+// you can audit its endpoint, engine version, encryption at rest,
+// node-to-node encryption, HTTPS enforcement, TLS security policy, and
+// audit-log configuration.
 aws.opensearch @defaults("domains") {
   // List of OpenSearch domains
   domains() []aws.opensearch.domain
 }
 
 // Amazon OpenSearch Service domain
+//
+// A single managed OpenSearch or legacy Elasticsearch domain, covering its
+// search cluster topology, network placement, and the security controls
+// that protect the data it holds: encryption at rest and its KMS key,
+// node-to-node encryption, HTTPS enforcement, the negotiated TLS security
+// policy, fine-grained access control, SAML and JWT authentication, and
+// audit logging. Also reports service software currency and the domain's
+// VPC, subnets, and security groups. Selected through the `domains` field
+// on the OpenSearch namespace.
 private aws.opensearch.domain @defaults("name engineVersion") {
   // ARN for the OpenSearch domain
   arn string
@@ -5471,7 +5740,11 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   vpcEgressEnabled bool
   // Whether HTTPS is required
   enforceHTTPS bool
-  // TLS security policy
+  // Minimum TLS security policy
+  //
+  // Minimum TLS version the domain endpoint negotiates. One of
+  // Policy-Min-TLS-1-0-2019-07, Policy-Min-TLS-1-2-2019-07, or
+  // Policy-Min-TLS-1-2-PFS-2023-10.
   tlsSecurityPolicy string
   // Whether a custom endpoint is enabled for the domain
   customEndpointEnabled bool
@@ -5497,7 +5770,11 @@ private aws.opensearch.domain @defaults("name engineVersion") {
   upgradeProcessing bool
   // Created timestamp
   createdAt time
-  // Whether auto-tune is enabled
+  // Auto-Tune state
+  //
+  // One of ENABLED, DISABLED, ENABLE_IN_PROGRESS, DISABLE_IN_PROGRESS,
+  // DISABLED_AND_ROLLBACK_SCHEDULED, DISABLED_AND_ROLLBACK_IN_PROGRESS,
+  // DISABLED_AND_ROLLBACK_COMPLETE, DISABLED_AND_ROLLBACK_ERROR, or ERROR.
   autoTuneState string
   // Whether audit logging is enabled for the domain
   auditLogEnabled bool
@@ -5553,18 +5830,25 @@ private aws.opensearch.domain @defaults("name engineVersion") {
 
 // AWS Certificate Manager (ACM)
 //
-// Use the ACM namespace to enumerate TLS certificates issued or imported
-// in the account. Iterate `certificates()` for every ACM certificate across
-// all enabled regions — each row surfaces the domain name, issuer, source
-// (AMAZON_ISSUED or IMPORTED), validity window, status, key and signature
-// algorithms, the parsed `network.certificate`, and the renewal posture
-// needed to audit certificate hygiene.
+// TLS certificates issued or imported into the account. The `certificates`
+// field enumerates every ACM certificate across all enabled regions, each
+// row surfacing the domain name, issuer, source (AMAZON_ISSUED or IMPORTED),
+// validity window, status, key and signature algorithms, the parsed
+// certificate, and the renewal posture needed to audit certificate hygiene
+// and impending expiry.
 aws.acm @defaults("certificates") {
   // List of ACM certificates configured within the account
   certificates() []aws.acm.certificate
 }
 
-// AWS Certificate Manager Certificate resource (provides an object representing an individual ACM certificate)
+// AWS Certificate Manager certificate
+//
+// An individual ACM certificate, whether issued by Amazon or imported. The
+// domain it secures, its validity window and status, the issuing authority,
+// key and signature algorithms, and the AWS resources currently using it (see
+// inUseBy) are all queryable, along with the parsed `certificate` and the
+// per-domain validation records used to audit expiry, renewal eligibility,
+// and certificate coverage.
 private aws.acm.certificate @defaults("domainName issuer createdAt notAfter") {
   // ARN for the certificate
   arn string
@@ -5576,7 +5860,10 @@ private aws.acm.certificate @defaults("domainName issuer createdAt notAfter") {
   createdAt time
   // FQDN for the certificate
   domainName string
-  // Status of the certificate: issued, expired, revoked, and so on
+  // Certificate status
+  //
+  // One of PENDING_VALIDATION, ISSUED, INACTIVE, EXPIRED,
+  // VALIDATION_TIMED_OUT, REVOKED, or FAILED.
   status string
   // Name of the entity associated with the public key in the certificate
   subject string
@@ -5588,7 +5875,9 @@ private aws.acm.certificate @defaults("domainName issuer createdAt notAfter") {
   keyAlgorithm string
   // Serial number of the certificate
   serial string
-  // Source of the certificate: AMAZON_ISSUED or IMPORTED
+  // Certificate source
+  //
+  // How the certificate entered ACM: AMAZON_ISSUED, IMPORTED, or PRIVATE.
   source string
   // Name of the certificate authority that issued and signed the certificate
   issuer string
@@ -5602,23 +5891,41 @@ private aws.acm.certificate @defaults("domainName issuer createdAt notAfter") {
   signatureAlgorithm string
   // ARNs of AWS resources the certificate is associated with (load balancers, CloudFront distributions, and so on)
   inUseBy []string
-  // Per-domain validation details, including validation method, status, and DNS validation records
+  // Per-domain validation details
+  //
+  // One entry per domain covered by the certificate. Each dict carries
+  // `DomainName`, the `ValidationMethod` (DNS or EMAIL), the
+  // `ValidationStatus` (PENDING_VALIDATION, SUCCESS, or FAILED),
+  // `ValidationDomain`, `ValidationEmails`, and for DNS validation a
+  // `ResourceRecord` holding the `Name`, `Type`, and `Value` of the CNAME
+  // record to publish.
   domainValidationOptions []dict
 }
 
 // Amazon EC2 Auto Scaling
 //
-// Use the Auto Scaling namespace to enumerate EC2 Auto Scaling groups in
-// the account. Iterate `groups()` for every ASG across all enabled regions
-// — each row surfaces the launch template or configuration, attached load
-// balancers and target groups, capacity bounds (min/max/desired), instance
-// distribution across availability zones, and lifecycle hooks.
+// EC2 Auto Scaling groups in the account across all enabled regions,
+// exposed through `groups`. Each group carries the launch template or
+// launch configuration it scales from, attached load balancers and
+// target groups, capacity bounds (minSize, maxSize, desiredCapacity),
+// instance distribution across availability zones, and lifecycle hooks,
+// so you can audit the scaling posture and network exposure of the
+// instances an account launches dynamically.
 aws.autoscaling @defaults("groups") {
   // List of autoscaling groups across the account
   groups() []aws.autoscaling.group
 }
 
-// AWS Auto Scaling group
+// Amazon EC2 Auto Scaling group
+//
+// Single EC2 Auto Scaling group and the policy that governs how it grows
+// and shrinks: capacity bounds (minSize, maxSize, desiredCapacity), the
+// launchTemplate or launchConfiguration new instances inherit, health
+// check type and grace period, termination policies, instance protection
+// from scale-in, and the load balancers and target groups it registers
+// instances with. Useful for confirming that dynamically launched
+// capacity carries the intended network exposure, IAM role, and
+// resilience settings.
 private aws.autoscaling.group @defaults("name region minSize maxSize") {
   // ARN for the autoscaling group
   arn string
@@ -5728,12 +6035,12 @@ private aws.autoscaling.group.tag @defaults("key value propagateAtLaunch") {
 
 // AWS Elastic Load Balancing (ELB)
 //
-// Use the ELB namespace to enumerate load balancers in the account across
-// all enabled regions. Iterate `loadBalancers()` for application, gateway,
-// and network load balancers (ELBv2), and `classicLoadBalancers()` for the
-// legacy Classic Load Balancers (ELBv1). Each row surfaces the listeners,
-// target groups, attached security groups and subnets, scheme (internet-facing
-// vs internal), and access-log configuration.
+// Load balancers in the account across all enabled regions. The
+// loadBalancers list covers application, gateway, and network load
+// balancers (ELBv2), and classicLoadBalancers covers the legacy Classic
+// Load Balancers (ELBv1). Each row surfaces the listeners, target groups,
+// attached security groups and subnets, scheme (internet-facing vs
+// internal), and access-log configuration.
 aws.elb {
   // List of classic load balancers
   classicLoadBalancers() []aws.elb.loadbalancer
@@ -5833,13 +6140,25 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   arn string
   // DNS name for the load balancer
   dnsName string
-  // List of listener configurations for the load balancer
+  // Listener configurations
+  //
+  // Raw listener descriptions as returned by the load balancer API. The
+  // shape differs between Classic Load Balancers and ELBv2 load balancers.
+  // For a normalized view with resolved default actions and certificates,
+  // use the listeners field.
   listenerDescriptions() []dict
   // User-specified name for the load balancer
   name string
   // Scheme for the load balancer: internet-facing or internal
   scheme string
-  // A list of attributes for the load balancer
+  // Load balancer attributes
+  //
+  // Raw attribute set as returned by the load balancer API. For Classic
+  // Load Balancers this is a single dict carrying the AccessLog,
+  // ConnectionDraining, ConnectionSettings, and CrossZoneLoadBalancing
+  // entries; for ELBv2 load balancers it is a list of Key and Value pairs.
+  // For a normalized, named view of the same settings, use the attribute
+  // field.
   attributes() []dict
   // Date and time the load balancer was created
   createdAt time
@@ -5889,7 +6208,15 @@ private aws.elb.loadbalancer @defaults("name region elbType scheme dnsName") {
   enforcesTls() bool
   // Typed attributes for ALB/NLB load balancers
   attribute() aws.elb.loadbalancer.attribute
-  // Health check configuration (classic load balancers only; null for ALB/NLB)
+  // Classic load balancer health check
+  //
+  // Health check configuration for a Classic Load Balancer, null for
+  // application, gateway, and network load balancers (which run health
+  // checks per target group). Dict keys are `Target` (the protocol, port,
+  // and path probed, for example `HTTP:80/index.html`), `Interval`
+  // (seconds between checks), `Timeout` (seconds before a check is
+  // considered failed), `HealthyThreshold`, and `UnhealthyThreshold` (the
+  // consecutive check counts required to change state).
   healthCheck dict
 }
 
@@ -5928,6 +6255,14 @@ private aws.elb.listener @defaults("arn port protocol") {
   // SSL policy for HTTPS/TLS listeners
   sslPolicy string
   // Default actions for the listener
+  //
+  // Actions the listener applies to requests that match no rule. Each dict
+  // has a `Type` (`forward`, `redirect`, `fixed-response`,
+  // `authenticate-cognito`, or `authenticate-oidc`), an `Order`, and the
+  // config block for that type (`TargetGroupArn` or `ForwardConfig`,
+  // `RedirectConfig`, `FixedResponseConfig`, `AuthenticateCognitoConfig`,
+  // or `AuthenticateOidcConfig`). For the forward targets resolved to
+  // typed resources, use the forwardTargetGroups field.
   defaultActions []dict
   // Target groups this listener forwards to by default
   //
@@ -5937,6 +6272,10 @@ private aws.elb.listener @defaults("arn port protocol") {
   // action does not forward (for example a redirect or fixed-response action).
   forwardTargetGroups() []aws.elb.targetgroup
   // Server certificates for the listener
+  //
+  // Certificates presented by an HTTPS or TLS listener. Each dict has
+  // `CertificateArn` (the ACM or IAM server certificate) and `IsDefault`
+  // (whether it is served when no SNI host name matches).
   certificates []dict
   // ALPN policy for TLS listeners
   alpnPolicy []string
@@ -5948,7 +6287,10 @@ private aws.elb.loadbalancer.attribute {
   loadBalancerArn string
   // Whether deletion protection is enabled
   deletionProtectionEnabled bool
-  // Whether cross-zone load balancing is enabled
+  // Cross-zone load balancing setting
+  //
+  // Value of the `load_balancing.cross_zone.enabled` attribute, either
+  // `true` or `false`. Always `true` for application load balancers.
   crossZoneEnabled string
   // Whether access logs are enabled
   accessLogsEnabled bool
@@ -5978,13 +6320,13 @@ private aws.elb.loadbalancer.attribute {
 
 // AWS CodeBuild
 //
-// Use the CodeBuild namespace to enumerate build and test projects in the
-// account across all enabled regions. Iterate `projects()` for every
-// CodeBuild project — each row surfaces the source provider, build
-// environment (image, compute type, environment variables), service role,
-// VPC and security-group configuration, artifact destinations, and
-// CloudWatch log settings. Iterate `reportGroups()` for the test and code
-// coverage report groups produced by builds, including their S3 export
+// Managed continuous integration service that compiles source, runs tests,
+// and produces deployable artifacts. The `projects` collection covers every
+// build project across enabled regions, each carrying its source provider,
+// build environment (image, compute type, environment variables), service
+// role, VPC and security-group configuration, artifact destinations, and
+// CloudWatch log settings. The `reportGroups` collection covers the test and
+// code coverage report groups produced by builds, including their S3 export
 // destinations.
 aws.codebuild {
   // List of build projects
@@ -5994,6 +6336,15 @@ aws.codebuild {
 }
 
 // AWS CodeBuild project
+//
+// Build project definition that ties a source repository to a build
+// environment and output artifacts. Projects carry several hardening-relevant
+// settings: whether builds run in Docker `privilegedMode`, whether
+// `projectVisibility` exposes build logs publicly (PUBLIC_READ vs PRIVATE),
+// the IAM `serviceRole` and `resourceAccessRole` granted to builds, the KMS
+// key used to encrypt output artifacts, the VPC and security groups build
+// containers attach to, and the environment variables passed to builds (which
+// may reference Parameter Store or Secrets Manager values).
 private aws.codebuild.project @defaults("arn name") {
   // ARN for the project
   arn string
@@ -6001,11 +6352,23 @@ private aws.codebuild.project @defaults("arn name") {
   description string
   // Name of the project
   name string
-  // Build environment information about the project
+  // Raw build environment configuration
+  //
+  // Keys are `Type`, `Image`, `ComputeType`, `Certificate`,
+  // `ComputeConfiguration`, `DockerServer`, `EnvironmentVariables`, `Fleet`,
+  // `ImagePullCredentialsType`, `PrivilegedMode`, and `RegistryCredential`.
+  // The same values are also exposed flattened as environmentType,
+  // environmentImage, environmentComputeType, and environmentVariables.
   environment dict
   // Region where the project exists
   region string
-  // Source used for the build project
+  // Raw primary source configuration
+  //
+  // Keys are `Type`, `Location`, `GitCloneDepth`, `Buildspec`, `Auth`,
+  // `BuildStatusConfig`, `GitSubmodulesConfig`, `InsecureSsl`,
+  // `ReportBuildStatus`, and `SourceIdentifier`. The same values are also
+  // exposed flattened as sourceType, sourceLocation, sourceBuildspec, and the
+  // related source fields.
   source dict
   // Tags for the project
   tags map[string]string
@@ -6048,6 +6411,10 @@ private aws.codebuild.project @defaults("arn name") {
   // S3 bucket owner access mode for primary artifacts: NONE, READ_ONLY, or FULL
   artifactsBucketOwnerAccess string
   // Secondary build output artifact configurations
+  //
+  // Each entry has `Type`, `Location`, `Name`, `NamespaceType`, `Packaging`,
+  // `Path`, `ArtifactIdentifier`, `BucketOwnerAccess`, `EncryptionDisabled`,
+  // and `OverrideArtifactName`.
   secondaryArtifacts []dict
   // Type of cache used by the build project: NO_CACHE, S3, or LOCAL
   cacheType string
@@ -6112,10 +6479,22 @@ private aws.codebuild.project @defaults("arn name") {
   // Identifier for the primary project source
   sourceIdentifier string
   // Secondary build input source configurations
+  //
+  // Each entry has `Type`, `Location`, `GitCloneDepth`, `Buildspec`, `Auth`,
+  // `BuildStatusConfig`, `GitSubmodulesConfig`, `InsecureSsl`,
+  // `ReportBuildStatus`, and `SourceIdentifier`.
   secondarySources []dict
   // Webhook configuration that connects repository events to this build project
+  //
+  // Keys are `Url`, `PayloadUrl`, `Secret`, `BranchFilter`, `FilterGroups`,
+  // `BuildType`, `ManualCreation`, `ScopeConfiguration`,
+  // `PullRequestBuildPolicy`, `LastModifiedSecret`, `Status`, and
+  // `StatusMessage`.
   webhook dict
   // Batch build configuration for the project
+  //
+  // Keys are `ServiceRole`, `CombineArtifacts`, `Restrictions`,
+  // `TimeoutInMins`, and `BatchReportMode`.
   buildBatchConfig dict
   // Maximum number of concurrent builds allowed for this project
   concurrentBuildLimit int
@@ -6159,6 +6538,13 @@ private aws.codebuild.project @defaults("arn name") {
 }
 
 // AWS CodeBuild report group
+//
+// Container for the test or code coverage reports that builds generate. The
+// `type` field selects whether the group collects TEST or CODE_COVERAGE
+// results, and the export configuration determines whether those reports are
+// retained in S3 (`exportConfigType` of S3) or kept only within CodeBuild
+// (NO_EXPORT). Audit report groups to confirm exported results land in an
+// encrypted bucket you control.
 private aws.codebuild.reportGroup @defaults("arn name type status") {
   // ARN for the report group
   arn string
@@ -6188,14 +6574,13 @@ private aws.codebuild.reportGroup @defaults("arn name type status") {
 
 // AWS CodePipeline
 //
-// Use the CodePipeline namespace to enumerate continuous delivery
-// pipelines and the webhooks that trigger them. Iterate `pipelines()` for
-// every pipeline across enabled regions — each row carries the pipeline
-// type (V1 or V2), execution mode, IAM service role, single- and
-// cross-region artifact stores, stage and action declarations (including
-// per-action configuration, input/output artifacts, and run order), Git
-// trigger filters, and pipeline-level variables. Iterate `webhooks()` to
-// surface the inbound webhook definitions that start pipelines, their
+// Continuous delivery pipelines and the webhooks that trigger them.
+// `pipelines` lists every pipeline across enabled regions, each carrying
+// the pipeline type (V1 or V2), execution mode, IAM service role, single-
+// and cross-region artifact stores, stage and action declarations
+// (including per-action configuration, input/output artifacts, and run
+// order), Git trigger filters, and pipeline-level variables. `webhooks`
+// surfaces the inbound webhook definitions that start pipelines, their
 // JsonPath filter rules, authentication mode (GITHUB_HMAC, IP,
 // UNAUTHENTICATED), allowed IP range, and last-triggered timestamp.
 aws.codepipeline {
@@ -6207,7 +6592,7 @@ aws.codepipeline {
 
 // AWS CodePipeline pipeline
 //
-// Examine a single CodePipeline pipeline — its type and execution mode,
+// A single CodePipeline pipeline, including its type and execution mode,
 // the IAM service role used to execute actions, the artifact store(s)
 // that hold stage outputs, and the ordered stages and actions that make
 // up the pipeline. For V2 pipelines, `triggers` carries the Git
@@ -6263,7 +6648,7 @@ private aws.codepipeline.pipeline @defaults("arn name pipelineType region") {
 
 // AWS CodePipeline webhook
 //
-// Examine an inbound webhook that starts a CodePipeline pipeline. The
+// An inbound webhook that starts a CodePipeline pipeline. The
 // `authentication` field reports how incoming requests are validated
 // (GITHUB_HMAC, IP, or UNAUTHENTICATED). For security, the raw
 // GITHUB_HMAC secret token is not exposed; `secretTokenPresent` reports
@@ -6310,16 +6695,12 @@ private aws.codepipeline.webhook @defaults("name arn authentication region") {
 
 // AWS CodeArtifact
 //
-// Use the CodeArtifact namespace to enumerate package repositories and
-// the domains that group them. Iterate `domains()` for every CodeArtifact
-// domain across enabled regions — each row reports the domain's owning
-// account, status, KMS encryption key, repository count, total asset
-// size, the backing S3 bucket ARN, and the JSON resource policy that
-// governs cross-account access. Iterate `repositories()` for every
-// repository in every domain — each row carries the repository
-// description, configured upstream repositories, external connections
-// (npm, pypi, maven, nuget, generic, ruby, swift, cargo), package-format
-// endpoint URLs, and the JSON resource policy applied to the repository.
+// CodeArtifact namespace covering the account's package repositories and
+// the domains that group them. The `domains` list reports every
+// CodeArtifact domain across enabled regions, and `repositories` lists
+// every repository in every domain. Query this to audit the KMS
+// encryption, resource policies, upstream chains, and public-registry
+// connections that govern cross-account access to packages.
 aws.codeartifact {
   // List of CodeArtifact domains across all enabled regions
   domains() []aws.codeartifact.domain
@@ -6329,11 +6710,12 @@ aws.codeartifact {
 
 // AWS CodeArtifact domain
 //
-// Examine a CodeArtifact domain — the logical container for package
-// repositories. A domain is encrypted by a single KMS key and is backed
-// by an internal S3 bucket. The `policy()` accessor fetches the resource
-// policy attached to the domain via `GetDomainPermissionsPolicy`; it
-// returns null when no policy is set or the caller is denied access.
+// CodeArtifact domain, the logical container that groups package
+// repositories and holds their shared configuration. A domain is
+// encrypted by a single KMS key (see `kmsKey`) and backed by an internal
+// S3 bucket (see `s3Bucket`). The `policy` resource policy governs
+// cross-account access to the domain and its repositories, and is null
+// when no policy is attached or the caller is denied access.
 private aws.codeartifact.domain @defaults("arn name owner status region") {
   // ARN of the domain
   arn string
@@ -6371,18 +6753,15 @@ private aws.codeartifact.domain @defaults("arn name owner status region") {
 
 // AWS CodeArtifact repository
 //
-// Examine a CodeArtifact repository — a single package repository inside
-// a domain. The repository holds package assets in one or more package
-// formats (npm, pypi, maven, nuget, generic, ruby, swift, cargo) and can
-// be configured with `upstreams` (other CodeArtifact repositories in the
-// same domain that callers fall through to on a cache miss) and
-// `externalConnections` (public package registries such as
-// `public:npmjs` or `public:pypi` that the repository ingests packages
-// from). The `policy()` accessor fetches the resource policy attached to
-// the repository via `GetRepositoryPermissionsPolicy`; it returns null
-// when no policy is set or the caller is denied access. The `endpoints`
-// map carries the per-package-format URL clients use to interact with
-// the repository.
+// CodeArtifact repository, a single package store inside a domain. The
+// repository holds package assets in one or more formats (npm, pypi,
+// maven, nuget, generic, ruby, swift, cargo). On a cache miss it falls
+// through to other repositories in the same domain listed in `upstreams`
+// and ingests from public registries such as `public:npmjs` declared in
+// `externalConnections`. The `policy` resource policy controls who can
+// read and publish packages, and is null when no policy is attached or
+// the caller is denied access. The `endpoints` map carries the
+// per-format URL clients use to reach the repository.
 private aws.codeartifact.repository @defaults("arn name domainName region") {
   // ARN of the repository
   arn string
@@ -6424,11 +6803,12 @@ private aws.codeartifact.repository @defaults("arn name domainName region") {
 
 // Amazon GuardDuty
 //
-// Use the GuardDuty namespace to enumerate threat-detection coverage and
-// findings in the account. Iterate `detectors()` for the per-region detector
-// configurations (each carrying its enabled features such as S3 protection,
-// EKS audit-log monitoring, malware protection, and runtime monitoring), and
-// `findings()` for the active findings produced across regions.
+// Threat-detection coverage and findings for the account. The `detectors`
+// list carries the per-region detector configurations, each with its enabled
+// protection features such as S3 protection, EKS audit-log monitoring, malware
+// protection, and runtime monitoring, while `findings` exposes the active
+// findings produced across regions. Query this to confirm GuardDuty is enabled
+// everywhere it should be and to review outstanding threat findings.
 aws.guardduty {
   // List of GuardDuty active findings
   findings() []aws.guardduty.finding
@@ -6486,7 +6866,12 @@ private aws.guardduty.detector.feature @defaults("name status") {
   status string
   // Time when the feature was last updated
   updatedAt time
-  // Additional configuration for sub-features (varies per feature)
+  // Sub-feature configuration
+  //
+  // Per sub-feature enablement carried under a protection feature. Each entry
+  // has `Name` (the sub-feature: EKS_ADDON_MANAGEMENT,
+  // ECS_FARGATE_AGENT_MANAGEMENT, or EC2_AGENT_MANAGEMENT), `Status` (ENABLED
+  // or DISABLED), and `UpdatedAt` (time of last change).
   additionalConfiguration []dict
 }
 
@@ -6556,7 +6941,12 @@ private aws.guardduty.detector.filter @defaults("name action") {
   description() string
   // Filter rank (1-100, lower ranks are applied first)
   rank() int
-  // Finding criteria for the filter
+  // Finding filter criteria
+  //
+  // Criteria that select which findings the filter matches. The `Criterion`
+  // key maps each finding property (such as `severity` or `type`) to a
+  // condition object with operators including `Equals`, `NotEquals`,
+  // `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, and `LessThanOrEqual`.
   findingCriteria() dict
   // Tags associated with the filter
   tags() map[string]string
@@ -6612,18 +7002,26 @@ private aws.guardduty.finding @defaults("title region severity") {
   actionType string
   // Number of times this finding has been generated
   count int
-  // Detailed resource information for the finding
+  // Resource details for the finding
+  //
+  // The AWS resource involved in the finding. Which sub-object is present
+  // depends on the resource type: `AccessKeyDetails`, `InstanceDetails`,
+  // `S3BucketDetails`, `EksClusterDetails`, `EcsClusterDetails`,
+  // `ContainerDetails`, `KubernetesDetails`, `LambdaDetails`,
+  // `EbsVolumeDetails`, `RdsDbInstanceDetails`, `RdsDbUserDetails`, or
+  // `RdsLimitlessDbDetails`. `ResourceType` names which one applies.
   resourceDetails() dict
 }
 
 // Amazon Macie
 //
-// Use the Macie namespace to enumerate Macie data-protection coverage and
-// data-classification activity in the account. Iterate `sessions()` for the
-// per-region Macie enablement state and finding publishing frequency,
-// `classificationJobs()` for the S3 sensitive-data discovery jobs that have
-// been run, `customDataIdentifiers()` for tenant-defined regex/keyword
-// detectors, and `findings()` for the active findings produced.
+// Data-protection coverage and data-classification activity for the account.
+// The `sessions` report per-region Macie enablement state and finding
+// publishing frequency, `classificationJobs` describe the S3 sensitive-data
+// discovery jobs that have run, `customDataIdentifiers` hold tenant-defined
+// regex and keyword detectors, `buckets` carry per-bucket sensitivity and
+// exposure, and `findings` surface the sensitive-data and policy findings
+// produced.
 aws.macie {
   // List of Macie sessions
   sessions() []aws.macie.session
@@ -6652,6 +7050,12 @@ aws.macie {
 }
 
 // Amazon Macie session
+//
+// Per-region enablement state for Amazon Macie. The `status` field reports
+// whether Macie is ENABLED or PAUSED in a region, `findingPublishingFrequency`
+// controls how often findings are published, and `serviceRoleIamRole` resolves
+// the IAM role Macie assumes. Query this to confirm Macie is turned on
+// everywhere it should be.
 private aws.macie.session @defaults("arn region status") {
   // ARN of the Macie session
   arn string
@@ -6674,6 +7078,12 @@ private aws.macie.session @defaults("arn region status") {
 }
 
 // Amazon Macie classification job
+//
+// Sensitive-data discovery job that analyzes objects in one or more S3 buckets.
+// The `jobType` distinguishes a ONE_TIME run from a SCHEDULED recurring job,
+// `status` reports the run state, and `buckets` resolves the S3 buckets a static
+// job targets. Query this to review which data was scanned, on what cadence, and
+// at what sampling rate.
 private aws.macie.classificationJob @defaults("jobId name status region") {
   // ARN of the classification job
   arn string
@@ -6693,19 +7103,35 @@ private aws.macie.classificationJob @defaults("jobId name status region") {
   lastRunTime() time
   // Sampling percentage for the job
   samplingPercentage() int
-  // Bucket definitions for the job
+  // S3 buckets the job targets, keyed by owner account
+  //
+  // Each entry has `AccountId` (the account that owns the buckets) and `Buckets`
+  // (the list of bucket names in that account). Present only for jobs that use
+  // static bucket definitions rather than dynamic criteria.
   bucketDefinitions() []dict
   // S3 buckets selected by the job's static bucket definitions (empty for jobs using dynamic bucket criteria)
   buckets() []aws.s3.bucket
-  // Schedule frequency for the job
+  // Recurrence pattern for a scheduled job
+  //
+  // One of `DailySchedule`, `WeeklySchedule` (with a day of week), or
+  // `MonthlySchedule` (with a day of month). Empty for ONE_TIME jobs.
   scheduleFrequency() dict
-  // Statistics for the job
+  // Run statistics for the job
+  //
+  // Contains `ApproximateNumberOfObjectsToProcess` (objects still to process in
+  // the current run) and `NumberOfRuns` (how many times the job has run).
   statistics() dict
   // Tags for the job
   tags() map[string]string
 }
 
 // Amazon Macie finding
+//
+// Sensitive-data or policy finding that Macie produced for an S3 bucket or
+// object. The `category` field distinguishes a CLASSIFICATION finding (sensitive
+// data was detected) from a POLICY finding (a bucket-level security change), and
+// `severity` carries the qualitative and numeric severity. Query this to triage
+// where sensitive data or risky configuration changes were found.
 private aws.macie.finding @defaults("id arn region type severity") {
   // Unique ID of the finding
   id string
@@ -6717,7 +7143,10 @@ private aws.macie.finding @defaults("id arn region type severity") {
   accountId string
   // Type of the finding
   type string
-  // Severity details of the finding
+  // Severity of the finding
+  //
+  // Contains `Description` (Low, Medium, or High) and `Score` (1 to 3, least to
+  // most severe).
   severity dict
   // Category of the finding: CLASSIFICATION or POLICY
   category string
@@ -6733,9 +7162,18 @@ private aws.macie.finding @defaults("id arn region type severity") {
   title string
   // Description of the finding
   description string
-  // Classification details for the finding
+  // Sensitive-data classification details
+  //
+  // For CLASSIFICATION findings: `JobArn` and `JobId` of the job that produced
+  // the finding, `OriginType` (SENSITIVE_DATA_DISCOVERY_JOB or
+  // AUTOMATED_SENSITIVE_DATA_DISCOVERY), `DetailedResultsLocation` (S3 path to
+  // the full discovery result), and `Result` (the sensitive-data types found).
   classificationDetails() dict
-  // Resources affected by the finding
+  // S3 resources the finding applies to
+  //
+  // Contains `S3Bucket` (details of the affected bucket: name, ARN, owner,
+  // encryption, public-access) and `S3Object` (details of the affected object,
+  // for object-scoped findings).
   resourcesAffected() dict
   // Name of the S3 bucket the finding applies to (empty if the finding is not bucket-scoped)
   bucketName string
@@ -6748,6 +7186,12 @@ private aws.macie.finding @defaults("id arn region type severity") {
 }
 
 // Amazon Macie custom data identifier
+//
+// Tenant-defined detector that Macie uses to find sensitive data matching a
+// custom pattern. The `regex` field holds the detection pattern and `keywords`
+// the terms that must appear nearby for a match. Query this to review the
+// organization-specific data types Macie looks for beyond its managed
+// identifiers.
 private aws.macie.customDataIdentifier @defaults("id name") {
   // Unique ID of the custom data identifier
   id string
@@ -6769,11 +7213,11 @@ private aws.macie.customDataIdentifier @defaults("id name") {
 
 // Amazon Macie bucket coverage entry
 //
-// Examine a single S3 bucket as Macie sees it: its sensitivity score, public-access
-// summary, server-side encryption defaults, sharing status, last-analyzed time, and
-// whether a classification job has run against it. Use `bucket` to traverse to the
-// underlying `aws.s3.bucket` resource for owner-side queries, and inspect
-// `automatedDiscoveryMonitoringStatus` to confirm whether the bucket is in scope
+// Single S3 bucket as Macie sees it: its sensitivity score, public-access
+// summary, server-side encryption defaults, sharing status, last-analyzed time,
+// and whether a classification job has run against it. The `bucket` field
+// resolves the underlying `aws.s3.bucket` for owner-side queries, and
+// `automatedDiscoveryMonitoringStatus` reports whether the bucket is in scope
 // for Macie's automated sensitive data discovery.
 private aws.macie.bucket @defaults("name region sensitivityScore sharedAccess") {
   // ARN of the bucket
@@ -6818,7 +7262,7 @@ private aws.macie.bucket @defaults("name region sensitivityScore sharedAccess") 
   automatedDiscoveryMonitoringStatus string
   // Information about classification jobs configured to analyze the bucket and details of the most recent run
   jobDetails dict
-  // Object replication state — whether the bucket replicates objects to buckets in other accounts and which accounts those are
+  // Object replication state: whether the bucket replicates objects to buckets in other accounts and which accounts those are
   replicationDetails dict
   // Object counts grouped by server-side encryption type (KMS-managed, S3-managed, customer-provided, none, unknown)
   objectCountByEncryptionType dict
@@ -6836,10 +7280,10 @@ private aws.macie.bucket @defaults("name region sensitivityScore sharedAccess") 
 
 // Amazon Macie allow list
 //
-// Examine a single Macie allow list. An allow list specifies text or a text pattern
-// (regex or S3-hosted word list) that Macie ignores when looking for sensitive data.
-// Inspect `criteria` for the underlying regex or S3 object reference, `status` for
-// the list's accessibility state, and `tags` for governance.
+// Allow list that specifies text or a text pattern (regex or S3-hosted word
+// list) that Macie ignores when looking for sensitive data. The `criteria` field
+// holds the underlying regex or S3 object reference, `status` reports the list's
+// accessibility state, and `tags` support governance.
 private aws.macie.allowList @defaults("id name region status") {
   // Unique ID of the allow list
   id string
@@ -6869,10 +7313,10 @@ private aws.macie.allowList @defaults("id name region status") {
 
 // Amazon Macie findings filter
 //
-// Examine a saved findings filter — the criteria Macie applies to findings, and
-// whether matching findings are archived (suppressed) or left alone. Use `action`
-// to identify suppression rules and `findingCriteria` to inspect the field-level
-// match conditions.
+// Saved findings filter: the criteria Macie applies to findings, and whether
+// matching findings are archived (suppressed) or left alone. The `action` field
+// identifies suppression rules and `findingCriteria` holds the field-level match
+// conditions.
 private aws.macie.findingsFilter @defaults("id name action region") {
   // Unique ID of the filter
   id string
@@ -6886,7 +7330,7 @@ private aws.macie.findingsFilter @defaults("id name action region") {
   action string
   // Description of the filter
   description() string
-  // Position of the filter in the Macie console — also the order matching is applied in
+  // Position of the filter in the Macie console, also the order matching is applied in
   position() int
   // Criteria of the filter, keyed by finding field name. Each value is a `{eq, neq, gt, gte, lt, lte}` set of comparison constraints
   findingCriteria() dict
@@ -6896,10 +7340,10 @@ private aws.macie.findingsFilter @defaults("id name action region") {
 
 // Amazon Macie member account
 //
-// Examine a member account associated with this Macie administrator account.
-// `relationshipStatus` indicates whether Macie is enabled on the member account
-// and whether the administrator can manage it; `administratorAccountId` is the
-// account ID of the delegated administrator.
+// Member account associated with this Macie administrator account. The
+// `relationshipStatus` field indicates whether Macie is enabled on the member
+// account and whether the administrator can manage it, and
+// `administratorAccountId` is the account ID of the delegated administrator.
 private aws.macie.member @defaults("accountId relationshipStatus region") {
   // Account ID of the member
   accountId string
@@ -6925,9 +7369,9 @@ private aws.macie.member @defaults("accountId relationshipStatus region") {
 
 // Amazon Macie membership invitation
 //
-// Examine an inbound Macie membership invitation that has not yet been accepted or
-// declined by this account. Use `relationshipStatus` to distinguish invited from
-// other states, and `accountId` to identify the inviting administrator.
+// Inbound Macie membership invitation that this account has not yet accepted or
+// declined. The `relationshipStatus` field distinguishes invited from other
+// states, and `accountId` identifies the inviting administrator.
 private aws.macie.invitation @defaults("invitationId accountId relationshipStatus region") {
   // Unique ID of the invitation
   invitationId string
@@ -6943,9 +7387,9 @@ private aws.macie.invitation @defaults("invitationId accountId relationshipStatu
 
 // Amazon Macie administrator association
 //
-// Examine the delegated administrator association for this Macie account in a
-// given region. Use `accountId` to identify the administrator account and
-// `relationshipStatus` to confirm the association is active.
+// Delegated administrator association for this Macie account in a given region.
+// The `accountId` field identifies the administrator account and
+// `relationshipStatus` confirms whether the association is active.
 private aws.macie.administrator @defaults("accountId relationshipStatus region") {
   // Account ID of the administrator account
   accountId string
@@ -6961,10 +7405,10 @@ private aws.macie.administrator @defaults("accountId relationshipStatus region")
 
 // Amazon Macie automated sensitive data discovery configuration
 //
-// Examine the automated sensitive data discovery state and policy for an account
-// in a given region. `status` reports whether discovery is currently running,
+// Automated sensitive data discovery state and policy for an account in a given
+// region. The `status` field reports whether discovery is currently running,
 // `autoEnableOrganizationMembers` controls onboarding of new org accounts, and
-// `classificationScopeId` / `sensitivityInspectionTemplateId` identify the
+// `classificationScopeId` and `sensitivityInspectionTemplateId` identify the
 // configuration objects that select which buckets and detectors are used.
 private aws.macie.automatedDiscoveryConfiguration @defaults("region status autoEnableOrganizationMembers") {
   // Region this configuration applies to
@@ -6987,9 +7431,9 @@ private aws.macie.automatedDiscoveryConfiguration @defaults("region status autoE
 
 // Amazon Macie classification result export configuration
 //
-// Examine where Macie writes data classification results in a given region: the
-// destination S3 bucket and KMS key. Use `bucket` and `kmsKey` to traverse to the
-// modeled S3 and KMS resources for further inspection (bucket policy, key rotation,
+// Destination where Macie writes data classification results in a given region:
+// the S3 bucket and KMS key. The `bucket` and `kmsKey` fields resolve the modeled
+// S3 and KMS resources for further inspection (bucket policy, key rotation,
 // grants).
 private aws.macie.classificationExportConfiguration @defaults("region s3BucketName") {
   // Region this configuration applies to
@@ -7010,12 +7454,13 @@ private aws.macie.classificationExportConfiguration @defaults("region s3BucketNa
 
 // Amazon Detective
 //
-// Use the Detective namespace to enumerate Detective behavior graphs in
-// the account. Iterate `graphs()` for the per-region behavior graphs,
-// each of which exposes member accounts and the data-source packages
-// (Detective core, EKS audit logs, Security Hub findings) feeding the
-// graph. Iterate `organizationAdminAccounts()` to enumerate the accounts
-// designated as Detective administrators across the AWS organization.
+// Detective behavior graphs in the account, organized per region. Each
+// graph exposes its member accounts and the data-source packages
+// (Detective core, EKS audit logs, Security Hub findings) feeding it, so
+// you can audit which telemetry is being ingested for investigation. The
+// `organizationAdminAccounts` list reports the accounts designated as
+// Detective administrators across the AWS organization, useful for
+// confirming delegated administration is centralized as intended.
 aws.detective {
   // List of Detective behavior graphs across regions
   graphs() []aws.detective.graph
@@ -7025,11 +7470,12 @@ aws.detective {
 
 // Amazon Detective behavior graph
 //
-// Examine a single Detective behavior graph, the data plane created when
-// Detective is enabled in a region. The `members()` field iterates the
-// account memberships participating in the graph and `datasourcePackages()`
-// reports the ingestion state of each supported data-source package keyed
-// by package name.
+// Single Detective behavior graph, the data plane created when Detective
+// is enabled in a region. Account memberships participating in the graph
+// are listed through `members`, and `datasourcePackages` reports the
+// ingestion state of each supported data-source package keyed by package
+// name, so you can confirm which telemetry sources are actively feeding
+// the graph.
 private aws.detective.graph @defaults("arn region createdAt") {
   // ARN of the behavior graph
   arn string
@@ -7093,12 +7539,14 @@ private aws.detective.organizationAdminAccount @defaults("accountId region deleg
 
 // AWS Security Hub
 //
-// Use the Security Hub namespace to enumerate per-region Security Hub
-// enablement and the standards, findings, automation, and insights it
-// produces. Iterate `hubs()` for every region where Security Hub is enabled
-// — each hub surfaces its standard subscriptions and control details,
-// active findings, automation rules, insights, and the member accounts
-// administered through this hub.
+// Cloud security posture management service that aggregates, organizes,
+// and prioritizes security findings from AWS services and partner
+// products. The `hubs` field returns one entry per region where Security
+// Hub is enabled, and each hub exposes its enabled standard subscriptions
+// and control details, active findings, automation rules, insights, and
+// the member accounts administered through it. Query it to confirm
+// Security Hub coverage across regions and to audit the standards and
+// findings that drive your account's security score.
 aws.securityhub {
   // List of Security Hubs in the account
   hubs() []aws.securityhub.hub
@@ -7114,8 +7562,13 @@ private aws.securityhub.hub @defaults("arn region") {
   region string
   // Raw list of enabled security standards
   //
-  // Deprecated in favor of `standardSubscriptions()`. Examples include
-  // CIS, PCI-DSS, AWS Foundational.
+  // Deprecated in favor of standardSubscriptions, which resolves each
+  // subscription with its control details. Each dict mirrors the
+  // standards-subscription shape, with keys including `StandardsArn`,
+  // `StandardsSubscriptionArn`, `StandardsStatus` (one of PENDING, READY,
+  // FAILED, DELETING, or INCOMPLETE), and `StandardsInput`. Examples of
+  // standards include CIS AWS Foundations, PCI DSS, and AWS Foundational
+  // Security Best Practices.
   enabledStandards() @maturity("deprecated") []dict
   // Typed standard subscriptions with control details
   standardSubscriptions() []aws.securityhub.standardSubscription
@@ -7220,6 +7673,11 @@ private aws.securityhub.finding @defaults("title severity workflowStatus") {
   // Region where the finding was generated
   region string
   // Finding state change history
+  //
+  // Ordered records of changes made to this finding. Each dict includes
+  // `FindingIdentifier`, `UpdateTime`, `FindingCreated`, `UpdateSource`
+  // (who or what made the change), and `Updates` (the list of changed
+  // fields with their old and new values).
   history() []dict
 }
 
@@ -7253,7 +7711,13 @@ private aws.securityhub.insight @defaults("name") {
   name string
   // Attribute that findings are grouped by
   groupByAttribute string
-  // Filter criteria as dict
+  // Filter criteria
+  //
+  // The finding-attribute filters that define this insight, in the ASFF
+  // finding-filters shape. Keys are finding attribute names such as
+  // `AwsAccountId`, `SeverityLabel`, `ResourceType`, `ComplianceStatus`,
+  // and `WorkflowStatus`, and each maps to a list of comparison objects
+  // with `Value` and `Comparison` (for example EQUALS or PREFIX).
   filters dict
   // Computed insight results
   results() []aws.securityhub.insightResult
@@ -7297,14 +7761,14 @@ private aws.securityhub.enabledProduct @defaults("productArn") {
 
 // AWS Shield Advanced
 //
-// Use the Shield namespace to inspect the account's Shield Advanced posture
-// against DDoS attacks. Read `subscriptionState` to confirm the service is
-// active, `subscription` for term and auto-renew details, `protections()`
-// and `protectionGroups()` for the resources covered, `drtAccess` for the
-// Shield Response Team access configuration, and `emergencyContacts()` for
-// the contacts notified during proactive engagement.
+// Shield Advanced DDoS protection posture for the account, covering the
+// subscription term and auto-renewal, the resources and protection groups
+// under active mitigation, Shield Response Team access, and the emergency
+// contacts notified during proactive engagement. Read subscriptionState to
+// confirm whether Shield Advanced is active before relying on the rest of
+// the posture.
 aws.shield @defaults("subscriptionState") {
-  // Whether Shield Advanced is active ("ACTIVE", "INACTIVE", or "UNKNOWN" if access is denied)
+  // Shield Advanced activation state (ACTIVE, INACTIVE, or UNKNOWN if access is denied)
   subscriptionState() string
   // Shield Advanced subscription details
   subscription() aws.shield.subscription
@@ -7367,7 +7831,9 @@ private aws.shield.protection @defaults("arn name resourceArn") {
   healthCheckIds []string
   // Raw application-layer automatic response configuration dict
   //
-  // Deprecated in favor of `applicationLayerAutomaticResponseEnabled` and
+  // Keyed by Status (ENABLED or DISABLED) and Action (a nested object holding
+  // either Block or Count). Deprecated in favor of
+  // `applicationLayerAutomaticResponseEnabled` and
   // `applicationLayerAutomaticResponseAction`.
   applicationLayerAutomaticResponseConfiguration @maturity("deprecated") dict
   // Whether automatic application-layer DDoS mitigation is enabled for the protection
@@ -7412,11 +7878,13 @@ private aws.shield.emergencyContact @defaults("emailAddress") {
 
 // AWS Secrets Manager
 //
-// Use the Secrets Manager namespace to enumerate secrets stored in the
-// account across all enabled regions. Iterate `secrets()` for every secret
-// — each row surfaces metadata, KMS encryption key, rotation configuration
-// and history, replica regions, version stages, the resource policy, and
-// when the secret was last accessed and changed.
+// Secrets stored in AWS Secrets Manager across all enabled regions of the
+// account. The `secrets` collection returns every secret with its metadata,
+// KMS encryption key, rotation configuration and history, replica regions,
+// version stages, resource-based policy, and the timestamps for when each
+// secret was last accessed and last changed. Query this to inventory stored
+// credentials, keys, and tokens and to audit their rotation and access
+// posture.
 aws.secretsmanager {
   // List of secrets
   secrets() []aws.secretsmanager.secret
@@ -7424,11 +7892,12 @@ aws.secretsmanager {
 
 // AWS Secrets Manager secret
 //
-// Examine an individual Secrets Manager secret. Use the `arn` field as the
-// selection key — for example
+// Individual secret managed by AWS Secrets Manager, holding an encrypted
+// credential, key, or token together with its rotation and access
+// configuration. The `arn` field selects the secret, for example
 // `aws.secretsmanager.secret(arn: "arn:aws:secretsmanager:us-east-1:111122223333:secret:prod/db-AbCdEf")`.
-// Surfaces the secret's KMS encryption key, rotation Lambda and schedule,
-// replica regions, version history (with stage labels like AWSCURRENT and
+// Exposes the KMS encryption key, rotation Lambda and schedule, replica
+// regions, version history (with stage labels like AWSCURRENT and
 // AWSPENDING), resource-based access policy, owning service when the secret
 // is service-managed, and the last accessed, changed, and rotated dates.
 aws.secretsmanager.secret @defaults("arn name") {
@@ -7538,13 +8007,14 @@ private aws.secretsmanager.secret.rotationRules {
 
 // Amazon Elastic Container Service (ECS)
 //
-// Use the ECS namespace to enumerate cluster, workload, and task-definition
-// state across all enabled regions. Iterate `clusters()` for ECS clusters
-// (with their services, container instances, capacity providers, and
-// settings), `containers()` for the running containers across those clusters,
-// `containerInstances()` for EC2-launch-type registered instances, and
-// `taskDefinitions()` for the task definition revisions registered in the
-// account.
+// Elastic Container Service inventory across all enabled regions: the
+// clusters running your workloads, the containers and container instances
+// executing within them, the capacity providers backing them, and the task
+// definitions registered in the account. The clusters field lists cluster
+// state (services, container instances, capacity providers, and settings),
+// containers the running containers, containerInstances the EC2-launch-type
+// instances registered to clusters, and taskDefinitions the registered task
+// definition revisions.
 aws.ecs  @defaults("clusters containers containerInstances") {
   // List of AWS ECS Clusters
   clusters() []aws.ecs.cluster
@@ -7562,11 +8032,11 @@ aws.ecs  @defaults("clusters containers containerInstances") {
 
 // Amazon ECS capacity provider
 //
-// Examine a capacity provider that determines the infrastructure a cluster's
-// tasks run on — either an EC2 Auto Scaling group (with managed scaling and
-// managed termination protection) or ECS Managed Instances. Traverse
-// `autoScalingGroup` for the backing group and inspect the `managedScaling*`
-// fields for the scaling policy. Select by `name`.
+// Capacity provider that determines the infrastructure a cluster's tasks run
+// on: either an EC2 Auto Scaling group (with managed scaling and managed
+// termination protection) or ECS Managed Instances. The autoScalingGroup
+// field resolves the backing group, and the managedScaling fields hold the
+// scaling policy. Selected by name.
 private aws.ecs.capacityProvider @defaults("name status region") {
   // ARN of the capacity provider
   arn string
@@ -7601,15 +8071,21 @@ private aws.ecs.capacityProvider @defaults("name status region") {
   // Managed draining of instances on scale-in (ENABLED, DISABLED)
   managedDraining string
   // ECS Managed Instances provider configuration
+  //
+  // Present when the capacity provider uses ECS Managed Instances. Keys:
+  // InfrastructureRoleArn, PropagateTags, InfrastructureOptimization,
+  // AutoRepairConfiguration, and InstanceLaunchTemplate (the launch template
+  // controlling instance profile, network configuration, capacity
+  // reservations, and instance requirements).
   managedInstancesProvider dict
 }
 
 // Amazon ECS account setting
 //
-// Examine an account-level or region-level ECS setting effective for the
-// caller — for example whether `guardDutyActivate` (ECS Runtime Monitoring)
-// or `containerInsights` is enabled, or which ARN/resource-ID format is in
-// use. Select by `name`.
+// Account-level or region-level ECS setting effective for the caller: for
+// example whether guardDutyActivate (ECS Runtime Monitoring) or
+// containerInsights is enabled, or which ARN and resource-ID format is in
+// use. Selected by name.
 private aws.ecs.accountSetting @defaults("name value region") {
   // Setting name
   //
@@ -7626,6 +8102,13 @@ private aws.ecs.accountSetting @defaults("name value region") {
 }
 
 // Amazon ECS cluster
+//
+// Logical grouping of ECS tasks, services, and container instances. A cluster
+// reports its running and pending task counts, registered container
+// instances, the services scheduled on it, its capacity providers and default
+// capacity provider strategy, and cluster settings such as Container Insights.
+// Fargate ephemeral storage encryption is reported through
+// fargateEphemeralStorageKmsKey.
 private aws.ecs.cluster @defaults("name region status runningTasksCount pendingTasksCount") {
   // ARN of the ECS cluster
   arn string
@@ -7639,9 +8122,17 @@ private aws.ecs.cluster @defaults("name region status runningTasksCount pendingT
   pendingTasksCount int
   // Count of container instances registered to the cluster
   registeredContainerInstancesCount int
-  // Configuration for the cluster
+  // Cluster configuration
+  //
+  // Keyed by ExecuteCommandConfiguration (ECS Exec logging and KMS key:
+  // KmsKeyId, Logging, LogConfiguration) and ManagedStorageConfiguration
+  // (KmsKeyId and FargateEphemeralStorageKmsKeyId for encrypting managed and
+  // Fargate ephemeral storage).
   configuration dict
-  // Cluster settings (e.g., Container Insights)
+  // Cluster settings
+  //
+  // Keyed by setting name; the containerInsights key reports the CloudWatch
+  // Container Insights level (enabled, enhanced, or disabled) for the cluster.
   settings map[string]string
   // Status of the cluster
   status string
@@ -7678,6 +8169,13 @@ private aws.ecs.cluster.capacityProviderStrategyItem @defaults("capacityProvider
 }
 
 // AWS ECS container instance
+//
+// EC2 or external instance registered to an ECS cluster to run tasks. The
+// record reports agent connectivity, registration and health status, running
+// and pending task counts, and the attributes and version information the
+// agent advertises. For EC2-launch instances, ec2Instance resolves the
+// backing instance and managedBy reports the infrastructure system that owns
+// it.
 private aws.ecs.instance {
   // Whether the agent is connected to ECS
   agentConnected bool
@@ -7705,7 +8203,10 @@ private aws.ecs.instance {
   registeredAt time
   // ECS container agent and Docker version information (agentVersion, agentHash, dockerVersion)
   versionInfo dict
-  // Custom and built-in attributes attached to the container instance
+  // Attributes attached to the container instance
+  //
+  // Custom and built-in name/value attributes the agent advertises for task
+  // placement. Each entry has Name, Value, TargetId, and TargetType.
   attributes []dict
   // Tags for the container instance
   tags map[string]string
@@ -7720,12 +8221,21 @@ private aws.ecs.instance {
 }
 
 // Amazon ECS task
+//
+// Running or stopped instantiation of a task definition. A task reports its
+// last status, launch type, health, the container instance or Fargate
+// platform it runs on, its containers, and (when stopped) the stopCode and
+// stoppedReason explaining why. Fargate ephemeral storage encryption is
+// reported through fargateEphemeralStorageKmsKey.
 private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   // ARN of the ECS task
   arn string
   // Cluster associated with the ECS task
   clusterName string
   // Connectivity status of the ECS task
+  //
+  // Whether the task can reach the network resources it needs: CONNECTED or
+  // DISCONNECTED.
   connectivity dict
   // Last reported status for the ECS task
   lastStatus string
@@ -7782,6 +8292,12 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
 }
 
 // Amazon ECS container
+//
+// Container running as part of an ECS task. The record reports the image and
+// its resolved digest, the container's status, public IP, resource limits,
+// and log driver. When the image is hosted in ECR in this account, ecrImage
+// resolves the registry image, and repositoryCredentialsSecret resolves the
+// Secrets Manager secret used to pull private images.
 private aws.ecs.container @defaults("containerName runtimeId clusterName region") {
   // Name of the ECS container + IP for unique identification
   name string
@@ -7846,6 +8362,12 @@ private aws.ecs.container @defaults("containerName runtimeId clusterName region"
 }
 
 // Amazon ECS Task Definition
+//
+// Blueprint describing how to run a set of containers as an ECS task: the
+// container definitions, volumes, network and namespace modes, CPU and memory
+// sizing, launch-type compatibility, and the IAM roles the task and the
+// container agent assume. Selected by ARN, which pins a specific family and
+// revision.
 private aws.ecs.taskDefinition @defaults("arn family revision") {
   // ARN of the task definition
   arn string
@@ -7902,6 +8424,13 @@ private aws.ecs.taskDefinition @defaults("arn family revision") {
 }
 
 // Amazon ECS Service
+//
+// Long-running scheduler that maintains a desired count of tasks from a task
+// definition on a cluster. A service exposes its desired and running counts,
+// deployment and network configuration, load balancer and service-discovery
+// registrations, capacity provider strategy, and placement constraints and
+// strategy. Whether ECS Exec is permitted on the tasks is reported by
+// enableExecuteCommand.
 private aws.ecs.service @defaults("arn name clusterArn status") {
   // ARN of the ECS service
   arn string
@@ -7970,6 +8499,12 @@ private aws.ecs.service @defaults("arn name clusterArn status") {
 }
 
 // Amazon ECS Task Set
+//
+// Group of tasks within a service that run a single task definition and launch
+// type, used by services with EXTERNAL or CODE_DEPLOY deployment controllers
+// to shift traffic between revisions. A task set reports its stability status,
+// running and pending counts, computed desired count, and network
+// configuration.
 private aws.ecs.taskSet @defaults("arn status taskDefinition launchType") {
   // ARN of the task set
   arn string
@@ -8038,14 +8573,24 @@ private aws.ecs.service.deploymentConfiguration @defaults("maximumPercent minimu
   // Circuit breaker configuration for the deployment
   deploymentCircuitBreaker() aws.ecs.service.deploymentConfiguration.deploymentCircuitBreaker
   // Deployment alarms configuration
+  //
+  // CloudWatch alarms that determine deployment failure and rollback. Keys:
+  // AlarmNames, Enable, and Rollback.
   alarms dict
   // Bake time in minutes for blue/green deployments
   bakeTimeInMinutes int
   // Canary configuration for deployments
+  //
+  // Blue/green canary traffic-shift settings. Keys: CanaryPercent (initial
+  // percentage of traffic shifted to the new revision) and
+  // CanaryBakeTimeInMinutes.
   canaryConfiguration dict
   // Lifecycle hooks configuration
   lifecycleHooks dict
   // Linear configuration for deployments
+  //
+  // Blue/green linear traffic-shift settings. Keys: StepPercent (percentage of
+  // traffic shifted per step) and StepBakeTimeInMinutes.
   linearConfiguration dict
   // Deployment strategy
   strategy string
@@ -8261,16 +8806,24 @@ private aws.ecs.taskDefinition.ephemeralStorage {
 
 // Amazon EMR
 //
-// Use the EMR namespace to enumerate Elastic MapReduce clusters and
-// account-level guardrails. Iterate `clusters()` for every EMR cluster
-// across enabled regions (with its release label, applications, instance
-// groups, security configuration, and run-time status), and read
-// `blockPublicAccessConfiguration` for the account-level block public
-// access posture for cluster security groups.
+// Managed Hadoop and Spark big-data platform in an account. The `clusters`
+// list enumerates every EMR cluster across enabled regions with its release
+// label, applications, instance groups, security configuration, and run-time
+// status; `blockPublicAccessConfiguration` reports the account-level block
+// public access posture applied to cluster security groups;
+// `securityConfigurations` covers the reusable encryption and authentication
+// profiles clusters can attach; and `studios` covers the web-based notebook
+// environments.
 aws.emr {
   // List of EMR clusters
   clusters() []aws.emr.cluster
-  // Block public access configuration (account-level)
+  // Account-level block public access configuration
+  //
+  // Governs whether EMR blocks clusters from launching with security groups
+  // that permit public inbound access. Keys: `BlockPublicSecurityGroupRules`
+  // (bool, whether the block is enforced) and
+  // `PermittedPublicSecurityGroupRuleRanges` (list of `{MinRange, MaxRange}`
+  // port ranges exempted from the block).
   blockPublicAccessConfiguration() dict
   // Security configurations defined in the account
   securityConfigurations() []aws.emr.securityConfiguration
@@ -8288,11 +8841,21 @@ private aws.emr.cluster @defaults("arn") {
   normalizedInstanceHours int
   // ARN of outpost where cluster is launched
   outpostArn string
-  // Details about the current status of the cluster
+  // Current status of the cluster
+  //
+  // Keys: `State` (cluster lifecycle state, one of STARTING, BOOTSTRAPPING,
+  // RUNNING, WAITING, TERMINATING, TERMINATED, TERMINATED_WITH_ERRORS),
+  // `StateChangeReason` (`{Code, Message}`), `Timeline`
+  // (`{CreationDateTime, ReadyDateTime, EndDateTime}`), and `ErrorDetails`.
   status dict
   // When the cluster was created
   createdAt time
-  // List of master instances for the cluster
+  // Master (primary) node instances of the cluster
+  //
+  // One entry per master EC2 instance. Keys include `Id`, `Ec2InstanceId`,
+  // `InstanceType`, `Market` (ON_DEMAND or SPOT), `PrivateIpAddress`,
+  // `PrivateDnsName`, `PublicIpAddress`, `PublicDnsName`, `EbsVolumes`, and
+  // `Status`.
   masterInstances() []dict
   // EMR cluster ID
   id string
@@ -8327,8 +8890,15 @@ private aws.emr.cluster @defaults("arn") {
   // Amazon EMR release label (for example, emr-6.10.0)
   releaseLabel() string
   // Open-source applications installed on the cluster
+  //
+  // One entry per application (for example Hadoop, Spark, Hive, Presto). Keys:
+  // `Name`, `Version`, `Args`, and `AdditionalInfo`.
   applications() []dict
   // Configuration overlay supplied to the cluster
+  //
+  // Software settings that override application defaults. Each entry has keys
+  // `Classification` (the config file the settings apply to), `Properties`
+  // (key/value overrides), and `Configurations` (nested child overlays).
   configurations() []dict
   // Size, in GiB, of the EBS root volume of each EC2 instance
   ebsRootVolumeSize() int
@@ -8338,11 +8908,18 @@ private aws.emr.cluster @defaults("arn") {
   ebsRootVolumeThroughput() int
   // Repository upgrade behavior on instance boot (SECURITY, NONE)
   repoUpgradeOnBoot() string
-  // Kerberos authentication attributes (passwords are redacted)
+  // Kerberos authentication attributes
+  //
+  // Present when the cluster uses Kerberos. Keys: `realm` (the Kerberos realm)
+  // and `adDomainJoinUser` (the Active Directory account used to join the
+  // domain). Password fields are redacted and never returned.
   kerberosAttributes() dict
   // Number of steps that can run concurrently on the cluster
   stepConcurrencyLevel() int
   // EC2 placement group configuration applied to the cluster
+  //
+  // One entry per instance role. Keys: `InstanceRole` (MASTER, CORE, or TASK)
+  // and `PlacementStrategy` (SPREAD, PARTITION, CLUSTER, or NONE).
   placementGroups() []dict
   // Whether the cluster terminates after completing all steps
   autoTerminate() bool
@@ -8372,9 +8949,9 @@ private aws.emr.cluster @defaults("arn") {
 
 // Amazon EMR security configuration
 //
-// Examine a named security configuration that EMR clusters can attach to
-// enable encryption at rest, encryption in transit, IAM-based authentication,
-// and Kerberos. The `name` field is the selection key — for example
+// Named security profile that EMR clusters attach to enable encryption at
+// rest, encryption in transit, IAM-based authentication, and Kerberos. The
+// `name` field is the selection key, for example
 // `aws.emr.securityConfiguration(name: "my-sec-config")`. The `configuration`
 // field returns the raw JSON document so you can audit any setting; common
 // settings are also flattened in `aws.emr.cluster.encryptionConfiguration`
@@ -8461,8 +9038,15 @@ private aws.emr.cluster.instanceGroup @defaults("name instanceGroupType instance
   // Custom AMI ID used to provision the instance group
   customAmiId string
   // EBS block devices mapped to the instance group
+  //
+  // One entry per volume. Keys: `Device` (the device name) and
+  // `VolumeSpecification` (`{VolumeType, SizeInGB, Iops, Throughput}`).
   ebsBlockDevices []dict
   // Configuration overlay applied to the instance group
+  //
+  // Software settings that override application defaults on this group. Each
+  // entry has keys `Classification`, `Properties` (key/value overrides), and
+  // `Configurations` (nested child overlays).
   configurations []dict
 }
 
@@ -8478,16 +9062,15 @@ private aws.emr.cluster.bootstrapAction @defaults("name scriptPath") {
 
 // Amazon EMR Studio
 //
-// Examine an EMR Studio — the managed web-based Jupyter / IDE
-// environment that data engineers use to author and run notebooks
-// against EMR clusters and serverless applications. Surfaces the
-// `authMode` (SSO or IAM) and identity-provider URL when SSO is used,
-// the `defaultS3Location` that backs Studio workspace files, the
-// `encryptionKey()` reference (audit whether a customer-managed KMS
-// key encrypts the workspace files, not the default AWS-managed key),
-// the VPC and subnets the Studio is deployed across, the service and
-// user IAM roles, and the workspace / engine security groups that
-// guard Studio notebook and compute traffic.
+// Managed web-based Jupyter and IDE environment that data engineers use to
+// author and run notebooks against EMR clusters and serverless applications.
+// Surfaces the `authMode` (SSO or IAM) and identity-provider URL when SSO is
+// used, the `defaultS3Location` that backs Studio workspace files, the
+// `encryptionKey` reference (audit whether a customer-managed KMS key
+// encrypts the workspace files rather than the default AWS-managed key), the
+// VPC and subnets the Studio is deployed across, the service and user IAM
+// roles, and the workspace and engine security groups that guard Studio
+// notebook and compute traffic.
 private aws.emr.studio @defaults("studioId name region") {
   // Studio ID
   studioId string
@@ -8533,21 +9116,20 @@ private aws.emr.studio @defaults("studioId name region") {
 
 // Amazon EventBridge
 //
-// Use the EventBridge namespace to enumerate event-driven plumbing in the
-// account: event buses and the rules attached to them, EventBridge Pipes
-// for source-to-target streaming, EventBridge Scheduler schedules and
-// schedule groups, the connections and API destinations that carry events
-// to external HTTP endpoints, archives and replays of recorded events,
-// and global endpoints for multi-Region routing. Iterate `eventBuses()`
-// for every bus (with its resource policy, KMS encryption, and
-// dead-letter configuration), `rules()` for every rule across buses
-// (with the event pattern or schedule, targets, and IAM role), `pipes()`
-// for filter/enrichment pipelines, `schedules()`/`scheduleGroups()` for
-// cron and one-time scheduled invocations, `connections()` and
-// `apiDestinations()` for outbound webhook integrations,
-// `archives()`/`replays()` for event retention and replay, and
-// `endpoints()` for global endpoints with failover and event
-// replication.
+// Event-driven plumbing in the account: event buses and the rules
+// attached to them, EventBridge Pipes for source-to-target streaming,
+// EventBridge Scheduler schedules and schedule groups, the connections
+// and API destinations that carry events to external HTTP endpoints,
+// archives and replays of recorded events, and global endpoints for
+// multi-Region routing. The `eventBuses` list covers every bus (with
+// its resource policy, KMS encryption, and dead-letter configuration),
+// `rules` covers every rule across buses (with the event pattern or
+// schedule, targets, and IAM role), `pipes` covers filter/enrichment
+// pipelines, `schedules` and `scheduleGroups` cover cron and one-time
+// scheduled invocations, `connections` and `apiDestinations` cover
+// outbound webhook integrations, `archives` and `replays` cover event
+// retention and replay, and `endpoints` covers global endpoints with
+// failover and event replication.
 aws.eventbridge @defaults("eventBuses") {
   // List of EventBridge event buses
   eventBuses() []aws.eventbridge.eventBus
@@ -8609,7 +9191,7 @@ private aws.eventbridge.rule @defaults("arn name state") {
   scheduleExpression string
   // ARN of the IAM role associated with the rule
   //
-  // Deprecated in favor of `iamRole()`.
+  // Deprecated in favor of `iamRole`.
   roleArn @maturity("deprecated") string
   // IAM role associated with the rule
   iamRole() aws.iam.role
@@ -8662,16 +9244,16 @@ private aws.eventbridge.rule.target @defaults("id arn") {
 
 // Amazon EventBridge connection
 //
-// Examine an EventBridge connection — the named credential record used by
-// API destinations to authenticate against an outbound HTTP endpoint.
-// Reveals the authorization type (BASIC, OAUTH_CLIENT_CREDENTIALS, or
-// API_KEY), the connection lifecycle state, the linked Secrets Manager
-// secret that holds the credentials, and the *shape* of the
-// `authParameters` and `invocationHttpParameters` (header / query /
-// body parameter names, OAuth endpoints, API-key header name). Secret
-// values — passwords, OAuth client secrets, and API-key values — are
-// never returned; only `*Present` indicator booleans and non-secret
-// metadata are surfaced.
+// Named credential record used by API destinations to authenticate
+// against an outbound HTTP endpoint. Covers the authorization type
+// (BASIC, OAUTH_CLIENT_CREDENTIALS, or API_KEY), the connection
+// lifecycle state, the linked Secrets Manager secret that holds the
+// credentials, and the shape of the `authParameters` and
+// `invocationHttpParameters` (header, query, and body parameter names,
+// OAuth endpoints, API-key header name). Secret values such as
+// passwords, OAuth client secrets, and API-key values are never
+// returned; only `*Present` indicator booleans and non-secret metadata
+// are surfaced.
 private aws.eventbridge.connection @defaults("arn name authorizationType connectionState") {
   // ARN of the connection
   arn string
@@ -8706,7 +9288,7 @@ private aws.eventbridge.connection @defaults("arn name authorizationType connect
   // For BASIC: `{type: "BASIC", usernamePresent: bool, username: string}`.
   // For OAUTH: `{type: "OAUTH", authorizationEndpoint, httpMethod, clientID, clientSecretPresent: bool, oauthHttpParameters}`.
   // For API_KEY: `{type: "API_KEY", apiKeyName, apiKeyValuePresent: bool}`.
-  // All passwords, OAuth client secrets, and API-key values are masked —
+  // All passwords, OAuth client secrets, and API-key values are masked;
   // only the presence booleans and non-secret metadata are returned.
   authParameters() dict
   // Additional HTTP parameters sent with every target invocation, with secret values redacted
@@ -8721,11 +9303,11 @@ private aws.eventbridge.connection @defaults("arn name authorizationType connect
 
 // Amazon EventBridge API destination
 //
-// Examine an EventBridge API destination — the named HTTP invocation
-// target (URL + method + per-second rate limit) that rules and pipes can
-// route events to. The destination borrows its credentials from a linked
-// `aws.eventbridge.connection`; traverse `connection()` to inspect the
-// authorization type and credential metadata.
+// Named HTTP invocation target (URL, method, and per-second rate limit)
+// that rules and pipes can route events to. The destination borrows its
+// credentials from a linked `aws.eventbridge.connection`; the
+// `connection` reference resolves to that record so its authorization
+// type and credential metadata can be inspected.
 private aws.eventbridge.apiDestination @defaults("arn name apiDestinationState invocationEndpoint") {
   // ARN of the API destination
   arn string
@@ -8759,12 +9341,12 @@ private aws.eventbridge.apiDestination @defaults("arn name apiDestinationState i
 
 // Amazon EventBridge archive
 //
-// Examine an EventBridge archive — recorded events from a single event
-// bus retained for the configured number of days and available for
-// replay through `aws.eventbridge.replay`. Reveals the source bus, the
-// optional event-pattern filter applied while recording, the current
-// archive state, the retention window, and the running event count and
-// size on disk.
+// Recorded events from a single event bus, retained for the configured
+// number of days and available for replay through
+// `aws.eventbridge.replay`. Covers the source bus, the optional
+// event-pattern filter applied while recording, the current archive
+// state, the retention window, and the running event count and size on
+// disk.
 private aws.eventbridge.archive @defaults("arn archiveName state retentionDays") {
   // ARN of the archive
   arn string
@@ -8798,10 +9380,10 @@ private aws.eventbridge.archive @defaults("arn archiveName state retentionDays")
 
 // Amazon EventBridge replay
 //
-// Examine an EventBridge replay — a one-time job that re-emits events
-// from an archive into one or more rules on a destination event bus.
-// Reveals the source archive, the destination bus, the replay state,
-// the event time window being replayed, and the lifecycle timestamps.
+// One-time job that re-emits events from an archive into one or more
+// rules on a destination event bus. Covers the source archive, the
+// destination bus, the replay state, the event time window being
+// replayed, and the lifecycle timestamps.
 private aws.eventbridge.replay @defaults("arn replayName state") {
   // ARN of the replay
   arn string
@@ -8841,12 +9423,12 @@ private aws.eventbridge.replay @defaults("arn replayName state") {
 
 // Amazon EventBridge global endpoint
 //
-// Examine an EventBridge global endpoint — a Regional-fault-tolerant
-// front door for one or more event buses that fails over to a secondary
-// Region based on a Route 53 health check and (optionally) replicates
-// events to the secondary in steady state. Reveals the primary /
-// secondary Region routing, the health check arn, the replication
-// state, the linked event buses, and the IAM role used for replication.
+// Region-fault-tolerant front door for one or more event buses that
+// fails over to a secondary Region based on a Route 53 health check and
+// optionally replicates events to the secondary in steady state. Covers
+// the primary and secondary Region routing, the health check arn, the
+// replication state, the linked event buses, and the IAM role used for
+// replication.
 private aws.eventbridge.endpoint @defaults("arn name state") {
   // ARN of the endpoint
   arn string
@@ -9164,7 +9746,7 @@ private aws.eventbridge.pipe.targetParameters.ecsTask @defaults("launchType task
   launchType string
   // Fargate platform version
   platformVersion string
-  // Whether ECS Exec is enabled — audit signal: allows shell access into running tasks
+  // Whether ECS Exec is enabled. Audit signal: allows shell access into running tasks.
   enableExecuteCommand bool
   // Whether ECS-managed tags are enabled
   enableECSManagedTags bool
@@ -9192,7 +9774,7 @@ private aws.eventbridge.pipe.targetParameters.ecsTask @defaults("launchType task
 
 // ECS task network configuration for an EventBridge Pipe target
 private aws.eventbridge.pipe.targetParameters.ecsTask.networkConfiguration @defaults("assignPublicIp") {
-  // Whether to assign a public IP to the task ENI: ENABLED or DISABLED — audit signal
+  // Whether to assign a public IP to the task ENI: ENABLED or DISABLED. Audit signal.
   assignPublicIp string
   // Subnets the task ENI is placed in
   subnets() []aws.vpc.subnet
@@ -9216,7 +9798,7 @@ private aws.eventbridge.pipe.targetParameters.batchJob @defaults("jobDefinition 
   hasContainerOverrides bool
   // Whether the job overrides container environment variables
   hasEnvironmentOverrides bool
-  // Names of overridden environment variables (keys only — values may contain credentials)
+  // Names of overridden environment variables (keys only; values may contain credentials)
   environmentVariableNames []string
   // Job parameters
   parameters map[string]string
@@ -9266,7 +9848,7 @@ private aws.eventbridge.pipe.targetParameters.redshiftData @defaults("database s
 
 // EventBridge Pipe SageMaker pipeline target parameters
 private aws.eventbridge.pipe.targetParameters.sagemakerPipeline {
-  // Pipeline parameter names (keys only — values may contain PII)
+  // Pipeline parameter names (keys only; values may contain PII)
   pipelineParameterNames []string
 }
 
@@ -9294,7 +9876,7 @@ private aws.eventbridge.pipe.targetParameters.timestream @defaults("databaseName
 
 // HTTP destination parameters (used by both target and enrichment)
 private aws.eventbridge.pipe.targetParameters.http {
-  // Header parameter names (keys only — bearer tokens routinely set in values)
+  // Header parameter names (keys only; bearer tokens routinely set in values)
   headerParameterKeys []string
   // Query string parameter names (keys only)
   queryStringParameterKeys []string
@@ -9306,7 +9888,7 @@ private aws.eventbridge.pipe.targetParameters.http {
 private aws.eventbridge.pipe.logConfiguration @defaults("level hasAnyDestination") {
   // Verbosity level: OFF, ERROR, INFO, TRACE
   level string
-  // Execution data sections included in logs (ALL = full event payloads in logs — audit signal)
+  // Execution data sections included in logs (ALL = full event payloads in logs; audit signal)
   includeExecutionData []string
   // Whether at least one log destination is configured
   hasAnyDestination bool
@@ -9372,7 +9954,7 @@ private aws.eventbridge.schedule @defaults("arn name state") {
   startDate() time
   // Date and time the schedule stops being evaluated (null when not bounded)
   endDate() time
-  // Behavior after the last invocation: NONE or DELETE — DELETE makes the schedule self-destructing
+  // Behavior after the last invocation: NONE or DELETE (DELETE makes the schedule self-destructing)
   actionAfterCompletion() string
   // Description of the schedule
   description() string
@@ -9426,7 +10008,7 @@ private aws.eventbridge.schedule.target @defaults("targetType arn") {
   roleArn @maturity("deprecated") string
   // IAM role assumed when invoking the target
   iamRole() aws.iam.role
-  // Target.Input payload sent to the target. WARNING: may contain sensitive data — audit carefully for credentials, tokens, or PII.
+  // Target.Input payload sent to the target. WARNING: may contain sensitive data. Audit carefully for credentials, tokens, or PII.
   input string
   // Target type discriminator: lambda, sqs, sns, stepFunction, kinesis, firehose, ecs, eventBridge, sagemakerPipeline, codebuild, universal, unknown
   targetType string
@@ -9440,7 +10022,7 @@ private aws.eventbridge.schedule.target @defaults("targetType arn") {
   sagemakerParameters() aws.eventbridge.schedule.target.sagemakerParameters
   // SQS queue invocation parameters (null unless targetType == sqs and a message-group is configured)
   sqsParameters() aws.eventbridge.schedule.target.sqsParameters
-  // Universal target — populated only when arn matches arn:aws:scheduler:::aws-sdk:<service>:<action>
+  // Universal target, populated only when arn matches arn:aws:scheduler:::aws-sdk:<service>:<action>
   universalTarget() aws.eventbridge.schedule.target.universalTarget
 }
 
@@ -9508,7 +10090,7 @@ private aws.eventbridge.schedule.target.kinesisParameters @defaults("partitionKe
 private aws.eventbridge.schedule.target.sagemakerParameters {
   // Pipeline execution parameters
   //
-  // Note: Values may contain PII or operational data — audit accordingly.
+  // Note: Values may contain PII or operational data. Audit accordingly.
   // AWS Scheduler enforces unique parameter names per pipeline,
   // so a map preserves all data without loss.
   pipelineParameters() map[string]string
@@ -9520,7 +10102,7 @@ private aws.eventbridge.schedule.target.sqsParameters @defaults("messageGroupId"
   messageGroupId string
 }
 
-// Universal target — invokes any AWS-SDK API via arn:aws:scheduler:::aws-sdk:<service>:<action>
+// Universal target that invokes any AWS-SDK API via arn:aws:scheduler:::aws-sdk:<service>:<action>
 private aws.eventbridge.schedule.target.universalTarget @defaults("service action") {
   // AWS service name (e.g. "s3") parsed from the universal target ARN
   service string
@@ -9550,13 +10132,13 @@ private aws.eventbridge.scheduleGroup @defaults("arn name state") {
 
 // Amazon CloudWatch
 //
-// Use the CloudWatch namespace to enumerate metrics, alarms, and Logs
-// configuration in the account across all enabled regions. Iterate
-// `logGroups()` for CloudWatch Logs log groups (with retention, KMS
-// encryption, and metric filters), `alarms()` for metric alarms, `metrics()`
-// for metric definitions and their dimensions, `resourcePolicies()` and
-// `logDestinations()` for Logs delivery and cross-account destinations, and
-// `logInsightQueries()` for saved Logs Insights queries.
+// Metrics, alarms, and CloudWatch Logs configuration for the account across
+// all enabled regions. Covers log groups (with retention, KMS encryption,
+// and metric filters), metric alarms, metric definitions and their
+// dimensions, Logs resource and account-level policies, cross-account log
+// destinations, saved Logs Insights queries, and Logs anomaly detectors,
+// the building blocks for auditing monitoring coverage and log
+// retention and encryption posture.
 aws.cloudwatch {
   // List of CloudWatch log groups
   logGroups() []aws.cloudwatch.loggroup
@@ -9573,7 +10155,7 @@ aws.cloudwatch {
   // CloudWatch Logs account-level policies
   //
   // Account-level policies returned by `DescribeAccountPolicies` across all
-  // policy types — data protection, subscription filter, field index,
+  // policy types: data protection, subscription filter, field index,
   // transformer, and metric extraction. Each entry exposes the policy
   // document, the policy type, the scope (ALL or SELECTION), and the
   // selection criteria that scopes the policy to a subset of log groups.
@@ -9631,10 +10213,9 @@ private aws.cloudwatch.metric @defaults("name region") {
 
 // Amazon CloudWatch metric dimension
 //
-// Examine a name/value pair that scopes a CloudWatch metric — for example
-// the `InstanceId` dimension on an EC2 metric. Each dimension narrows the
-// metric to a single resource or facet; the parent metric exposes a list of
-// these as `dimensions()`.
+// Name/value pair that scopes a CloudWatch metric, for example the
+// `InstanceId` dimension on an EC2 metric. Each dimension narrows the metric
+// to a single resource or facet.
 aws.cloudwatch.metricdimension @defaults("name value") {
   // Name of the dimension
   name string
@@ -9644,11 +10225,11 @@ aws.cloudwatch.metricdimension @defaults("name value") {
 
 // Amazon CloudWatch metric statistics
 //
-// Examine the time-series datapoints (min/max/average/sum) for a CloudWatch
-// metric over the last 24 hours in hour intervals. The init constructor
-// takes `namespace`, `region`, and `name` — for example
+// Time-series datapoints (min/max/average/sum) for a CloudWatch metric over
+// the last 24 hours in hour intervals. Select a metric with `namespace`,
+// `region`, and `name`, for example
 // `aws.cloudwatch.metricstatistics(namespace: "AWS/EC2", region: "us-east-1", name: "CPUUtilization")`.
-// Use `datapoints` to read the per-hour values.
+// The `datapoints` field holds the per-hour values.
 aws.cloudwatch.metricstatistics @defaults("name region") {
   init(namespace string, region string, name string)
   // Namespace for the metric
@@ -9857,7 +10438,7 @@ private aws.cloudwatch.resourcepolicy @defaults("policyName") {
 
 // Amazon CloudWatch Logs account policy
 //
-// Examine an account-level CloudWatch Logs policy returned by
+// Account-level CloudWatch Logs policy returned by
 // `DescribeAccountPolicies`. Account policies cover data protection
 // (PII masking), subscription filters, field indexes, transformers, and
 // metric extraction; each applies either to every log group in the
@@ -9897,13 +10478,12 @@ private aws.cloudwatch.logAccountPolicy @defaults("policyName policyType") {
 
 // Amazon CloudWatch Logs anomaly detector
 //
-// Examine a CloudWatch Logs anomaly detector — a managed model that
-// continuously analyzes log events from one or more log groups and
-// surfaces anomalies as findings. The `logGroupArnList` selects the log
-// groups under analysis, `kmsKey()` is the customer-managed key
-// protecting the model (if any), `evaluationFrequency` controls how
-// often the model re-evaluates, and `filterPattern` restricts which log
-// events feed into the model.
+// Managed model that continuously analyzes log events from one or more log
+// groups and surfaces anomalies as findings. The `logGroupArnList` selects
+// the log groups under analysis, `kmsKey` is the customer-managed key
+// protecting the model (if any), `evaluationFrequency` controls how often
+// the model re-evaluates, and `filterPattern` restricts which log events
+// feed into the model.
 private aws.cloudwatch.logAnomalyDetector @defaults("detectorName anomalyDetectorStatus") {
   // ARN of the anomaly detector
   anomalyDetectorArn string
@@ -9935,21 +10515,20 @@ private aws.cloudwatch.logAnomalyDetector @defaults("detectorName anomalyDetecto
 
 // Amazon CloudFront
 //
-// Use the CloudFront namespace to enumerate the global CDN configuration
-// for the account. Iterate `distributions()` for every distribution (with
-// origins, default and ordered cache behaviors, viewer-protocol policy, WAF
-// and ACM associations, logging, and custom error responses), `functions()`
-// for the lightweight viewer-request/response functions, `anycastIpLists()`
-// for static-IP allocations, `trustStores()` for the CA bundles used for
-// origin mTLS and Distribution Tenants, `responseHeadersPolicies()`,
-// `cachePolicies()`, `originRequestPolicies()`, and
-// `continuousDeploymentPolicies()` for the reusable policy objects that
-// distributions reference, `originAccessControls()` for the OAC
-// configurations that govern signed origin access, `keyValueStores()` for
-// the data stores that CloudFront Functions read from, and `publicKeys()`,
-// `keyGroups()`, `fieldLevelEncryptionConfigs()`, and
-// `fieldLevelEncryptionProfiles()` for signed-URL and field-level
-// encryption material.
+// Global content delivery network configuration for the account. The
+// distributions collection covers every distribution (with its origins,
+// default and ordered cache behaviors, viewer-protocol policy, WAF and
+// ACM associations, logging, and custom error responses); functions
+// covers the lightweight viewer-request and viewer-response functions;
+// anycastIpLists covers static-IP allocations; and trustStores covers
+// the CA bundles used for origin mTLS and Distribution Tenants. The
+// reusable policy objects distributions reference are available through
+// responseHeadersPolicies, cachePolicies, originRequestPolicies, and
+// continuousDeploymentPolicies, while originAccessControls governs
+// signed origin access and keyValueStores holds the data CloudFront
+// Functions read at runtime. Signed-URL and field-level encryption
+// material is available through publicKeys, keyGroups,
+// fieldLevelEncryptionConfigs, and fieldLevelEncryptionProfiles.
 aws.cloudfront @defaults("distributions functions") {
   // List of CloudFront distributions
   distributions() []aws.cloudfront.distribution
@@ -10034,8 +10613,12 @@ private aws.cloudfront.distribution @defaults("domainName status") {
   // Details on the origins of this distribution
   origins []aws.cloudfront.distribution.origin
   // Default cache behavior for the distribution
+  //
+  // Notable keys: `{TargetOriginId, ViewerProtocolPolicy, AllowedMethods, Compress, CachePolicyId, OriginRequestPolicyId, ResponseHeadersPolicyId, FieldLevelEncryptionId, RealtimeLogConfigArn, FunctionAssociations, LambdaFunctionAssociations, TrustedKeyGroups, TrustedSigners, SmoothStreaming}`. Keys use the CloudFront API's PascalCase. The `viewerProtocolPolicy` field lifts that value to a top-level scalar.
   defaultCacheBehavior dict
   // All cache behaviors for the distribution
+  //
+  // Each item carries the same keys as `defaultCacheBehavior` plus a `PathPattern` that selects the request paths the behavior applies to. Keys use the CloudFront API's PascalCase.
   cacheBehaviors []dict
   // HTTP version of the distribution
   httpVersion string
@@ -10151,7 +10734,7 @@ private aws.cloudfront.function @defaults("name status") {
 
 // Amazon CloudFront response headers policy
 //
-// Examine the response headers CloudFront adds to or removes from
+// Set of response headers CloudFront adds to or removes from
 // responses sent to viewers. The policy carries CORS settings,
 // security-header directives (HSTS, X-Frame-Options, Referrer-Policy,
 // Content-Security-Policy, X-Content-Type-Options, X-XSS-Protection),
@@ -10193,7 +10776,7 @@ private aws.cloudfront.responseHeadersPolicy @defaults("name type lastModifiedTi
 
 // Amazon CloudFront origin access control (OAC)
 //
-// Examine the OAC configurations that authenticate CloudFront's
+// Configuration that authenticates CloudFront's
 // requests to private origins such as S3 buckets, MediaStore containers,
 // MediaPackage v2 channels, and Lambda Function URLs. The `signingBehavior`
 // field controls when CloudFront signs origin requests; the
@@ -10222,7 +10805,7 @@ private aws.cloudfront.originAccessControl @defaults("name originAccessControlOr
 
 // Amazon CloudFront cache policy
 //
-// Examine the values CloudFront includes in the cache key (and forwards
+// Values CloudFront includes in the cache key (and forwards
 // to the origin) for cache behaviors that reference this policy: the
 // HTTP headers, cookies, and query strings to include, whether to honor
 // gzip/Brotli accept-encoding, and the minimum, default, and maximum
@@ -10255,7 +10838,7 @@ private aws.cloudfront.cachePolicy @defaults("name type defaultTtl maxTtl") {
 
 // Amazon CloudFront origin request policy
 //
-// Examine which values CloudFront forwards from viewer requests to the
+// Values CloudFront forwards from viewer requests to the
 // origin without including them in the cache key. `type` is `managed` for
 // AWS-managed policies and `custom` for ones created in the account.
 private aws.cloudfront.originRequestPolicy @defaults("name type lastModifiedTime") {
@@ -10287,7 +10870,7 @@ private aws.cloudfront.originRequestPolicy @defaults("name type lastModifiedTime
 
 // Amazon CloudFront continuous deployment policy
 //
-// Examine the configuration that routes a portion of viewer traffic from
+// Configuration that routes a portion of viewer traffic from
 // a primary distribution to a staging distribution. The `trafficConfig`
 // field describes whether routing is based on a request header
 // (`SingleHeader`) or a traffic-weight split (`SingleWeight`).
@@ -10308,7 +10891,7 @@ private aws.cloudfront.continuousDeploymentPolicy @defaults("id enabled lastModi
 
 // Amazon CloudFront key value store
 //
-// Examine the key-value stores associated with CloudFront Functions. A
+// Key-value store associated with CloudFront Functions. A
 // store keeps data separate from function code so values can change
 // without republishing a function.
 private aws.cloudfront.keyValueStore @defaults("name status lastModifiedTime") {
@@ -10328,7 +10911,7 @@ private aws.cloudfront.keyValueStore @defaults("name status lastModifiedTime") {
 
 // Amazon CloudFront public key
 //
-// Examine the public keys uploaded to CloudFront for use with signed
+// Public key uploaded to CloudFront for use with signed
 // URLs/cookies and field-level encryption. The `encodedKey` field
 // returns the PEM-encoded public key material.
 private aws.cloudfront.publicKey @defaults("name createdTime") {
@@ -10346,9 +10929,9 @@ private aws.cloudfront.publicKey @defaults("name createdTime") {
 
 // Amazon CloudFront key group
 //
-// Examine the groups of public keys CloudFront uses to verify the
+// Group of public keys CloudFront uses to verify the
 // signatures of signed URLs and signed cookies. The `items` field lists
-// the public key identifiers and `publicKeys()` returns the matching
+// the public key identifiers and `publicKeys` returns the matching
 // `aws.cloudfront.publicKey` resources.
 private aws.cloudfront.keyGroup @defaults("name lastModifiedTime") {
   // Unique identifier of the key group
@@ -10367,7 +10950,7 @@ private aws.cloudfront.keyGroup @defaults("name lastModifiedTime") {
 
 // Amazon CloudFront field-level encryption configuration
 //
-// Examine the field-level encryption configurations the account can
+// Field-level encryption configuration the account can
 // attach to cache behaviors. The `queryArgProfileConfig` and
 // `contentTypeProfileConfig` fields describe how a request's query
 // argument or content type selects a field-level encryption profile.
@@ -10390,7 +10973,7 @@ private aws.cloudfront.fieldLevelEncryptionConfig @defaults("id lastModifiedTime
 
 // Amazon CloudFront field-level encryption profile
 //
-// Examine the profiles that pair public keys with the request fields
+// Profile that pairs public keys with the request fields
 // they encrypt. `encryptionEntities` enumerates the (publicKeyId,
 // providerId, fieldPatterns) tuples that drive encryption.
 private aws.cloudfront.fieldLevelEncryptionProfile @defaults("name lastModifiedTime") {
@@ -10410,15 +10993,14 @@ private aws.cloudfront.fieldLevelEncryptionProfile @defaults("name lastModifiedT
 
 // AWS CloudHSM
 //
-// Use the CloudHSM namespace to audit the dedicated hardware security
-// modules an account runs for key custody across all enabled regions.
-// Iterate `clusters()` for every CloudHSM cluster — each row surfaces the
-// operating mode (FIPS or non-FIPS), the cluster and HSM state, the VPC,
-// subnets, and security group the cluster runs in, the backup policy and
-// retention window, the cluster trust certificates, and the individual HSM
-// instances backing the cluster. Iterate `backups()` for every cluster
-// backup, including its state, source cluster and region, and whether it is
-// set to never expire.
+// CloudHSM namespace for the dedicated hardware security modules an account
+// runs for key custody across all enabled regions. The clusters collection
+// covers every CloudHSM cluster, surfacing the operating mode (FIPS or
+// non-FIPS), the cluster and HSM state, the VPC, subnets, and security group
+// the cluster runs in, the backup policy and retention window, the cluster
+// trust certificates, and the individual HSM instances backing the cluster.
+// The backups collection covers every cluster backup, including its state,
+// source cluster and region, and whether it is set to never expire.
 aws.cloudhsm {
   // List of CloudHSM clusters
   clusters() []aws.cloudhsm.cluster
@@ -10428,10 +11010,10 @@ aws.cloudhsm {
 
 // AWS CloudHSM cluster
 //
-// Examine a CloudHSM cluster — the group of hardware security modules that
-// store and use cryptographic keys on dedicated FIPS 140-2 validated
-// hardware. Each cluster is selected by its cluster ID — for example
-// `aws.cloudhsm.cluster(clusterId: "cluster-abcd1234")` — and exposes its
+// Group of hardware security modules that store and use cryptographic keys
+// on dedicated FIPS 140-2 validated hardware. Each cluster is selected by
+// its cluster ID, for example
+// `aws.cloudhsm.cluster(clusterId: "cluster-abcd1234")`, and exposes its
 // operating mode, lifecycle state, the VPC, subnets, and security group it
 // runs in, the backup policy and retention window, the trust certificates
 // established for the cluster, and the HSM instances that back it.
@@ -10478,9 +11060,9 @@ private aws.cloudhsm.cluster @defaults("clusterId state mode region") {
 
 // AWS CloudHSM instance
 //
-// Examine a single hardware security module that backs a CloudHSM cluster.
-// Each HSM is selected by its HSM ID — for example
-// `aws.cloudhsm.hsm(hsmId: "hsm-abcd1234")` — and exposes its lifecycle
+// Single hardware security module that backs a CloudHSM cluster. Each HSM is
+// selected by its HSM ID, for example
+// `aws.cloudhsm.hsm(hsmId: "hsm-abcd1234")`, and exposes its lifecycle
 // state, the cluster it belongs to, the Availability Zone and subnet it runs
 // in, and the elastic network interface that fronts it.
 private aws.cloudhsm.hsm @defaults("hsmId state availabilityZone") {
@@ -10510,9 +11092,8 @@ private aws.cloudhsm.hsm @defaults("hsmId state availabilityZone") {
 
 // AWS CloudHSM cluster backup
 //
-// Examine a backup of a CloudHSM cluster. Each backup is keyed by its ARN —
-// for example
-// `aws.cloudhsm.backup(arn: "arn:aws:cloudhsm:us-east-1:123456789012:backup/backup-abcd1234")` —
+// Backup of a CloudHSM cluster. Each backup is keyed by its ARN, for example
+// `aws.cloudhsm.backup(arn: "arn:aws:cloudhsm:us-east-1:123456789012:backup/backup-abcd1234")`,
 // and exposes the originating cluster, its state, operating mode, whether it
 // is configured to never expire, and the source region and backup it was
 // copied from when applicable.
@@ -10551,12 +11132,12 @@ private aws.cloudhsm.backup @defaults("backupId state clusterId region") {
 
 // AWS CloudTrail
 //
-// Use the CloudTrail namespace to enumerate audit-trail coverage for the
-// account. Iterate `trails()` for every CloudTrail trail (with its S3
-// destination, KMS encryption, log file validation, multi-region and
-// org-trail flags, event selectors, and CloudWatch Logs integration),
-// `eventDataStores()` for CloudTrail Lake event data stores, and
-// `channels()` for channels used to ingest events from external sources.
+// Audit-trail coverage for the account, the record of who did what and when
+// across AWS API activity. `trails` enumerates every configured trail with
+// its S3 destination, KMS encryption, log file validation, and multi-region
+// and organization flags. `eventDataStores` covers CloudTrail Lake event
+// data stores, and `channels` covers the channels that ingest events from
+// external event sources.
 aws.cloudtrail @defaults("trails") {
   // List of CloudTrail trails associated with the account
   trails() []aws.cloudtrail.trail
@@ -10567,6 +11148,14 @@ aws.cloudtrail @defaults("trails") {
 }
 
 // AWS CloudTrail trail
+//
+// Configuration and delivery status of a single CloudTrail trail, the
+// mechanism that records account API activity to an S3 bucket and optionally
+// to CloudWatch Logs. Central to audit and compliance checks: whether
+// logging is currently enabled, whether log file validation and KMS
+// encryption protect the records, whether the trail spans all regions and
+// the whole organization, and which management and data events its event
+// selectors capture.
 private aws.cloudtrail.trail @defaults("name region") {
   // ARN of the trail
   arn string
@@ -10588,7 +11177,7 @@ private aws.cloudtrail.trail @defaults("name region") {
   snsTopic() aws.sns.topic
   // ARN of the SNS topic the trail uses to send notifications
   //
-  // Deprecated in favor of `snsTopic()`.
+  // Deprecated in favor of `snsTopic`.
   snsTopicARN @maturity("deprecated") string
   // Raw status dict for the trail
   //
@@ -10601,11 +11190,11 @@ private aws.cloudtrail.trail @defaults("name region") {
   cloudWatchLogsRole() aws.iam.role
   // ARN of the IAM role for the logs endpoint
   //
-  // Deprecated in favor of `cloudWatchLogsRole()`.
+  // Deprecated in favor of `cloudWatchLogsRole`.
   cloudWatchLogsRoleArn @maturity("deprecated") string
   // ARN of the CloudWatch Logs log group used by the trail
   //
-  // Deprecated in favor of `logGroup()`.
+  // Deprecated in favor of `logGroup`.
   cloudWatchLogsLogGroupArn @maturity("deprecated") string
   // Raw list of event selectors configured for the trail
   //
@@ -10653,19 +11242,19 @@ private aws.cloudtrail.trail @defaults("name region") {
   latestDeliveredAt() time
   // Time of the most recent delivery of log files to the trail's S3 bucket
   //
-  // Deprecated in favor of `latestDeliveredAt()`.
+  // Deprecated in favor of `latestDeliveredAt`.
   latestDeliveryTime() @maturity("deprecated") time
   // Time of the most recent notification sent to the trail's SNS topic
   latestNotifiedAt() time
   // Time of the most recent notification sent to the trail's SNS topic
   //
-  // Deprecated in favor of `latestNotifiedAt()`.
+  // Deprecated in favor of `latestNotifiedAt`.
   latestNotificationTime() @maturity("deprecated") time
   // Time of the most recent log delivery to CloudWatch Logs
   latestCloudWatchLogsDeliveredAt() time
   // Time of the most recent log delivery to CloudWatch Logs
   //
-  // Deprecated in favor of `latestCloudWatchLogsDeliveredAt()`.
+  // Deprecated in favor of `latestCloudWatchLogsDeliveredAt`.
   latestCloudWatchLogsDeliveryTime() @maturity("deprecated") time
   // Most recent error message from delivering log files to S3
   latestDeliveryError() string
@@ -10673,15 +11262,15 @@ private aws.cloudtrail.trail @defaults("name region") {
   latestDigestDeliveredAt() time
   // Time of the most recent digest file delivery to the trail's S3 bucket
   //
-  // Deprecated in favor of `latestDigestDeliveredAt()`.
+  // Deprecated in favor of `latestDigestDeliveredAt`.
   latestDigestDeliveryTime() @maturity("deprecated") time
   // Time of the most recent delivery attempt to S3 (string-formatted timestamp from AWS legacy API)
   latestDeliveryAttemptedAt() string
-  // Whether the most recent delivery attempt to S3 succeeded (string-formatted timestamp or empty)
+  // Timestamp of the most recent successful log file delivery attempt to S3 (string-formatted, or empty if there has been no successful delivery)
   latestDeliveryAttemptSucceededAt() string
   // Time of the most recent notification attempt to SNS (string-formatted timestamp from AWS legacy API)
   latestNotificationAttemptedAt() string
-  // Whether the most recent notification attempt to SNS succeeded (string-formatted timestamp or empty)
+  // Timestamp of the most recent successful SNS notification attempt (string-formatted, or empty if there has been no successful notification)
   latestNotificationAttemptSucceededAt() string
 }
 
@@ -10785,9 +11374,19 @@ private aws.cloudtrail.channel @defaults("name sourceType") {
   region string
   // Source name (e.g., the AWS service name)
   source() string
-  // Destinations where events are delivered (account, type, location)
+  // Destinations where events arriving on the channel are delivered
+  //
+  // Each entry has `Location` (the ARN of the receiving CloudTrail Lake event
+  // data store, or the name of the AWS service for a service-linked channel)
+  // and `Type` (EVENT_DATA_STORE or AWS_SERVICE).
   destinations() []dict
   // Ingestion status for the channel
+  //
+  // Keys `LatestIngestionAttemptEventID`, `LatestIngestionAttemptTime`,
+  // `LatestIngestionErrorCode`, `LatestIngestionSuccessEventID`, and
+  // `LatestIngestionSuccessTime` report the most recent ingestion attempt and
+  // the most recent successful ingestion, plus the error code of the latest
+  // failure.
   ingestionStatus() dict
   // Tags for the channel
   tags() map[string]string
@@ -11216,14 +11815,14 @@ private aws.s3.bucket.websiteConfiguration.routingRule.conditionConf {
 
 // AWS Application Auto Scaling
 //
-// Use the Application Auto Scaling namespace to inspect the scalable
-// targets and policies registered for a single service namespace — for
-// example `aws.applicationAutoscaling(namespace: "ecs")`. The `namespace`
-// field is the selection key (valid values include `ecs`, `rds`, `lambda`,
-// `dynamodb`, `sagemaker`, `elasticmapreduce`, `kafka`, `comprehend`,
-// `appstream`, `elasticache`, `cassandra`, `neptune`, `workspaces`, `ec2`,
-// and `custom-resource`). Iterate `scalableTargets()` for the registered
-// targets in that namespace.
+// Application Auto Scaling configuration for a single service namespace,
+// covering the scalable targets and scaling policies registered in it.
+// The `namespace` field is the selection key (valid values include
+// `ecs`, `rds`, `lambda`, `dynamodb`, `sagemaker`, `elasticmapreduce`,
+// `kafka`, `comprehend`, `appstream`, `elasticache`, `cassandra`,
+// `neptune`, `workspaces`, `ec2`, and `custom-resource`), for example
+// `aws.applicationAutoscaling(namespace: "ecs")`. The `scalableTargets`
+// field lists the registered targets in that namespace.
 aws.applicationAutoscaling @defaults("namespace") {
   init(namespace string)
   // Service namespace to query for application auto scaling
@@ -11250,7 +11849,11 @@ private aws.applicationAutoscaling.target @defaults("arn") {
   minCapacity int
   // Maximum capacity set for the auto scaling target
   maxCapacity int
-  // suspendedState for the auto scaling target
+  // Suspended scaling states for the target
+  //
+  // Keys `DynamicScalingInSuspended`, `DynamicScalingOutSuspended`, and
+  // `ScheduledScalingSuspended` are booleans indicating whether scale-in,
+  // scale-out, or scheduled scaling is currently suspended for the target.
   suspendedState dict
   // Creation date for the auto scaling target
   createdAt time
@@ -11277,12 +11880,28 @@ private aws.applicationAutoscaling.policy @defaults("arn name policyType") {
   // Date the policy was created
   createdAt time
   // CloudWatch alarms associated with the policy
+  //
+  // Each entry has `AlarmARN` and `AlarmName` for a CloudWatch alarm that
+  // triggers this scaling policy.
   alarms []dict
   // Target tracking scaling policy configuration
+  //
+  // Present when `policyType` is `TargetTrackingScaling`. Keys include
+  // `TargetValue`, `PredefinedMetricSpecification`,
+  // `CustomizedMetricSpecification`, `DisableScaleIn`, `ScaleInCooldown`,
+  // and `ScaleOutCooldown`.
   targetTrackingConfig dict
   // Step scaling policy configuration
+  //
+  // Present when `policyType` is `StepScaling`. Keys include
+  // `AdjustmentType`, `StepAdjustments`, `Cooldown`,
+  // `MetricAggregationType`, and `MinAdjustmentMagnitude`.
   stepScalingConfig dict
   // Predictive scaling policy configuration
+  //
+  // Present when `policyType` is `PredictiveScaling`. Keys include
+  // `MetricSpecifications`, `Mode`, `MaxCapacityBreachBehavior`,
+  // `MaxCapacityBuffer`, and `SchedulingBufferTime`.
   predictiveScalingConfig dict
 }
 
@@ -11308,21 +11927,23 @@ private aws.applicationAutoscaling.scheduledAction @defaults("arn name schedule"
   startAt time
   // Date the action is scheduled to end
   endAt time
-  // Min and max capacity to set when the action runs
+  // Capacity bounds applied when the scheduled action runs
+  //
+  // Keys `MinCapacity` and `MaxCapacity` set the capacity range for the
+  // target at the scheduled time.
   scalableTargetAction dict
 }
 
 // AWS Elastic Disaster Recovery (DRS)
 //
-// Use the DRS namespace to enumerate the source servers replicated to the
-// account and the recovery operations performed on them. Iterate
-// `sourceServers()` for each replicated server (with its replication
-// progress, lifecycle state, and last launch result), `recoveryInstances()`
-// for the EC2 instances launched from those source servers during recovery
-// or drill events, `jobs()` for the recovery, drill, and failback jobs that
-// have been kicked off, and `replicationConfigurationTemplates()` for the
-// account-wide templates that define default replication settings for new
-// source servers.
+// Disaster-recovery replication and recovery state for the account. The
+// `sourceServers` list covers each replicated server, with its replication
+// progress, lifecycle state, and last launch result. `recoveryInstances`
+// covers the EC2 instances launched from those source servers during
+// recovery or drill events, `jobs` covers the recovery, drill, and failback
+// jobs that have been kicked off, and `replicationConfigurationTemplates`
+// covers the account-wide templates that define default replication settings
+// for new source servers.
 aws.drs @defaults("sourceServers") {
   // List of source servers being replicated
   sourceServers() []aws.drs.sourceServer
@@ -11335,6 +11956,13 @@ aws.drs @defaults("sourceServers") {
 }
 
 // AWS DRS source server
+//
+// Server being replicated into the account for disaster recovery, covering
+// its replication state and lag, lifecycle timestamps, recommended recovery
+// instance type, source machine properties (CPU, disks, RAM, OS), staging
+// area, and the recovery instance launched from it. Selected by
+// `sourceServerID` or `arn`, for example
+// `aws.drs.sourceServer(sourceServerID: "s-...")`.
 private aws.drs.sourceServer @defaults("sourceServerID arn") {
   // Source server ID
   sourceServerID string
@@ -11343,6 +11971,13 @@ private aws.drs.sourceServer @defaults("sourceServerID arn") {
   // Version of the DRS agent installed on the source server
   agentVersion string
   // Data replication status and progress
+  //
+  // Keys: DataReplicationError, DataReplicationInitiation, DataReplicationState,
+  // EtaDateTime, LagDuration, ReplicatedDisks (per-disk backlog and replicated
+  // byte counts), StagingAvailabilityZone, and StagingOutpostArn. The commonly
+  // queried values are also flattened onto this resource as dataReplicationState,
+  // dataReplicationLagDuration, dataReplicationEtaAt, and
+  // dataReplicationStagingAvailabilityZone.
   dataReplicationInfo dict
   // State of the data replication (e.g. INITIATING, INITIAL_SYNC, BACKLOG, CONTINUOUS, STALLED, DISCONNECTED)
   dataReplicationState string
@@ -11355,6 +11990,13 @@ private aws.drs.sourceServer @defaults("sourceServerID arn") {
   // Result of last launch (NOT_STARTED, PENDING, SUCCEEDED, FAILED)
   lastLaunchResult string
   // Lifecycle state information
+  //
+  // Keys: AddedToServiceDateTime, FirstByteDateTime, LastSeenByServiceDateTime,
+  // ElapsedReplicationDuration, and LastLaunch (result and status of the most
+  // recent launch). The individual timestamps are also flattened onto this
+  // resource as lifeCycleAddedToServiceAt, lifeCycleFirstByteAt,
+  // lifeCycleLastSeenAt, lifeCycleElapsedReplicationDuration, and
+  // lifeCycleLastLaunchStatus.
   lifeCycle dict
   // Date the source server was added to the service
   lifeCycleAddedToServiceAt time
@@ -11367,6 +12009,12 @@ private aws.drs.sourceServer @defaults("sourceServerID arn") {
   // Status of the source server's last launch (PENDING, IN_PROGRESS, LAUNCHED, FAILED, TERMINATED)
   lifeCycleLastLaunchStatus string
   // Source server properties (OS, disks, network)
+  //
+  // Keys: Cpus, Disks, NetworkInterfaces, Os, RamBytes, RecommendedInstanceType,
+  // SupportsNitroInstances, IdentificationHints, and LastUpdatedDateTime. The
+  // scalar summaries are also flattened onto this resource as sourceCpuCount,
+  // sourceDiskCount, sourceRamBytes, sourceRecommendedInstanceType, and
+  // sourceSupportsNitroInstances.
   sourceProperties dict
   // Number of CPUs reported by the source server
   sourceCpuCount int
@@ -11395,12 +12043,16 @@ private aws.drs.sourceServer @defaults("sourceServerID arn") {
   // For failed-over and failed-back EC2 source servers, the source server on the opposite replication direction
   reversedDirectionSourceServer() aws.drs.sourceServer
   // Staging area configuration
+  //
+  // Extended staging source server, when replication is staged through a
+  // separate account. Keys: StagingAccountID, StagingSourceServerArn, Status
+  // (EXTENDED, NOT_EXTENDED, or EXTENSION_ERROR), and ErrorMessage.
   stagingArea dict
   // Replication direction: FAILOVER_AND_FAILBACK or ONE_WAY
   replicationDirection string
   // ID of the recovery instance launched from this source server
   //
-  // Deprecated in favor of `recoveryInstance()`.
+  // Deprecated in favor of `recoveryInstance`.
   recoveryInstanceId @maturity("deprecated") string
   // Recovery instance launched from this source server
   recoveryInstance() aws.drs.recoveryInstance
@@ -11414,12 +12066,12 @@ private aws.drs.sourceServer @defaults("sourceServerID arn") {
 
 // AWS DRS recovery instance
 //
-// Examine recovery instances launched in EC2 from replicated source servers.
-// Each recovery instance is selected by `arn` — for example
-// `aws.drs.recoveryInstance(arn: "arn:aws:drs:us-east-1:123456789012:recovery-instance/i-...")`
-// — and exposes the underlying EC2 instance, the source server it was
-// recovered from, the launching DRS job, the EC2 instance state, data
-// replication progress for failback, and whether the launch was a drill.
+// Recovery instance launched in EC2 from a replicated source server. Exposes
+// the underlying EC2 instance, the source server it was recovered from, the
+// launching DRS job, the EC2 instance state, data replication progress for
+// failback, and whether the launch was a drill. Selected by `arn`, for
+// example `aws.drs.recoveryInstance(arn:
+// "arn:aws:drs:us-east-1:111111111111:recovery-instance/i-...")`.
 private aws.drs.recoveryInstance @defaults("recoveryInstanceID arn ec2InstanceState") {
   // Recovery instance ID
   recoveryInstanceID string
@@ -11450,14 +12102,31 @@ private aws.drs.recoveryInstance @defaults("recoveryInstanceID arn ec2InstanceSt
   // Date and time of the Point in Time (PIT) snapshot this recovery instance was launched from
   pointInTimeSnapshotAt time
   // Data replication info for failback (state, lag, replicated disks)
+  //
+  // Keys: DataReplicationError, DataReplicationInitiation, DataReplicationState,
+  // EtaDateTime, LagDuration, ReplicatedDisks, StagingAvailabilityZone, and
+  // StagingOutpostArn. The state and lag are also flattened onto this resource
+  // as dataReplicationState and dataReplicationLagDuration.
   dataReplicationInfo dict
-  // State of failback data replication (e.g. STOPPED, INITIATING, INITIAL_SYNC, REPLICATION, RESCAN, STALLED, DISCONNECTED, NOT_STARTED)
+  // State of failback data replication
+  //
+  // One of STOPPED, INITIATING, INITIAL_SYNC, BACKLOG, CREATING_SNAPSHOT,
+  // CONTINUOUS, PAUSED, RESCAN, STALLED, DISCONNECTED,
+  // REPLICATION_STATE_NOT_AVAILABLE, or NOT_STARTED.
   dataReplicationState string
   // Failback data replication lag duration (ISO 8601 duration)
   dataReplicationLagDuration string
   // Failback related information for this recovery instance
+  //
+  // Keys: State (failback state), FailbackLaunchType, FailbackToOriginalServer,
+  // FailbackClientID, FailbackJobID, FailbackInitiationTime,
+  // FailbackClientLastSeenByServiceDateTime, AgentLastSeenByServiceDateTime,
+  // FirstByteDateTime, and ElapsedReplicationDuration.
   failback dict
   // Properties of the recovery instance machine (CPUs, disks, RAM, OS)
+  //
+  // Keys: Cpus, Disks, NetworkInterfaces, Os, RamBytes, IdentificationHints,
+  // and LastUpdatedDateTime.
   recoveryInstanceProperties dict
   // ARN of the source Outpost
   sourceOutpostArn string
@@ -11466,6 +12135,11 @@ private aws.drs.recoveryInstance @defaults("recoveryInstanceID arn ec2InstanceSt
 }
 
 // AWS DRS job
+//
+// Asynchronous DRS operation such as a recovery launch, drill, failback, or
+// termination, covering its type, status, how it was initiated, the servers
+// and resources participating, and the creation and completion timestamps.
+// Selected by `jobID`, for example `aws.drs.job(jobID: "drsjob-...")`.
 private aws.drs.job @defaults("jobID type status") {
   // Job ID
   jobID string
@@ -11484,8 +12158,16 @@ private aws.drs.job @defaults("jobID type status") {
   // Job completion timestamp
   endedAt time
   // Servers participating in job
+  //
+  // Each entry has keys: SourceServerID, RecoveryInstanceID, LaunchStatus
+  // (PENDING, IN_PROGRESS, LAUNCHED, FAILED, or TERMINATED), and
+  // LaunchActionsStatus.
   participatingServers []dict
   // Resources participating in the job (e.g. source networks)
+  //
+  // Each entry has keys: ParticipatingResourceID (identifies the source
+  // network) and LaunchStatus (PENDING, IN_PROGRESS, LAUNCHED, FAILED, or
+  // TERMINATED).
   participatingResources []dict
   // Resource tags
   tags map[string]string
@@ -11493,12 +12175,11 @@ private aws.drs.job @defaults("jobID type status") {
 
 // AWS DRS replication configuration template
 //
-// Examine the templates that define default replication settings for new
-// source servers — the staging-area subnet, the EBS volume type and
-// encryption mode, bandwidth throttling, the data plane routing mechanism,
-// the security groups attached to the replication server, and the
-// point-in-time snapshot retention policy. Each template is selected by
-// `replicationConfigurationTemplateID` — for example
+// Template defining default replication settings for new source servers: the
+// staging-area subnet, the EBS volume type and encryption mode, bandwidth
+// throttling, the data plane routing mechanism, the security groups attached
+// to the replication server, and the point-in-time snapshot retention policy.
+// Selected by `replicationConfigurationTemplateID`, for example
 // `aws.drs.replicationConfigurationTemplate(replicationConfigurationTemplateID: "rct-...")`.
 private aws.drs.replicationConfigurationTemplate @defaults("replicationConfigurationTemplateID arn") {
   // Replication configuration template ID
@@ -11526,6 +12207,9 @@ private aws.drs.replicationConfigurationTemplate @defaults("replicationConfigura
   // Internet protocol used for replication (IPV4, IPV6)
   internetProtocol string
   // Point in time (PIT) snapshot retention rules
+  //
+  // Each rule has keys: RuleID, Enabled, Interval, Units (MINUTE, HOUR, or
+  // DAY), and RetentionDuration.
   pitPolicy []dict
   // EC2 instance type used for the replication server
   replicationServerInstanceType string
@@ -11546,6 +12230,11 @@ private aws.drs.replicationConfigurationTemplate @defaults("replicationConfigura
 }
 
 // AWS DRS replication configuration
+//
+// Per-source-server replication settings: the staging-area subnet, EBS
+// encryption mode and KMS key, replicated disks, bandwidth throttling, data
+// plane routing, and whether a dedicated replication server and the default
+// security group are used. Selected by `sourceServerID`.
 private aws.drs.replicationConfiguration @defaults("sourceServerID") {
   // Associated source server ID
   sourceServerID string
@@ -11567,9 +12256,13 @@ private aws.drs.replicationConfiguration @defaults("sourceServerID") {
   ebsEncryptionKey() aws.kms.key
   // ARN of the custom KMS key for EBS encryption
   //
-  // Deprecated in favor of `ebsEncryptionKey()`.
+  // Deprecated in favor of `ebsEncryptionKey`.
   ebsEncryptionKeyArn @maturity("deprecated") string
   // Disk replication configuration
+  //
+  // Each disk has keys: DeviceName, IsBootDisk, StagingDiskType,
+  // OptimizedStagingDiskType (AUTO, GP2, GP3, IO1, SC1, ST1, or STANDARD),
+  // Iops, and Throughput.
   replicatedDisks []dict
   // Bandwidth throttling in Mbps
   bandwidthThrottling int
@@ -11586,6 +12279,11 @@ private aws.drs.replicationConfiguration @defaults("sourceServerID") {
 }
 
 // AWS DRS launch configuration
+//
+// Per-source-server settings that govern how a recovery instance is launched:
+// the instance-type right-sizing method, launch disposition, private-IP and
+// tag copying, the EC2 launch template, licensing, and post-launch actions.
+// Selected by `sourceServerID`.
 private aws.drs.launchConfiguration @defaults("sourceServerID") {
   // Associated source server ID
   sourceServerID string
@@ -11600,21 +12298,27 @@ private aws.drs.launchConfiguration @defaults("sourceServerID") {
   // EC2 launch template ID
   ec2LaunchTemplateID string
   // Licensing configuration
+  //
+  // Single key OsByol: whether the recovery instance uses a bring-your-own
+  // operating-system license rather than a license included by AWS.
   licensing dict
   // Post-launch actions
   postLaunchEnabled bool
   // Launch into instance properties
+  //
+  // Single key LaunchIntoEC2InstanceID: the ID of an existing EC2 instance the
+  // recovery is launched into, when configured.
   launchIntoInstanceProperties dict
 }
 
 // AWS Backup
 //
-// Use the AWS Backup namespace to enumerate cross-service backup
-// configuration and the recovery points produced. Iterate `vaults()` for
-// every backup vault (with its KMS encryption, access policy, lock
-// configuration, and stored recovery points), and `plans()` for the backup
-// plans that drive scheduled backups across services like RDS, EBS, EFS,
-// FSx, DynamoDB, and S3.
+// Cross-service backup configuration and the recovery points it produces.
+// The `vaults` field lists every backup vault with its KMS encryption,
+// access policy, lock configuration, and stored recovery points; `plans`
+// lists the backup plans that drive scheduled backups across services like
+// RDS, EBS, EFS, FSx, DynamoDB, and S3; and `scanJobs` lists the malware
+// scans run against recovery points.
 aws.backup @defaults("vaults") {
   // List of vaults for the service
   vaults() []aws.backup.vault
@@ -11672,6 +12376,10 @@ private aws.backup.vaultRecoveryPoint @defaults("resourceType completionDate sta
   // ARN of the backup vault this recovery point was copied from, if it is a copy
   sourceBackupVaultArn string
   // Information about who created the recovery point
+  //
+  // Has keys `BackupPlanArn`, `BackupPlanId`, `BackupPlanVersion`, and
+  // `BackupRuleId` identifying the backup plan and rule that produced the
+  // recovery point.
   createdBy dict
   // IAM role used to create the recovery point
   iamRole() aws.iam.role
@@ -11740,11 +12448,11 @@ private aws.backup.plan @defaults("name region") {
 
 // AWS Backup plan resource selection
 //
-// Examine which resources a backup plan protects. The `resources` and
+// Resources that a backup plan protects. The `resources` and
 // `notResources` lists hold the resource ARNs explicitly assigned to or
 // excluded from the plan, while `listOfTags` and `conditions` capture the
 // tag-based rules that assign matching resources. Use it to audit backup
-// coverage — for example, confirm that production databases are targeted by
+// coverage, for example confirming that production databases are targeted by
 // a plan with `aws.backup.plan.selections.any(resources.any(_ == /arn:aws:rds:/))`.
 private aws.backup.plan.selection @defaults("name") {
   // Selection ID
@@ -11900,16 +12608,21 @@ private aws.backup.scanJob @defaults("resourceName resourceType state scanResult
 
 // Amazon DynamoDB
 //
-// Use the DynamoDB namespace to enumerate tables, replicas, backups, and
-// the in-memory accelerator. Iterate `tables()` for every DynamoDB table
-// (with its key schema, throughput mode, encryption, point-in-time recovery,
-// global secondary indexes, and stream specification), `globalTables()` for
-// multi-region replicated tables, `backups()` for on-demand and continuous
-// backups, `exports()` for table exports to S3, `daxClusters()` for DAX
-// (DynamoDB Accelerator) clusters, and `limits()` for per-region account
-// limits.
+// DynamoDB tables, global tables, backups, exports, and the in-memory
+// accelerator across every enabled region. Table records expose key schema,
+// throughput mode, encryption at rest, point-in-time recovery, global
+// secondary indexes, and stream configuration; global tables expose their
+// per-region replica settings; DAX clusters expose node-level encryption and
+// endpoint settings. Query this namespace to audit encryption posture,
+// backup and recovery coverage, and stream exposure for the account's NoSQL
+// data stores.
 aws.dynamodb {
-  // List of backups for DynamoDB
+  // On-demand and system backups across all DynamoDB tables
+  //
+  // Each entry carries BackupArn, BackupName, BackupCreationDateTime,
+  // BackupExpiryDateTime, BackupSizeBytes, BackupStatus (CREATING, ACTIVE, or
+  // DELETED), BackupType (USER, SYSTEM, or AWS_BACKUP), and the source
+  // TableName, TableId, and TableArn.
   backups() []dict
   // List of global tables for DynamoDB
   globalTables() []aws.dynamodb.globaltable
@@ -11941,7 +12654,9 @@ private aws.dynamodb.dax.cluster @defaults("arn clusterName") {
   activeNodes int
   // Region where the cluster exists
   region string
-  // Whether server-side encryption (SSE) is enabled (ENABLING, ENABLED, DISABLING, DISABLED)
+  // Server-side encryption (SSE) status
+  //
+  // One of ENABLING, ENABLED, DISABLING, or DISABLED.
   sseStatus string
   // Whether server-side encryption at rest is enabled
   encrypted bool
@@ -12001,7 +12716,12 @@ private aws.dynamodb.globaltable @defaults("name") {
   arn string
   // Table name
   name string
-  // List of replica settings for the table
+  // Per-region replica settings for the global table
+  //
+  // Each entry carries RegionName, ReplicaStatus, ReplicaBillingModeSummary,
+  // ReplicaProvisionedReadCapacityUnits,
+  // ReplicaProvisionedWriteCapacityUnits, ReplicaTableClassSummary, and
+  // ReplicaGlobalSecondaryIndexSettings.
   replicaSettings() []dict
 }
 
@@ -12015,9 +12735,18 @@ private aws.dynamodb.table @defaults("name region") {
   region string
   // Table ID
   id string
-  // Backups for the table
+  // On-demand and system backups of the table
+  //
+  // Each entry carries BackupArn, BackupName, BackupCreationDateTime,
+  // BackupExpiryDateTime, BackupSizeBytes, BackupStatus (CREATING, ACTIVE, or
+  // DELETED), and BackupType (USER, SYSTEM, or AWS_BACKUP).
   backups() []dict
-  // Description of server-side encryption for the table
+  // Server-side encryption settings for the table
+  //
+  // Carries Status (ENABLING, ENABLED, DISABLING, DISABLED, or UPDATING),
+  // SSEType (AES256 or KMS), KMSMasterKeyArn, and
+  // InaccessibleEncryptionDateTime. See sseType and sseKmsKey for the
+  // resolved values.
   sseDescription() dict
   // Type of server-side encryption: "AES256" (AWS-owned) or "KMS" (customer-managed or AWS-managed KMS key)
   sseType() string
@@ -12026,8 +12755,19 @@ private aws.dynamodb.table @defaults("name region") {
   // KMS key used for server-side encryption at rest
   sseKmsKey() aws.kms.key
   // Provisioned throughput settings for the table
+  //
+  // Carries ReadCapacityUnits, WriteCapacityUnits, NumberOfDecreasesToday,
+  // LastIncreaseDateTime, and LastDecreaseDateTime. Capacity units are zero
+  // on PAY_PER_REQUEST (on-demand) tables.
   provisionedThroughput() dict
   // Continuous backups and point-in-time recovery settings for the table
+  //
+  // Carries ContinuousBackupsStatus (ENABLED or DISABLED) and a nested
+  // PointInTimeRecoveryDescription with PointInTimeRecoveryStatus,
+  // EarliestRestorableDateTime, LatestRestorableDateTime, and
+  // RecoveryPeriodInDays. See continuousBackupsEnabled,
+  // pointInTimeRecoveryEnabled, and pitrRecoveryPeriodInDays for the resolved
+  // values.
   continuousBackups() dict
   // Whether point-in-time recovery (PITR) is enabled
   pointInTimeRecoveryEnabled() bool
@@ -12093,24 +12833,42 @@ private aws.dynamodb.table @defaults("name region") {
   // Regions where the table is replicated (global tables)
   replicaRegions() []string
   // Time to live (TTL) settings for the table
+  //
+  // Carries TimeToLiveStatus (ENABLING, DISABLING, ENABLED, or DISABLED) and
+  // AttributeName, the item attribute holding the expiry timestamp. Null when
+  // TTL has never been configured.
   ttlDescription() dict
   // Global secondary indexes on the table
+  //
+  // Each entry carries IndexName, IndexArn, IndexStatus (CREATING, UPDATING,
+  // DELETING, or ACTIVE), IndexSizeBytes, ItemCount, Backfilling, KeySchema,
+  // Projection, and ProvisionedThroughput.
   globalSecondaryIndexes() []dict
 }
 
 // Amazon Simple Queue Service (SQS)
 //
-// Use the SQS namespace to enumerate message queues in the account across
-// all enabled regions. Iterate `queues()` for every SQS queue — each row
-// surfaces the queue's KMS encryption, dead-letter queue, message retention
-// and visibility settings, FIFO and content-based deduplication flags,
-// access policy, and the per-queue delivery and receive-wait configuration.
+// Message queues in the account across all enabled regions. The `queues`
+// field returns every SQS queue, each row surfacing its KMS encryption,
+// dead-letter queue, message retention and visibility settings, FIFO and
+// content-based deduplication flags, access policy, and the per-queue
+// delivery and receive-wait configuration. Inspect the access policy and
+// the `isPublic` predicate on each queue to find queues reachable by
+// untrusted principals.
 aws.sqs {
   // List of Amazon SQS queues
   queues() []aws.sqs.queue
 }
 
 // Amazon Simple Queue Service (SQS) Queue
+//
+// Single SQS message queue and its configuration. Covers encryption at
+// rest through kmsKey or sqsManagedSseEnabled, the dead-letter queue and
+// redrive settings, message retention, delivery delay, and visibility
+// timeout. The resource-based access policy is available as raw policy
+// JSON or as parsed policyStatements, with isPublic flagging queues whose
+// policy grants access to any principal. FIFO queues additionally expose
+// deduplicationScope, fifoThroughputLimit, and contentBasedDeduplication.
 private aws.sqs.queue {
   // ARN for the queue
   arn() string
@@ -12136,7 +12894,7 @@ private aws.sqs.queue {
   region string
   // Whether SSE is enabled for the queue
   sqsManagedSseEnabled() bool
-  // Type of queue: Fifo or Standard
+  // Type of queue: fifo or standard
   queueType() string
   // URL for the queue
   url string
@@ -12146,7 +12904,12 @@ private aws.sqs.queue {
   deduplicationScope() string
   // FIFO throughput limit (perQueue or perMessageGroupId)
   fifoThroughputLimit() string
-  // Access policy for the queue (parsed JSON)
+  // Queue access policy
+  //
+  // Resource-based access policy as a parsed IAM policy document, with the
+  // standard Version, Id, and Statement keys. See policyStatements for the
+  // individual statements and isPublic for whether any statement grants
+  // public access.
   policy() dict
   // Parsed statements from the queue access policy
   policyStatements() []aws.iam.policyStatement
@@ -12156,7 +12919,12 @@ private aws.sqs.queue {
   tags() map[string]string
   // Whether content-based deduplication is enabled (FIFO queues only)
   contentBasedDeduplication() bool
-  // Redrive allow policy controlling which source queues can use this queue as a dead-letter queue (parsed JSON)
+  // Redrive allow policy
+  //
+  // Policy controlling which source queues may use this queue as their
+  // dead-letter queue, as a parsed JSON object. The redrivePermission key
+  // is one of allowAll, denyAll, or byQueue, and sourceQueueArns lists the
+  // permitted source queue ARNs when the permission is byQueue.
   redriveAllowPolicy() dict
 }
 
@@ -12194,13 +12962,11 @@ aws.rds {
 
 // Amazon RDS option group
 //
-// Examine engine-specific feature options bundled into a named group and
-// attached to DB instances. Use the optionGroupName field as the selection
-// key — for example
-// `aws.rds.optionGroup(optionGroupName: "default:postgres-16")`. Each row
-// reports the engine name, major engine version, the configured options
-// (as a list of dicts), and whether the group can be applied to both VPC
-// and non-VPC instances.
+// Engine-specific feature options bundled into a named group and attached
+// to DB instances. The optionGroupName field selects the group, for example
+// `aws.rds.optionGroup(optionGroupName: "default:postgres-16")`. Reports the
+// engine name, major engine version, the configured options, and whether the
+// group can be applied to both VPC and non-VPC instances.
 private aws.rds.optionGroup @defaults("optionGroupName engineName majorEngineVersion") {
   // ARN of the option group
   arn string
@@ -12228,21 +12994,21 @@ private aws.rds.optionGroup @defaults("optionGroupName engineName majorEngineVer
   copyTimestamp time
   // Configured options in the group
   //
-  // Each entry contains optionName, optionVersion, optionDescription, persistent,
-  // permanent, port, optionSettings (list of name/value/allowed-values),
-  // vpcSecurityGroupMemberships, and dbSecurityGroupMemberships.
+  // Each entry contains OptionName, OptionVersion, OptionDescription, Persistent,
+  // Permanent, Port, OptionSettings (list of Name/Value/AllowedValues),
+  // VpcSecurityGroupMemberships, and DBSecurityGroupMemberships.
   options []dict
 }
 
 // Amazon Aurora global cluster
 //
-// Examine an Aurora global database — a single cluster that spans multiple
-// regions with one writer and one or more reader regions. Use the
-// globalClusterIdentifier field as the selection key — for example
+// Aurora global database: a single database that spans multiple regions
+// with one writer and one or more reader regions. The
+// globalClusterIdentifier field selects the cluster, for example
 // `aws.rds.globalCluster(globalClusterIdentifier: "my-aurora-global")`.
-// Each row reports the engine and version, member DB clusters, encryption
-// state, deletion-protection, the global write endpoint, and any pending
-// failover or switchover state.
+// Reports the engine and version, member DB clusters, encryption state,
+// deletion protection, the global write endpoint, and any pending failover
+// or switchover state.
 private aws.rds.globalCluster @defaults("globalClusterIdentifier engine status") {
   // ARN of the global cluster
   arn string
@@ -12268,11 +13034,15 @@ private aws.rds.globalCluster @defaults("globalClusterIdentifier engine status")
   storageEncrypted bool
   // Storage encryption type
   storageEncryptionType string
-  // Pending or in-progress switchover/failover state, or null when none
+  // Pending or in-progress switchover or failover state, or null when none
+  //
+  // Contains FromDbClusterArn, ToDbClusterArn, IsDataLossAllowed (true for a
+  // failover, false for a switchover), and Status (for example pending,
+  // failing-over, switching-over, or cancelling).
   failoverState dict
   // Member DB clusters of the global cluster
   //
-  // Each entry contains dbClusterArn, isWriter, globalWriteForwardingStatus, synchronizationStatus, and readers (list of secondary cluster ARNs).
+  // Each entry contains DBClusterArn, IsWriter, GlobalWriteForwardingStatus, SynchronizationStatus, and Readers (list of secondary cluster ARNs).
   members []dict
 }
 
@@ -12302,13 +13072,12 @@ private aws.rds.backupsetting {
 
 // Amazon RDS database cluster
 //
-// Examine an Aurora or Multi-AZ DB cluster and its members. Use the `id`
-// field as the selection key — for example
-// `aws.rds.dbcluster(id: "prod-aurora-cluster")`. Each row surfaces the
-// engine and version, member DB instances, snapshots, KMS encryption and
-// storage type, backup retention, deletion protection, IAM database
-// authentication, network exposure (publicly accessible, VPC, security
-// groups), and the pending maintenance actions for the cluster.
+// Aurora or Multi-AZ DB cluster and its members. The `id` field selects the
+// cluster, for example `aws.rds.dbcluster(id: "prod-aurora-cluster")`.
+// Surfaces the engine and version, member DB instances, snapshots, KMS
+// encryption and storage type, backup retention, deletion protection, IAM
+// database authentication, network exposure (publicly accessible, VPC,
+// security groups), and the pending maintenance actions for the cluster.
 aws.rds.dbcluster @defaults("id region engine engineVersion") {
   // ARN for the database cluster
   arn string
@@ -12423,6 +13192,8 @@ aws.rds.dbcluster @defaults("id region engine engineVersion") {
   // KMS key used to encrypt the activity stream
   activityStreamKmsKey() aws.kms.key
   // Master user secret managed by Secrets Manager
+  //
+  // Contains secretArn, kmsKeyId, and secretStatus.
   masterUserSecret dict
   // Whether tags are automatically copied to snapshots of the DB cluster
   copyTagsToSnapshot bool
@@ -12462,6 +13233,11 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
   // ID of the snapshot
   id string
   // Attribute values that describe permissions to restore the snapshot
+  //
+  // Each entry contains AttributeName and AttributeValues. For the "restore"
+  // attribute, AttributeValues lists the AWS account IDs allowed to restore
+  // the snapshot; the value "all" means the snapshot is public. The isPublic
+  // field derives its result from this.
   attributes() []dict
   // Type of snapshot: manual or automated
   type string
@@ -12513,12 +13289,12 @@ private aws.rds.snapshot @defaults("id region type encrypted createdAt") {
 
 // Amazon RDS database instance
 //
-// Examine an RDS DB instance — the per-engine database server that lives
-// either standalone or as a member of an Aurora or Multi-AZ cluster. Use
-// the `id` field as the selection key — for example
-// `aws.rds.dbinstance(id: "prod-mysql-01")`. Each row surfaces the engine
-// and version, instance class, KMS encryption, storage type and IOPS,
-// backup retention, deletion and minor-version-upgrade flags, public
+// RDS DB instance: the per-engine database server that lives either
+// standalone or as a member of an Aurora or Multi-AZ cluster. The `id`
+// field selects the instance, for example
+// `aws.rds.dbinstance(id: "prod-mysql-01")`. Surfaces the engine and
+// version, instance class, KMS encryption, storage type and IOPS, backup
+// retention, deletion and minor-version-upgrade flags, public
 // accessibility, VPC and security-group placement, IAM authentication
 // state, parameter groups, snapshots, and pending maintenance actions.
 aws.rds.dbinstance @defaults("id region engine engineVersion") {
@@ -12667,6 +13443,8 @@ aws.rds.dbinstance @defaults("id region engine engineVersion") {
   // KMS key used to encrypt the activity stream
   activityStreamKmsKey() aws.kms.key
   // Master user secret managed by Secrets Manager
+  //
+  // Contains secretArn, kmsKeyId, and secretStatus.
   masterUserSecret dict
   // Whether the DB instance uses a customer-owned IP address (CoIP) for Outpost deployments
   customerOwnedIpEnabled bool
@@ -12718,11 +13496,10 @@ private aws.rds.pendingMaintenanceAction {
 
 // Amazon RDS DB cluster parameter group
 //
-// Examine a named set of engine parameters that applies to one or more
-// Aurora or Multi-AZ DB clusters. Use the `name` field as the selection
-// key — for example
-// `aws.rds.clusterParameterGroup(name: "default.aurora-postgresql15")`.
-// Iterate `parameters()` for the individual parameter values configured in
+// Named set of engine parameters that applies to one or more Aurora or
+// Multi-AZ DB clusters. The `name` field selects the group, for example
+// `aws.rds.clusterParameterGroup(name: "default.aurora-postgresql15")`. The
+// `parameters` field lists the individual parameter values configured in
 // the group; the `family` field records which engine version family the
 // group is compatible with.
 aws.rds.clusterParameterGroup @defaults("name family region arn") {
@@ -12741,12 +13518,12 @@ aws.rds.clusterParameterGroup @defaults("name family region arn") {
 
 // Amazon RDS DB parameter group
 //
-// Examine a named set of engine parameters that applies to one or more RDS
-// DB instances. Use the `name` field as the selection key — for example
-// `aws.rds.parameterGroup(name: "default.mysql8.0")`. Iterate
-// `parameters()` for the individual parameter values configured in the
-// group; the `family` field records which engine version family the group
-// is compatible with.
+// Named set of engine parameters that applies to one or more RDS DB
+// instances. The `name` field selects the group, for example
+// `aws.rds.parameterGroup(name: "default.mysql8.0")`. The `parameters`
+// field lists the individual parameter values configured in the group; the
+// `family` field records which engine version family the group is
+// compatible with.
 aws.rds.parameterGroup @defaults("name family region arn") {
   // ARN for resource
   arn string
@@ -12764,11 +13541,11 @@ aws.rds.parameterGroup @defaults("name family region arn") {
 
 // Amazon RDS parameter
 //
-// Examine a single engine parameter belonging to an RDS DB parameter group
-// or cluster parameter group. Surfaces the parameter's name, current value,
-// allowed values, default vs user-set source, modifiability flag, when the
-// change is applied (immediate vs pending-reboot), and the data and apply
-// types reported by the engine.
+// Single engine parameter belonging to an RDS DB parameter group or cluster
+// parameter group. Surfaces the parameter's name, current value, allowed
+// values, default vs user-set source, modifiability flag, when the change
+// is applied (immediate vs pending-reboot), and the data and apply types
+// reported by the engine.
 aws.rds.parameterGroup.parameter @defaults("name value") {
   // Specifies the valid range of values for the parameter
   allowedValues string
@@ -12797,14 +13574,13 @@ aws.rds.parameterGroup.parameter @defaults("name value") {
 
 // Amazon ElastiCache
 //
-// Use the ElastiCache namespace to enumerate Redis and Memcached cache
-// deployments and the configuration objects they reference. Iterate
-// `cacheClusters()` for cluster-mode deployments,
-// `serverlessCaches()` for serverless caches, `parameterGroups()` and
-// `subnetGroups()` for the parameter and subnet bindings used by clusters,
-// `users()` for the RBAC users defined for Redis access, `snapshots()` for
-// cache snapshots, and `serviceUpdates()` for available service updates
-// the account can apply.
+// In-memory caching service for Redis, Valkey, and Memcached workloads
+// in an account and region. Cache clusters carry engine version,
+// encryption at rest and in transit, network placement, and security
+// group bindings, while serverless caches, parameter groups, subnet
+// groups, RBAC users, snapshots, and available service updates round out
+// the configuration surface an audit needs to reason about cache exposure,
+// data protection, and patch posture.
 aws.elasticache @defaults("cacheClusters") {
   // List of cache clusters
   cacheClusters() []aws.elasticache.cluster
@@ -12823,6 +13599,13 @@ aws.elasticache @defaults("cacheClusters") {
 }
 
 // Amazon ElastiCache cluster
+//
+// Single Redis, Valkey, or Memcached cache cluster and the security
+// posture around it: at-rest and in-transit encryption, Redis auth-token
+// enforcement, the VPC subnet group and security groups that gate network
+// access, the KMS key protecting data at rest, the parameter group
+// applied, snapshot retention, and the SNS topic notified of cluster
+// events. The `exposure` field summarizes ingress reachability.
 private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine") {
   // ARN for the cluster
   arn string
@@ -12862,11 +13645,21 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
   engineVersion string
   // Network type associated with the cluster: ipv4 or ipv6
   ipDiscovery string
-  // Log delivery configurations being modified
+  // Log delivery configurations
+  //
+  // One entry per configured log stream. Each dict carries
+  // `DestinationType` (cloudwatch-logs or kinesis-firehose),
+  // `DestinationDetails` (the target log group or Firehose stream),
+  // `LogType` (slow-log or engine-log), `LogFormat` (text or json),
+  // `Status` (enabling, disabling, modifying, active, or error), and
+  // `Message` (an error message when status is error).
   logDeliveryConfigurations []dict
   // Supported network connection type for the cluster: ipv4, ipv6, or dual_stack
   networkType string
-  // Describes a notification topic and its status
+  // ARN of the SNS topic that receives cluster event notifications
+  //
+  // Empty when no notification topic is configured. See `notificationTopic`
+  // for the resolved SNS topic.
   notificationConfiguration string
   // SNS topic that receives cluster event notifications
   notificationTopic() aws.sns.topic
@@ -12915,6 +13708,12 @@ private aws.elasticache.cluster @defaults("cacheClusterId region nodeType engine
 }
 
 // Amazon ElastiCache serverless cache
+//
+// Serverless Redis, Valkey, or Memcached cache that scales capacity
+// automatically, selected by `name`. Exposes the cache engine and version,
+// the KMS key encrypting data at rest, the VPC subnets and security groups
+// that gate access, and snapshot retention, so an audit can confirm
+// encryption and network isolation without a provisioned cluster.
 private aws.elasticache.serverlessCache @defaults("name description status engine engineVersion") {
   // ARN for the cache
   arn string
@@ -12953,6 +13752,12 @@ private aws.elasticache.serverlessCache @defaults("name description status engin
 }
 
 // Amazon ElastiCache parameter group
+//
+// Named set of engine parameters applied to cache clusters, selected by
+// `name`. The `family` field ties the group to an engine version line
+// (for example redis7 or memcached1.6), and `isGlobal` marks groups bound
+// to a Global datastore. Clusters reference their group through the
+// cluster's `parameterGroup` field.
 private aws.elasticache.parameterGroup @defaults("name family") {
   // ARN of the parameter group
   arn string
@@ -12969,6 +13774,11 @@ private aws.elasticache.parameterGroup @defaults("name family") {
 }
 
 // Amazon ElastiCache subnet group
+//
+// Collection of VPC subnets that a cache cluster can be launched into,
+// selected by `name`. Determines the VPC and availability zones a cluster
+// lives in, which is what constrains its network exposure. The `vpc`
+// field resolves the owning VPC.
 private aws.elasticache.subnetGroup @defaults("name") {
   // ARN of the subnet group
   arn string
@@ -12979,6 +13789,11 @@ private aws.elasticache.subnetGroup @defaults("name") {
   // Description of the subnet group
   description string
   // Subnets in this group
+  //
+  // One entry per member subnet. Each dict carries `SubnetIdentifier`
+  // (the subnet ID), `SubnetAvailabilityZone` (a nested object with the
+  // zone `Name`), `SupportedNetworkTypes` (ipv4, ipv6, or dual_stack), and
+  // `SubnetOutpost` when the subnet sits on an Outpost.
   subnets []dict
   // Supported network types (ipv4, ipv6, dual_stack)
   supportedNetworkTypes []string
@@ -12987,6 +13802,12 @@ private aws.elasticache.subnetGroup @defaults("name") {
 }
 
 // Amazon ElastiCache RBAC user
+//
+// Redis or Valkey RBAC user that governs which commands and keys a client
+// may access. The `accessString` encodes the granted permissions and the
+// `authentication` field records whether a password is required, making
+// this the resource to audit for over-privileged or password-less cache
+// access.
 private aws.elasticache.user @defaults("userName status engine") {
   // ARN of the user
   arn string
@@ -13006,11 +13827,19 @@ private aws.elasticache.user @defaults("userName status engine") {
   status string
   // User group IDs the user belongs to
   userGroupIds []string
-  // Authentication details
+  // Authentication mode for the user
+  //
+  // Dict with `Type` (the authentication mode, one of password, no-password,
+  // or iam) and `PasswordCount` (number of configured passwords, up to two).
   authentication dict
 }
 
 // Amazon ElastiCache service update
+//
+// Available ElastiCache service update the account can apply, selected by
+// `name`. Carries the `severity` (critical, important, medium, or low),
+// the recommended apply-by date, and whether it auto-applies, so an audit
+// can flag clusters running with outstanding critical or security updates.
 private aws.elasticache.serviceUpdate @defaults("name severity status") {
   // Service update name
   name string
@@ -13041,6 +13870,12 @@ private aws.elasticache.serviceUpdate @defaults("name severity status") {
 }
 
 // Amazon ElastiCache snapshot
+//
+// Point-in-time backup of a cache cluster or replication group, selected
+// by `name`. Records the source cluster, engine, node type, and the KMS
+// key encrypting the snapshot, so an audit can confirm that cached data
+// captured in backups is protected. The `snapshotSource` field
+// distinguishes automated from manual snapshots.
 private aws.elasticache.snapshot @defaults("name status engine") {
   // ARN of the snapshot
   arn string
@@ -13076,14 +13911,12 @@ private aws.elasticache.snapshot @defaults("name status engine") {
 
 // Amazon Redshift
 //
-// Use the Redshift namespace to enumerate provisioned Redshift data
-// warehouses and the configuration around them. Iterate `clusters()` for
-// every Redshift cluster (with its node type, encryption, audit logging,
-// VPC and security-group placement, IAM roles, parameter group, and
-// snapshot retention), `subnetGroups()` for cluster subnet groups,
-// `eventSubscriptions()` for event notifications, `scheduledActions()` for
-// scheduled resize/pause/resume actions, and `snapshotSchedules()` for
-// snapshot schedule definitions.
+// Provisioned Redshift data warehouses and the configuration around them.
+// Covers Redshift clusters (with their node type, encryption, audit
+// logging, VPC and security-group placement, IAM roles, parameter group,
+// and snapshot retention), cluster subnet groups, event notification
+// subscriptions, scheduled resize, pause, and resume actions, and snapshot
+// schedule definitions.
 aws.redshift @defaults("clusters") {
   // List of clusters
   clusters() []aws.redshift.cluster
@@ -13098,6 +13931,14 @@ aws.redshift @defaults("clusters") {
 }
 
 // Amazon Redshift cluster
+//
+// A provisioned Redshift data warehouse cluster. Reports the node type and
+// count, engine version, encryption at rest and the KMS key protecting it,
+// VPC and Availability Zone placement, attached security groups, the IAM
+// roles the cluster can assume, and its public-accessibility and
+// internet-exposure posture. Use it to audit whether a warehouse is
+// encrypted, reachable from the internet, retaining snapshots, and logging
+// its activity.
 private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus region") {
   // Whether major upgrades are applied automatically
   allowVersionUpgrade bool
@@ -13129,7 +13970,14 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   kmsKey() aws.kms.key
   // Whether enhanced VPC routing is enabled for the cluster traffic
   enhancedVpcRouting bool
-  // Logging configuration for the cluster
+  // Audit-logging delivery status for the cluster
+  //
+  // Dict with the keys `LoggingEnabled` (bool, true when audit logging is
+  // on), `BucketName` and `S3KeyPrefix` (the S3 destination for delivered
+  // logs), `LogDestinationType` (`s3` or `cloudwatch`), `LogExports` (the
+  // exported log types: `connectionlog`, `useractivitylog`, `userlog`), and
+  // the delivery timestamps `LastSuccessfulDeliveryTime`, `LastFailureTime`,
+  // and `LastFailureMessage`.
   logging() dict
   // Master user name for the cluster.
   masterUsername string
@@ -13141,7 +13989,12 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   nodeType string
   // Number of nodes in the cluster
   numberOfNodes int
-  // Detailed list of parameters for each parameter group name
+  // Parameters across all of the cluster's parameter groups
+  //
+  // Each dict describes one parameter with the keys `ParameterName`,
+  // `ParameterValue`, `Description`, `Source` (for example `engine-default`
+  // or `user`), `DataType`, `AllowedValues`, `ApplyType`, `IsModifiable`,
+  // and `MinimumEngineVersion`.
   parameters() []dict
   // Weekly time range for system maintenance (in UTC)
   preferredMaintenanceWindow string
@@ -13158,6 +14011,10 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   // Connection endpoint port for the cluster (0 when the cluster has no endpoint)
   endpointPort int
   // VPC endpoints associated with the cluster (used when publiclyAccessible is false)
+  //
+  // Each dict carries `VpcEndpointId`, `VpcId`, and `NetworkInterfaces`, a
+  // list whose entries hold `NetworkInterfaceId`, `SubnetId`,
+  // `AvailabilityZone`, `PrivateIpAddress`, and `Ipv6Address`.
   endpointVpcEndpoints []dict
   // Region where the cluster exists
   region string
@@ -13175,7 +14032,11 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
   totalStorageCapacityInMegaBytes int
   // Name of the maintenance track for the cluster
   maintenanceTrackName string
-  // HSM status for the cluster
+  // Hardware security module status for the cluster
+  //
+  // Dict with the keys `hsmClientCertificateIdentifier`,
+  // `hsmConfigurationIdentifier`, and `status` (the state of applying the HSM
+  // settings to the cluster).
   hsmStatus dict
   // Status of modifications to the cluster (e.g., resizing)
   modifyStatus string
@@ -13242,6 +14103,12 @@ private aws.redshift.cluster @defaults("dbName clusterVersion clusterStatus regi
 }
 
 // Amazon Redshift cluster snapshot
+//
+// A point-in-time backup of a Redshift cluster, selected by its ARN. Reports
+// the snapshot type (manual or automated), encryption status and KMS key,
+// the source cluster and its node configuration, the accounts authorized to
+// restore it, and cross-region copy origin. Use it to audit backup
+// encryption and which accounts can restore a snapshot.
 private aws.redshift.snapshot @defaults("arn clusterIdentifier status createdAt") {
   // Snapshot ARN
   arn string
@@ -13253,7 +14120,11 @@ private aws.redshift.snapshot @defaults("arn clusterIdentifier status createdAt"
   cluster() aws.redshift.cluster
   // AWS account ID of the snapshot owner
   ownerAccount string
-  // Accounts authorized to restore the snapshot, each with an account ID and optional alias
+  // Accounts authorized to restore the snapshot
+  //
+  // Each dict carries `accountId` (the authorized AWS account ID) and
+  // `accountAlias` (an optional alias for that account, empty when none is
+  // set).
   accountsWithRestoreAccess []dict
   // Region where the snapshot exists
   region string
@@ -13300,6 +14171,11 @@ private aws.redshift.snapshot @defaults("arn clusterIdentifier status createdAt"
 }
 
 // Amazon Redshift cluster subnet group
+//
+// A set of VPC subnets that Redshift clusters are launched into. Reports the
+// member subnets, supported IP address types, associated VPC, and status,
+// which together determine the network placement available to clusters that
+// reference the group.
 private aws.redshift.subnetGroup @defaults("name status") {
   // Subnet group name
   name string
@@ -13312,6 +14188,10 @@ private aws.redshift.subnetGroup @defaults("name status") {
   // Status of the subnet group (e.g., Complete)
   status string
   // Subnets in this group
+  //
+  // Each dict carries `SubnetIdentifier`, `SubnetStatus`, and
+  // `SubnetAvailabilityZone`, an object whose `Name` field names the
+  // Availability Zone the subnet sits in.
   subnets []dict
   // Supported cluster IP address types
   supportedClusterIpAddressTypes []string
@@ -13322,6 +14202,11 @@ private aws.redshift.subnetGroup @defaults("name status") {
 }
 
 // Amazon Redshift event notification subscription
+//
+// An Amazon SNS notification subscription for Redshift events. Reports which
+// event categories and severity it filters, the source objects it watches,
+// the destination SNS topic, and whether it is enabled, so you can confirm
+// that operators are alerted on cluster and snapshot events.
 private aws.redshift.eventSubscription @defaults("name status") {
   // Subscription name
   name string
@@ -13354,6 +14239,11 @@ private aws.redshift.eventSubscription @defaults("name status") {
 }
 
 // Amazon Redshift scheduled action (resize, pause, resume)
+//
+// A scheduled resize, pause, or resume operation for a Redshift cluster.
+// Reports the schedule expression, active window, the IAM role used to run
+// it, and the target action parameters, so you can review automated cluster
+// lifecycle and cost-control automation.
 private aws.redshift.scheduledAction @defaults("name state") {
   // Scheduled action name
   name string
@@ -13372,10 +14262,20 @@ private aws.redshift.scheduledAction @defaults("name state") {
   // End time of the action schedule
   endTime time
   // Target action details (resize, pause, or resume parameters)
+  //
+  // Dict populated with whichever action the schedule runs: `ResizeCluster`
+  // (with `ClusterIdentifier`, `ClusterType`, `NodeType`, `NumberOfNodes`,
+  // and `Classic`), `PauseCluster` (with `ClusterIdentifier`), or
+  // `ResumeCluster` (with `ClusterIdentifier`).
   targetAction dict
 }
 
 // Amazon Redshift snapshot schedule
+//
+// A reusable snapshot schedule that automates when snapshots are taken.
+// Reports its cron-like schedule definitions and how many clusters reference
+// it, letting you confirm that automated backups are configured for the
+// warehouses that need them.
 private aws.redshift.snapshotSchedule @defaults("id description") {
   // Schedule identifier
   id string
@@ -13393,18 +14293,17 @@ private aws.redshift.snapshotSchedule @defaults("id description") {
 
 // Amazon Route 53
 //
-// Use the Route 53 namespace to enumerate DNS hosting and health-check
-// configuration for the account. Iterate `hostedZones()` for public and
-// private hosted zones (with their record sets, DNSSEC configuration, and
-// VPC associations), `healthChecks()` for the health checks used in
-// failover routing and CloudWatch alarms, `queryLoggingConfigs()` for the
-// CloudWatch Logs delivery of public-zone queries, `domains()` for
-// domains registered through Route 53 Domains, `trafficPolicies()` and
-// `trafficPolicyInstances()` for DNS routing logic backed by traffic
-// policies, `cidrCollections()` for CIDR-based routing data sets, and
-// `resolver` for the regional Route 53 Resolver (endpoints, rules, query
-// log configs, and DNS Firewall rule groups, domain lists, and per-VPC
-// configuration).
+// DNS hosting and health-check configuration for the account. `hostedZones`
+// covers public and private hosted zones (with their record sets, DNSSEC
+// configuration, and VPC associations), `healthChecks` the health checks
+// used in failover routing and CloudWatch alarms, `queryLoggingConfigs`
+// the CloudWatch Logs delivery of public-zone queries, `domains` the
+// domains registered through Route 53 Domains, `trafficPolicies` and
+// `trafficPolicyInstances` the DNS routing logic backed by traffic
+// policies, and `cidrCollections` the CIDR-based routing data sets. The
+// `resolver` namespace covers the regional Route 53 Resolver (endpoints,
+// rules, query log configs, and DNS Firewall rule groups, domain lists,
+// and per-VPC configuration).
 aws.route53 {
   // List of all hosted zones in the account
   hostedZones() []aws.route53.hostedZone
@@ -13426,17 +14325,16 @@ aws.route53 {
 
 // Route 53 Resolver namespace
 //
-// Examine the regional Route 53 Resolver service that handles DNS queries
-// for VPCs. Iterate `endpoints()` for inbound and outbound resolver
-// endpoints (the network interfaces that bridge a VPC to on-premises DNS),
-// `rules()` for the forwarding rules that route specific domains to those
-// endpoints and `ruleAssociations()` for the VPCs they apply to, and
-// `queryLogConfigs()` plus `queryLogConfigAssociations()` for VPC DNS
-// query logging targeted at CloudWatch Logs, S3, or Kinesis Data Firehose.
-// For DNS Firewall, iterate `firewallRuleGroups()` and their per-VPC
-// `firewallRuleGroupAssociations()`, the `firewallDomainLists()` used to
-// match traffic, and the per-VPC `firewallConfigs()` that select fail-open
-// vs fail-closed behavior.
+// Regional Route 53 Resolver service that handles DNS queries for VPCs.
+// `endpoints` covers inbound and outbound resolver endpoints (the network
+// interfaces that bridge a VPC to on-premises DNS), `rules` the forwarding
+// rules that route specific domains to those endpoints, and
+// `ruleAssociations` the VPCs they apply to. `queryLogConfigs` and
+// `queryLogConfigAssociations` cover VPC DNS query logging targeted at
+// CloudWatch Logs, S3, or Kinesis Data Firehose. For DNS Firewall,
+// `firewallRuleGroups` and their per-VPC `firewallRuleGroupAssociations`,
+// the `firewallDomainLists` used to match traffic, and the per-VPC
+// `firewallConfigs` that select fail-open vs fail-closed behavior.
 aws.route53.resolver {
   // Resolver endpoints (inbound and outbound) across all regions
   endpoints() []aws.route53.resolver.endpoint
@@ -13459,6 +14357,14 @@ aws.route53.resolver {
 }
 
 // Route 53 hosted zone
+//
+// Container for the DNS records of a domain, either public (resolvable on
+// the internet) or private (resolvable only inside associated VPCs, per
+// `isPrivate`). `records` enumerates the resource record sets, `dnssec`
+// and `keySigningKeys` cover the DNSSEC signing chain, `vpcs` the VPCs a
+// private zone is associated with, and `queryLoggingConfig` the CloudWatch
+// Logs delivery of public-zone queries. The zone is selected by `id`, for
+// example `/hostedzone/Z1234567890ABC`.
 private aws.route53.hostedZone @defaults("id name type isPrivate") {
   // Unique identifier for the hosted zone (e.g., /hostedzone/Z1234567890ABC)
   id string
@@ -13468,7 +14374,9 @@ private aws.route53.hostedZone @defaults("id name type isPrivate") {
   resourceRecordSetCount int
   // Hosted zone type: PUBLIC or PRIVATE
   type string
-  // Hosted zone configuration including comment and private zone settings
+  // Hosted zone configuration
+  //
+  // Has `comment` (string) and `privateZone` (bool).
   config dict
   // Whether this is a private hosted zone
   isPrivate bool
@@ -13482,7 +14390,9 @@ private aws.route53.hostedZone @defaults("id name type isPrivate") {
   //
   // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Falls back to "terraform" when no provenance tag is present but the callerReference carries Terraform's "terraform-" prefix. Empty when the hosted zone is unmanaged or managed by a tool that leaves no recognizable signal.
   managedBy() string
-  // List of VPCs associated with a private hosted zone
+  // VPCs associated with a private hosted zone
+  //
+  // Each entry has `vpcId` (string) and `vpcRegion` (string).
   vpcs() []dict
   // ARN of the hosted zone
   arn string
@@ -13512,12 +14422,11 @@ private aws.route53.hostedZone @defaults("id name type isPrivate") {
 
 // Route 53 DNSSEC view for a hosted zone
 //
-// Examine the DNSSEC signing posture of a single hosted zone — whether
-// Route 53 is currently signing (`SIGNING`, `NOT_SIGNING`, or
-// `INTERNAL_FAILURE`), any status message returned by the API, and the
-// `keySigningKeys()` that back the chain of trust. DNSSEC is only
-// available on public hosted zones; on private zones the status is fixed
-// to `NOT_SIGNING`.
+// DNSSEC signing posture of a single hosted zone: whether Route 53 is
+// currently signing (`SIGNING`, `NOT_SIGNING`, or `INTERNAL_FAILURE`), any
+// status message returned by the API, and the `keySigningKeys` that back
+// the chain of trust. DNSSEC is only available on public hosted zones; on
+// private zones the status is fixed to `NOT_SIGNING`.
 private aws.route53.hostedZone.dnssec @defaults("status") {
   // DNSSEC signing status
   //
@@ -13531,6 +14440,15 @@ private aws.route53.hostedZone.dnssec @defaults("status") {
 }
 
 // Route 53 DNS resource record set
+//
+// Single resource record set in a hosted zone, keyed by `name` and `type`
+// (A, AAAA, CNAME, MX, TXT, and so on). `resourceRecords` carries the
+// record values, while alias records (`isAlias`) instead point at an AWS
+// resource, resolvable through `aliasLoadBalancer` or
+// `aliasCloudFrontDistribution`. Routing-policy fields (`weight`, `region`,
+// `failover`, `geoLocation`, `multiValueAnswer`, `cidrRoutingConfig`)
+// describe how Route 53 chooses among records that share a name, and
+// `healthCheck` ties the record to its failover health check.
 private aws.route53.record @defaults("name type") {
   // Hosted zone ID this record belongs to
   //
@@ -13546,7 +14464,11 @@ private aws.route53.record @defaults("name type") {
   ttl int
   // List of resource record values (IP addresses, domain names, etc.)
   resourceRecords() []string
-  // Alias target configuration (for AWS resource aliases)
+  // Alias target configuration for AWS resource aliases
+  //
+  // Has `dnsName` (string), `hostedZoneId` (string), and
+  // `evaluateTargetHealth` (bool). The `aliasTargetDnsName` and
+  // `aliasTargetHostedZoneId` fields expose the first two directly.
   aliasTarget() dict
   // Whether this is an alias record
   isAlias bool
@@ -13579,8 +14501,14 @@ private aws.route53.record @defaults("name type") {
   // Failover type: PRIMARY or SECONDARY
   failover string
   // Geographic location for geolocation routing
+  //
+  // Has `continentCode`, `countryCode`, and `subdivisionCode` (all
+  // strings).
   geoLocation() dict
-  // Geographic proximity routing bias
+  // Geographic proximity routing location and bias
+  //
+  // Has `awsRegion` (string), `localZoneGroup` (string), `bias` (int), and,
+  // when custom coordinates are set, `latitude` and `longitude` (strings).
   geoProximityLocation() dict
   // Multi-value answer routing flag
   multiValueAnswer bool
@@ -13589,12 +14517,24 @@ private aws.route53.record @defaults("name type") {
   // Health check details
   healthCheck() aws.route53.healthCheck
   // CIDR routing configuration
+  //
+  // Has `collectionId` (string) and `locationName` (string), selecting a
+  // location within the `aws.route53.cidrCollection` referenced by
+  // `collectionId`.
   cidrRoutingConfig() dict
   // Traffic policy instance ID (if managed by traffic policy)
   trafficPolicyInstanceId string
 }
 
 // Route 53 health check
+//
+// Health check that Route 53 uses to drive DNS failover and to alarm on
+// endpoint availability. `type` selects what is measured (HTTP, HTTPS,
+// TCP, CALCULATED, or CLOUDWATCH_METRIC); for endpoint checks the target
+// is given by `ipAddress` or `fullyQualifiedDomainName` plus `port` and
+// `resourcePath`, and `status` reports the latest observed result.
+// CALCULATED checks aggregate `childHealthChecks` against
+// `healthThreshold`, and `inverted` flips the pass/fail sense.
 private aws.route53.healthCheck @defaults("id type protocol") {
   // Unique identifier for the health check
   id string
@@ -13632,7 +14572,11 @@ private aws.route53.healthCheck @defaults("id type protocol") {
   childHealthChecks() []string
   // Minimum number of healthy children required
   healthThreshold int
-  // For CLOUDWATCH_METRIC health checks: alarm configuration
+  // Alarm configuration for CLOUDWATCH_METRIC health checks
+  //
+  // Has `comparisonOperator`, `metricName`, `namespace`, and `statistic`
+  // (strings), `evaluationPeriods` and `period` (ints), `threshold`
+  // (float), and `dimensions` (a list of `{name, value}` entries).
   cloudWatchAlarmConfiguration() dict
   // Whether the health check is inverted
   inverted bool
@@ -13643,6 +14587,11 @@ private aws.route53.healthCheck @defaults("id type protocol") {
 }
 
 // Route 53 query logging configuration
+//
+// Configuration that streams the public DNS queries answered for a hosted
+// zone to CloudWatch Logs. `hostedZone` traverses to the logged zone and
+// `logGroup` to the destination CloudWatch Logs log group. At most one
+// configuration exists per hosted zone.
 private aws.route53.queryLoggingConfig @defaults("id hostedZoneId") {
   // Unique identifier for the configuration
   id string
@@ -13659,6 +14608,11 @@ private aws.route53.queryLoggingConfig @defaults("id hostedZoneId") {
 }
 
 // Route 53 DNSSEC key signing key
+//
+// Key signing key (KSK) that anchors DNSSEC for a hosted zone, backed by a
+// customer managed KMS key reachable through `kmsKey`. `status` reports
+// whether the key is ACTIVE, and `dsRecord` carries the delegation-signer
+// record to publish in the parent zone to complete the chain of trust.
 private aws.route53.keySigningKey @defaults("name status") {
   // Name of the key signing key
   name string
@@ -13703,6 +14657,12 @@ private aws.route53.keySigningKey @defaults("name status") {
 }
 
 // Amazon Route 53 registered domain
+//
+// Domain name registered through Route 53 Domains, selected by
+// `domainName`. `autoRenew` and `transferLock` reflect renewal and
+// transfer-protection posture, `expiresAt` the registration expiry, the
+// `*Privacy` fields whether WHOIS privacy protection is on for each
+// contact, and `statusList` the EPP status codes set on the domain.
 private aws.route53.domain @defaults("domainName autoRenew transferLock") {
   // Registered domain name
   domainName string
@@ -13727,6 +14687,9 @@ private aws.route53.domain @defaults("domainName autoRenew transferLock") {
   // EPP status codes (e.g., clientTransferProhibited)
   statusList() []string
   // Nameservers for the domain
+  //
+  // Each entry has `Name` (string) and `GlueIps` (list of glue-record IP
+  // addresses).
   nameservers() []dict
   // Registrar name
   registrarName() string
@@ -13736,9 +14699,9 @@ private aws.route53.domain @defaults("domainName autoRenew transferLock") {
 
 // Route 53 traffic policy
 //
-// Examine the JSON-encoded routing logic of a single traffic policy — the
-// rules, endpoints, and decision tree that Route 53 uses when this policy
-// is applied to a hosted zone through a `trafficPolicyInstance`. The
+// JSON-encoded routing logic of a single traffic policy: the rules,
+// endpoints, and decision tree that Route 53 uses when this policy is
+// applied to a hosted zone through a `trafficPolicyInstance`. The
 // `document` field carries the raw policy JSON in the format documented at
 // https://docs.aws.amazon.com/Route53/latest/APIReference/api-policies-traffic-policy-document-format.html.
 // Listing returns the latest version of each policy; use `version` to
@@ -13762,13 +14725,12 @@ private aws.route53.trafficPolicy @defaults("id name version type") {
 
 // Route 53 traffic policy instance
 //
-// Examine a single traffic policy applied to a hosted zone. A traffic
-// policy instance is the materialized record set that Route 53 creates
-// when a `trafficPolicy` is bound to a DNS name in a hosted zone. Use
-// `trafficPolicy()` to traverse to the policy version that produced it,
-// `hostedZone()` to reach the zone, `state` to confirm the records are
-// `Applied` (vs. `Creating`, `Failed`, or `Deleting`), and `message` for
-// the failure reason when state is `Failed`.
+// Materialized record set that Route 53 creates when a `trafficPolicy` is
+// bound to a DNS name in a hosted zone. `trafficPolicy` traverses to the
+// policy version that produced it, `hostedZone` reaches the zone, `state`
+// confirms the records are `Applied` (vs. `Creating`, `Failed`, or
+// `Deleting`), and `message` carries the failure reason when state is
+// `Failed`.
 private aws.route53.trafficPolicyInstance @defaults("id name state") {
   // Unique identifier for the traffic policy instance
   id string
@@ -13796,12 +14758,11 @@ private aws.route53.trafficPolicyInstance @defaults("id name state") {
 
 // Route 53 CIDR collection
 //
-// Examine a single CIDR collection — a named bag of IP ranges grouped
-// into locations that backs CIDR-based DNS routing on resource record
-// sets. Use `locations` to enumerate the locations defined for the
-// collection along with the CIDR blocks they cover; the collection is
-// referenced from `aws.route53.record.cidrRoutingConfig` by `id` and
-// `locationName`.
+// Named set of IP ranges grouped into locations that backs CIDR-based DNS
+// routing on resource record sets. `locations` enumerates the locations
+// defined for the collection along with the CIDR blocks they cover; the
+// collection is referenced from `aws.route53.record.cidrRoutingConfig` by
+// `id` and `locationName`.
 private aws.route53.cidrCollection @defaults("name id version") {
   // ARN of the CIDR collection
   arn string
@@ -13819,15 +14780,15 @@ private aws.route53.cidrCollection @defaults("name id version") {
 
 // Route 53 Resolver endpoint
 //
-// Examine a single resolver endpoint — the ENI-backed bridge that
-// connects a VPC to DNS resolvers either inside or outside AWS. Inbound
-// endpoints (`direction == "INBOUND"`) accept DNS queries from
-// on-premises networks into Route 53 Resolver; outbound endpoints
-// (`direction == "OUTBOUND"`) forward VPC queries out through the
-// `targetIps` of resolver `rule`s. Each endpoint pins two or more IP
-// addresses (`ipAddresses`) in subnets of the host VPC (`hostVpc()`) and
-// is protected by security groups (`securityGroups()`). Use `status` and
-// `statusMessage` to verify the endpoint is healthy.
+// Network-interface-backed bridge that connects a VPC to DNS resolvers
+// either inside or outside AWS. Inbound endpoints (`direction ==
+// "INBOUND"`) accept DNS queries from on-premises networks into Route 53
+// Resolver; outbound endpoints (`direction == "OUTBOUND"`) forward VPC
+// queries out through the `targetIps` of resolver rules. Each endpoint
+// pins two or more IP addresses (`ipAddresses`) in subnets of the host VPC
+// (`hostVpc`) and is protected by security groups (`securityGroups`). The
+// `status` and `statusMessage` fields report whether the endpoint is
+// healthy.
 private aws.route53.resolver.endpoint @defaults("id name direction status") {
   // Unique identifier for the resolver endpoint
   id string
@@ -13872,15 +14833,14 @@ private aws.route53.resolver.endpoint @defaults("id name direction status") {
 
 // Route 53 Resolver rule
 //
-// Examine a single resolver rule — the DNS forwarding decision applied
-// to outbound queries from a VPC. The `domainName` field selects which
-// queries the rule matches and `ruleType` (`FORWARD`, `SYSTEM`, or
-// `RECURSIVE`) determines how the rule behaves: `FORWARD` rules ship
-// matching queries to `targetIps` through the outbound `resolverEndpoint()`,
-// `SYSTEM` rules intentionally override a broader forwarding rule for a
-// subdomain, and `RECURSIVE` rules are managed by Resolver itself. Use
-// `shareStatus` and `ownerId` to identify rules shared via Resource Access
-// Manager.
+// DNS forwarding decision applied to outbound queries from a VPC. The
+// `domainName` field selects which queries the rule matches and `ruleType`
+// (`FORWARD`, `SYSTEM`, or `RECURSIVE`) determines how the rule behaves:
+// `FORWARD` rules ship matching queries to `targetIps` through the outbound
+// `resolverEndpoint`, `SYSTEM` rules intentionally override a broader
+// forwarding rule for a subdomain, and `RECURSIVE` rules are managed by
+// Resolver itself. The `shareStatus` and `ownerId` fields identify rules
+// shared via Resource Access Manager.
 private aws.route53.resolver.rule @defaults("id name domainName ruleType status") {
   // Unique identifier for the resolver rule
   id string
@@ -13918,10 +14878,10 @@ private aws.route53.resolver.rule @defaults("id name domainName ruleType status"
 
 // Route 53 Resolver rule association
 //
-// Examine a single VPC↔resolver-rule association. Use `vpc()` to reach
-// the VPC the rule applies to and `resolverRule()` to traverse back to
-// the rule definition. The `status` field reflects whether the binding
-// is `CREATING`, `COMPLETE`, `DELETING`, `FAILED`, or `OVERRIDDEN`.
+// Binding between a VPC and a resolver rule. `vpc` reaches the VPC the
+// rule applies to and `resolverRule` traverses back to the rule
+// definition. The `status` field reflects whether the binding is
+// `CREATING`, `COMPLETE`, `DELETING`, `FAILED`, or `OVERRIDDEN`.
 private aws.route53.resolver.ruleAssociation @defaults("id name status") {
   // Unique identifier for the association
   id string
@@ -13947,15 +14907,14 @@ private aws.route53.resolver.ruleAssociation @defaults("id name status") {
 
 // Route 53 Resolver query log configuration
 //
-// Examine a single query log configuration — the destination Route 53
-// Resolver uses to log DNS queries originating in associated VPCs. The
-// `destinationArn` field carries the raw ARN of the target (S3 bucket,
-// CloudWatch Logs log group, or Kinesis Data Firehose delivery stream)
-// and the typed `s3Bucket()`, `cloudwatchLogGroup()`, and
-// `firehoseDeliveryStream()` accessors resolve to whichever destination
-// is in use. Use `associationCount` for a quick check that the
-// configuration is in active use and pair with
-// `aws.route53.resolver.queryLogConfigAssociations` to enumerate the VPCs.
+// Destination Route 53 Resolver uses to log DNS queries originating in
+// associated VPCs. The `destinationArn` field carries the raw ARN of the
+// target (S3 bucket, CloudWatch Logs log group, or Kinesis Data Firehose
+// delivery stream), and the `s3Bucket`, `cloudwatchLogGroup`, and
+// `firehoseDeliveryStream` accessors resolve to whichever destination is
+// in use. The `associationCount` field reports how many VPCs use the
+// configuration; pair with
+// `aws.route53.resolver.queryLogConfigAssociations` to enumerate them.
 private aws.route53.resolver.queryLogConfig @defaults("id name status destinationArn") {
   // Unique identifier for the query log configuration
   id string
@@ -13992,11 +14951,10 @@ private aws.route53.resolver.queryLogConfig @defaults("id name status destinatio
 
 // Route 53 Resolver query log configuration association
 //
-// Examine a single VPC↔query-log-configuration binding. Use `vpc()` to
-// reach the VPC whose DNS queries are being logged and
-// `resolverQueryLogConfig()` for the configuration. When `status` is
-// `FAILED`, `error` and `errorMessage` indicate the cause (such as
-// `DESTINATION_NOT_FOUND` or `ACCESS_DENIED`).
+// Binding between a VPC and a query log configuration. `vpc` reaches the
+// VPC whose DNS queries are being logged and `resolverQueryLogConfig` the
+// configuration. When `status` is `FAILED`, `error` and `errorMessage`
+// indicate the cause (such as `DESTINATION_NOT_FOUND` or `ACCESS_DENIED`).
 private aws.route53.resolver.queryLogConfigAssociation @defaults("id status") {
   // Unique identifier for the association
   id string
@@ -14024,15 +14982,14 @@ private aws.route53.resolver.queryLogConfigAssociation @defaults("id status") {
 
 // Route 53 Resolver DNS Firewall rule group
 //
-// Examine a single DNS Firewall rule group — the ordered set of rules
-// that DNS Firewall applies to queries originating in VPCs the group is
-// associated with. Iterate `rules` to inspect every rule in priority
-// order, including the `action` (`ALLOW`, `ALERT`, `BLOCK`), the
-// `firewallDomainListId` that supplies the match list, the optional
+// Ordered set of rules that DNS Firewall applies to queries originating in
+// VPCs the group is associated with. `firewallRules` returns every rule in
+// priority order, including the `action` (`ALLOW`, `ALERT`, `BLOCK`), the
+// `firewallDomainList` that supplies the match list, the optional
 // `blockResponse` and `blockOverride*` fields for `BLOCK` rules, and
-// `qtype` to scope a rule to a specific DNS record type. Pair with
-// `aws.route53.resolver.firewallRuleGroupAssociation` to find the VPCs
-// the group filters.
+// `qtype` scoping a rule to a specific DNS record type. Pair with
+// `aws.route53.resolver.firewallRuleGroupAssociation` to find the VPCs the
+// group filters.
 private aws.route53.resolver.firewallRuleGroup @defaults("id name ruleCount status") {
   // Unique identifier for the rule group
   id string
@@ -14075,14 +15032,14 @@ private aws.route53.resolver.firewallRuleGroup @defaults("id name ruleCount stat
 
 // Route 53 Resolver DNS Firewall rule
 //
-// Examine a single rule within a DNS Firewall rule group. `action`
-// decides what happens to a matching DNS query — `ALLOW` lets it through,
-// `BLOCK` stops resolution, and `ALERT` permits it while recording a
-// finding. `priority` sets evaluation order within the group (lower runs
-// first). A rule matches either a domain list — reachable through
-// `firewallDomainList()` — or, for managed threat rules, AWS DNS threat
-// protection (`dnsThreatProtection`, `confidenceThreshold`). `BLOCK`
-// rules carry `blockResponse` and the `blockOverride*` fields.
+// Single rule within a DNS Firewall rule group. `action` decides what
+// happens to a matching DNS query: `ALLOW` lets it through, `BLOCK` stops
+// resolution, and `ALERT` permits it while recording a finding. `priority`
+// sets evaluation order within the group (lower runs first). A rule matches
+// either a domain list, reachable through `firewallDomainList`, or, for
+// managed threat rules, AWS DNS threat protection (`dnsThreatProtection`,
+// `confidenceThreshold`). `BLOCK` rules carry `blockResponse` and the
+// `blockOverride*` fields.
 private aws.route53.resolver.firewallRule @defaults("name priority action") {
   // Name of the rule
   name string
@@ -14141,12 +15098,11 @@ private aws.route53.resolver.firewallRule @defaults("name priority action") {
 
 // Route 53 Resolver DNS Firewall rule group association
 //
-// Examine a single binding between a DNS Firewall rule group and a VPC.
-// Use `vpc()` to reach the VPC and `firewallRuleGroup()` for the rules
-// applied. The `priority` field controls evaluation order when multiple
-// rule groups are bound to the same VPC; `mutationProtection`
-// (`ENABLED`/`DISABLED`) controls whether the association can be removed
-// without first turning off protection.
+// Binding between a DNS Firewall rule group and a VPC. `vpc` reaches the
+// VPC and `firewallRuleGroup` the rules applied. The `priority` field
+// controls evaluation order when multiple rule groups are bound to the
+// same VPC; `mutationProtection` (`ENABLED`/`DISABLED`) controls whether
+// the association can be removed without first turning off protection.
 private aws.route53.resolver.firewallRuleGroupAssociation @defaults("id name status priority") {
   // Unique identifier for the association
   id string
@@ -14188,12 +15144,11 @@ private aws.route53.resolver.firewallRuleGroupAssociation @defaults("id name sta
 
 // Route 53 Resolver DNS Firewall domain list
 //
-// Examine a single DNS Firewall domain list — the named bag of domain
-// names that `firewallRuleGroup` rules match against. `managedOwnerName`
-// is populated for AWS-managed lists (such as
-// `AWSManagedDomainsMalwareDomainList`) and empty for user-managed
-// lists; in either case `domainCount` reflects the total entries
-// regardless of how many `domains()` are materialized.
+// Named set of domain names that `firewallRuleGroup` rules match against.
+// `managedOwnerName` is populated for AWS-managed lists (such as
+// `AWSManagedDomainsMalwareDomainList`) and empty for user-managed lists;
+// in either case `domainCount` reflects the total entries regardless of
+// how many `domains` are materialized.
 private aws.route53.resolver.firewallDomainList @defaults("id name domainCount status") {
   // Unique identifier for the domain list
   id string
@@ -14230,13 +15185,12 @@ private aws.route53.resolver.firewallDomainList @defaults("id name domainCount s
 
 // Route 53 Resolver DNS Firewall per-VPC configuration
 //
-// Examine the DNS Firewall per-VPC configuration that controls how the
-// firewall fails when it cannot evaluate a query. With
-// `firewallFailOpen == "ENABLED"`, queries are allowed through when the
-// firewall cannot reach a decision (availability over security); with
-// `firewallFailOpen == "DISABLED"` (the default), queries are dropped
-// (security over availability). Use `vpc()` to reach the VPC the
-// configuration applies to.
+// DNS Firewall per-VPC configuration that controls how the firewall fails
+// when it cannot evaluate a query. With `firewallFailOpen == "ENABLED"`,
+// queries are allowed through when the firewall cannot reach a decision
+// (availability over security); with `firewallFailOpen == "DISABLED"` (the
+// default), queries are dropped (security over availability). `vpc` reaches
+// the VPC the configuration applies to.
 private aws.route53.resolver.firewallConfig @defaults("resourceId firewallFailOpen") {
   // Unique identifier for the firewall configuration
   id string
@@ -14257,14 +15211,16 @@ private aws.route53.resolver.firewallConfig @defaults("resourceId firewallFailOp
 
 // Amazon Elastic Container Registry (ECR)
 //
-// Use the ECR namespace to enumerate container image registries and the
-// images they hold. Iterate `privateRepositories()` and
-// `publicRepositories()` for private (per-account) and public ECR
-// repositories (with their image-tag immutability, scan-on-push setting,
-// repository policy, and lifecycle policy), and `images()` for images
-// across those repos with their tags, digests, and image-scan findings.
-// Read `replicationConfiguration` for cross-region/account replication and
-// `scanningConfiguration` for the registry-level scanning posture.
+// Container image registries for an AWS account and the images they hold.
+// `privateRepositories` and `publicRepositories` list the per-account
+// private and public repositories, each carrying image-tag immutability,
+// the scan-on-push setting, the repository access policy, and the
+// lifecycle policy. `images` spans the images across those repositories
+// with their tags, digests, and vulnerability scan findings.
+// `replicationConfiguration` describes cross-region and cross-account
+// replication, and `scanningConfiguration` gives the registry-level
+// scanning posture. Audit these to confirm private repositories are not
+// unintentionally exposed and that image scanning is enabled.
 aws.ecr {
   // List of private repositories
   privateRepositories() []aws.ecr.repository
@@ -14273,6 +15229,12 @@ aws.ecr {
   // List of images
   images() []aws.ecr.image
   // Registry replication configuration
+  //
+  // Cross-region and cross-account replication settings for the registry.
+  // The `rules` key holds the replication rules; each rule carries
+  // `destinations` (a list of {region, registryId} targets) and optional
+  // `repositoryFilters` ({filter, filterType} entries) that scope which
+  // repositories replicate.
   replicationConfiguration() dict
   // Registry-level scanning configuration
   scanningConfiguration() aws.ecr.scanningConfiguration
@@ -14403,6 +15365,10 @@ private aws.ecr.image @defaults("uri region") {
   // Findings from the most recent image scan (basic scan findings; private repositories only)
   scanFindings() []aws.ecr.image.scanFinding
   // Severity counts from the most recent image scan
+  //
+  // Number of findings at each severity level, keyed by severity:
+  // INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL, and UNDEFINED. Each value
+  // is the finding count for that level.
   scanFindingSeverityCounts() dict
 }
 
@@ -14416,7 +15382,11 @@ private aws.ecr.image.scanFinding @defaults("severity name") {
   uri string
   // Severity: INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL, or UNDEFINED
   severity string
-  // Attributes associated with the finding (e.g., CVSS score)
+  // Finding attributes
+  //
+  // Key/value metadata attached to the finding, keyed by attribute name
+  // (for example package_name, package_version, CVSS2_SCORE, and
+  // CVSS2_VECTOR) with string values.
   attributes dict
 }
 
@@ -14433,18 +15403,24 @@ private aws.ecr.scanningConfiguration.rule @defaults("scanFrequency") {
   // Scan frequency: SCAN_ON_PUSH, CONTINUOUS_SCAN, or MANUAL
   scanFrequency string
   // Repository filters applied by this rule
+  //
+  // Each entry has `filter` (a repository name pattern) and `filterType`
+  // (WILDCARD). Repositories matching a filter fall under this rule's scan
+  // frequency.
   repositoryFilters []dict
 }
 
 // AWS Database Migration Service (DMS)
 //
-// Use the DMS namespace to enumerate the replication infrastructure
-// configured for database migration in the account. Iterate
-// `replicationInstances()` for the replication instances DMS uses to copy
-// data between source and target endpoints, `endpoints()` for the source
-// and target connection definitions, `replicationTasks()` for the
-// migration tasks bound to instances, and `replicationSubnetGroups()` for
-// the subnet groups that scope replication instances to a VPC.
+// Replication infrastructure configured for database migration in the
+// account. The `replicationInstances` are the compute DMS uses to copy
+// data between source and target endpoints, `endpoints` hold the source
+// and target connection definitions, `replicationTasks` are the migration
+// jobs bound to those instances, and `replicationSubnetGroups` scope
+// replication instances to a VPC. Query these to audit whether migration
+// endpoints encrypt their connections, whether replication instances are
+// publicly accessible, and how source and target databases are wired
+// together.
 aws.dms @defaults("replicationInstances") {
   // List of DMS replication instances
   replicationInstances() []aws.dms.replicationInstance
@@ -14505,6 +15481,11 @@ private aws.dms.replicationInstance @defaults("arn replicationInstanceIdentifier
   // Subnet group that scopes the replication instance to a VPC
   subnetGroup() aws.dms.replicationSubnetGroup
   // Pending modifications scheduled for the next maintenance window
+  //
+  // Present only when a change is queued. Keys are `AllocatedStorage`,
+  // `EngineVersion`, `MultiAZ`, `NetworkType`, and
+  // `ReplicationInstanceClass`; each holds the new value that will be
+  // applied to the corresponding attribute at the next window.
   pendingModifiedValues dict
 }
 
@@ -14614,13 +15595,13 @@ private aws.dms.replicationSubnetGroup @defaults("replicationSubnetGroupIdentifi
 
 // Amazon API Gateway (REST APIs)
 //
-// Use the API Gateway namespace to enumerate REST APIs (the v1 product) and
-// the configuration around them. Iterate `restApis()` for every REST API
-// across enabled regions (with its stages, methods, authorizers, and
-// resource policies), `apiKeys()` for the API keys callers can use,
-// `usagePlans()` for throttling and quota plans bound to API stages, and
-// `vpcLinks()` for private integration links into VPCs. HTTP and WebSocket
-// APIs (the v2 product) live under `aws.apigatewayv2`.
+// REST APIs (the v1 product) and the configuration around them across every
+// enabled region. The `restApis` field lists each REST API with its stages,
+// methods, authorizers, and resource policies; `apiKeys` lists the API keys
+// callers present for request metering; `usagePlans` lists the throttling and
+// quota plans bound to API stages; and `vpcLinks` lists the private
+// integration links into VPCs. HTTP and WebSocket APIs (the v2 product) live
+// under `aws.apigatewayv2`.
 aws.apigateway @defaults("restApis") {
   // List of REST APIs across all enabled regions in the account
   restApis() []aws.apigateway.restapi
@@ -14696,7 +15677,13 @@ private aws.apigateway.stage @defaults("arn") {
   description string
   // ID of the deployment the stage is attached to
   deploymentId string
-  // Method settings for the stage
+  // Per-method settings for the stage
+  //
+  // Keyed by method path: `*/*` holds the stage-wide default and a
+  // `{resourcePath}/{httpMethod}` key overrides a specific method. Each value
+  // carries that method's loggingLevel (OFF, ERROR, INFO), metricsEnabled,
+  // dataTraceEnabled, throttlingBurstLimit, throttlingRateLimit,
+  // cachingEnabled, cacheTtlInSeconds, and cacheDataEncrypted settings.
   methodSettings dict
   // Whether a cache cluster is enabled for the stage
   cacheClusterEnabled bool
@@ -14728,7 +15715,7 @@ private aws.apigateway.stage @defaults("arn") {
 
 // Amazon API Gateway authorizer
 private aws.apigateway.authorizer @defaults("name type restApiId") {
-  // ARN for the authorizer (synthetic — API Gateway authorizers do not have a native ARN)
+  // ARN for the authorizer (synthetic; API Gateway authorizers do not have a native ARN)
   arn string
   // Identifier of the authorizer
   id string
@@ -14764,7 +15751,7 @@ private aws.apigateway.authorizer @defaults("name type restApiId") {
 
 // Amazon API Gateway request validator
 private aws.apigateway.requestValidator @defaults("name restApiId") {
-  // ARN for the request validator (synthetic — API Gateway request validators do not have a native ARN)
+  // ARN for the request validator (synthetic; API Gateway request validators do not have a native ARN)
   arn string
   // Identifier of the request validator
   id string
@@ -14782,8 +15769,8 @@ private aws.apigateway.requestValidator @defaults("name restApiId") {
 
 // Deployment of an API Gateway REST API
 //
-// Examine a single deployment of a REST API: when it was created, its
-// description, and a snapshot of the API methods it captured. The deployment
+// Single deployment of a REST API: when it was created, its description, and
+// the snapshot of API methods it captured in `apiSummary`. The deployment
 // history records when each version of the API was pushed live, which is the
 // change provenance for the API. Select by the deployment `id` within a REST
 // API.
@@ -14842,15 +15829,15 @@ private aws.apigateway.usagePlan @defaults("name id") {
   productCode string
   // Associated API stages (each entry has apiId, stage, and per-method throttle settings)
   apiStages []dict
-  // Quota limit — the target maximum number of permitted requests per period; -1 if unset
+  // Target maximum number of permitted requests per period; -1 if unset
   quotaLimit int
-  // Quota offset — requests subtracted from the limit in the initial period; -1 if unset
+  // Requests subtracted from the limit in the initial quota period; -1 if unset
   quotaOffset int
   // Quota period (DAY, WEEK, MONTH); empty if unset
   quotaPeriod string
-  // Throttle burst limit — request burst rate; -1 if unset
+  // Request burst rate for throttling; -1 if unset
   throttleBurstLimit int
-  // Throttle rate limit — steady-state request rate per second; -1 if unset
+  // Steady-state request rate per second for throttling; -1 if unset
   throttleRateLimit float
   // Tags for the usage plan
   tags map[string]string
@@ -14884,14 +15871,13 @@ private aws.apigateway.vpcLink @defaults("name id status") {
 
 // Amazon API Gateway v2 (HTTP and WebSocket APIs)
 //
-// Use the v2 namespace to enumerate HTTP and WebSocket APIs separately
-// from the REST APIs surfaced under aws.apigateway. Iterate `apis()` to
-// get every v2 API in the account across configured regions; on each
-// api, traverse its `stages()`, `routes()`, and `authorizers()` for the
-// security configuration that determines which callers can reach which
-// route. Use `domainNames()` for per-region custom-domain entries — the
-// best place to audit ACM cert mappings, mTLS authentication, and
-// domain routing modes.
+// HTTP and WebSocket APIs in the account across all configured regions,
+// kept separate from the REST APIs surfaced under aws.apigateway. Each
+// api exposes its stages, routes, and authorizers, the security
+// configuration that determines which callers can reach which route.
+// The domainNames collection holds per-region custom-domain entries,
+// the best place to audit ACM certificate mappings, mutual TLS
+// authentication, and domain routing modes.
 aws.apigatewayv2 @defaults("apis") {
   // HTTP and WebSocket APIs across all configured regions
   apis() []aws.apigatewayv2.api
@@ -14901,7 +15887,7 @@ aws.apigatewayv2 @defaults("apis") {
 
 // HTTP or WebSocket API in API Gateway v2
 //
-// Examine an HTTP or WebSocket API along with its stages, routes, and
+// HTTP or WebSocket API together with its stages, routes, and
 // authorizers. Use the apiId field as the selection key — for example
 // `aws.apigatewayv2.api(apiId: "abc123xyz")`. The `protocolType` field
 // disambiguates HTTP versus WebSocket; for WebSocket APIs the
@@ -14955,11 +15941,11 @@ private aws.apigatewayv2.api @defaults("apiId name protocolType") {
 
 // Stage of an API Gateway v2 API
 //
-// Examine a deployed stage — the named environment that exposes a
-// particular deployment of the parent API. Selection key is the
-// composite of api id and stage name. The `accessLogSettings` and
-// `defaultRouteSettings` fields drive logging and throttling audits;
-// the `routeSettings` map holds per-route overrides.
+// Deployed stage, the named environment that exposes a particular
+// deployment of the API. Selection key is the composite of api id and
+// stage name. The `accessLogSettings` and `defaultRouteSettings` fields
+// drive logging and throttling audits; the `routeSettings` map holds
+// per-route overrides.
 private aws.apigatewayv2.stage @defaults("stageName apiId") {
   // Stage name
   stageName string
@@ -14983,9 +15969,17 @@ private aws.apigatewayv2.stage @defaults("stageName apiId") {
   //
   // Keys: throttlingBurstLimit, throttlingRateLimit, detailedMetricsEnabled, dataTraceEnabled, loggingLevel.
   defaultRouteSettings dict
-  // Per-route setting overrides keyed by route key
+  // Per-route setting overrides
+  //
+  // Keyed by route key; each value carries the same shape as
+  // defaultRouteSettings (throttlingBurstLimit, throttlingRateLimit,
+  // detailedMetricsEnabled, dataTraceEnabled, loggingLevel).
   routeSettings dict
-  // Access-log destination and format, or null when access logging is off
+  // Access-log configuration
+  //
+  // Keys: destinationArn (CloudWatch Logs log group or Kinesis Data
+  // Firehose delivery stream) and format (the $context log format
+  // string). Null when access logging is off.
   accessLogSettings dict
   // Whether the stage is owned and managed by another AWS service
   apiGatewayManaged bool
@@ -15001,11 +15995,11 @@ private aws.apigatewayv2.stage @defaults("stageName apiId") {
 
 // Route in an API Gateway v2 API
 //
-// Examine the mapping from an incoming request (HTTP method+path, or
-// WebSocket route-selection value) to its integration target. Selection
-// key is the composite of api id and route id. The `authorizationType`
-// and `authorizerId` fields are the audit-relevant entry points for who
-// is allowed to reach the route.
+// Mapping from an incoming request (HTTP method+path, or WebSocket
+// route-selection value) to its integration target. Selection key is
+// the composite of api id and route id. The `authorizationType` and
+// `authorizerId` fields are the audit-relevant entry points for who is
+// allowed to reach the route.
 private aws.apigatewayv2.route @defaults("routeKey apiId authorizationType") {
   // Route ID
   routeId string
@@ -15041,11 +16035,11 @@ private aws.apigatewayv2.route @defaults("routeKey apiId authorizationType") {
 
 // Authorizer in an API Gateway v2 API
 //
-// Examine an authorizer that validates requests before they reach a
-// route. Selection key is the composite of api id and authorizer id.
-// The `authorizerType` field determines how the rest of the
-// configuration is interpreted — JWT uses `jwtConfiguration`, REQUEST
-// uses `authorizerUri` and `identitySource`.
+// Authorizer that validates requests before they reach a route.
+// Selection key is the composite of api id and authorizer id. The
+// `authorizerType` field determines how the rest of the configuration
+// is interpreted: JWT uses `jwtConfiguration`, REQUEST uses
+// `authorizerUri` and `identitySource`.
 private aws.apigatewayv2.authorizer @defaults("name authorizerType apiId") {
   // Authorizer ID
   authorizerId string
@@ -15079,12 +16073,12 @@ private aws.apigatewayv2.authorizer @defaults("name authorizerType apiId") {
 
 // Custom domain registered with API Gateway v2
 //
-// Examine a custom domain mapped to one or more v2 APIs. Selection key
-// is the domain name. Inspect `domainNameConfigurations` for the ACM
-// certificate ARN, security policy, and endpoint type per
-// configuration; `mutualTlsAuthentication` for client-cert-required
-// audits; and `routingMode` to see whether traffic is routed by api
-// mappings or routing rules.
+// Custom domain mapped to one or more v2 APIs. Selection key is the
+// domain name. The `domainNameConfigurations` field holds the ACM
+// certificate ARN, security policy, and endpoint type per configuration;
+// `mutualTlsAuthentication` covers client-cert-required audits; and
+// `routingMode` shows whether traffic is routed by api mappings or
+// routing rules.
 private aws.apigatewayv2.domainName @defaults("domainName routingMode") {
   // Domain name
   domainName string
@@ -15113,16 +16107,15 @@ private aws.apigatewayv2.domainName @defaults("domainName routingMode") {
 
 // AWS Lake Formation
 //
-// Use the Lake Formation namespace to audit how data-lake access is governed
-// across all enabled regions. Iterate `settings()` for the
-// per-region governance configuration — the data lake administrators, the
-// default database and table permissions granted to new resources (the
-// signal for whether the lake falls back to open IAM access or enforces Lake
-// Formation grants), the trusted resource owners, and the external
-// data-filtering settings. Iterate `permissions()` for every Lake Formation
-// grant (principal, resource, and the actions allowed, with or without grant
-// option). Iterate `resources()` for every S3 location registered with Lake
-// Formation, along with the IAM role used to access it.
+// Data-lake access governance across all enabled regions. The `settings`
+// give the per-region governance configuration: the data lake
+// administrators, the default database and table permissions granted to new
+// resources (the signal for whether the lake falls back to open IAM access
+// or enforces Lake Formation grants), the trusted resource owners, and the
+// external data-filtering settings. The `permissions` list every Lake
+// Formation grant (principal, resource, and the actions allowed, with or
+// without grant option). The `resources` list every S3 location registered
+// with Lake Formation, along with the IAM role used to access it.
 aws.lakeformation {
   // Per-region Lake Formation data lake settings
   settings() []aws.lakeformation.dataLakeSettings
@@ -15134,9 +16127,9 @@ aws.lakeformation {
 
 // AWS Lake Formation data lake settings
 //
-// Examine the Lake Formation governance configuration for one region. Each
-// settings record is selected by its region — for example
-// `aws.lakeformation.dataLakeSettings(region: "us-east-1")` — and exposes the
+// Lake Formation governance configuration for one region. Each settings
+// record is selected by its region, for example
+// `aws.lakeformation.dataLakeSettings(region: "us-east-1")`, and exposes the
 // data lake administrators, the default permissions handed to newly created
 // databases and tables, the trusted resource owners, and the external
 // data-filtering controls. A `createDatabaseDefaultPermissions` or
@@ -15172,7 +16165,7 @@ private aws.lakeformation.dataLakeSettings @defaults("region") {
 
 // AWS Lake Formation permission grant
 //
-// Examine a single Lake Formation grant — the binding of a principal to a set
+// Single Lake Formation grant, the binding of a principal to a set
 // of actions on a catalog resource. Each grant exposes the principal it is
 // granted to, the resource it applies to, and the permissions allowed, along
 // with the subset that the principal may further grant to others.
@@ -15199,9 +16192,9 @@ private aws.lakeformation.permission @defaults("principal region") {
 
 // AWS Lake Formation registered resource
 //
-// Examine an S3 location registered with Lake Formation. Each resource is
-// keyed by its ARN — for example
-// `aws.lakeformation.resource(arn: "arn:aws:s3:::my-data-lake-bucket")` — and
+// S3 location registered with Lake Formation. Each resource is
+// keyed by its ARN, for example
+// `aws.lakeformation.resource(arn: "arn:aws:s3:::my-data-lake-bucket")`, and
 // exposes the IAM role Lake Formation assumes to access the location and the
 // access modes enabled for it.
 private aws.lakeformation.resource @defaults("arn region") {
@@ -15223,14 +16216,14 @@ private aws.lakeformation.resource @defaults("arn region") {
 
 // AWS Lambda
 //
-// Use the Lambda namespace to enumerate serverless functions and the
-// building blocks around them. Iterate `functions()` for every Lambda
-// function across enabled regions (with its runtime, handler, package type,
-// IAM execution role, environment variables, KMS key, VPC configuration,
-// concurrency settings, code signing config, and resource policy),
-// `layers()` for shared Lambda layers, and `eventSourceMappings()` for the
-// event source mappings that connect functions to Kinesis, DynamoDB
-// Streams, SQS, MSK, MQ, and self-managed Kafka.
+// Serverless compute namespace covering functions and the building blocks
+// around them. The functions collection returns every Lambda function across
+// enabled regions, including its runtime, handler, package type, IAM execution
+// role, environment variables, KMS key, VPC configuration, concurrency
+// settings, code signing config, and resource policy. The layers collection
+// returns shared Lambda layers, and eventSourceMappings returns the mappings
+// that connect functions to Kinesis, DynamoDB Streams, SQS, MSK, MQ, and
+// self-managed Kafka.
 aws.lambda {
   // List of Lambda functions across all regions in the account
   functions() []aws.lambda.function
@@ -15254,7 +16247,12 @@ private aws.lambda.function @defaults("arn") {
   dlqTargetArn string
   // Recursive loop detection mode, either "Allow" or "Terminate"
   recursiveLoop() string
-  // Policy for the function
+  // Resource-based policy attached to the function
+  //
+  // The raw IAM policy document, with `Version` and `Statement` keys, that
+  // controls which principals and services may invoke the function. See
+  // policyStatements for the parsed statements and isPublic for the derived
+  // public-access verdict. Null when the function has no resource policy.
   policy() dict
   // Parsed statements from the function resource policy
   policyStatements() []aws.iam.policyStatement
@@ -15350,7 +16348,11 @@ private aws.lambda.function @defaults("arn") {
   snapStartApplyOn string
   // SnapStart optimization status: On or Off
   snapStartOptimizationStatus string
-  // File system mount configurations (EFS or S3 Files)
+  // File system mount configurations
+  //
+  // Each entry is a dict with `Arn` (the Amazon EFS or Amazon S3 Files access
+  // point ARN that provides file system access) and `LocalMountPath` (the path
+  // under /mnt/ where the function accesses the mounted file system).
   fileSystemConfigs []dict
   // Code signing profile version ARN
   signingProfileVersionArn string
@@ -15364,9 +16366,17 @@ private aws.lambda.function @defaults("arn") {
   provisionedConcurrencyConfigs() []aws.lambda.function.provisionedConcurrencyConfig
   // Code signing configuration (null if not configured)
   codeSigningConfig() aws.lambda.codeSigningConfig
-  // Event invoke configuration (destinations, max retry attempts, max event age)
+  // Asynchronous invocation configuration
+  //
+  // Dict with `maximumRetryAttempts`, `maximumEventAgeInSeconds`, and
+  // `destinationConfig` (which holds `onSuccess` and `onFailure` destination
+  // ARNs). Empty when the function has no event invoke configuration.
   eventInvokeConfig() dict
-  // Runtime management configuration (update mode and ARN)
+  // Runtime management configuration
+  //
+  // Dict with `updateRuntimeOn` (the runtime update mode: Auto, Manual, or
+  // FunctionUpdate) and, when the runtime is pinned, `runtimeVersionArn`
+  // identifying the specific managed runtime version.
   runtimeManagementConfig() dict
   // Published versions of this function
   versions() []aws.lambda.function.version
@@ -15558,7 +16568,11 @@ private aws.lambda.eventSourceMapping @defaults("uuid eventSourceArn") {
   startingPosition string
   // ARN of the on-failure destination
   onFailureDestinationArn string
-  // Filter criteria as JSON
+  // Event filtering criteria
+  //
+  // Dict with a `Filters` array whose entries each carry a `Pattern` string
+  // holding a JSON event-filter rule. Records that match none of the patterns
+  // are discarded before the function is invoked.
   filterCriteria dict
   // Maximum concurrency for SQS event sources
   maximumConcurrency int
@@ -15616,15 +16630,13 @@ private aws.lambda.codeSigningConfig @defaults("arn") {
 
 // AWS Systems Manager (SSM)
 //
-// Use the SSM namespace to enumerate the operational fleet, automation, and
-// configuration objects Systems Manager manages. Iterate `instances()` for
-// SSM-managed nodes (EC2 and on-premises), `parameters()` for Parameter
-// Store entries, `documents()` for SSM documents, `patchBaselines()` for
-// the patch baselines applied by Patch Manager, `maintenanceWindows()` for
-// scheduled maintenance windows, `associations()` for State Manager
-// associations binding documents to managed nodes, and
-// `complianceSummaries()` for the per-resource compliance roll-ups SSM
-// produces.
+// Operational fleet, automation, and configuration objects Systems Manager
+// manages. The `instances` field covers SSM-managed nodes (EC2 and
+// on-premises), `parameters` the Parameter Store entries, `documents` the SSM
+// documents, `patchBaselines` the baselines applied by Patch Manager,
+// `maintenanceWindows` the scheduled maintenance windows, `associations` the
+// State Manager associations binding documents to managed nodes, and
+// `complianceSummaries` the per-resource compliance roll-ups SSM produces.
 aws.ssm @defaults("instances") {
   // List of SSM instances
   instances() []aws.ssm.instance
@@ -15651,9 +16663,9 @@ aws.ssm @defaults("instances") {
   serviceSettings() []aws.ssm.serviceSetting
   // Session Manager preferences document body (`SSM-SessionManagerRunShell`)
   //
-  // Returns the JSON content of the Session Manager run-shell preferences document — including
-  // S3/CloudWatch logging destinations, KMS key ID for session encryption, idle timeout, and
-  // run-as configuration. Empty when the document has not been customized in the account.
+  // JSON content of the Session Manager run-shell preferences document, including
+  // S3/CloudWatch logging destinations, KMS key ID for session encryption, idle timeout,
+  // and run-as configuration. Empty when the document has not been customized in the account.
   sessionManagerPreferences() dict
 }
 
@@ -15744,17 +16756,15 @@ private aws.ssm.instance @defaults("instanceId region platformName platformVersi
 
 // Amazon Elastic Compute Cloud (EC2)
 //
-// Use the EC2 namespace to enumerate compute and networking primitives in
-// the account. Iterate `instances()` for EC2 instances, `volumes()` and
-// `snapshots()` for EBS storage, `securityGroups()` and `networkAcls()` for
-// L4 access controls, `images()` and `keypairs()` for AMIs and SSH key
-// pairs, `internetGateways()`, `transitGateways()`, `customerGateways()`,
-// `vpnConnections()`, `clientVpnEndpoints()`, and `eips()` for the
-// edge-network components, and `launchTemplates()` /
-// `launchConfigurations()` for the templates that drive Auto Scaling and
-// Spot fleets. Also surfaces account-level guardrails as maps keyed by
-// region (`ebsEncryptionByDefault`, `serialConsoleAccessEnabled`,
-// `imageBlockPublicAccess`).
+// Compute and networking primitives across the account: instances for EC2
+// compute, volumes and snapshots for EBS storage, securityGroups and
+// networkAcls for L4 access controls, images and keypairs for AMIs and SSH
+// key pairs, internetGateways, transitGateways, customerGateways,
+// vpnConnections, clientVpnEndpoints, and eips for the edge-network
+// components, and launchTemplates and launchConfigurations for the templates
+// that drive Auto Scaling and Spot fleets. Account-level guardrails surface
+// as maps keyed by region (ebsEncryptionByDefault,
+// serialConsoleAccessEnabled, imageBlockPublicAccess).
 aws.ec2 {
   // List of security groups available to the account
   securityGroups() []aws.ec2.securitygroup
@@ -16095,7 +17105,10 @@ private aws.ec2.internetgateway @defaults("arn") {
   id string
   // Region where the internet gateway exists
   region string
-  // VPC attachments
+  // VPC attachments of the internet gateway
+  //
+  // Each entry carries VpcId (the attached VPC) and State (the attachment
+  // state, such as available or detached).
   attachments []dict
   // Tags on the internet gateway
   tags map[string]string
@@ -16203,7 +17216,11 @@ private aws.ec2.dhcpOptions @defaults("id region") {
   region string
   // Tags on the DHCP options set
   tags map[string]string
-  // DHCP configurations (each entry has a key and list of values)
+  // DHCP configuration settings for the options set
+  //
+  // Each entry carries Key (for example domain-name, domain-name-servers,
+  // ntp-servers, netbios-name-servers, or netbios-node-type) and Values, the
+  // list of configured values for that key.
   configurations []dict
 }
 
@@ -16307,7 +17324,12 @@ private aws.ec2.clientVpnEndpoint @defaults("id status region") {
   clientLoginBannerOptions dict
   // Connection logging options (CloudWatch log group/stream, enabled flag)
   connectionLogOptions dict
-  // Authentication options
+  // Authentication methods enabled on the endpoint
+  //
+  // Each entry carries Type (certificate-authentication,
+  // directory-service-authentication, or federated-authentication) and the
+  // matching detail object: MutualAuthentication, ActiveDirectory, or
+  // FederatedAuthentication.
   authenticationOptions []dict
   // Transit Gateway the endpoint is attached to (transit-gateway mode only)
   transitGateway() aws.ec2.transitgateway
@@ -16355,7 +17377,10 @@ private aws.ec2.egressOnlyInternetGateway @defaults("id region") {
   arn string
   // Region where the gateway exists
   region string
-  // VPC attachments
+  // VPC attachments of the egress-only internet gateway
+  //
+  // Each entry carries VpcId (the attached VPC) and State (the attachment
+  // state, such as available or detached).
   attachments []dict
   // Tags on the gateway
   tags map[string]string
@@ -16431,19 +17456,19 @@ private aws.ec2.instanceConnectEndpoint @defaults("id state subnetId") {
   state string
   // Subnet ID the endpoint is in
   //
-  // Deprecated in favor of `subnet()`.
+  // Deprecated in favor of `subnet`.
   subnetId @maturity("deprecated") string
   // Subnet the endpoint is in
   subnet() aws.vpc.subnet
   // VPC ID the endpoint is in
   //
-  // Deprecated in favor of `vpc()`.
+  // Deprecated in favor of `vpc`.
   vpcId @maturity("deprecated") string
   // VPC the endpoint is in
   vpc() aws.vpc
   // Security group IDs associated with the endpoint
   //
-  // Deprecated in favor of `securityGroups()`.
+  // Deprecated in favor of `securityGroups`.
   securityGroupIds @maturity("deprecated") []string
   // Security groups associated with the endpoint
   securityGroups() []aws.ec2.securitygroup
@@ -16631,7 +17656,10 @@ private aws.ec2.snapshot @defaults("id region volumeSize state") {
   id string
   // Region where the snapshot exists
   region string
-  // Users/groups that have the permissions to create volumes from the snapshot
+  // Accounts and groups permitted to create volumes from the snapshot
+  //
+  // Each entry carries either UserId (an AWS account ID granted permission)
+  // or Group (set to all when the snapshot is shared publicly).
   createVolumePermission() []dict
   // ID of the volume used to create the snapshot
   volumeId string
@@ -16691,7 +17719,12 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
   arn string
   // ID of the EC2 volume
   id string
-  // Information about the volume attachments
+  // Attachments joining the volume to instances
+  //
+  // Each entry carries InstanceId, Device (the mount point, such as
+  // /dev/sda1), State (attaching, attached, detaching, detached, or busy),
+  // AttachTime, DeleteOnTermination, and the AssociatedResource /
+  // InstanceOwningService set when the volume is managed by an AWS service.
   attachments []dict
   // Whether the volume is encrypted
   encrypted bool
@@ -16739,10 +17772,10 @@ private aws.ec2.volume @defaults("id region volumeType size encrypted state") {
 
 // AWS Signer
 //
-// Use the Signer namespace to enumerate code-signing profiles in the
-// account. Iterate `signingProfiles()` to examine the signing platform,
-// profile status, signing-material certificate, and signature validity
-// period that govern how artifacts (such as Lambda deployment packages and
+// Code-signing profiles in the account. The signingProfiles field
+// enumerates each profile with its signing platform, profile status,
+// signing-material certificate, and signature validity period, which
+// together govern how artifacts (such as Lambda deployment packages and
 // container images) are signed.
 aws.signer @defaults("signingProfiles") {
   // List of signing profiles in the account
@@ -16751,11 +17784,11 @@ aws.signer @defaults("signingProfiles") {
 
 // AWS Signer code-signing profile
 //
-// Examine a code-signing profile — the named configuration Signer uses to
-// produce signatures for a given platform. Each profile carries the signing
-// `platformId`, the profile `status`, the certificate ARN of its signing
-// material, and the validity period stamped onto generated signatures,
-// establishing the provenance of artifacts signed through it.
+// Named configuration Signer uses to produce signatures for a given
+// platform. Each profile carries the signing platform in platformId, the
+// profile status, the certificate ARN of its signing material, and the
+// validity period stamped onto generated signatures, establishing the
+// provenance of artifacts signed through it.
 private aws.signer.signingProfile @defaults("profileName platformId status") {
   // ARN of the signing profile
   arn string
@@ -16791,14 +17824,13 @@ private aws.signer.signingProfile @defaults("profileName platformId status") {
 
 // Amazon Inspector
 //
-// Use the Inspector namespace to enumerate Inspector v2 vulnerability and
-// posture coverage in the account. Iterate `coverages()` for the per-resource
-// scan coverage status (which EC2 instances, ECR images, and Lambda
-// functions Inspector is currently scanning) and `findings()` for the
-// active findings produced across all enabled regions. Iterate
-// `accountStatuses()` and `configurations()` for the account enablement
-// posture and scan settings that govern whether those findings are produced
-// at all.
+// Inspector v2 vulnerability and posture coverage for the account. The
+// coverages report the per-resource scan status (which EC2 instances, ECR
+// images, and Lambda functions Inspector is currently scanning), while the
+// findings expose the active vulnerability, network-reachability, and code
+// findings produced across all enabled regions. Account statuses and
+// configurations report the enablement posture and scan settings that govern
+// whether those findings are produced at all.
 aws.inspector {
   // List of coverage results for the AWS account
   coverages() []aws.inspector.coverage
@@ -17046,6 +18078,12 @@ private aws.inspector.finding.networkReachability @defaults("protocol openPortSt
   // Open port range end
   openPortEnd int
   // Network path steps
+  //
+  // Each step traces one hop along the path that reaches the open port. Keyed
+  // by `ComponentId` (the component the traffic passes through),
+  // `ComponentType` (the kind of component, such as an internet gateway or
+  // security group), and `ComponentArn` (the component ARN, which can be
+  // null).
   networkPath []dict
 }
 
@@ -17060,6 +18098,10 @@ private aws.inspector.finding.codeVulnerability @defaults("detectorName") {
   // Detector tags
   detectorTags []string
   // File path where the vulnerability was found
+  //
+  // Keyed by `FileName` (the file the code vulnerability was found in),
+  // `FilePath` (the path to that file), and `StartLine` and `EndLine` (the
+  // first and last line numbers of the affected code).
   filePath dict
   // Reference URLs
   referenceUrls []string
@@ -17107,9 +18149,17 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   platformDetails string
   // Public DNS name for the instance
   publicDnsName string
-  // Status of the specified instance
+  // Health and scheduled-event status of the instance
+  //
+  // Carries InstanceState, the SystemStatus and InstanceStatus check results
+  // (each with an overall Status plus per-check Details), AttachedEbsStatus,
+  // any scheduled Events, and AvailabilityZone. Only populated while the
+  // instance is running.
   instanceStatus() dict
   // Reason for the most recent state transition
+  //
+  // Carries Code (for example Client.UserInitiatedShutdown or
+  // Server.SpotInstanceTermination) and a human-readable Message.
   stateReason dict
   // Reason for the most recent state transition
   stateTransitionReason string
@@ -17171,7 +18221,7 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   loadBalancers() []aws.elb.loadbalancer
   // Internet-exposure analysis for the instance
   //
-  // Breaks down whether and how the instance is reachable from the internet — the contributing signals, the security-group ingress rules that open it, and any internet-facing load balancers that front it.
+  // Whether and how the instance is reachable from the internet: the contributing signals, the security-group ingress rules that open it, and any internet-facing load balancers that front it.
   exposure() aws.ec2.instance.exposure
   // CloudFormation stack that manages this instance, if any
   cloudformationStack() aws.cloudformation.stack
@@ -17374,6 +18424,9 @@ private aws.ec2.image @defaults("ownerAlias id name") {
   // Instance this AMI was created from, when it is still present in this account
   sourceInstance() aws.ec2.instance
   // Marketplace and origin product codes associated with the image
+  //
+  // Each entry carries ProductCodeId and ProductCodeType (marketplace or
+  // devpay).
   productCodes []dict
   // Provenance watermarks recorded on the image
   watermarks []aws.ec2.image.watermark
@@ -17381,12 +18434,12 @@ private aws.ec2.image @defaults("ownerAlias id name") {
 
 // Amazon EC2 image provenance watermark
 //
-// Examine a provenance watermark recorded on an AMI. Watermarks capture image
-// lineage when an AMI is copied or shared: each one names the source AMI it was
-// derived from through `sourceImageId` and the Region that source lived in, and
-// is identified by `watermarkKey` in `accountId:watermarkName` format — for
-// example `123456789012:approvedAmi`, where the account ID is the watermark
-// creator and the name is customer-provided.
+// Provenance record capturing AMI lineage when an image is copied or shared.
+// Each watermark names the source AMI it was derived from through
+// `sourceImageId` and the Region that source lived in, and is identified by
+// `watermarkKey` in `accountId:watermarkName` format (for example
+// `123456789012:approvedAmi`, where the account ID is the watermark creator
+// and the name is customer-provided).
 private aws.ec2.image.watermark @defaults("watermarkKey sourceImageId") {
   // Watermark identifier in accountId:watermarkName format (for example, 123456789012:approvedAmi)
   watermarkKey string
@@ -17438,7 +18491,7 @@ private aws.ec2.image.ebsBlockDevice @defaults("volumeSize volumeType encrypted"
   volumeType string
   // ARN of the KMS key for encryption
   //
-  // Deprecated in favor of `kmsKey()`.
+  // Deprecated in favor of `kmsKey`.
   kmsKeyId @maturity("deprecated") string
   // KMS key used for encryption
   kmsKey() aws.kms.key
@@ -17452,10 +18505,10 @@ private aws.ec2.image.ebsBlockDevice @defaults("volumeSize volumeType encrypted"
 
 // EC2 instance internet-exposure breakdown
 //
-// Explains the internetReachable verdict for an instance: the public-IP,
-// public-subnet, security-group, and network-ACL signals that combine into it,
-// plus the specific security-group ingress rules that open the instance and any
-// internet-facing load balancers that route to it.
+// Breakdown behind the internetReachable verdict for an instance: the
+// public-IP, public-subnet, security-group, and network-ACL signals that
+// combine into it, plus the specific security-group ingress rules that open
+// the instance and any internet-facing load balancers that route to it.
 private aws.ec2.instance.exposure @defaults("internetReachable hasPublicIp inPublicSubnet") {
   // Whether the instance is directly reachable from the internet (public IP and public subnet and an open security group and a permitting network ACL)
   internetReachable bool
@@ -17567,11 +18620,20 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
   ipv6Ranges []string
   // IPv6 address ranges with per-range descriptions (each entry: {cidr, description})
   ipv6RangeDetails []dict
-  // List of prefix IDs
+  // Managed prefix lists referenced by the rule
+  //
+  // Each entry carries PrefixListId (the referenced managed prefix list) and
+  // Description. See prefixLists for the resolved managed prefix list
+  // resources.
   prefixListIds []dict
   // Managed prefix lists this rule targets
   prefixLists() []aws.ec2.managedPrefixList
-  // List of user ID group pairs
+  // Security group references the rule allows
+  //
+  // Each entry carries GroupId and GroupName of the referenced security
+  // group, UserId of the account that owns it, VpcId and
+  // VpcPeeringConnectionId when the reference crosses a VPC peering
+  // connection, PeeringStatus, and an optional Description.
   userIdGroupPairs []dict
   // Whether the rule allows traffic from the entire internet
   //
@@ -17582,14 +18644,14 @@ private aws.ec2.securitygroup.ippermission @defaults("id toPort fromPort ipProto
 
 // AWS Config
 //
-// Use the Config namespace to enumerate AWS Config recording, rule
-// evaluation, and aggregation in the account. Iterate `recorders()` for
-// the per-region configuration recorders that capture resource state,
-// `deliveryChannels()` for the S3 bucket and SNS topic each recorder
-// publishes to, `rules()` for the managed and custom Config rules
-// evaluating compliance, `aggregators()` for cross-account/region
-// aggregators, and `conformancePacks()` for the pre-built compliance
-// frameworks deployed.
+// AWS Config recording, rule evaluation, and aggregation for the
+// account. The `recorders` are the per-region configuration recorders
+// that capture resource state, `deliveryChannels` the S3 bucket and
+// SNS topic each recorder publishes to, `rules` the managed and custom
+// Config rules that evaluate compliance, `aggregators` the
+// cross-account and cross-region aggregators, and `conformancePacks`
+// the pre-built compliance frameworks deployed. Query it to confirm
+// Config is enabled and actively recording in every region.
 aws.config {
   // List of configuration recorders for each region in the account
   recorders() []aws.config.recorder
@@ -17609,7 +18671,14 @@ private aws.config.rule @defaults("name id region state") {
   arn string
   // State of the rule
   state string
-  // Rule identifier that causes the function to evaluate resources
+  // Rule source
+  //
+  // Origin of the rule and what triggers evaluation. Keys: `Owner`
+  // (AWS, CUSTOM_LAMBDA, or CUSTOM_POLICY), `SourceIdentifier` (the
+  // managed-rule identifier or the Lambda function ARN),
+  // `SourceDetails` (the events and frequency that trigger evaluation),
+  // and `CustomPolicyDetails` (Guard policy runtime and text for
+  // custom-policy rules).
   source dict
   // ID of the Config rule
   id string
@@ -17658,6 +18727,10 @@ private aws.config.rule.remediation @defaults("targetType targetId") {
   // Number of seconds to wait before retrying a failed remediation
   retryAttemptSeconds int
   // Parameters passed to the remediation target
+  //
+  // Keyed by remediation parameter name. Each value carries either a
+  // `StaticValue` (a fixed list of values) or a `ResourceValue` (a
+  // value resolved from the non-compliant resource, such as its ID).
   parameters dict
 }
 
@@ -17728,6 +18801,10 @@ private aws.config.conformancePack @defaults("name region") {
   // S3 key prefix for conformance pack artifacts
   deliveryS3KeyPrefix string
   // Input parameters for the conformance pack
+  //
+  // Each entry has keys `ParameterName` and `ParameterValue`, supplying
+  // a value for a parameter referenced by the conformance pack
+  // template.
   inputParameters []dict
   // Time of the last update request
   lastUpdateRequestedTime time
@@ -17785,9 +18862,9 @@ private aws.config.aggregator.organizationAggregationSource {
 
 // Amazon Elastic Kubernetes Service (EKS)
 //
-// Use the EKS namespace to enumerate Kubernetes clusters managed by EKS
-// across all enabled regions. Iterate `clusters()` for every EKS cluster —
-// each row surfaces the control-plane Kubernetes version, networking,
+// Managed Kubernetes control planes running in the account across all
+// enabled regions. The `clusters` field enumerates every EKS cluster,
+// each surfacing the control-plane Kubernetes version, networking,
 // authentication mode, encryption configuration, IAM identity mappings,
 // node groups, Fargate profiles, add-ons, and the OIDC identity provider
 // associated with the cluster.
@@ -17813,6 +18890,9 @@ private aws.eks.nodegroup @defaults("name scalingConfig.DesiredSize diskSize sta
   // Capacity type for the EKS node group (ON_DEMAND, SPOT)
   capacityType() string
   // Scaling configuration for the EKS node group
+  //
+  // Keys: `MinSize`, `MaxSize`, and `DesiredSize` (node counts the managed
+  // node group maintains).
   scalingConfig() dict
   // Instance types for the EKS node group
   instanceTypes() []string
@@ -17829,16 +18909,34 @@ private aws.eks.nodegroup @defaults("name scalingConfig.DesiredSize diskSize sta
   // List of autoscaling groups for the node group
   autoscalingGroups() []aws.autoscaling.group
   // Warm pool configuration for the node group
+  //
+  // Keys: `Enabled`, `MinSize`, `MaxGroupPreparedCapacity`, `ReuseOnScaleIn`,
+  // and `PoolState` (one of Stopped, Running, or Hibernated).
   warmPoolConfig() dict
-  // Health status of the node group (contains issues list)
+  // Health status of the node group
+  //
+  // Contains an `Issues` list, where each entry has `Code`, `Message`, and
+  // `ResourceIds` describing an infrastructure problem with the node group.
   health() dict
   // Kubernetes taints applied to nodes in the group
+  //
+  // Each entry has `Key`, `Value`, and `Effect` (one of NO_SCHEDULE,
+  // NO_EXECUTE, or PREFER_NO_SCHEDULE).
   taints() []dict
   // AMI release version
   releaseVersion() string
-  // Remote access configuration for the node group (SSH key, source security groups)
+  // Remote access configuration for the node group
+  //
+  // Keys: `Ec2SshKey` (EC2 key pair granting SSH access to the nodes) and
+  // `SourceSecurityGroups` (security group IDs allowed SSH access). When a
+  // key is set with no source security groups, the SSH port is open to the
+  // internet.
   remoteAccess() dict
-  // Update configuration for the node group (maxUnavailable settings)
+  // Update configuration for the node group
+  //
+  // Keys: `MaxUnavailable`, `MaxUnavailablePercentage`, and `UpdateStrategy`
+  // controlling how many nodes are replaced in parallel during a version
+  // update.
   updateConfig() dict
   // Kubernetes version of the node group
   nodeVersion() string
@@ -17876,14 +18974,17 @@ private aws.eks.addon @defaults("name addonVersion status") {
   configurationValues() string
   // Region where the add-on exists
   region string
-  // Health status of the add-on (contains issues list)
+  // Health status of the add-on
+  //
+  // Contains an `Issues` list, where each entry has `Code`, `Message`, and
+  // `ResourceIds` describing a problem with the add-on.
   health() dict
 }
 
 // Amazon EKS cluster
 //
-// Examine an EKS Kubernetes cluster control plane. Use the `arn` field as
-// the selection key — for example
+// EKS Kubernetes cluster control plane. Use the `arn` field as the
+// selection key, for example
 // `aws.eks.cluster(arn: "arn:aws:eks:us-east-1:111122223333:cluster/prod")`.
 // Each row surfaces the Kubernetes server version, EKS platform version,
 // API endpoint, KMS envelope-encryption key, control-plane logging types
@@ -17923,8 +19024,16 @@ aws.eks.cluster @defaults("arn version status") {
   // Resource types encrypted with the KMS key (e.g., "secrets")
   encryptionResources() []string
   // Cluster logging configuration
+  //
+  // Contains a `ClusterLogging` list, where each entry has `Enabled` and a
+  // `Types` list of control-plane log types (api, audit, authenticator,
+  // controllerManager, scheduler) exported to CloudWatch Logs.
   logging() dict
   // Kubernetes network configuration
+  //
+  // Keys: `ServiceIpv4Cidr` and `ServiceIpv6Cidr` (CIDR blocks pods and
+  // services get IPs from), `IpFamily` (ipv4 or ipv6), and
+  // `ElasticLoadBalancing` (Auto Mode load-balancing capability).
   networkConfig() dict
   // Control plane egress routing mode
   //
@@ -17951,6 +19060,9 @@ aws.eks.cluster @defaults("arn version status") {
   // `STANDARD` support automatically upgrades at the end of standard support. `EXTENDED` automatically enters extended support at the end of standard support.
   supportType() string
   // Cluster authentication mode
+  //
+  // One of API, API_AND_CONFIG_MAP, or CONFIG_MAP, controlling whether access
+  // is granted through EKS access entries, the aws-auth ConfigMap, or both.
   authenticationMode() string
   // Whether deletion protection is enabled or not
   deletionProtection() bool
@@ -17976,7 +19088,10 @@ aws.eks.cluster @defaults("arn version status") {
   clusterSecurityGroups() []aws.ec2.securitygroup
   // Cluster security group created by Amazon EKS for control-plane-to-data-plane communication
   clusterSecurityGroup() aws.ec2.securitygroup
-  // Cluster health status (contains issues list)
+  // Cluster health status
+  //
+  // Contains an `Issues` list, where each entry has `Code`, `Message`, and
+  // `ResourceIds` describing a control-plane health problem.
   health() dict
   // Base64-encoded certificate authority data for the cluster
   certificateAuthority() string
@@ -17984,15 +19099,33 @@ aws.eks.cluster @defaults("arn version status") {
   insights() []aws.eks.insight
   // Available add-on versions compatible with this cluster's Kubernetes version
   availableAddonVersions() []aws.eks.addonVersion
-  // Upgrade policy for the cluster (contains supportType)
+  // Upgrade policy for the cluster
+  //
+  // Contains `SupportType`, one of STANDARD (auto-upgrade at the end of
+  // standard support) or EXTENDED (enter extended support at the end of
+  // standard support).
   upgradePolicy() dict
   // Zonal shift configuration for the cluster
+  //
+  // Contains `Enabled`, indicating whether ARC zonal shift is enabled to
+  // shift traffic away from an impaired Availability Zone.
   zonalShiftConfig() dict
   // Compute configuration for Auto Mode clusters
+  //
+  // Keys: `Enabled` (whether EKS Auto Mode manages EC2 compute), `NodePools`
+  // (the built-in node pools in use), and `NodeRoleArn` (IAM role assigned to
+  // Auto Mode instances).
   computeConfig() dict
   // Storage configuration for Auto Mode clusters
+  //
+  // Contains `BlockStorage` with an `Enabled` flag indicating whether EKS
+  // Auto Mode manages EBS volumes.
   storageConfig() dict
   // Remote network configuration for hybrid nodes
+  //
+  // Keys: `RemoteNodeNetworks` and `RemotePodNetworks`, each a list of
+  // objects with a `Cidrs` list of CIDR blocks that may contain hybrid nodes
+  // or hybrid-node pods.
   remoteNetworkConfig() dict
 }
 
@@ -18052,7 +19185,10 @@ private aws.eks.fargateProfile @defaults("name status") {
   podExecutionRoleArn() @maturity("deprecated") string
   // IAM role used for Fargate pod execution
   podExecutionRole() aws.iam.role
-  // Selectors that determine which pods run on Fargate (namespace and label matchers)
+  // Selectors that determine which pods run on Fargate
+  //
+  // Each entry has `Namespace` and `Labels` (a map of label key-value pairs);
+  // a pod must match the namespace and all labels to run on the profile.
   selectors() []dict
   // Subnet IDs for the Fargate profile
   //
@@ -18139,6 +19275,9 @@ private aws.eks.insight @defaults("name category insightStatus") {
   // Description of the insight (may contain Markdown)
   description() string
   // Status of the insight
+  //
+  // Keys: `Status` (one of PASSING, WARNING, ERROR, or UNKNOWN) and `Reason`
+  // explaining the status.
   insightStatus() dict
   // Kubernetes version associated with the insight
   kubernetesVersion() string
@@ -18147,8 +19286,15 @@ private aws.eks.insight @defaults("name category insightStatus") {
   // Additional informational links
   additionalInfo() map[string]string
   // Category-specific summary details
+  //
+  // Keys: `DeprecationDetails` (deprecated resource usage for
+  // UPGRADE_READINESS checks) and `AddonCompatibilityDetails` (add-on
+  // compatibility findings).
   categorySpecificSummary() dict
   // Resources affected by the insight
+  //
+  // Each entry has `Arn`, `KubernetesResourceUri`, and `InsightStatus` (the
+  // per-resource status object) for a resource flagged by the insight.
   resources() []dict
   // Last time the insight was refreshed
   lastRefreshTime() time
@@ -18171,6 +19317,10 @@ private aws.eks.addonVersion @defaults("addonName addonVersion") {
   // Compute types supported by this version
   computeTypes []string
   // Kubernetes version compatibilities
+  //
+  // Each entry has `ClusterVersion` (supported Kubernetes version),
+  // `PlatformVersions` (supported EKS platform versions), and `DefaultVersion`
+  // (whether this is the default add-on version for that cluster version).
   compatibilities() []dict
   // Whether the add-on requires configuration
   requiresConfiguration bool
@@ -18180,12 +19330,13 @@ private aws.eks.addonVersion @defaults("addonName addonVersion") {
 
 // Amazon Neptune
 //
-// Use the Neptune namespace to enumerate the managed graph database
-// deployments in the account. Iterate `clusters()` for Neptune DB clusters
-// (with their endpoints, IAM authentication, KMS encryption, backup
-// retention, parameter group, and reader/writer instances), and
-// `instances()` for individual Neptune DB instances and their per-instance
-// configuration.
+// Managed graph database deployments in the account. Query `clusters`
+// for Neptune DB clusters with their endpoints, IAM database
+// authentication, KMS encryption, backup retention, parameter group,
+// and reader and writer instances, and `instances` for individual
+// Neptune DB instances and their per-instance configuration. Auditing
+// this namespace surfaces unencrypted clusters, clusters without IAM
+// database authentication, and publicly accessible instances.
 aws.neptune @defaults("clusters") {
   // List of database clusters
   clusters() []aws.neptune.cluster
@@ -18194,6 +19345,14 @@ aws.neptune @defaults("clusters") {
 }
 
 // Amazon Neptune cluster
+//
+// Managed graph database cluster, including its connection and reader
+// endpoints, engine version, KMS encryption state, IAM database
+// authentication setting, backup retention, deletion protection, and
+// associated VPC security groups. Query it to find clusters that are
+// unencrypted, lack IAM database authentication, or have deletion
+// protection disabled. `snapshots` returns the cluster's DB snapshots
+// and `exposure` describes its network reachability.
 private aws.neptune.cluster @defaults("arn name status") {
   // ARN for the cluster
   arn string
@@ -18217,7 +19376,7 @@ private aws.neptune.cluster @defaults("arn name status") {
   kmsKey() aws.kms.key
   // Region where the cluster exists
   region string
-  // Time when the cluster was created
+  // Time when a stopped cluster is scheduled to automatically restart
   automaticRestartTime time
   // List of EC2 Availability Zones
   availabilityZones []string
@@ -18282,6 +19441,12 @@ private aws.neptune.cluster @defaults("arn name status") {
 }
 
 // Amazon Neptune instance
+//
+// Individual Neptune DB instance within a cluster, including its
+// compute class, engine version, KMS encryption state, public
+// accessibility, enhanced monitoring configuration, and certificate
+// authority. Query it to find instances that are publicly accessible,
+// unencrypted, or missing IAM database authentication.
 private aws.neptune.instance @defaults("arn name status"){
   // ARN for the instance
   arn string
@@ -18306,6 +19471,9 @@ private aws.neptune.instance @defaults("arn name status"){
   // List of log types that this DB instance is configured to export to CloudWatch logs
   enabledCloudwatchLogsExports []string
   // Connection endpoint
+  //
+  // Dict with the instance's DNS `Address`, the `Port` the database
+  // engine listens on, and the Route 53 `HostedZoneId` for the address.
   endpoint dict
   // Name of the database engine
   engine string
@@ -18315,7 +19483,7 @@ private aws.neptune.instance @defaults("arn name status"){
   enhancedMonitoringResourceArn string
   // Whether mapping of Amazon Identity and Access Management (IAM) accounts to database accounts is enabled
   iamDatabaseAuthenticationEnabled bool
-  // Time when the cluster was created
+  // Time when the instance was created
   createdAt time
   // Amazon KMS key identifier for the encrypted DB instance
   //
@@ -18335,7 +19503,7 @@ private aws.neptune.instance @defaults("arn name status"){
   //
   // Deprecated in favor of `monitoringRole()`.
   monitoringRoleArn @maturity("deprecated") string
-  // Whether the cluster has instances in multiple availability zones
+  // Whether the instance is a Multi-AZ deployment
   multiAZ bool
   // Daily time range during which automated backups are created
   preferredBackupWindow string
@@ -18362,6 +19530,11 @@ private aws.neptune.instance @defaults("arn name status"){
 }
 
 // Amazon Neptune DB cluster snapshot
+//
+// Point-in-time DB cluster snapshot, including its encryption state,
+// engine version, allocated storage, source snapshot, and snapshot
+// type (manual or automated). Query it to find unencrypted snapshots
+// or snapshots retained beyond their intended lifetime.
 private aws.neptune.snapshot @defaults("arn status createdAt") {
   // Snapshot ARN
   arn string
@@ -18401,12 +19574,11 @@ private aws.neptune.snapshot @defaults("arn status createdAt") {
 
 // Amazon Cognito
 //
-// Use the Cognito namespace to enumerate user-facing identity stores in
-// the account. Iterate `userPools()` for user-pool directories (with their
-// password policy, MFA configuration, app clients, identity providers,
-// hosted UI domain, and Lambda triggers), and `identityPools()` for
-// federated identity pools (with their authentication providers, role
-// mappings, and unauthenticated-identity policy).
+// Identity stores in the account. `userPools` are user-pool directories
+// carrying their password policy, MFA configuration, app clients, identity
+// providers, hosted UI domain, and Lambda triggers. `identityPools` are
+// federated identity pools carrying their authentication providers, role
+// mappings, and unauthenticated-identity policy.
 aws.cognito @defaults("userPools") {
   // List of Cognito user pools
   userPools() []aws.cognito.userPool
@@ -18431,6 +19603,11 @@ private aws.cognito.userPool @defaults("arn name") {
   // MFA configuration: OFF, ON, OPTIONAL
   mfaConfiguration() string
   // Password policy
+  //
+  // Password-strength requirements enforced on user-pool sign-up and
+  // reset. Keys: MinimumLength, RequireUppercase, RequireLowercase,
+  // RequireNumbers, RequireSymbols, TemporaryPasswordValidityDays, and
+  // PasswordHistorySize (how many previous passwords are blocked from reuse).
   passwordPolicy() dict
   // Advanced security mode: OFF, AUDIT, ENFORCED
   advancedSecurityMode() string
@@ -18611,7 +19788,7 @@ private aws.cognito.userPoolIdentityProvider @defaults("providerName providerTyp
   // Provider-specific configuration
   //
   // Includes fields like client_id, client_secret, MetadataURL, etc.
-  // Keys vary by providerType — for SAML: MetadataURL/MetadataFile, IDPSignout;
+  // Keys vary by providerType. For SAML: MetadataURL/MetadataFile, IDPSignout;
   // for OIDC: client_id, client_secret, attributes_request_method, oidc_issuer,
   // authorize_scopes; for Google/Facebook/Amazon/Apple: provider client credentials
   // and scopes.
@@ -18663,15 +19840,15 @@ private aws.cognito.identityPool @defaults("id name") {
 
 // Amazon DocumentDB
 //
-// Use the DocumentDB namespace to enumerate the MongoDB-compatible managed
-// document database deployments. Iterate `clusters()` for instance-based
-// clusters (with their writer/reader instances, KMS encryption, parameter
-// group, and audit-log configuration), `instances()` for individual cluster
-// members, `snapshots()` and `clusterParameterGroups()` for backup and
-// configuration objects, `globalClusters()` for cross-region replicated
-// global databases, `elasticClusters()` and `elasticSnapshots()` for the
-// shard-based elastic deployments, and `pendingMaintenanceActions()` for
-// pending engine maintenance items.
+// MongoDB-compatible managed document database deployments in the account.
+// `clusters` covers instance-based clusters (with their writer/reader
+// instances, KMS encryption, parameter group, and audit-log configuration)
+// and `instances` the individual cluster members. `snapshots` and
+// `clusterParameterGroups` expose the backup and configuration objects,
+// `globalClusters` the cross-region replicated global databases, and
+// `elasticClusters` with `elasticSnapshots` the shard-based elastic
+// deployments. `pendingMaintenanceActions` lists pending engine maintenance
+// items across clusters and instances.
 aws.documentdb @defaults("clusters") {
   // List of DocumentDB clusters
   clusters() []aws.documentdb.cluster
@@ -18760,6 +19937,9 @@ private aws.documentdb.cluster @defaults("arn name status") {
   // Whether the DB cluster is encrypted
   storageEncrypted bool
   // Whether client connections to the cluster are required to use TLS
+  //
+  // Derived from the `tls` parameter in the cluster parameter group: true when
+  // that parameter enforces TLS, false when it is disabled or unset.
   transitEncryptionEnabled() bool
   // Storage type
   storageType string
@@ -18875,6 +20055,12 @@ private aws.documentdb.instance @defaults("arn name status") {
   // Pending maintenance actions scheduled for this instance
   pendingMaintenanceActions() []aws.documentdb.pendingMaintenanceAction
   // Pending modifications applied at the next maintenance window
+  //
+  // Only the attributes with a scheduled change are present. Possible keys are
+  // allocatedStorage, backupRetentionPeriod, caCertificateIdentifier,
+  // dbInstanceClass, dbInstanceIdentifier, dbSubnetGroupName, engineVersion,
+  // iops, licenseModel, masterUserPassword (always redacted), multiAZ, port,
+  // storageType, logTypesToEnable, and logTypesToDisable.
   pendingModifiedValues map[string]string
   // Tags for the instance
   tags() map[string]string
@@ -19092,12 +20278,12 @@ private aws.documentdb.elasticSnapshot @defaults("name status snapshotType") {
 
 // Amazon Timestream for LiveAnalytics
 //
-// Use the Timestream LiveAnalytics namespace to enumerate the time-series
-// databases and tables in the account's LiveAnalytics deployment. Iterate
-// `databases()` for the databases (with their KMS encryption and tables)
-// and `tables()` for the underlying tables (with retention windows for
-// memory and magnetic stores, the schema and partition keys, and any
-// scheduled query targets).
+// Time-series databases and tables in the account's LiveAnalytics
+// deployment. The `databases` collection covers each database with its
+// KMS encryption key and table count, while `tables` covers the underlying
+// tables with their memory-store and magnetic-store retention windows and
+// magnetic-store write configuration. Useful for auditing encryption at
+// rest and data-retention policy across the time-series estate.
 aws.timestream.liveanalytics @defaults("databases") {
   // List of databases
   databases() []aws.timestream.liveanalytics.database
@@ -19143,25 +20329,40 @@ private aws.timestream.liveanalytics.table @defaults("name region") {
   createdAt time
   // Time when the table was last updated
   updatedAt time
-  // Magnetic store properties for the table
+  // Magnetic store write configuration
+  //
+  // Keys: `EnableMagneticStoreWrites` (bool) and
+  // `MagneticStoreRejectedDataLocation`, whose nested `S3Configuration`
+  // holds `BucketName`, `ObjectKeyPrefix`, `EncryptionOption`, and
+  // `KmsKeyId` for the S3 location where records rejected during magnetic
+  // writes are reported.
   magneticStoreWriteProperties dict
-  // Retention duration properties for the table
+  // Data retention configuration
+  //
+  // Keys: `MemoryStoreRetentionPeriodInHours` (how long a record stays in
+  // the memory store) and `MagneticStoreRetentionPeriodInDays` (how long a
+  // record is retained in the magnetic store before deletion).
   retentionProperties dict
 }
 
 // AWS CodeDeploy
 //
-// Use the CodeDeploy namespace to enumerate deployment applications in
-// the account. Iterate `applications()` for every CodeDeploy application
-// across enabled regions — each entry surfaces its compute platform
-// (EC2/On-premises, Lambda, ECS), deployment groups, deployment
-// configurations, and the trigger and alarm settings used during rollouts.
+// CodeDeploy applications across the account's enabled regions. Each
+// application in `applications` reports its compute platform (EC2/on-premises,
+// Lambda, or ECS) and provides access to its deployment groups and the
+// deployment history used to release code.
 aws.codedeploy {
   // List of CodeDeploy applications across all enabled regions
   applications() []aws.codedeploy.application
 }
 
 // AWS CodeDeploy Application
+//
+// CodeDeploy application, the container that groups the deployment groups and
+// deployments used to release code to a given compute platform. The
+// `computePlatform` field reports whether it targets EC2/on-premises servers,
+// Lambda functions, or ECS services, and `linkedToGitHub` indicates whether
+// revisions are pulled from a linked GitHub account.
 private aws.codedeploy.application @defaults("applicationName computePlatform createdAt region") {
   // ARN of the application
   arn string
@@ -19186,6 +20387,13 @@ private aws.codedeploy.application @defaults("applicationName computePlatform cr
 }
 
 // AWS CodeDeploy Deployment Group
+//
+// Set of instances or ECS/Lambda targets that a CodeDeploy application deploys
+// to, together with the rollout controls applied during a release. The
+// `serviceRole`, EC2 and on-premises tag filters that select targets, the
+// in-place versus blue/green deployment style, and the load balancer wiring
+// that shifts traffic are all queryable. The last successful and last
+// attempted deployments are reachable for tracking release history.
 private aws.codedeploy.deploymentGroup @defaults("deploymentGroupName computePlatform deploymentGroupId region") {
   // Application name this deployment group belongs to
   applicationName string
@@ -19203,7 +20411,11 @@ private aws.codedeploy.deploymentGroup @defaults("deploymentGroupName computePla
   //
   // Deprecated in favor of `serviceRole()`.
   serviceRoleArn @maturity("deprecated") string
-  // Target revision for the deployment group (includes type, location, etc.)
+  // Application revision most recently targeted for deployment
+  //
+  // Location of the revision. The `RevisionType` key selects the source (S3,
+  // GitHub, String, or AppSpecContent), with the matching `S3Location`,
+  // `GitHubLocation`, `String_`, or `AppSpecContent` key carrying the details.
   targetRevision() dict
   // Tags for the deployment group
   tags() map[string]string
@@ -19213,23 +20425,53 @@ private aws.codedeploy.deploymentGroup @defaults("deploymentGroupName computePla
   deployments() []aws.codedeploy.deployment
   // Auto scaling groups associated with the deployment group
   autoScalingGroups() []aws.autoscaling.group
-  // EC2 tag filters for the deployment group
+  // EC2 instance tag filters that select deployment targets
+  //
+  // Each entry has a `Key`, `Value`, and `Type` (one of KEY_ONLY, VALUE_ONLY,
+  // or KEY_AND_VALUE) describing which tagged EC2 instances the deployment
+  // group targets.
   ec2TagFilters() []dict
-  // On-premises instance tag filters for the deployment group
+  // On-premises instance tag filters that select deployment targets
+  //
+  // Each entry has a `Key`, `Value`, and `Type` (one of KEY_ONLY, VALUE_ONLY,
+  // or KEY_AND_VALUE) describing which tagged on-premises instances the
+  // deployment group targets.
   onPremisesInstanceTagFilters() []dict
   // Last successful deployment information
   lastSuccessfulDeployment() aws.codedeploy.deployment
   // Last attempted deployment information
   lastAttemptedDeployment() aws.codedeploy.deployment
-  // Deployment style (BLUE_GREEN or IN_PLACE)
+  // Deployment style
+  //
+  // The `DeploymentType` key is IN_PLACE or BLUE_GREEN, and `DeploymentOption`
+  // is WITH_TRAFFIC_CONTROL or WITHOUT_TRAFFIC_CONTROL, indicating whether a
+  // load balancer reroutes traffic during the deployment.
   deploymentStyle() dict
   // Blue/green deployment configuration
+  //
+  // Settings that govern a blue/green rollout. The `DeploymentReadyOption` key
+  // controls when the replacement fleet begins receiving traffic,
+  // `GreenFleetProvisioningOption` how that fleet is provisioned, and
+  // `TerminateBlueInstancesOnDeploymentSuccess` whether and when the original
+  // instances are terminated.
   blueGreenDeploymentConfiguration() dict
-  // Load balancer info
+  // Load balancers that route traffic during deployment
+  //
+  // The `ElbInfoList` key lists Classic Load Balancers, `TargetGroupInfoList`
+  // the Application/Network Load Balancer target groups used for in-place
+  // deployments, and `TargetGroupPairInfoList` the target group pairs used for
+  // blue/green traffic shifting.
   loadBalancerInfo() dict
 }
 
 // AWS CodeDeploy Deployment
+//
+// Single release of an application revision to a deployment group. The
+// `status` field tracks progress through Created, Queued, InProgress, Baking,
+// Succeeded, Failed, Stopped, and Ready, while `errorInformation` explains
+// failures, `rollbackInfo` records rollbacks, and `deploymentOverview` breaks
+// down instance-level results. The `creator` field shows what initiated the
+// deployment, such as a user, Auto Scaling, or an automatic rollback.
 private aws.codedeploy.deployment @defaults("deploymentId status applicationName deploymentGroupName createdAt region") {
   // Application name for the deployment
   applicationName string
@@ -19257,33 +20499,49 @@ private aws.codedeploy.deployment @defaults("deploymentId status applicationName
   creator string
   // Whether to ignore application stop failures
   ignoreApplicationStopFailures bool
-  // Information about the instances targeted by the deployment (complex structure, represented as dict)
+  // Instances that make up the replacement environment in a blue/green deployment
+  //
+  // The `AutoScalingGroups` key lists Auto Scaling group names, `TagFilters`
+  // the EC2 tag filters, and `Ec2TagSet` the grouped tag sets that identify the
+  // instances brought up as the replacement environment.
   targetInstances() dict
-  // Revision information for the deployment (S3 location, GitHub location, etc.)
+  // Application revision that was deployed
+  //
+  // Location of the deployed revision. The `RevisionType` key selects the
+  // source (S3, GitHub, String, or AppSpecContent), with the matching
+  // `S3Location`, `GitHubLocation`, `String_`, or `AppSpecContent` key carrying
+  // the details.
   revision() dict
   // Region of the deployment
   region string
-  // Error information, if any
+  // Error that caused the deployment to fail
+  //
+  // Present only when the deployment failed. The `Code` key holds the
+  // CodeDeploy error code and `Message` a human-readable explanation.
   errorInformation() dict
   // Deployment overview (counts for Pending, InProgress, Succeeded, Failed, Skipped, Ready)
   deploymentOverview() dict
   // Whether this deployment is a rollback
   isRollback() bool
-  // Rollback information if this deployment is a rollback or was rolled back
+  // Rollback details for the deployment
+  //
+  // The `RollbackDeploymentId` key identifies the deployment created to roll
+  // back, `RollbackTriggeringDeploymentId` the deployment whose failure
+  // triggered the rollback, and `RollbackMessage` a description of the outcome.
   rollbackInfo() dict
 }
 
 // Amazon WorkDocs
 //
-// Use the WorkDocs namespace to enumerate users, folders, and documents
-// provisioned in the account's WorkDocs sites. Iterate `users()` for every
-// WorkDocs user across enabled regions — each entry reports the user's
-// status, role, time zone, organization assignment, storage allocation,
-// recycle bin and root folder. Iterate `folders()` and `documents()` for
-// the immediate children of every user's root folder, including creator
-// references, resource state, labels, and (for documents) latest version
-// metadata. Folder and document discovery is bounded to one level below
-// each user's root folder; deeper subtrees are not traversed.
+// Managed content-collaboration service across the account's WorkDocs
+// sites. The `users` field enumerates every WorkDocs user across enabled
+// regions, each reporting status, role, time zone, organization
+// assignment, storage allocation, recycle bin, and root folder. The
+// `folders` and `documents` fields return the immediate children of every
+// user's root folder, including creator references, resource state,
+// labels, and (for documents) latest-version metadata. Folder and document
+// discovery is bounded to one level below each user's root folder; deeper
+// subtrees are not traversed.
 aws.workdocs {
   // List of WorkDocs users across all enabled regions
   users() []aws.workdocs.user
@@ -19295,11 +20553,11 @@ aws.workdocs {
 
 // Amazon WorkDocs user
 //
-// Examine a user provisioned in a WorkDocs site — the username, email,
+// User provisioned in a WorkDocs site, including the username, email,
 // status (ACTIVE, INACTIVE, PENDING), role (USER, ADMIN, POWERUSER,
 // MINIMALUSER, WORKSPACESUSER), locale, time zone, organization assignment,
-// storage rule (allocated bytes, type) and current utilization. The user
-// also exposes typed references to its `rootFolder` and `recycleBinFolder`
+// storage rule (allocated bytes, type), and current utilization. The
+// `rootFolder` and `recycleBinFolder` fields resolve to the user's folders
 // so audits can traverse into the WorkDocs hierarchy without copying ids.
 private aws.workdocs.user @defaults("username emailAddress status") {
   // Internal user ID
@@ -19346,8 +20604,8 @@ private aws.workdocs.user @defaults("username emailAddress status") {
 
 // Amazon WorkDocs folder
 //
-// Examine a folder stored in WorkDocs — its name, creator, parent folder,
-// resource state (ACTIVE, RESTORING, RECYCLING, RECYCLED), latest version
+// Folder stored in WorkDocs, including its name, creator, parent folder,
+// resource state (ACTIVE, RESTORING, RECYCLING, RECYCLED), latest-version
 // size, signature, and labels. Folders are discovered by walking one level
 // below each WorkDocs user's root folder; deeper subtrees are not yet
 // traversed.
@@ -19384,7 +20642,7 @@ private aws.workdocs.folder @defaults("name id resourceState") {
 
 // Amazon WorkDocs document
 //
-// Examine a document stored in WorkDocs — its parent folder, creator,
+// Document stored in WorkDocs, including its parent folder, creator,
 // resource state (ACTIVE, RESTORING, RECYCLING, RECYCLED), labels, and
 // the metadata of the document's latest version (content type, size,
 // signature, status, source, and timestamps). Documents are discovered by
@@ -19405,7 +20663,11 @@ private aws.workdocs.document @defaults("id resourceState") {
   modifiedTimestamp time
   // Resource state of the document: ACTIVE, RESTORING, RECYCLING, or RECYCLED
   resourceState string
-  // Metadata of the latest version of the document (id, name, contentType, size, signature, status, source, and content/version timestamps)
+  // Metadata of the document's latest version
+  //
+  // Keys: `id`, `name`, `contentType`, `size`, `signature`, `status`,
+  // `creatorId`, `source`, `createdTimestamp`, `modifiedTimestamp`,
+  // `contentCreatedTimestamp`, and `contentModifiedTimestamp`.
   latestVersionMetadata dict
   // Labels applied to the document
   labels []string
@@ -19417,13 +20679,13 @@ private aws.workdocs.document @defaults("id resourceState") {
 
 // Amazon AppStream 2.0
 //
-// Use the AppStream namespace to enumerate the application-streaming
-// service deployments in the account. Iterate `fleets()` for the streaming
-// fleets, `stacks()` for the user-facing stacks bound to those fleets,
-// `imageBuilders()` for builder workstations, `images()` for streaming
-// images, `applications()` for application icons in app-block-based
-// fleets, and `users()` for the user-pool users (AuthenticationType =
-// USERPOOL; SAML and API users are not enumerable).
+// Application-streaming service deployments in the account. The `fleets`
+// are the streaming instance pools, `stacks` are the user-facing entry
+// points bound to those fleets, `imageBuilders` are the builder
+// workstations, `images` are the streaming images, `applications` are the
+// app definitions used in elastic and app-block-based fleets, and `users`
+// are the user-pool users. Only USERPOOL users are enumerable; SAML 2.0
+// and API users are not returned by the AppStream API.
 aws.appstream @defaults("fleets") {
   // List of AppStream fleets across all enabled regions
   fleets() []aws.appstream.fleet
@@ -19463,7 +20725,12 @@ private aws.appstream.fleet @defaults("name state fleetType region") {
   enableDefaultInternetAccess bool
   // Whether Instance Metadata Service Version 1 (IMDSv1) is disabled for the fleet
   disableIMDSV1 bool
-  // Domain join configuration
+  // Active Directory domain join configuration
+  //
+  // Dict with keys `DirectoryName` (fully qualified domain the streaming
+  // instances join) and `OrganizationalUnitDistinguishedName` (the OU
+  // computer accounts are placed in). Empty when the fleet is not
+  // domain-joined.
   domainJoinInfo dict
   // Maximum number of concurrent sessions for the fleet
   maxConcurrentSessions int
@@ -19553,13 +20820,37 @@ private aws.appstream.stack @defaults("name region") {
   description string
   // Time when the stack was created
   createdAt time
-  // Access endpoints for the stack
+  // VPC interface endpoints for streaming
+  //
+  // List of dicts, each with keys `EndpointType` (the interface endpoint
+  // type, always STREAMING) and `VpceId` (the VPC endpoint identifier
+  // through which users reach the stack). Present when the stack is
+  // configured for private, VPC-only streaming access.
   accessEndpoints []dict
-  // Application settings for the stack
+  // Persistent application settings configuration
+  //
+  // Dict with keys `Enabled` (whether users' application settings persist
+  // across streaming sessions), `SettingsGroup` (the settings group the
+  // stack shares), and `S3BucketName` (the bucket that stores the
+  // persisted settings).
   applicationSettings dict
-  // Storage connectors for the stack
+  // Persistent storage connectors for the stack
+  //
+  // List of dicts, each with keys `ConnectorType` (one of HOMEFOLDERS,
+  // GOOGLE_DRIVE, or ONE_DRIVE), `ResourceIdentifier` (the connector's
+  // backing resource), `Domains`, and `DomainsRequireAdminConsent` (the
+  // Google Drive or OneDrive domains made available to users).
   storageConnectors []dict
-  // User settings for the stack
+  // Streaming session action permissions
+  //
+  // List of dicts, each with keys `Action`, `Permission` (ENABLED or
+  // DISABLED), and `MaximumLength`. Each entry enables or disables one
+  // action between the streaming session and the local device: one of
+  // CLIPBOARD_COPY_FROM_LOCAL_DEVICE, CLIPBOARD_COPY_TO_LOCAL_DEVICE,
+  // FILE_UPLOAD, FILE_DOWNLOAD, PRINTING_TO_LOCAL_DEVICE,
+  // DOMAIN_PASSWORD_SIGNIN, or DOMAIN_SMART_CARD_SIGNIN. Audit these to
+  // confirm data-exfiltration paths (clipboard, file transfer, printing)
+  // are restricted.
   userSettings []dict
   // Domains where AppStream streaming sessions can be embedded
   embedHostDomains []string
@@ -19607,7 +20898,12 @@ private aws.appstream.imageBuilder @defaults("name state platform region") {
   enableDefaultInternetAccess bool
   // Whether Instance Metadata Service Version 1 (IMDSv1) is disabled for the image builder
   disableIMDSV1 bool
-  // Domain join configuration
+  // Active Directory domain join configuration
+  //
+  // Dict with keys `DirectoryName` (fully qualified domain the image
+  // builder joins) and `OrganizationalUnitDistinguishedName` (the OU its
+  // computer account is placed in). Empty when the image builder is not
+  // domain-joined.
   domainJoinInfo dict
   // VPC configuration (SubnetIds, SecurityGroupIds)
   vpcConfig dict
@@ -19617,7 +20913,11 @@ private aws.appstream.imageBuilder @defaults("name state platform region") {
   //
   // Deprecated in favor of `iamRole()`.
   iamRoleArn @maturity("deprecated") string
-  // Network access configuration
+  // Elastic network interface configuration
+  //
+  // Dict with keys `EniId` (the network interface attached to the image
+  // builder in your VPC), `EniPrivateIpAddress` (its private IP address),
+  // and `EniIpv6Addresses` (any IPv6 addresses on the interface).
   networkAccessConfiguration dict
   // Time when the image builder was created
   createdAt time
@@ -19759,7 +21059,12 @@ private aws.appstream.session @defaults("id userId state fleetName stackName") {
   region string
 }
 
-// Amazon AppStream 2.0 entitlement — gates which applications a SAML 2.0 user can access in a stack
+// Amazon AppStream 2.0 entitlement
+//
+// Entitlement that gates which applications a SAML 2.0 user can access in
+// a stack. The `appVisibility` field selects whether all applications in
+// the stack or only associated applications are entitled, and
+// `attributes` holds the SAML PrincipalTag pairs a user must match.
 private aws.appstream.entitlement @defaults("name stackName appVisibility region") {
   // Synthetic ARN for the entitlement (entitlements have no native ARN)
   arn string
@@ -19785,14 +21090,13 @@ private aws.appstream.entitlement @defaults("name stackName appVisibility region
 
 // AWS AppSync
 //
-// Use the AppSync namespace to enumerate the managed GraphQL APIs in the
-// account. Iterate `apis()` for every GraphQL API across configured
-// regions — each API surfaces its primary and additional authentication
-// configuration, field-level CloudWatch logging level, X-Ray tracing
-// state, the WAF web ACL guarding the endpoint, query-depth and
-// resolver-count limits, the GraphQL introspection setting, public or
-// private visibility, the API keys issued for it, and the encryption
-// state of its server-side response cache.
+// Managed GraphQL APIs in the account, enumerated across all configured
+// regions through the `apis` field. Each API surfaces its primary and
+// additional authentication configuration, field-level CloudWatch logging
+// level, X-Ray tracing state, the WAF web ACL guarding the endpoint,
+// query-depth and resolver-count limits, the GraphQL introspection
+// setting, public or private visibility, the API keys issued for it, and
+// the encryption state of its server-side response cache.
 aws.appsync @defaults("apis") {
   // GraphQL APIs across all configured regions
   apis() []aws.appsync.graphqlApi
@@ -19800,11 +21104,10 @@ aws.appsync @defaults("apis") {
 
 // AWS AppSync GraphQL API
 //
-// Examine a managed GraphQL API: how callers authenticate, whether
+// Managed GraphQL API, covering how callers authenticate, whether
 // requests are logged and traced, which WAF web ACL filters traffic, and
-// how the response cache is encrypted. Use the apiId field as the
-// selection key — for example
-// `aws.appsync.graphqlApi(apiId: "lzpabcdef5b...")`. The
+// how the response cache is encrypted. The apiId field is the selection
+// key, for example `aws.appsync.graphqlApi(apiId: "lzpabcdef5b...")`. The
 // `authenticationType` and `additionalAuthenticationProviders` fields
 // together describe every way the API accepts callers; the `cache*`
 // fields describe the server-side response cache and are null when no
@@ -19868,7 +21171,7 @@ private aws.appsync.graphqlApi @defaults("name authenticationType region") {
 
 // AWS AppSync API key
 //
-// Examine an API key issued for a GraphQL API — its description and the
+// API key issued for a GraphQL API, including its description and the
 // times it expires and is deleted. API keys are a weak authentication
 // mechanism; check `aws.appsync.graphqlApi.authenticationType` to confirm
 // whether an API depends on them.
@@ -19887,19 +21190,17 @@ private aws.appsync.apiKey @defaults("id description expires") {
 
 // AWS App Runner
 //
-// Use the App Runner namespace to enumerate the managed
-// container/source service in the account. Iterate `services()` for the
-// running services — each surfaces its source (container image or code
-// repository), instance CPU/memory, IAM instance role, network
-// connectivity (egress through a VPC connector, ingress publicly or via
-// a VPC endpoint), KMS encryption key, health check parameters, and the
-// associated observability and auto-scaling configurations. Iterate
-// `autoScalingConfigurations()` and `observabilityConfigurations()` for
-// the reusable revision sets that services bind to, `connections()` for
-// the source-provider (GitHub, Bitbucket) credentials registered for code
-// repositories, `vpcConnectors()` for the egress VPC attachments, and
-// `vpcIngressConnections()` for the PrivateLink ingress endpoints fronting
-// private services.
+// App Runner services in the account and the reusable configuration
+// revisions they bind to. Each service surfaces its source (container
+// image or code repository), instance CPU/memory, IAM instance role,
+// network connectivity (egress through a VPC connector, ingress publicly
+// or via a VPC endpoint), KMS encryption key, health check parameters,
+// and the associated observability and auto-scaling configurations. The
+// namespace also exposes the auto-scaling and observability revision sets
+// that services bind to, the source-provider (GitHub, Bitbucket)
+// connections registered for code repositories, the egress VPC
+// connectors, and the PrivateLink ingress connections fronting private
+// services.
 aws.apprunner @defaults("services") {
   // App Runner services across all enabled regions
   services() []aws.apprunner.service
@@ -19917,12 +21218,12 @@ aws.apprunner @defaults("services") {
 
 // AWS App Runner service
 //
-// Examine a managed container/source service: where its code or image
+// Managed container or source service, covering where its code or image
 // comes from, what IAM role the application runs as, whether traffic
 // reaches the public internet or is constrained to a VPC, whether the
-// service log/source copy is encrypted with a customer-managed KMS key,
-// and which observability and auto-scaling revisions are bound to it.
-// The `arn` field is the selection key — for example
+// service log and source copy are encrypted with a customer-managed KMS
+// key, and which observability and auto-scaling revisions are bound to
+// it. The `arn` field is the selection key, for example
 // `aws.apprunner.service(arn: "arn:aws:apprunner:us-east-1:123456789012:service/my-app/abc123")`.
 // The `sourceConfiguration` field is a dict because its shape depends on
 // whether the service deploys a container image or a source code
@@ -19982,12 +21283,11 @@ private aws.apprunner.service @defaults("serviceName status region") {
 
 // AWS App Runner auto scaling configuration revision
 //
-// Examine a revision of an auto-scaling configuration — the bounds and
+// Revision of an auto-scaling configuration, holding the bounds and
 // per-instance concurrency target that App Runner uses to scale services
 // bound to the revision. Multiple revisions share the same `name`; the
-// `latest` and `revision` fields select among them. Auto-scaling
-// configurations are referenced from `aws.apprunner.service` via
-// `autoScalingConfiguration()`. The `arn` field is the selection key.
+// `latest` and `revision` fields select among them. The `arn` field is
+// the selection key.
 private aws.apprunner.autoScalingConfiguration @defaults("name revision status region") {
   // ARN of the auto scaling configuration revision
   arn string
@@ -20017,9 +21317,9 @@ private aws.apprunner.autoScalingConfiguration @defaults("name revision status r
 
 // AWS App Runner source-provider connection
 //
-// Examine a stored connection to a source code provider (GitHub,
-// Bitbucket, etc.) that App Runner uses to pull code from private
-// repositories. Services with a code source reference a connection via
+// Stored connection to a source code provider (GitHub, Bitbucket, etc.)
+// that App Runner uses to pull code from private repositories. A service
+// with a code source references a connection through
 // `sourceConfiguration.authenticationConfiguration.connectionArn`.
 private aws.apprunner.connection @defaults("name providerType status region") {
   // ARN of the connection
@@ -20042,12 +21342,11 @@ private aws.apprunner.connection @defaults("name providerType status region") {
 
 // AWS App Runner VPC connector
 //
-// Examine a VPC connector used by App Runner services to route egress
-// traffic into a customer VPC — the subnets and security groups the
-// service ENI is attached to. Multiple revisions can share the same
-// `name`; the `revision` field selects among them. VPC connectors are
-// referenced from `aws.apprunner.service` via `vpcConnector()` when
-// `egressType` is VPC.
+// VPC connector used by App Runner services to route egress traffic into
+// a customer VPC, exposing the subnets and security groups the service
+// ENI is attached to. Multiple revisions can share the same `name`; the
+// `revision` field selects among them. A service attaches a VPC connector
+// when its `egressType` is VPC.
 private aws.apprunner.vpcConnector @defaults("name revision status region") {
   // ARN of the VPC connector revision
   arn string
@@ -20071,12 +21370,11 @@ private aws.apprunner.vpcConnector @defaults("name revision status region") {
 
 // AWS App Runner observability configuration revision
 //
-// Examine a revision of an observability configuration — currently the
-// tracing vendor used to publish traces from services bound to the
-// revision. Multiple revisions share the same `name`; the `latest` and
-// `revision` fields select among them. Observability configurations are
-// referenced from `aws.apprunner.service` via `observabilityConfiguration()`
-// when observability is enabled.
+// Revision of an observability configuration, currently the tracing
+// vendor used to publish traces from services bound to the revision.
+// Multiple revisions share the same `name`; the `latest` and `revision`
+// fields select among them. A service binds an observability
+// configuration when observability is enabled.
 private aws.apprunner.observabilityConfiguration @defaults("name revision status region") {
   // ARN of the observability configuration revision
   arn string
@@ -20102,11 +21400,11 @@ private aws.apprunner.observabilityConfiguration @defaults("name revision status
 
 // AWS App Runner VPC ingress connection
 //
-// Examine a PrivateLink ingress endpoint that fronts a privately
-// accessible App Runner service — the domain name customers resolve to,
-// the VPC endpoint that terminates the connection, and the service the
-// endpoint is bound to. VPC ingress connections only exist for services
-// with `isPubliclyAccessible = false`.
+// PrivateLink ingress endpoint that fronts a privately accessible App
+// Runner service, exposing the domain name customers resolve to, the VPC
+// endpoint that terminates the connection, and the service the endpoint
+// is bound to. VPC ingress connections only exist for services with
+// `isPubliclyAccessible = false`.
 private aws.apprunner.vpcIngressConnection @defaults("name status domainName region") {
   // ARN of the VPC ingress connection
   arn string
@@ -20134,21 +21432,19 @@ private aws.apprunner.vpcIngressConnection @defaults("name status domainName reg
 
 // Amazon Athena
 //
-// Use the Athena namespace to enumerate the serverless interactive
-// query-engine configuration in the account. Iterate `workgroups()` for
-// the query workgroups that scope query execution — each workgroup
-// surfaces its enforced result-location S3 bucket, KMS encryption mode
-// (SSE-S3, SSE-KMS, CSE-KMS), engine version (Athena SQL or Spark), the
-// per-query and per-workgroup data-scanned bytes limits, CloudWatch
-// metrics state, requester-pays setting, and whether the configuration
-// is enforced on submitted queries. Iterate `dataCatalogs()` for the
-// data catalogs registered against Athena (the AWS Glue Data Catalog
-// alongside any Hive metastore connectors, federated Lambda catalogs,
-// or cross-account catalogs) — each entry exposes its type, parameters,
-// and the associated connector. Iterate `namedQueries()` for the saved
-// queries belonging to those workgroups so audits can review the SQL
-// text, target database, and owning workgroup. Iterate
-// `capacityReservations()` for the provisioned data-processing-unit
+// Serverless interactive query-engine configuration in the account.
+// The workgroups scope query execution, each surfacing its enforced
+// result-location S3 bucket, KMS encryption mode (SSE-S3, SSE-KMS, or
+// CSE-KMS), engine version (Athena SQL or Spark), the per-query and
+// per-workgroup data-scanned byte limits, CloudWatch metrics state,
+// requester-pays setting, and whether the configuration is enforced on
+// submitted queries. The data catalogs registered against Athena cover
+// the AWS Glue Data Catalog alongside any Hive metastore connectors,
+// federated Lambda catalogs, and cross-account catalogs, each exposing
+// its type, parameters, and associated connector. The named queries are
+// the saved SQL statements belonging to those workgroups, useful for
+// reviewing query text, target database, and owning workgroup. The
+// capacity reservations hold the provisioned data-processing-unit
 // capacity reserved for query execution.
 aws.athena @defaults("workgroups") {
   // List of Athena workgroups
@@ -20182,6 +21478,11 @@ private aws.athena.workgroup @defaults("name state region") {
   // Whether requester pays is enabled for the workgroup
   requesterPaysEnabled() bool
   // Engine version information
+  //
+  // Dict with `SelectedEngineVersion` (the version the workgroup
+  // requested, such as "AUTO" or "Athena engine version 3") and
+  // `EffectiveEngineVersion` (the version actually running, resolved from
+  // the selection when the requested version is "AUTO").
   engineVersion() dict
   // Query result configuration
   //
@@ -20330,12 +21631,12 @@ private aws.athena.table @defaults("name tableType") {
 
 // AWS Directory Service
 //
-// Use the Directory Service namespace to enumerate Active Directory
-// deployments (AWS Managed Microsoft AD, AD Connector, and Simple AD) in
-// the account. Iterate `directories()` for every directory across enabled
-// regions — each entry surfaces the directory type, size, DNS IPs, the
-// VPC/subnet placement, trust relationships, SSO state, security
-// settings, and the AWS-applications enabled against the directory.
+// Active Directory deployments in the account (AWS Managed Microsoft AD,
+// AD Connector, and Simple AD). The `directories` field lists every
+// directory across enabled regions, exposing each one's type, size, DNS
+// IP addresses, VPC and subnet placement, single sign-on state, RADIUS
+// MFA settings, and cross-account sharing configuration. Query it to
+// audit domain controller placement, MFA posture, and directory sharing.
 aws.directoryservice @defaults("directories") {
   // List of directories across all enabled regions
   directories() []aws.directoryservice.directory
@@ -20389,7 +21690,13 @@ private aws.directoryservice.directory @defaults("directoryId name type stage re
   vpcSettings() aws.directoryservice.vpcSettings
   // AD Connector settings for the directory
   connectSettings() aws.directoryservice.connectSettings
-  // Owner directory description (for shared directories)
+  // Owner directory description
+  //
+  // Details of the directory in the owner account, populated when this
+  // directory is shared into the account (empty for directories this
+  // account owns). Keys: `AccountId`, `DirectoryId`, `DnsIpAddrs`,
+  // `DnsIpv6Addrs`, `NetworkType`, `RadiusSettings`, `RadiusStatus`, and
+  // `VpcSettings`.
   ownerDirectoryDescription dict
   // Directory sharing method: ORGANIZATIONS or HANDSHAKE
   shareMethod string
@@ -20475,13 +21782,13 @@ private aws.directoryservice.connectSettings @defaults("vpcId customerUserName")
 
 // Amazon WorkSpaces
 //
-// Use the WorkSpaces namespace to enumerate the persistent virtual desktop
-// service in the account. Iterate `directories()` for the registered
-// workspace directories (with their authentication settings and
-// SAML/Active-Directory bindings), `instances()` for the running WorkSpaces
-// (with running mode, root and user volume encryption, compute type, and
-// state), `ipGroups()` for IP access control groups, `images()` for
-// workspace images, and `bundles()` for the available workspace bundles.
+// Persistent virtual desktop service in the account. The `directories`
+// field lists the registered workspace directories with their
+// authentication settings and SAML or Active Directory bindings,
+// `instances` the running WorkSpaces with running mode, root and user
+// volume encryption, compute type, and state, `ipGroups` the IP access
+// control groups, `images` the available workspace images, and `bundles`
+// the workspace bundles.
 aws.workspaces @defaults("directories") {
   // List of registered workspace directories across all enabled regions
   directories() []aws.workspaces.directory
@@ -20496,6 +21803,13 @@ aws.workspaces @defaults("directories") {
 }
 
 // Amazon WorkSpaces directory
+//
+// Registered directory that WorkSpaces are provisioned into, covering the
+// directory type (Simple AD, AD Connector, customer-managed, or IAM
+// Identity Center), the authentication configuration including
+// certificate-based auth, the device types permitted to connect, the
+// self-service actions users may perform, and the associated IP access
+// control groups and subnets.
 private aws.workspaces.directory @defaults("directoryId directoryName state region") {
   // Directory identifier
   directoryId string
@@ -20513,15 +21827,34 @@ private aws.workspaces.directory @defaults("directoryId directoryName state regi
   dnsIpAddresses []string
   // Endpoint encryption mode: STANDARD_TLS or FIPS_VALIDATED
   endpointEncryptionMode string
-  // Workspace access properties for device types
+  // Client device types allowed to access WorkSpaces
+  //
+  // Each DeviceType* key (DeviceTypeAndroid, DeviceTypeChromeOs,
+  // DeviceTypeIos, DeviceTypeLinux, DeviceTypeOsx, DeviceTypeWeb,
+  // DeviceTypeWindows, DeviceTypeWorkSpacesThinClient, and
+  // DeviceTypeZeroClient) holds ALLOW or DENY. AccessEndpointConfig holds
+  // the streaming access endpoint configuration.
   workspaceAccessProperties dict
-  // Default workspace creation properties
+  // Default properties applied to newly created WorkSpaces
+  //
+  // Keys CustomSecurityGroupId, DefaultOu, EnableInternetAccess,
+  // EnableMaintenanceMode, InstanceIamRoleArn, and
+  // UserEnabledAsLocalAdministrator control the security group, the
+  // machine-account organizational unit, internet access, maintenance
+  // mode, the instance IAM role, and whether users are local
+  // administrators on their WorkSpace.
   defaultCreationProperties dict
-  // Certificate-based authentication properties
+  // Certificate-based authentication configuration
+  //
+  // CertificateAuthorityArn is the ARN of the ACM Private CA that issues
+  // client certificates, and Status is ENABLED or DISABLED.
   certificateBasedAuthProperties dict
   // Associated IP access control group IDs
   ipGroupIds []string
-  // Self-service permissions for users
+  // Self-service actions users may perform on their own WorkSpace
+  //
+  // Keys ChangeComputeType, IncreaseVolumeSize, RebuildWorkspace,
+  // RestartWorkspace, and SwitchRunningMode each hold ENABLED or DISABLED.
   selfservicePermissions dict
   // IAM role identifier
   iamRoleId string
@@ -20539,13 +21872,14 @@ private aws.workspaces.directory @defaults("directoryId directoryName state regi
 
 // Amazon WorkSpaces Web
 //
-// Use the WorkSpaces Web namespace to enumerate the browser-based remote
-// access service in the account. Iterate `portals()` for the published
-// portals, `userAccessLoggingSettings()` for Kinesis Data Streams logging
-// configurations, `ipAccessSettings()` for IP allowlist policies,
-// `trustStores()` for trust stores backing certificate-based auth, and
-// `userSettings()` for the per-portal session policies (clipboard,
-// download/upload, print, and idle timeout).
+// Browser-based remote access service that streams a secure, managed web
+// browser to users without provisioning full desktops. The portals
+// published in the account carry the session security posture: the browser
+// and network settings that apply, whether copy, paste, download, upload,
+// and print are permitted, the IP allowlists that gate access, the trust
+// stores backing certificate-based authentication, and the Kinesis stream
+// capturing user access logs. Query it to audit how remote browser sessions
+// are secured across every enabled region.
 aws.workspacesweb @defaults("portals") {
   // List of WorkSpaces Web portals across all enabled regions
   portals() []aws.workspacesweb.portal
@@ -20560,6 +21894,13 @@ aws.workspacesweb @defaults("portals") {
 }
 
 // Amazon WorkSpaces Web portal
+//
+// Access point that users open to launch a streamed browser session, along
+// with the security controls bound to it: the authentication type (Standard
+// or IAM Identity Center), the customer-managed KMS key protecting sensitive
+// data, and the associated user settings, trust store, IP access settings,
+// and user access logging configuration. Query it to confirm each portal
+// enforces the intended session policies and encryption.
 private aws.workspacesweb.portal @defaults("displayName portalStatus region") {
   // Portal ARN
   portalArn string
@@ -20591,25 +21932,25 @@ private aws.workspacesweb.portal @defaults("displayName portalStatus region") {
   networkSettingsArn string
   // ARN of the associated user settings
   //
-  // Deprecated in favor of `userSettings()`.
+  // Deprecated in favor of `userSettings`.
   userSettingsArn @maturity("deprecated") string
   // User session and browser settings applied to this portal; null if not configured
   userSettings() aws.workspacesweb.userSetting
   // ARN of the associated trust store
   //
-  // Deprecated in favor of `trustStore()`.
+  // Deprecated in favor of `trustStore`.
   trustStoreArn @maturity("deprecated") string
   // Certificate trust store used to verify peer certificates for this portal; null if not configured
   trustStore() aws.workspacesweb.trustStore
   // ARN of the associated IP access settings
   //
-  // Deprecated in favor of `ipAccessSettings()`.
+  // Deprecated in favor of `ipAccessSettings`.
   ipAccessSettingsArn @maturity("deprecated") string
   // IP-based access controls applied to this portal; null if not configured
   ipAccessSettings() aws.workspacesweb.ipAccessSetting
   // ARN of the associated user access logging settings
   //
-  // Deprecated in favor of `userAccessLoggingSetting()`.
+  // Deprecated in favor of `userAccessLoggingSetting`.
   userAccessLoggingSettingsArn @maturity("deprecated") string
   // User access logging configuration for this portal; null if not configured
   userAccessLoggingSetting() aws.workspacesweb.userAccessLoggingSetting
@@ -20626,6 +21967,11 @@ private aws.workspacesweb.portal @defaults("displayName portalStatus region") {
 }
 
 // Amazon WorkSpaces Web IP access settings
+//
+// IP allowlist policy that restricts which source addresses may start
+// streaming sessions on the portals it is attached to. The ipRules field
+// holds the permitted CIDR ranges; review it to confirm portal access is
+// limited to trusted networks.
 private aws.workspacesweb.ipAccessSetting @defaults("displayName region") {
   // ARN of the IP access settings
   ipAccessSettingsArn string
@@ -20648,6 +21994,10 @@ private aws.workspacesweb.ipAccessSetting @defaults("displayName region") {
 }
 
 // Amazon WorkSpaces Web trust store
+//
+// Collection of certificate authority certificates used to verify client
+// certificates during certificate-based authentication to a portal. Review
+// the portals a trust store backs to see which access points rely on it.
 private aws.workspacesweb.trustStore @defaults("trustStoreArn region") {
   // ARN of the trust store
   trustStoreArn string
@@ -20658,6 +22008,12 @@ private aws.workspacesweb.trustStore @defaults("trustStoreArn region") {
 }
 
 // Amazon WorkSpaces Web user settings
+//
+// Session policy that governs what a user can do inside a streamed browser:
+// whether copy, paste, file download and upload, printing, and deep links
+// are permitted, whether WebAuthn passwordless authentication is allowed,
+// and the disconnect and idle timeouts. These controls determine how much
+// data can move between the remote session and the local device.
 private aws.workspacesweb.userSetting @defaults("userSettingsArn region") {
   // ARN of the user settings
   userSettingsArn string
@@ -20690,6 +22046,11 @@ private aws.workspacesweb.userSetting @defaults("userSettingsArn region") {
 }
 
 // Amazon WorkSpaces workspace instance
+//
+// Provisioned virtual desktop assigned to a user, exposing its running
+// state, root and user volume encryption status and KMS key, network
+// placement (subnet and security groups), and connection history. Use it
+// to find unencrypted volumes and idle or unhealthy desktops.
 private aws.workspaces.workspace @defaults("workspaceId userName state region") {
   // Workspace identifier
   workspaceId string
@@ -20738,6 +22099,11 @@ private aws.workspaces.workspace @defaults("workspaceId userName state region") 
 }
 
 // Amazon WorkSpaces image
+//
+// Custom or bundled image that WorkSpaces bundles are built from,
+// including its operating system, current state, and the account that
+// owns it. Use `ownerAccountId` to track images shared from other
+// accounts.
 private aws.workspaces.image @defaults("imageId name state region") {
   // Image identifier
   imageId string
@@ -20745,7 +22111,9 @@ private aws.workspaces.image @defaults("imageId name state region") {
   name string
   // Image description
   description string
-  // Operating system details
+  // Operating system of the image
+  //
+  // The Type key holds WINDOWS or LINUX.
   operatingSystem dict
   // State: AVAILABLE, PENDING, ERROR
   state string
@@ -20758,6 +22126,10 @@ private aws.workspaces.image @defaults("imageId name state region") {
 }
 
 // Amazon WorkSpaces bundle
+//
+// Hardware and software template that defines a WorkSpace's compute type,
+// root and user volume sizes, and base image. Bundles are either owned by
+// the account or provided by AMAZON, distinguished by the `owner` field.
 private aws.workspaces.bundle @defaults("bundleId name region") {
   // Bundle identifier
   bundleId string
@@ -20767,11 +22139,19 @@ private aws.workspaces.bundle @defaults("bundleId name region") {
   description string
   // Owner account ID or AMAZON
   owner string
-  // Compute type configuration
+  // Compute type of the bundle
+  //
+  // The Name key holds the compute class, one of VALUE, STANDARD,
+  // PERFORMANCE, POWER, POWERPRO, GRAPHICS, GRAPHICSPRO, or one of the
+  // GENERALPURPOSE_* and GRAPHICS_G* GPU variants.
   computeType dict
-  // User storage configuration
+  // User volume storage of the bundle
+  //
+  // The Capacity key holds the user volume size in GB as a string.
   userStorage dict
-  // Root storage configuration
+  // Root volume storage of the bundle
+  //
+  // The Capacity key holds the root volume size in GB as a string.
   rootStorage dict
   // Bundle state: AVAILABLE, PENDING, ERROR
   state string
@@ -20788,6 +22168,10 @@ private aws.workspaces.bundle @defaults("bundleId name region") {
 }
 
 // Amazon WorkSpaces IP access control group
+//
+// Set of CIDR rules that restrict which source IP addresses can connect
+// to the WorkSpaces in the directories associated with the group. Review
+// `userRules` to confirm access is limited to trusted network ranges.
 private aws.workspaces.ipGroup @defaults("groupId groupName region") {
   // IP group identifier
   groupId string
@@ -20797,13 +22181,20 @@ private aws.workspaces.ipGroup @defaults("groupId groupName region") {
   groupName string
   // IP group description
   groupDesc string
-  // IP rules (each has ipRule and ruleDesc)
+  // IP address rules that gate WorkSpaces access
+  //
+  // Each entry has an IpRule key (an allowed CIDR range) and a RuleDesc
+  // key (its description).
   userRules []dict
   // AWS region
   region string
 }
 
 // Amazon WorkSpaces Web user access logging setting
+//
+// Configuration that streams portal user access events to an Amazon Kinesis
+// data stream for audit and monitoring. Review it to confirm session
+// activity on the associated portals is captured for downstream analysis.
 private aws.workspacesweb.userAccessLoggingSetting @defaults("userAccessLoggingSettingsArn region") {
   // Settings ARN
   userAccessLoggingSettingsArn string
@@ -20811,7 +22202,7 @@ private aws.workspacesweb.userAccessLoggingSetting @defaults("userAccessLoggingS
   kinesisStream() aws.kinesis.stream
   // Kinesis data stream ARN for logging
   //
-  // Deprecated in favor of `kinesisStream()`.
+  // Deprecated in favor of `kinesisStream`.
   kinesisStreamArn @maturity("deprecated") string
   // AWS region
   region string
@@ -20819,15 +22210,15 @@ private aws.workspacesweb.userAccessLoggingSetting @defaults("userAccessLoggingS
 
 // Amazon Kinesis
 //
-// Use the Kinesis namespace to enumerate streaming-data primitives in the
-// account. Iterate `streams()` for Kinesis Data Streams (with their
-// retention period, shard count, encryption, stream mode, and registered
-// consumers), `firehoseDeliveryStreams()` for Kinesis Data Firehose
-// delivery streams (with their source, destination, transformation, and
-// backup configuration), `streamConsumers()` for the enhanced fan-out
-// consumers registered across all data streams, and `videoStreams()` for
-// Kinesis Video Streams (with their media type, retention, and encryption
-// key).
+// Streaming-data primitives in the account. The streams field lists
+// Kinesis Data Streams with their retention period, shard count,
+// encryption, stream mode, and registered consumers. The
+// firehoseDeliveryStreams field lists Kinesis Data Firehose delivery
+// streams with their source, destination, transformation, and backup
+// configuration. The streamConsumers field lists the enhanced fan-out
+// consumers registered across all data streams, and videoStreams lists
+// Kinesis Video Streams with their media type, retention, and encryption
+// key.
 aws.kinesis @defaults("streams") {
   // List of Kinesis data streams
   streams() []aws.kinesis.stream
@@ -20861,9 +22252,17 @@ private aws.kinesis.stream @defaults("name status region") {
   openShardCount() int
   // Number of enhanced fan-out consumers registered with the stream
   consumerCount() int
-  // Stream mode details (ON_DEMAND or PROVISIONED)
+  // Capacity mode of the stream
+  //
+  // Dict with a single `StreamMode` key whose value is `ON_DEMAND` or
+  // `PROVISIONED`.
   streamModeDetails dict
-  // Enhanced monitoring settings
+  // Enhanced (shard-level) monitoring settings
+  //
+  // Each entry has a `ShardLevelMetrics` key listing the enabled CloudWatch
+  // shard-level metrics: IncomingBytes, IncomingRecords, OutgoingBytes,
+  // OutgoingRecords, WriteProvisionedThroughputExceeded,
+  // ReadProvisionedThroughputExceeded, IteratorAgeMilliseconds, or ALL.
   enhancedMonitoring() []dict
   // Date and time the stream was created
   createdAt time
@@ -20893,11 +22292,11 @@ private aws.kinesis.streamConsumer @defaults("name status") {
 
 // Amazon Kinesis Video Streams stream
 //
-// Examine a Kinesis Video Streams stream that ingests time-encoded media
-// (video, audio, or other time-series data) from connected devices. Each
-// stream exposes its media type, the device it is associated with, how long
-// data is retained, the encryption key, lifecycle status, and tags. Use the
-// stream ARN as the selection key.
+// Kinesis Video Streams stream that ingests time-encoded media (video,
+// audio, or other time-series data) from connected devices. Each stream
+// exposes its media type, the device it is associated with, how long data
+// is retained, the encryption key, lifecycle status, and tags. The stream
+// ARN is the selection key.
 private aws.kinesis.videoStream @defaults("name status mediaType region") {
   // ARN of the video stream
   arn string
@@ -21030,8 +22429,15 @@ private aws.kinesis.firehoseDeliveryStream.destination.s3 @defaults("bucketArn c
   // CloudWatch logging options
   cloudWatchLogging aws.kinesis.firehoseDeliveryStream.cloudWatchLogging
   // Data format conversion configuration
+  //
+  // Keys: `Enabled`, `InputFormatConfiguration`,
+  // `OutputFormatConfiguration`, and `SchemaConfiguration`. Present when
+  // records are converted from JSON to Apache Parquet or ORC before delivery.
   dataFormatConversion dict
   // Dynamic partitioning configuration
+  //
+  // Keys: `Enabled` and `RetryOptions`. When enabled, records are
+  // partitioned into S3 prefixes derived from their content.
   dynamicPartitioning dict
   // Data processing configuration
   processingConfiguration dict
@@ -21162,6 +22568,9 @@ private aws.kinesis.firehoseDeliveryStream.destination.httpEndpoint @defaults("e
   // Data processing configuration
   processingConfiguration dict
   // Request configuration
+  //
+  // Keys: `ContentEncoding` (NONE or GZIP) and `CommonAttributes`, the list
+  // of name/value attribute pairs sent with each request to the endpoint.
   requestConfiguration dict
   // Retry duration in seconds
   retryDurationInSeconds int
@@ -21171,13 +22580,12 @@ private aws.kinesis.firehoseDeliveryStream.destination.httpEndpoint @defaults("e
 
 // Amazon MemoryDB
 //
-// Use the MemoryDB namespace to enumerate the Redis-compatible managed
-// in-memory database deployments in the account. Iterate `clusters()` for
-// every cluster (with its engine version, KMS encryption, parameter group,
-// auto-failover state, and replication topology), `acls()` and `users()`
-// for the RBAC primitives controlling client access, `snapshots()` for
-// cluster snapshots, and `subnetGroups()` for the VPC subnet bindings
-// clusters are launched into.
+// Redis and Valkey compatible managed in-memory database deployments in the
+// account. The clusters collection covers each cluster with its engine
+// version, KMS encryption at rest, TLS setting, parameter group, and snapshot
+// retention. The acls and users collections expose the RBAC primitives that
+// control client access, snapshots holds point-in-time cluster backups, and
+// subnetGroups holds the VPC subnet bindings clusters launch into.
 aws.memorydb @defaults("clusters") {
   // List of MemoryDB clusters
   clusters() []aws.memorydb.cluster
@@ -21276,6 +22684,10 @@ private aws.memorydb.user @defaults("name status") {
   // Minimum engine version supported by the user
   minimumEngineVersion string
   // Authentication configuration
+  //
+  // Password and IAM authentication state for the user. The `Type` key is one
+  // of password, no-password, or iam, and `PasswordCount` gives the number of
+  // passwords assigned to the user (maximum two).
   authentication dict
   // Region where the user exists
   region string
@@ -21296,6 +22708,12 @@ private aws.memorydb.snapshot @defaults("name status") {
   // KMS key used for the encrypted snapshot
   kmsKey() aws.kms.key
   // Cluster configuration at the time of the snapshot
+  //
+  // Cluster settings captured when the backup was taken. Keys include Name,
+  // Description, NodeType, Engine, EngineVersion, NumShards, Port,
+  // ParameterGroupName, SubnetGroupName, VpcId, MaintenanceWindow,
+  // SnapshotRetentionLimit, SnapshotWindow, TopicArn, MultiRegionClusterName,
+  // MultiRegionParameterGroupName, and Shards (per-shard node details).
   clusterConfiguration dict
   // Data tiering status: true or false
   dataTiering string
@@ -21325,12 +22743,13 @@ private aws.memorydb.subnetGroup @defaults("name") {
 
 // Amazon Timestream for InfluxDB
 //
-// Use the Timestream-for-InfluxDB namespace to enumerate the managed
-// InfluxDB time-series databases in the account. Iterate `instances()` for
-// individual InfluxDB DB instances and `clusters()` for multi-AZ clusters
-// — each row surfaces the instance class or cluster topology, network
-// type, allocated storage, deployment type, log delivery configuration,
-// VPC and subnet placement, and the assigned port.
+// Managed InfluxDB time-series databases in the account. The `instances`
+// collection covers individual InfluxDB DB instances and `clusters` covers
+// multi-AZ clusters. Each row surfaces the instance class or cluster
+// topology, network type, allocated storage, deployment type, log delivery
+// configuration, VPC and subnet placement, public accessibility, and the
+// assigned port. Useful for auditing network exposure and log delivery of
+// managed InfluxDB deployments.
 aws.timestream.influxdb @defaults("instances clusters") {
   // List of InfluxDB instances
   instances() []aws.timestream.influxdb.instance
@@ -21436,16 +22855,24 @@ private aws.timestream.influxdb.cluster @defaults("arn name status") {
 
 // Amazon Aurora DSQL
 //
-// Use the DSQL namespace to enumerate Aurora DSQL clusters in the account.
-// Iterate `clusters()` for every Aurora DSQL cluster — each row surfaces
-// the cluster identifier, status, multi-region linked clusters, deletion
-// protection, witness region, KMS encryption settings, and creation time.
+// Aurora DSQL clusters in the account. The `clusters` field enumerates every
+// Aurora DSQL cluster, exposing its status, deletion protection, witness
+// region, multi-Region peer configuration, KMS encryption settings, and
+// change data capture streams, so you can audit where cluster data is stored
+// and where it is replicated out of the database.
 aws.dsql @defaults("clusters") {
   // List of Aurora DSQL clusters
   clusters() []aws.dsql.cluster
 }
 
 // Amazon Aurora DSQL cluster
+//
+// Single Aurora DSQL cluster and its security posture: connection endpoint,
+// deletion protection, and encryption, where encryptionType distinguishes an
+// AWS-owned key from a customer-managed KMS key resolved through kmsKey. For a
+// multi-Region cluster, multiRegionPeers and witnessRegion describe the linked
+// configuration, and streams surfaces change data capture streams that
+// replicate row-level changes out of the database.
 private aws.dsql.cluster @defaults("arn identifier status region") {
   // ARN of the cluster
   arn string
@@ -21492,12 +22919,18 @@ private aws.dsql.cluster.stream @defaults("arn status") {
   // Region of the stream
   region string
   // Status of the stream
+  //
+  // One of CREATING, ACTIVE, DELETING, DELETED, FAILED, or IMPAIRED.
   status string
   // Time the stream was created
   createdAt time
-  // Format of the stream records
+  // Serialization format of the stream records
+  //
+  // Currently JSON.
   format() string
   // Ordering mode of the stream
+  //
+  // Currently UNORDERED.
   ordering() string
   // Kinesis stream the change data is delivered to
   kinesisStream() aws.kinesis.stream
@@ -21560,18 +22993,17 @@ private aws.neptuneAnalytics.graph @defaults("arn name status region") {
 
 // AWS Glue
 //
-// Use the Glue namespace to enumerate the data-integration service in the
-// account. Iterate `crawlers()` for the crawlers populating the Data
-// Catalog, `jobs()` for ETL jobs, `triggers()` for the schedule, on-demand,
-// and event triggers that fire them, `databases()` for the catalog
-// databases (with their tables surfaced as `database.tables()`),
-// `workflows()` for orchestrated job/crawler workflows,
-// `connections()` for catalog-stored data store connections,
-// `securityConfigurations()` for the encryption settings reused across
-// jobs and crawlers, `catalogEncryptionSettings()` for the per-region
-// Data Catalog encryption posture, `schemaRegistries()` and `schemas()`
-// for the Glue Schema Registry, and `resourcePolicies()` for the Data
-// Catalog resource-based policies.
+// Serverless data-integration service for discovering, cataloging,
+// transforming, and moving data. The `crawlers` populate the Data
+// Catalog with table definitions, `jobs` run ETL scripts, and
+// `triggers` fire jobs and crawlers on a schedule, on demand, or from
+// events. The Data Catalog is exposed through `databases` and their
+// tables, `workflows` orchestrate multi-step job and crawler runs, and
+// `connections` hold the credentials and network details for reaching
+// backing data stores. Security posture is queryable through
+// `securityConfigurations` and per-region `catalogEncryptionSettings`,
+// `schemaRegistries` and `schemas` cover the Schema Registry, and
+// `resourcePolicies` hold the Data Catalog resource-based policies.
 aws.glue @defaults("crawlers") {
   // List of Glue crawlers
   crawlers() []aws.glue.crawler
@@ -21584,6 +23016,8 @@ aws.glue @defaults("crawlers") {
   // List of Glue Data Catalog databases
   databases() []aws.glue.database
   // Data Catalog encryption settings per region
+  //
+  // Each entry: {EncryptionAtRest: {CatalogEncryptionMode: DISABLED|SSE-KMS|SSE-KMS-WITH-SERVICE-ROLE, SseAwsKmsKeyId, CatalogEncryptionServiceRole}, ConnectionPasswordEncryption: {ReturnConnectionPasswordEncrypted: bool, AwsKmsKeyId}, region}. A CatalogEncryptionMode of DISABLED means Data Catalog metadata is not encrypted at rest.
   catalogEncryptionSettings() []dict
   // List of Glue workflows
   workflows() []aws.glue.workflow
@@ -21599,15 +23033,16 @@ aws.glue @defaults("crawlers") {
 
 // AWS Glue crawler
 //
-// Examine a single crawler that populates the Data Catalog with table
-// definitions from one or more data stores. Surfaces the crawl `targets`
-// (S3, JDBC, MongoDB, DynamoDB, Catalog, Delta, Iceberg, Hudi), the
-// `schedule`, the `state` (READY/RUNNING/STOPPING), the IAM `role` it
-// assumes (resolvable via `iamRole()`), the optional Glue security
-// configuration encrypting its logs and bookmarks (resolvable via
-// `glueSecurityConfiguration()`), the `schemaChangePolicy`,
+// Crawler that populates the Data Catalog with table definitions
+// discovered from one or more data stores. The crawl `targets` cover
+// S3, JDBC, MongoDB, DynamoDB, Catalog, Delta, Iceberg, and Hudi
+// sources, and `schedule` and `state` (READY, RUNNING, STOPPING) track
+// how and when it runs. The `iamRole` it assumes and the optional
+// `glueSecurityConfiguration` encrypting its logs and bookmarks govern
+// its access to data and its data protection. The `schemaChangePolicy`,
 // `recrawlPolicy`, `lineageConfiguration`, `lakeFormationConfiguration`,
-// `tablePrefix`, and the `lastCrawl` summary.
+// `tablePrefix`, and `lastCrawl` summary describe how discovered schema
+// changes are applied and the outcome of the most recent crawl.
 private aws.glue.crawler @defaults("name state databaseName region") {
   // Name of the crawler
   name string
@@ -21671,15 +23106,15 @@ private aws.glue.crawler @defaults("name state databaseName region") {
 
 // AWS Glue ETL job
 //
-// Examine an ETL job definition. Surfaces the `command` that drives the
-// job (script location, Python/Ray runtime), the IAM `role` assumed at
-// runtime (resolvable via `iamRole()`), the worker fleet (`workerType`,
-// `numberOfWorkers`, or DPU-based `maxCapacity`), the `glueVersion` and
-// `executionClass`, the `executionProperty.MaxConcurrentRuns`, the
-// `notificationProperty.NotifyDelayAfter`, the optional Glue security
-// configuration encrypting logs and bookmarks (resolvable via
-// `glueSecurityConfiguration()`), and the `defaultArguments` passed to
-// every run.
+// ETL job definition that extracts, transforms, and loads data. The
+// `command` drives the job (script location, Python or Ray runtime), and
+// the `iamRole` assumed at runtime governs what it can read and write.
+// The worker fleet is sized by `workerType` and `numberOfWorkers`, or by
+// DPU-based `maxCapacity`, alongside `glueVersion` and `executionClass`.
+// The `executionProperty.MaxConcurrentRuns`,
+// `notificationProperty.NotifyDelayAfter`, the optional
+// `glueSecurityConfiguration` encrypting logs and bookmarks, and the
+// `defaultArguments` passed to every run complete the definition.
 private aws.glue.job @defaults("name region") {
   // Name of the job
   name string
@@ -21730,16 +23165,30 @@ private aws.glue.job @defaults("name region") {
 }
 
 // AWS Glue security configuration
+//
+// Reusable set of encryption settings that Glue jobs and crawlers apply
+// to their output and operational data. The `s3Encryption`,
+// `cloudWatchEncryption`, and `jobBookmarksEncryption` settings control
+// how data written to Amazon S3, logs sent to CloudWatch, and job
+// bookmark state are encrypted, including which KMS key is used.
+// Selected by `name`, for example
+// `aws.glue.securityConfigurations.where(name == "prod-sec")`.
 private aws.glue.securityConfiguration @defaults("name") {
   // Name of the security configuration
   name string
   // Date and time the security configuration was created
   createdAt time
   // S3 encryption configuration
+  //
+  // Shape: {S3EncryptionMode: DISABLED|SSE-KMS|SSE-S3, KmsKeyArn}. Controls how data the job or crawler writes to Amazon S3 is encrypted; DISABLED means no server-side encryption is applied by Glue.
   s3Encryption dict
   // CloudWatch encryption configuration
+  //
+  // Shape: {CloudWatchEncryptionMode: DISABLED|SSE-KMS, KmsKeyArn}. Controls how logs sent to CloudWatch Logs are encrypted.
   cloudWatchEncryption dict
   // Job bookmarks encryption configuration
+  //
+  // Shape: {JobBookmarksEncryptionMode: DISABLED|CSE-KMS, KmsKeyArn}. Controls how job bookmark state, which tracks already-processed data, is encrypted.
   jobBookmarksEncryption dict
   // Region where the security configuration exists
   region string
@@ -21747,12 +23196,13 @@ private aws.glue.securityConfiguration @defaults("name") {
 
 // AWS Glue Data Catalog database
 //
-// Examine a Data Catalog database — the namespace that holds catalog
-// tables. Iterate `tables()` for the tables in the database. Surfaces
-// the owning `catalogId`, the optional `locationUri`, free-form
-// `parameters`, the Lake Formation `createTableDefaultPermissions`
-// granted on tables created inside the database, and the
-// `targetDatabase` / `federatedDatabase` pointers when the database is
+// Data Catalog database, the namespace that holds catalog tables. The
+// `tables` collection contains the tables in the database, and
+// `catalogId` identifies the owning catalog. The optional `locationUri`,
+// free-form `parameters`, and the Lake Formation
+// `createTableDefaultPermissions` granted on tables created inside it
+// describe its configuration. The `targetDatabase` and
+// `federatedDatabase` pointers identify the source when the database is
 // a resource link or a federated reference to an external metastore.
 private aws.glue.database @defaults("name region") {
   // Name of the database
@@ -21785,13 +23235,14 @@ private aws.glue.database @defaults("name region") {
 
 // AWS Glue Data Catalog database table
 //
-// Examine a single Data Catalog table. Surfaces the `storageDescriptor`
-// (location, columns, input/output format, serde, encryption-relevant
-// subfields), the `partitionKeys`, the `tableType` (EXTERNAL_TABLE,
-// MANAGED_TABLE, VIRTUAL_VIEW, GOVERNED), the `viewExpandedText` for
-// views, free-form `parameters`, and the
-// `isRegisteredWithLakeFormation` flag indicating whether table access
-// is governed by Lake Formation. When the table is a resource link or
+// Data Catalog table describing a dataset's schema and physical layout.
+// The `storageDescriptor` holds the location, columns, input and output
+// format, serde, and encryption-relevant subfields, and `partitionKeys`
+// lists the partitioning columns. The `tableType` (EXTERNAL_TABLE,
+// MANAGED_TABLE, VIRTUAL_VIEW, GOVERNED) and `viewExpandedText` for views
+// classify it, while free-form `parameters` and the
+// `isRegisteredWithLakeFormation` flag indicate whether table access is
+// governed by Lake Formation. When the table is a resource link or
 // federated reference, `federatedTable` carries the underlying
 // identifier.
 private aws.glue.database.table @defaults("name databaseName region") {
@@ -21841,12 +23292,13 @@ private aws.glue.database.table @defaults("name databaseName region") {
 
 // AWS Elastic Beanstalk
 //
-// Use the Elastic Beanstalk namespace to enumerate platform-managed web
-// application deployments in the account. Iterate `applications()` for
-// every Beanstalk application (with its application versions and resource
-// lifecycle policy), and `environments()` for the running environments
-// (with their platform, solution stack, tier, configuration settings,
-// option settings, instance role, and health status).
+// Platform-managed web application deployments in the account. The
+// `applications` collection returns every Beanstalk application with its
+// application versions and version lifecycle policy, and `environments`
+// returns the running environments with their platform, solution stack,
+// tier, configuration option settings, instance role, and health status.
+// Use it to audit deployment inventory, artifact retention rules, and the
+// IAM roles Elastic Beanstalk assumes on your behalf.
 aws.elasticbeanstalk @defaults("environments") {
   // List of Elastic Beanstalk applications
   applications() []aws.elasticbeanstalk.application
@@ -21855,6 +23307,13 @@ aws.elasticbeanstalk @defaults("environments") {
 }
 
 // AWS Elastic Beanstalk application
+//
+// Single Elastic Beanstalk application, the top-level container that
+// groups related environments, application versions, and configuration
+// templates. Fields cover the version lifecycle policy (max-age and
+// max-count retention rules, whether matched source bundles are removed
+// from Amazon S3, and the service role applied), letting you audit how
+// old deployment artifacts are cleaned up.
 private aws.elasticbeanstalk.application @defaults("arn name") {
   // ARN of the application
   arn string
@@ -21893,6 +23352,11 @@ private aws.elasticbeanstalk.application @defaults("arn name") {
 }
 
 // AWS Elastic Beanstalk application version
+//
+// Deployable iteration of an Elastic Beanstalk application, identified by
+// its `versionLabel`. Fields report the processing status, the source
+// bundle location in Amazon S3, the source repository and type, and the
+// CodeBuild build reference when the version was built by CodeBuild.
 private aws.elasticbeanstalk.applicationVersion @defaults("arn versionLabel status") {
   // ARN of the application version
   arn string
@@ -21927,6 +23391,14 @@ private aws.elasticbeanstalk.applicationVersion @defaults("arn versionLabel stat
 }
 
 // AWS Elastic Beanstalk environment
+//
+// Running deployment of an Elastic Beanstalk application version onto
+// provisioned AWS resources. Fields report the platform and solution
+// stack, the tier (web server or worker), the operational and health
+// status, the public CNAME and endpoint, the backing load balancer and
+// live resource summary, and the full set of configuration option
+// settings, so you can audit how an environment is exposed and
+// configured.
 private aws.elasticbeanstalk.environment @defaults("arn name status") {
   // ARN of the environment
   arn string
@@ -21954,7 +23426,11 @@ private aws.elasticbeanstalk.environment @defaults("arn name status") {
   cname string
   // Endpoint URL
   endpointUrl string
-  // Environment tier (Worker or WebServer)
+  // Environment tier
+  //
+  // Dict with keys `Name` (WebServer or Worker), `Type` (Standard for a web
+  // server, SQS/HTTP for a worker), and `Version`. The name and type are
+  // also available as the scalar tierName and tierType fields.
   tier dict
   // Name of the environment tier: WebServer or Worker
   tierName string
@@ -21970,7 +23446,11 @@ private aws.elasticbeanstalk.environment @defaults("arn name status") {
   abortableOperationInProgress bool
   // Classic load balancer associated with this environment (Beanstalk only exposes the Classic ELB; ALB/NLB environments do not populate this field)
   loadBalancer() aws.elb.loadbalancer
-  // Links to other environments in the same group declared in the environment manifest
+  // Links to other environments in the same group
+  //
+  // Dependencies declared in the environment manifest. Each entry has keys
+  // `EnvironmentName` (the linked environment) and `LinkName` (the name of
+  // the link).
   environmentLinks []dict
   // Live summary of the AWS resources backing this environment
   //
@@ -22061,6 +23541,12 @@ private aws.rds.eventSubscription @defaults("arn name status") {
 }
 
 // AWS Glue workflow
+//
+// Orchestration container that coordinates a set of jobs and crawlers as
+// a single logical run driven by shared triggers. The
+// `defaultRunProperties` provide run-scoped values passed to the jobs,
+// and `maxConcurrentRuns` caps how many runs of the workflow can execute
+// at once.
 private aws.glue.workflow @defaults("name region") {
   // Name of the workflow
   name string
@@ -22084,16 +23570,17 @@ private aws.glue.workflow @defaults("name region") {
 
 // AWS Glue connection
 //
-// Examine a Data Catalog connection definition that Glue jobs and
-// crawlers use to reach a backing data store. Surfaces the
-// `connectionType` (JDBC, KAFKA, MONGODB, NETWORK, MARKETPLACE, CUSTOM,
-// SFTP, VIEW_VALIDATION_REDSHIFT, VIEW_VALIDATION_ATHENA),
-// `connectionProperties` keys (audit `PASSWORD` vs `SECRET_ID` to flag
-// inline credentials versus Secrets Manager references — values for
-// sensitive keys are redacted, see the field comment),
-// `matchCriteria`, and the optional `physicalConnectionRequirements`
-// (subnet, security groups, availability zone) for connections that
-// run inside a customer VPC.
+// Data Catalog connection definition that Glue jobs and crawlers use to
+// reach a backing data store. The `connectionType` (JDBC, KAFKA,
+// MONGODB, NETWORK, MARKETPLACE, CUSTOM, SFTP, VIEW_VALIDATION_REDSHIFT,
+// VIEW_VALIDATION_ATHENA) selects the store, and the
+// `connectionProperties` keys hold its settings. Auditing `PASSWORD`
+// against `SECRET_ID` flags inline credentials versus Secrets Manager
+// references (values for sensitive keys are redacted, see the field
+// comment). The `matchCriteria` and the optional
+// `physicalConnectionRequirements` (subnet, security groups,
+// availability zone) apply to connections that run inside a customer
+// VPC.
 private aws.glue.connection @defaults("name connectionType region") {
   // Name of the connection
   name string
@@ -22111,7 +23598,9 @@ private aws.glue.connection @defaults("name connectionType region") {
   connectionProperties map[string]string
   // List of criteria the connection's data store must match (e.g. enforced source identity)
   matchCriteria []string
-  // Physical connection details (subnet, security groups, availability zone) when the connection runs inside a customer VPC
+  // Physical connection details when the connection runs inside a customer VPC
+  //
+  // Shape: {SubnetId, SecurityGroupIdList, AvailabilityZone}. Populated for connections (NETWORK, and VPC-attached JDBC or Kafka) that reach a data store inside a customer VPC.
   physicalConnectionRequirements dict
   // Date the connection was created
   createdAt time
@@ -22121,15 +23610,15 @@ private aws.glue.connection @defaults("name connectionType region") {
 
 // AWS Glue trigger
 //
-// Examine a Glue trigger — the schedule, on-demand button, predicate, or
-// EventBridge event source that fires a chain of jobs and crawlers.
-// Surfaces the `type` (SCHEDULED, CONDITIONAL, ON_DEMAND, EVENT), the
-// `state` (CREATING, ACTIVATING, ACTIVATED, DEACTIVATING, DEACTIVATED,
-// DELETING, UPDATING), the cron `schedule`, the `actions` it runs
-// (jobs and crawlers with their per-run arguments), the `predicate`
-// linking it to upstream triggers in CONDITIONAL mode, the
-// `eventBatchingCondition` for EVENT triggers, and the optional
-// `workflowName` it belongs to.
+// Glue trigger: the schedule, on-demand button, predicate, or
+// EventBridge event source that fires a chain of jobs and crawlers. The
+// `type` (SCHEDULED, CONDITIONAL, ON_DEMAND, EVENT) and `state`
+// (CREATING, ACTIVATING, ACTIVATED, DEACTIVATING, DEACTIVATED, DELETING,
+// UPDATING) describe how it fires and its lifecycle. The cron
+// `schedule`, the `actions` it runs (jobs and crawlers with their
+// per-run arguments), the `predicate` linking it to upstream triggers in
+// CONDITIONAL mode, the `eventBatchingCondition` for EVENT triggers, and
+// the optional `workflowName` it belongs to define its behavior.
 private aws.glue.trigger @defaults("name type state region") {
   // Name of the trigger
   name string
@@ -22163,12 +23652,12 @@ private aws.glue.trigger @defaults("name type state region") {
 
 // AWS Glue Schema Registry
 //
-// Examine a Glue Schema Registry — the namespace that groups schemas
-// (Avro, JSON, Protobuf) used by streaming applications and consumers
-// to validate message formats. Iterate `schemas()` on the top-level
-// `aws.glue` namespace and filter by `registryName` to list schemas in a
-// specific registry. Surfaces the `status` (AVAILABLE, DELETING) and
-// the create / update timestamps.
+// Glue Schema Registry, the namespace that groups schemas (Avro, JSON,
+// Protobuf) used by streaming applications and consumers to validate
+// message formats. The `aws.glue.schemas` collection filtered by
+// `registryName` lists the schemas in a specific registry. The `status`
+// (AVAILABLE, DELETING) and the create and update timestamps track its
+// lifecycle.
 private aws.glue.schemaRegistry @defaults("name region status") {
   // Name of the registry
   name string
@@ -22190,15 +23679,16 @@ private aws.glue.schemaRegistry @defaults("name region status") {
 
 // AWS Glue Schema Registry schema
 //
-// Examine a single schema in the Glue Schema Registry. Surfaces the
-// `dataFormat` (AVRO, JSON, PROTOBUF), the evolution `compatibility`
-// mode (NONE, DISABLED, BACKWARD, BACKWARD_ALL, FORWARD, FORWARD_ALL,
-// FULL, FULL_ALL), the `schemaStatus` (AVAILABLE, PENDING, DELETING),
-// the `latestVersionNumber` registered, the `nextSchemaVersionNumber`
-// that will be assigned to the next registered version, the
-// `schemaCheckpoint` version number (the last version at which the
-// compatibility mode was changed), and the `registryName` and
-// `registryArn` of the parent registry.
+// Schema in the Glue Schema Registry that defines and versions a message
+// format. The `dataFormat` (AVRO, JSON, PROTOBUF) and the evolution
+// `compatibility` mode (NONE, DISABLED, BACKWARD, BACKWARD_ALL, FORWARD,
+// FORWARD_ALL, FULL, FULL_ALL) govern how new versions may change the
+// format, and `schemaStatus` (AVAILABLE, PENDING, DELETING) tracks its
+// lifecycle. The `latestVersionNumber` registered, the
+// `nextSchemaVersionNumber` to be assigned next, the `schemaCheckpoint`
+// version (the last version at which the compatibility mode was
+// changed), and the `registryName` and `registryArn` of the parent
+// registry complete the record.
 private aws.glue.schema @defaults("schemaName registryName dataFormat compatibility") {
   // Name of the schema
   schemaName string
@@ -22234,11 +23724,11 @@ private aws.glue.schema @defaults("schemaName registryName dataFormat compatibil
 
 // AWS Glue Data Catalog resource policy
 //
-// Examine a Glue Data Catalog resource-based policy. The policy
-// document in `policyInJson` grants cross-account or cross-service
-// access to catalog objects (databases, tables, connections). `GetResourcePolicies`
-// returns the account-wide default policy and any per-resource policies
-// attached in the region; each is identified by its `policyHash`.
+// Glue Data Catalog resource-based policy. The policy document in
+// `policyInJson` grants cross-account or cross-service access to catalog
+// objects (databases, tables, connections). The account-wide default
+// policy and any per-resource policies attached in the region are each
+// identified by their `policyHash`.
 private aws.glue.resourcePolicy @defaults("region createdAt") {
   // Policy hash that identifies this resource policy
   policyHash string
@@ -22254,13 +23744,13 @@ private aws.glue.resourcePolicy @defaults("region createdAt") {
 
 // Amazon MSK (Managed Streaming for Apache Kafka)
 //
-// Use the MSK namespace to enumerate the managed Apache Kafka deployments
-// in the account. Iterate `clusters()` for MSK provisioned and serverless
-// clusters (with their broker count, instance type, encryption-at-rest and
-// in-transit settings, client authentication options, monitoring level,
-// and bootstrap broker endpoints), `configurations()` for the reusable
-// Kafka cluster configurations, and `replicators()` for the cross-cluster
-// MSK replicators.
+// Managed Apache Kafka deployments in the account. The `clusters` field
+// lists MSK provisioned and serverless clusters with their broker count,
+// instance type, encryption-at-rest and in-transit settings, client
+// authentication options, monitoring level, and bootstrap broker
+// endpoints. The `configurations` field lists the reusable Kafka cluster
+// configurations, and `replicators` lists the cross-cluster MSK
+// replicators.
 aws.msk @defaults("clusters replicators") {
   // List of MSK clusters
   clusters() []aws.msk.cluster
@@ -22290,7 +23780,7 @@ private aws.msk.cluster @defaults("name state clusterType region") {
   numberOfBrokerNodes() int
   // Broker instance type
   brokerInstanceType() string
-  // Whether encryption in transit between clients and brokers uses TLS, TLS_PLAINTEXT, or PLAINTEXT
+  // Encryption setting for data in transit between clients and brokers: TLS, TLS_PLAINTEXT, or PLAINTEXT
   encryptionInTransitClientBroker() string
   // Whether broker-to-broker communication within the cluster is encrypted
   encryptionInTransitInCluster() bool
@@ -22356,15 +23846,15 @@ private aws.msk.cluster @defaults("name state clusterType region") {
   loggingInfo() aws.msk.cluster.loggingInfo
   // Enhanced and open monitoring configuration
   monitoring() aws.msk.cluster.monitoring
-  // Bootstrap broker endpoints (lazy-loaded via GetBootstrapBrokers)
+  // Bootstrap broker endpoints
   bootstrapBrokers() aws.msk.cluster.bootstrapBrokers
-  // Resource-based cluster policy (lazy-loaded via GetClusterPolicy)
+  // Resource-based cluster policy
   clusterPolicy() aws.msk.cluster.clusterPolicy
-  // Cluster operation history (lazy-loaded via ListClusterOperationsV2)
+  // Cluster operation history
   operations() []aws.msk.cluster.operation
-  // Broker and controller nodes in the cluster (lazy-loaded via ListNodes)
+  // Broker and controller nodes in the cluster
   nodes() []aws.msk.cluster.node
-  // Cross-account client VPC connections (lazy-loaded via ListClientVpcConnections)
+  // Cross-account client VPC connections
   clientVpcConnections() []aws.msk.cluster.clientVpcConnection
   // Serverless cluster configuration (null on PROVISIONED clusters)
   serverlessConfig() aws.msk.cluster.serverlessConfig
@@ -22404,7 +23894,7 @@ private aws.msk.cluster.clientAuthentication @defaults("iamEnabled scramEnabled 
   unauthenticatedEnabled bool
   // Whether any real auth mode (IAM/SCRAM/TLS) is enabled; unauthenticated is reported separately
   anyEnabled bool
-  // SCRAM secrets associated with the cluster (lazy: ListScramSecrets)
+  // SCRAM secrets associated with the cluster
   scramSecrets() []aws.secretsmanager.secret
   // ACM Private CA ARNs accepted for mTLS client authentication
   certificateAuthorityArns []string
@@ -22510,7 +24000,7 @@ private aws.msk.cluster.monitoring @defaults("enhancedMonitoring jmxExporterEnab
   prometheusAnyEnabled bool
 }
 
-// Bootstrap broker endpoints for an MSK cluster (from GetBootstrapBrokers)
+// Bootstrap broker endpoints for an MSK cluster
 private aws.msk.cluster.bootstrapBrokers @defaults("hasPublicEndpoint hasPlaintextEndpoint") {
   // Plaintext (unencrypted) broker connection string
   plaintext string
@@ -22662,7 +24152,7 @@ private aws.msk.configuration @defaults("name state latestRevision region") {
   createdAt time
   // Region where the configuration lives
   region string
-  // Contents of the server.properties file (lazy-loaded via DescribeConfigurationRevision)
+  // Contents of the server.properties file
   serverProperties() string
 }
 
@@ -22828,16 +24318,16 @@ private aws.msk.replicator.logDelivery.s3 @defaults("enabled") {
 
 // Amazon MQ
 //
-// Use the MQ namespace to enumerate managed message brokers and stored
-// broker configurations in the account. Iterate `brokers()` for every Amazon
-// MQ broker — each row surfaces the broker engine (ActiveMQ or RabbitMQ),
-// engine version, deployment mode (single-instance, active/standby, cluster),
-// public accessibility, instance type, KMS encryption, security groups and
-// subnets, log destinations, LDAP server metadata, the maintenance window,
-// the applied configuration revision, the user list, and the wire-protocol
-// endpoints. Iterate `configurations()` for every stored broker configuration
-// that can be attached to a broker, along with its engine type, engine
-// version, authentication strategy, and latest revision.
+// Managed message brokers and stored broker configurations in the
+// account. `brokers` returns every Amazon MQ broker, covering the engine
+// (ActiveMQ or RabbitMQ), engine version, deployment mode
+// (single-instance, active/standby, or cluster), public accessibility,
+// instance type, KMS encryption, security groups, subnets, log
+// destinations, LDAP server metadata, the maintenance window, the applied
+// configuration revision, and the broker user accounts. `configurations`
+// returns every stored broker configuration that can be attached to a
+// broker, along with its engine type, engine version, authentication
+// strategy, and latest revision.
 aws.mq @defaults("brokers") {
   // List of MQ brokers
   brokers() []aws.mq.broker
@@ -22846,6 +24336,14 @@ aws.mq @defaults("brokers") {
 }
 
 // Amazon MQ message broker
+//
+// Amazon MQ broker running ActiveMQ or RabbitMQ. Audit its internet
+// exposure through `exposure` (the public-accessibility flag combined
+// with security group ingress), its encryption at rest (whether it uses
+// an AWS-owned or customer-managed KMS key), authentication strategy,
+// general and audit log destinations in CloudWatch, cross-region
+// data-replication settings, automatic minor version upgrades, the
+// maintenance window, and the changes that will apply at the next reboot.
 private aws.mq.broker @defaults("name engineType deploymentMode state region") {
   // ARN of the broker
   arn string
@@ -22905,7 +24403,7 @@ private aws.mq.broker @defaults("name engineType deploymentMode state region") {
   dataReplicationRole() string
   // CRDR replication partner broker ID (the `b-…` UUID)
   //
-  // The MQ DescribeBroker API exposes only the partner's broker ID and region — not its name — so a fully qualified ARN cannot be synthesized without an extra DescribeBroker call; resolve the partner via `aws.mq.brokers.where(...)` when needed.
+  // The MQ DescribeBroker API exposes only the partner's broker ID and region (not its name), so a fully qualified ARN cannot be synthesized without an extra DescribeBroker call. Resolve the partner via `aws.mq.brokers.where(...)` when needed.
   replicationPartnerBrokerId() string
   // CRDR replication partner region (e.g. us-east-1)
   replicationPartnerRegion() string
@@ -22943,9 +24441,9 @@ private aws.mq.broker @defaults("name engineType deploymentMode state region") {
 
 // Amazon MQ broker configuration
 //
-// Examine a stored ActiveMQ or RabbitMQ broker configuration that can be
-// attached to a broker. Each configuration is keyed by its ARN — for example
-// `aws.mq.configuration(arn: "arn:aws:mq:us-east-1:123456789012:configuration:c-abcd...")` —
+// Stored ActiveMQ or RabbitMQ broker configuration that can be attached to
+// a broker. Each configuration is keyed by its ARN, for example
+// `aws.mq.configuration(arn: "arn:aws:mq:us-east-1:123456789012:configuration:c-abcd...")`,
 // and exposes the broker engine type and version, authentication strategy,
 // description, creation time, latest revision number, and tags. The latest
 // revision number, creation time, and description are flattened onto the
@@ -22981,13 +24479,13 @@ private aws.mq.configuration @defaults("name engineType engineVersion region") {
 
 // AWS Batch
 //
-// Use the Batch namespace to enumerate the building blocks of managed
-// batch computing in the account. Iterate `computeEnvironments()` for the
-// EC2/Spot/Fargate compute environments, `jobQueues()` for the queues that
-// dispatch jobs into those environments, `jobDefinitions()` for reusable
-// container/EKS/multi-node job definitions, `schedulingPolicies()` for
-// fair-share scheduling policies, and `jobs()` for non-terminal jobs
-// currently in flight (SUBMITTED, PENDING, RUNNABLE, STARTING, RUNNING).
+// Managed batch computing in the account, covering the full set of Batch
+// building blocks. The computeEnvironments field lists the EC2, Spot, and
+// Fargate compute environments; jobQueues lists the queues that dispatch
+// jobs into those environments; jobDefinitions lists reusable container,
+// EKS, and multi-node job definitions; schedulingPolicies lists fair-share
+// scheduling policies; and jobs lists non-terminal jobs currently in flight
+// (SUBMITTED, PENDING, RUNNABLE, STARTING, RUNNING).
 aws.batch @defaults("computeEnvironments") {
   // List of Batch compute environments
   computeEnvironments() []aws.batch.computeEnvironment
@@ -23067,7 +24565,11 @@ private aws.batch.computeEnvironment @defaults("arn name state status") {
   launchTemplateName() string
   // Launch template version
   launchTemplateVersion() string
-  // Launch template overrides (per-instance-type userdata/version overrides)
+  // Per-instance-type launch template overrides
+  //
+  // Launch template selections that apply to specific instance types. Each
+  // entry carries launchTemplateId, launchTemplateName, version, and
+  // targetInstanceTypes.
   launchTemplateOverrides() []dict
   // EKS cluster backing the compute environment (EKS orchestration only)
   eksCluster() aws.eks.cluster
@@ -23107,7 +24609,12 @@ private aws.batch.jobQueue @defaults("arn name state status") {
   computeEnvironmentOrderTyped() []aws.batch.jobQueue.computeEnvironmentOrder
   // Fair-share scheduling policy attached to this queue (null when absent)
   schedulingPolicy() aws.batch.schedulingPolicy
-  // Actions taken when jobs remain in a state longer than the configured threshold
+  // Actions taken when jobs remain in a state past a time threshold
+  //
+  // Each entry carries action (the action Batch performs, such as CANCEL),
+  // maxTimeSeconds (how long the job may stay in the state before the action
+  // fires), reason, and state (the job state the rule watches, such as
+  // RUNNABLE).
   jobStateTimeLimitActions() []dict
   // Non-terminal jobs in this queue (SUBMITTED/PENDING/RUNNABLE/STARTING/RUNNING)
   jobs() []aws.batch.job
@@ -23160,13 +24667,13 @@ private aws.batch.jobDefinition @defaults("arn name type status") {
   ecs() dict
   // Container images referenced by the job definition
   //
-  // Examine every container image used anywhere in the job definition:
-  // single-node container properties, each multi-node node-range container,
-  // ECS task containers, and EKS pod containers and init containers. Each
-  // entry parses the image reference into `image` (the raw reference),
-  // `registry` (the registry host, with bare names and single-segment
-  // repositories normalized to `docker.io`), `repository`, `tag`, and
-  // `digest`. The `tag` and `digest` are empty when the reference omits them.
+  // Every container image used anywhere in the job definition: single-node
+  // container properties, each multi-node node-range container, ECS task
+  // containers, and EKS pod containers and init containers. Each entry
+  // parses the image reference into `image` (the raw reference), `registry`
+  // (the registry host, with bare names and single-segment repositories
+  // normalized to `docker.io`), `repository`, `tag`, and `digest`. The
+  // `tag` and `digest` are empty when the reference omits them.
   images() []dict
   // Typed retry strategy
   retry() aws.batch.jobDefinition.retryStrategy
@@ -23268,16 +24775,14 @@ private aws.batch.jobDefinition.timeout @defaults("attemptDurationSeconds") {
 
 // AWS Batch job
 //
-// Examine a single Batch job's runtime state. Use the `arn` field as the
-// selection key — for example
-// `aws.batch.job(arn: "arn:aws:batch:us-east-1:111122223333:job/abc123")`.
-// Each row surfaces the job's lifecycle (status, status reason, created /
-// started / stopped timestamps), typed references to the parent
-// `jobQueue()` and `jobDefinition()`, the `computeEnvironment()` the job
-// landed on, container/array/multi-node attempts, dependencies, and
-// retry/timeout settings. The parent collection only enumerates
-// non-terminal statuses by default (SUBMITTED, PENDING, RUNNABLE,
-// STARTING, RUNNING).
+// Runtime state of a single Batch job. The arn field selects the job, for
+// example `aws.batch.job(arn: "arn:aws:batch:us-east-1:111122223333:job/abc123")`.
+// Each row surfaces the job's lifecycle (status, status reason, created,
+// started, and stopped timestamps), references to the parent jobQueue and
+// jobDefinition, the computeEnvironment the job landed on, container,
+// array, and multi-node attempts, dependencies, and retry and timeout
+// settings. The collection enumerates only non-terminal statuses by default
+// (SUBMITTED, PENDING, RUNNABLE, STARTING, RUNNING).
 aws.batch.job @defaults("id name status jobQueueArn") {
   // Job ID
   id string
@@ -23345,13 +24850,13 @@ private aws.batch.job.dependency @defaults("jobId type") {
 
 // AWS Batch scheduling policy
 //
-// Examine a fair-share scheduling policy that governs how Batch
-// dispatches jobs across share identifiers within a queue. Use the `arn`
-// field as the selection key — for example
+// Fair-share scheduling policy that governs how Batch dispatches jobs
+// across share identifiers within a queue. The arn field selects the
+// policy, for example
 // `aws.batch.schedulingPolicy(arn: "arn:aws:batch:us-east-1:111122223333:scheduling-policy/fairshare-prod")`.
-// Each row surfaces the share decay window, compute reservation, and
-// the list of share-distribution entries that bias scheduling weight
-// toward specific share identifiers.
+// Each row surfaces the share decay window, compute reservation, and the
+// list of share-distribution entries that bias scheduling weight toward
+// specific share identifiers.
 aws.batch.schedulingPolicy @defaults("arn name") {
   // ARN of the scheduling policy
   arn string
@@ -23461,16 +24966,16 @@ private aws.batch.jobDefinition.eksContainer @defaults("name image") {
 
 // Amazon Lightsail
 //
-// Use the Lightsail namespace to enumerate the simplified VPS-style
-// resources Lightsail provisions in the account. Iterate `instances()`
-// for Lightsail compute instances (with their bundle, blueprint, public
-// and private IPs, attached static IPs, key-pair, and instance-level
-// firewall rules), `databases()` for managed relational databases (with
-// their engine, parameter snapshot, public accessibility, and backup
-// retention), `loadBalancers()` for Lightsail load balancers (with their
-// HTTPS certificates and attached instances), and `buckets()` for
-// Lightsail object-storage buckets (with their access rules and
-// resource attachments).
+// Simplified virtual-private-server resources Lightsail provisions in the
+// account: `instances` for compute instances (with their bundle, blueprint,
+// public and private IPs, static IPs, key pair, and instance-level firewall
+// rules), `databases` for managed relational databases (with their engine,
+// public accessibility, and backup retention), `loadBalancers` for load
+// balancers (with their HTTPS certificates and attached instances), `buckets`
+// for object-storage buckets (with their access rules and resource
+// attachments), `disks` for block-storage volumes, and `distributions` for
+// content-delivery network endpoints. Use it to inventory Lightsail workloads
+// and audit which ones are reachable from the public internet.
 aws.lightsail @defaults("instances") {
   // List of Lightsail instances
   instances() []aws.lightsail.instance
@@ -23487,6 +24992,13 @@ aws.lightsail @defaults("instances") {
 }
 
 // Amazon Lightsail content delivery network (CDN) distribution
+//
+// Content-delivery endpoint that caches and serves content from a Lightsail
+// origin. Reports whether the distribution is enabled, the SSL/TLS certificate
+// and minimum viewer TLS protocol version it enforces, its alternative domain
+// names, IP address type, and the origin and cache behaviors that govern what
+// gets cached. Use it to confirm distributions terminate TLS with a current
+// protocol version and pull from the intended origin.
 private aws.lightsail.distribution @defaults("name arn") {
   // Name of the distribution
   name string
@@ -23512,13 +25024,32 @@ private aws.lightsail.distribution @defaults("name arn") {
   ipAddressType string
   // Minimum TLS protocol version that the distribution accepts for viewer connections
   viewerMinimumTlsProtocolVersion string
-  // Origin the distribution pulls content from, including its IP address type
+  // Origin the distribution pulls content from
+  //
+  // Dict with keys `Name` (origin resource name), `ProtocolPolicy` (protocol
+  // used to connect to the origin: http-only or https-only), `RegionName`,
+  // `ResourceType` (typically Instance), `IpAddressType`, and `ResponseTimeout`
+  // (seconds the distribution waits for an origin response).
   origin dict
   // Default cache behavior of the distribution
+  //
+  // Dict with a single `Behavior` key: `cache` caches and serves the entire
+  // site as static content, `dont-cache` caches only the paths listed in
+  // cacheBehaviors.
   defaultCacheBehavior dict
   // Per-path cache behaviors of the distribution
+  //
+  // Overrides to the default cache behavior for specific paths. Each dict has a
+  // `Path` (directory, file, or wildcard such as `*.jpg`) and a `Behavior`
+  // (`cache` or `dont-cache`).
   cacheBehaviors []dict
   // Cache behavior settings of the distribution
+  //
+  // Dict with keys `AllowedHTTPMethods` and `CachedHTTPMethods` (the HTTP
+  // methods forwarded to and cached from the origin), `DefaultTTL`,
+  // `MinimumTTL`, and `MaximumTTL` (seconds objects stay cached), and
+  // `ForwardedCookies`, `ForwardedHeaders`, and `ForwardedQueryStrings`
+  // (which request attributes the cache key varies on).
   cacheBehaviorSettings dict
   // Date the distribution was created
   createdAt time
@@ -23527,6 +25058,12 @@ private aws.lightsail.distribution @defaults("name arn") {
 }
 
 // Amazon Lightsail instance
+//
+// Virtual-private-server compute instance. Reports its blueprint and bundle,
+// run state, public and private addressing (including whether it holds a
+// static IP), SSH key and username, and the inbound firewall governing which
+// ports are reachable. Use `inboundRules` to audit which port ranges the
+// instance exposes to the public internet.
 private aws.lightsail.instance @defaults("name arn state") {
   // Name of the instance
   name string
@@ -23574,17 +25111,17 @@ private aws.lightsail.instance @defaults("name arn state") {
   tags map[string]string
   // Raw inbound firewall rule dicts
   //
-  // Deprecated in favor of `inboundRules`, which resolves each rule to a typed
+  // Deprecated in favor of `inboundRules`, which resolves each rule to an
   // aws.lightsail.instance.inboundRule exposing fromPort, toPort, protocol,
   // cidrs, ipv6Cidrs, and a publicAccess predicate.
   firewallRules() @maturity("deprecated") []dict
   // Inbound firewall rules
   //
-  // Examine the inbound firewall governing the instance. Each rule exposes the
-  // port range it opens (`fromPort` to `toPort`), the `protocol`, the source
-  // ranges (`cidrs`, `ipv6Cidrs`), and a `publicAccess` predicate that is true
-  // when the rule admits any address (`0.0.0.0/0` or `::/0`) — marking the
-  // port range as reachable from the public internet.
+  // Inbound firewall governing the instance. Each rule exposes the port range
+  // it opens (`fromPort` to `toPort`), the `protocol`, the source ranges
+  // (`cidrs`, `ipv6Cidrs`), and a `publicAccess` predicate that is true when
+  // the rule admits any address (`0.0.0.0/0` or `::/0`), marking the port range
+  // as reachable from the public internet.
   inboundRules() []aws.lightsail.instance.inboundRule
   // Open ports on the instance with access policies
   //
@@ -23596,11 +25133,11 @@ private aws.lightsail.instance @defaults("name arn state") {
 
 // Inbound firewall rule for a Lightsail instance
 //
-// Examine a single inbound networking rule on the instance — the port range it
-// opens (`fromPort` to `toPort`), the `protocol` (tcp, udp, icmp, icmpv6, or
-// all), and the source ranges (`cidrs`, `ipv6Cidrs`). The `publicAccess`
-// predicate is true when the rule admits any source address (`0.0.0.0/0` or
-// `::/0`), marking the port range as reachable from the public internet.
+// Single inbound networking rule on the instance: the port range it opens
+// (`fromPort` to `toPort`), the `protocol` (tcp, udp, icmp, icmpv6, or all),
+// and the source ranges (`cidrs`, `ipv6Cidrs`). The `publicAccess` predicate
+// is true when the rule admits any source address (`0.0.0.0/0` or `::/0`),
+// marking the port range as reachable from the public internet.
 private aws.lightsail.instance.inboundRule @defaults("fromPort toPort protocol publicAccess") {
   // Lowest port in the range the rule opens
   fromPort int
@@ -23617,6 +25154,12 @@ private aws.lightsail.instance.inboundRule @defaults("fromPort toPort protocol p
 }
 
 // Amazon Lightsail relational database
+//
+// Managed MySQL or PostgreSQL database. Reports its engine and version, run
+// state, master username and database name, backup retention and windows, and
+// whether the database is reachable from outside the account. Check
+// `publiclyAccessible` and `backupRetentionEnabled` to audit exposure and
+// recoverability.
 private aws.lightsail.database @defaults("name arn state") {
   // Name of the database
   name string
@@ -23679,6 +25222,12 @@ private aws.lightsail.database @defaults("name arn state") {
 }
 
 // Amazon Lightsail load balancer
+//
+// Load balancer distributing traffic across attached Lightsail instances.
+// Reports its listener protocol and public ports, the health-check path and
+// per-instance health, attached TLS certificates and security policy, and
+// whether HTTPS redirection and session stickiness are enabled. Use it to
+// confirm listeners terminate TLS and redirect HTTP traffic to HTTPS.
 private aws.lightsail.loadBalancer @defaults("name arn state") {
   // Name of the load balancer
   name string
@@ -23701,8 +25250,15 @@ private aws.lightsail.loadBalancer @defaults("name arn state") {
   // Instance port
   instancePort int
   // Instance health summary
+  //
+  // Health of each attached instance. Each dict has `InstanceName`,
+  // `InstanceHealth` (initial, healthy, unhealthy, unused, draining, or
+  // unavailable), and `InstanceHealthReason` explaining a non-healthy state.
   instanceHealthSummary() []dict
-  // TLS certificate summaries (name, isAttached)
+  // TLS certificate summaries
+  //
+  // Each dict has `Name` (the SSL/TLS certificate name) and `IsAttached`
+  // (whether the certificate is attached to the load balancer).
   tlsCertificateSummaries() []dict
   // Name of the TLS security policy attached to the load balancer
   tlsPolicyName string
@@ -23723,6 +25279,11 @@ private aws.lightsail.loadBalancer @defaults("name arn state") {
 }
 
 // Amazon Lightsail block storage disk
+//
+// Block-storage volume that can be attached to a Lightsail instance. Reports
+// its size and provisioned IOPS, state, whether it is a system disk, and the
+// instance it is attached to (`attachedTo`) with the device path it is exposed
+// at. Use it to inventory storage and find unattached volumes.
 private aws.lightsail.disk @defaults("name arn state sizeInGb isAttached") {
   // Name of the disk
   name string
@@ -23759,6 +25320,11 @@ private aws.lightsail.disk @defaults("name arn state sizeInGb isAttached") {
 }
 
 // Amazon Lightsail bucket
+//
+// Object-storage bucket. Reports its storage bundle, state, object versioning
+// setting, public-access rules, the accounts and Lightsail resources granted
+// access, and its endpoint URL. Check `accessRules` and `readonlyAccessAccounts`
+// to audit who can read objects in the bucket.
 private aws.lightsail.bucket @defaults("name arn") {
   // Name of the bucket
   name string
@@ -23777,10 +25343,18 @@ private aws.lightsail.bucket @defaults("name arn") {
   // URL of the bucket
   url string
   // Access rules for the bucket
+  //
+  // Dict with `GetObject` (anonymous access to objects: `public` makes all
+  // objects readable by anyone, `private` restricts them) and
+  // `AllowPublicOverrides` (whether individual-object ACLs may override
+  // GetObject to make specific objects public).
   accessRules() dict
   // AWS account IDs with read-only access to the bucket
   readonlyAccessAccounts []string
   // Lightsail resources that have access to the bucket
+  //
+  // Each dict has `name` (the Lightsail instance name) and `resourceType`
+  // (typically Instance).
   resourcesReceivingAccess() []dict
   // Date the bucket was created
   createdAt time
@@ -23790,16 +25364,15 @@ private aws.lightsail.bucket @defaults("name arn") {
 
 // AWS CloudFormation
 //
-// Use the CloudFormation namespace to enumerate infrastructure-as-code
-// deployments in the account. Iterate `stacks()` for every CloudFormation
-// stack across enabled regions (with its template-driven parameters,
-// outputs, capabilities, drift status, deletion-protection flag, and
-// notification topics), and `stackSets()` for stack sets that deploy a
-// single template across multiple accounts and regions in an organization
-// (with their permission model, drift status, administration/execution
-// roles, and the organizational unit IDs they target). Both ACTIVE and
-// DELETED stack sets are returned; filter with `where(status == "ACTIVE")`
-// if you only want live ones.
+// Infrastructure-as-code deployments in the account. The `stacks` list
+// contains every CloudFormation stack across enabled regions, each with its
+// template-driven parameters, outputs, capabilities, drift status,
+// deletion-protection flag, and notification topics. The `stackSets` list
+// contains stack sets that deploy a single template across multiple accounts
+// and regions in an organization, each with its permission model, drift
+// status, administration and execution roles, and the organizational unit
+// IDs it targets. Both ACTIVE and DELETED stack sets are returned; filter
+// with `where(status == "ACTIVE")` if you only want live ones.
 aws.cloudformation @defaults("stacks") {
   // List of CloudFormation stacks
   stacks() []aws.cloudformation.stack
@@ -23808,6 +25381,15 @@ aws.cloudformation @defaults("stacks") {
 }
 
 // AWS CloudFormation stack
+//
+// A single CloudFormation stack, the unit that provisions and manages a
+// collection of AWS resources together from one template. The `status` field
+// reports where the stack sits in its lifecycle (for example CREATE_COMPLETE,
+// UPDATE_COMPLETE, or ROLLBACK_COMPLETE), `driftStatus` reports whether the
+// live resources still match the template, and `enableTerminationProtection`
+// guards the stack against accidental deletion. Nested stacks expose their
+// `parentStack` and `rootStack`, and `resources` links each template entry to
+// the concrete AWS resource it created.
 private aws.cloudformation.stack @defaults("name status") {
   // Unique ID of the stack
   stackId string
@@ -23836,8 +25418,17 @@ private aws.cloudformation.stack @defaults("name status") {
   // IAM role used to create/update the stack
   iamRole() aws.iam.role
   // Stack parameters
+  //
+  // Each entry carries `key` and `value` (the parameter name and its supplied
+  // value), plus `resolvedValue` when the value was resolved from Systems
+  // Manager Parameter Store and `usePreviousValue` when an update reused the
+  // prior value.
   parameters() []dict
   // Stack outputs
+  //
+  // Each entry carries `key` and `value` (the output name and its value),
+  // plus `description` and `exportName` when the template exports the output
+  // for cross-stack references.
   outputs() []dict
   // Stack tags
   tags map[string]string
@@ -23857,11 +25448,11 @@ private aws.cloudformation.stack @defaults("name status") {
 
 // CloudFormation stack resource
 //
-// Examine a single resource managed by a CloudFormation stack — the
-// logical-to-physical mapping that records which concrete AWS resource the
-// stack provisioned for a given template entry. Each row carries the
-// `logicalId` from the template, the `physicalId` of the created resource,
-// its `resourceType`, current status, and drift state, making it the
+// A single resource managed by a CloudFormation stack, recording the
+// logical-to-physical mapping of which concrete AWS resource the stack
+// provisioned for a given template entry. Each row carries the `logicalId`
+// from the template, the `physicalId` of the created resource, its
+// `resourceType`, current status, and drift state, making it the
 // authoritative link between a stack and the resources it owns.
 private aws.cloudformation.stack.resource @defaults("logicalId resourceType status") {
   // Logical ID of the resource as defined in the stack template
@@ -23881,6 +25472,14 @@ private aws.cloudformation.stack.resource @defaults("logicalId resourceType stat
 }
 
 // AWS CloudFormation stack set
+//
+// A CloudFormation stack set, a single template deployed as stack instances
+// across multiple accounts and regions. The `permissionModel` field selects
+// how deployments are authorized (SERVICE_MANAGED through AWS Organizations,
+// or SELF_MANAGED with explicit administration and execution roles),
+// `driftStatus` reports whether deployed instances still match the template,
+// and `organizationalUnitIds` lists the organizational units targeted for
+// service-managed deployment.
 private aws.cloudformation.stackSet @defaults("name status") {
   // Unique ID of the stack set
   stackSetId string
@@ -23914,11 +25513,10 @@ private aws.cloudformation.stackSet @defaults("name status") {
 
 // Amazon Keyspaces (for Apache Cassandra)
 //
-// Use the Keyspaces namespace to enumerate the managed Apache Cassandra
-// service in the account. Iterate `keyspaces()` for every keyspace
-// across enabled regions — each row surfaces the replication strategy
-// (single-region or multi-region), the regions a multi-region keyspace
-// is replicated to, and the tables defined in the keyspace.
+// Managed Apache Cassandra service in the account. The `keyspaces` field
+// enumerates every keyspace across enabled regions, each exposing its
+// replication strategy (single-region or multi-region), the regions a
+// multi-region keyspace replicates to, and the tables it defines.
 aws.keyspaces {
   // List of keyspaces
   keyspaces() []aws.keyspaces.keyspace
@@ -23936,7 +25534,12 @@ private aws.keyspaces.keyspace @defaults("arn name replicationStrategy") {
   replicationStrategy string
   // Regions where the keyspace is replicated (multi-region only)
   replicationRegions []string
-  // Per-region status of the multi-region keyspace (region, keyspaceStatus, tablesReplicationProgress)
+  // Per-region replication status of a multi-region keyspace
+  //
+  // One row per replica region. Each row has `region` (the AWS region),
+  // `keyspaceStatus` (the keyspace state in that region), and
+  // `tablesReplicationProgress` (the progress of table replication to
+  // that region). Empty for single-region keyspaces.
   replicationGroupStatuses() []dict
   // Tables in this keyspace
   tables() []aws.keyspaces.table
@@ -24002,7 +25605,13 @@ private aws.keyspaces.table @defaults("arn keyspaceName name status") {
   latestStreamArn() string
   // Free-form description message attached to the table
   comment() string
-  // Per-region settings for a multi-region table (region, status, throughputMode, readCapacityUnits, writeCapacityUnits, warmThroughputStatus)
+  // Per-region settings for a multi-region table
+  //
+  // One row per replica region. Each row has `region` (the AWS region),
+  // `status` (the table state in that region), `throughputMode`
+  // (PAY_PER_REQUEST or PROVISIONED), `readCapacityUnits` and
+  // `writeCapacityUnits` (provisioned capacity when applicable), and
+  // `warmThroughputStatus`. Empty for single-region tables.
   replicaSpecifications() []dict
   // Tags for the table
   tags() map[string]string
@@ -24052,13 +25661,17 @@ private aws.ssm.document @defaults("name documentType") {
   platformTypes []string
   // Tags on the document
   tags map[string]string
-  // Document content (JSON/YAML body), lazy-loaded
+  // Document content (JSON or YAML body)
   content() string
   // Review status: Approved, Pending, Rejected, Not reviewed
   reviewStatus string
   // Creation date of the document
   createdAt time
   // Account sharing permissions for the document
+  //
+  // Each entry has `accountId` (the account the document is shared with, or `all`
+  // for public sharing) and either `type` (`Share`) or `sharedVersion` (the specific
+  // document version shared with that account).
   permissions() []dict
 }
 
@@ -24079,6 +25692,11 @@ private aws.ssm.patchBaseline @defaults("id name operatingSystem") {
   // Whether this is the default baseline for its operating system
   isDefault bool
   // Approval rules for the patch baseline
+  //
+  // Each rule has `approveAfterDays` (days after a patch is released before it is
+  // auto-approved), `complianceLevel` (severity assigned to patches the rule approves),
+  // `enableNonSecurity` (whether non-security updates are included), and `patchFilters`
+  // (a list of `key`/`values` filters selecting the patches the rule applies to).
   approvalRules []dict
   // List of explicitly approved patches
   approvedPatches []string
@@ -24089,8 +25707,16 @@ private aws.ssm.patchBaseline @defaults("id name operatingSystem") {
   // Action for rejected patches: ALLOW_AS_DEPENDENCY or BLOCK
   rejectedPatchesAction string
   // Global filters for the patch baseline
+  //
+  // Filters applied to every patch before the approval rules run. Each entry has `key`
+  // (the filter attribute, for example `PRODUCT`, `CLASSIFICATION`, or `SEVERITY`) and
+  // `values` (the matching values).
   globalFilters []dict
   // Patch sources
+  //
+  // Alternate patch repositories for non-default operating systems. Each entry has `name`
+  // (the source name), `products` (the products it applies to), and `configuration` (the
+  // repository configuration, for example a yum or apt source definition).
   sources []dict
   // Creation date
   createdAt time
@@ -24146,11 +25772,12 @@ private aws.ssm.maintenanceWindow @defaults("id name") {
 
 // Maintenance window task registration
 //
-// Examine a task that the maintenance window runs against its registered targets — the document or
-// function `taskArn` points to, the IAM `iamRole()` SSM assumes to execute it, the priority within
-// the window, and the parallelism guardrails (`maxConcurrency`, `maxErrors`, `cutoffBehavior`).
-// `taskType` is one of `RUN_COMMAND`, `AUTOMATION`, `LAMBDA`, or `STEP_FUNCTIONS`. Selected by the
-// composite `region/windowId/windowTaskId` key returned by `DescribeMaintenanceWindowTasks`.
+// Task the maintenance window runs against its registered targets: the document or
+// function `taskArn` points to, the IAM role `iamRole` SSM assumes to execute it, the
+// priority within the window, and the parallelism guardrails (`maxConcurrency`,
+// `maxErrors`, `cutoffBehavior`). `taskType` is one of `RUN_COMMAND`, `AUTOMATION`,
+// `LAMBDA`, or `STEP_FUNCTIONS`. Selected by the composite `region/windowId/windowTaskId`
+// key returned by `DescribeMaintenanceWindowTasks`.
 private aws.ssm.maintenanceWindow.task @defaults("name taskType priority") {
   // Maintenance window ID the task is registered to
   windowId string
@@ -24191,9 +25818,10 @@ private aws.ssm.maintenanceWindow.task @defaults("name taskType priority") {
 
 // Maintenance window target registration
 //
-// Examine a target group bound to the maintenance window — the managed nodes or resource tags
-// `targets` selects, and the `resourceType` (`INSTANCE` or `RESOURCE_GROUP`). Selected by the
-// composite `region/windowId/windowTargetId` key returned by `DescribeMaintenanceWindowTargets`.
+// Target group bound to the maintenance window: the managed nodes or resource tags
+// `targets` selects, and the `resourceType` (`INSTANCE` or `RESOURCE_GROUP`). Selected
+// by the composite `region/windowId/windowTargetId` key returned by
+// `DescribeMaintenanceWindowTargets`.
 private aws.ssm.maintenanceWindow.target @defaults("name resourceType") {
   // Maintenance window ID the target is registered to
   windowId string
@@ -24230,6 +25858,9 @@ private aws.ssm.association @defaults("associationId name") {
   // Managed node ID the association targets when not using the `targets` selector
   instanceId string
   // Targets for the association
+  //
+  // Each entry has `key` (the selector, for example `InstanceIds`, `tag:<name>`, or
+  // `ParameterValues`) and `values` (the matching values).
   targets []dict
   // Cron or rate schedule expression
   schedule string
@@ -24244,7 +25875,10 @@ private aws.ssm.association @defaults("associationId name") {
   lastExecutionDate time
   // Last date the association ran successfully
   lastSuccessfulExecutionDate() time
-  // Overview of the association execution status (status, detailedStatus, associationStatusAggregatedCount)
+  // Overview of the association execution status
+  //
+  // Has `status` (the aggregate status), `detailedStatus` (a more specific state such as
+  // `PendingExecution`), and `statusCounts` (a map of managed node status name to count).
   overview dict
   // Severity assigned to non-compliant associations
   //
@@ -24276,16 +25910,20 @@ private aws.ssm.complianceSummary @defaults("complianceType resourceId status") 
   // Count of non-compliant items
   nonCompliantCount int
   // Execution summary
+  //
+  // Details of the most recent compliance evaluation run: `executionTime` (when it ran),
+  // `executionId` (the run identifier), and `executionType` (the kind of run, for example
+  // `Command`).
   executionSummary dict
 }
 
 // Patch group to patch baseline mapping
 //
-// Examine which patch baseline a Patch Manager patch group consumes. A patch group is a tag-valued
-// label (the `Patch Group` tag on managed nodes) bound to one baseline per operating system. The
-// `baselineIdentity` dict carries the baseline ID, name, description, operating system, and default
-// flag returned by `DescribePatchGroups`; the typed `baseline()` accessor resolves the matching
-// `aws.ssm.patchBaseline`.
+// Which patch baseline a Patch Manager patch group consumes. A patch group is a
+// tag-valued label (the `Patch Group` tag on managed nodes) bound to one baseline per
+// operating system. The `baselineIdentity` dict carries the baseline ID, name,
+// description, operating system, and default flag returned by `DescribePatchGroups`, and
+// `baseline` resolves the matching `aws.ssm.patchBaseline`.
 private aws.ssm.patchGroup @defaults("patchGroup operatingSystem baselineName") {
   // Patch group name (the value of the `Patch Group` tag on managed nodes)
   patchGroup string
@@ -24301,7 +25939,10 @@ private aws.ssm.patchGroup @defaults("patchGroup operatingSystem baselineName") 
   // `REDHAT_ENTERPRISE_LINUX`, `SUSE`, `CENTOS`, `ORACLE_LINUX`, `DEBIAN`, `MACOS`, `RASPBIAN`, or
   // `ROCKY_LINUX`.
   operatingSystem string
-  // Identity of the baseline the patch group is bound to (id, name, description, OS, default flag)
+  // Identity of the baseline the patch group is bound to
+  //
+  // Has `baselineId`, `baselineName`, `baselineDescription`, `operatingSystem`, and
+  // `defaultBaseline` (whether it is the default baseline for the operating system).
   baselineIdentity dict
   // Patch baseline the patch group is bound to
   baseline() aws.ssm.patchBaseline
@@ -24309,12 +25950,12 @@ private aws.ssm.patchGroup @defaults("patchGroup operatingSystem baselineName") 
 
 // SSM account-level service setting
 //
-// Examine the value, status, and last modifier of a single SSM account-level service setting
-// returned by `GetServiceSetting`. The `settingId` field selects the setting — for example
-// `aws.ssm.serviceSetting(settingId: "/ssm/documents/console/public-sharing-permission")` — and
-// `status` is one of `Default`, `Customized`, or `PendingUpdate`. Settings of interest for posture
-// audits include the document public-sharing toggle, Session Manager logging destinations,
-// Parameter Store default tier, and managed-instance activation tier.
+// Value, status, and last modifier of a single SSM account-level service setting
+// returned by `GetServiceSetting`. The `settingId` field selects the setting, for example
+// `aws.ssm.serviceSetting(settingId: "/ssm/documents/console/public-sharing-permission")`.
+// `status` is one of `Default`, `Customized`, or `PendingUpdate`. Settings of interest for
+// posture audits include the document public-sharing toggle, Session Manager logging
+// destinations, Parameter Store default tier, and managed-instance activation tier.
 private aws.ssm.serviceSetting @defaults("settingId settingValue status") {
   // Setting ID (e.g., `/ssm/documents/console/public-sharing-permission`)
   settingId string
@@ -24386,7 +26027,10 @@ private aws.ec2.vpcEndpointServiceConfiguration.connection @defaults("endpointId
   endpointState string
   // IP address type of the connection: ipv4, ipv6, dualstack
   ipAddressType string
-  // DNS entries for this connection
+  // Private DNS entries the service exposes to the connection
+  //
+  // Each entry carries dnsName (the DNS name) and hostedZoneId (the Route 53
+  // hosted zone that contains it).
   dnsEntries []dict
   // Network load balancer ARNs in use
   networkLoadBalancerArns []string
@@ -24398,13 +26042,13 @@ private aws.ec2.vpcEndpointServiceConfiguration.connection @defaults("endpointId
 
 // Amazon VPC IP Address Manager (IPAM)
 //
-// Examine an IPAM installation, the account-wide controller that allocates,
-// audits, and monitors IPv4/IPv6 CIDR space across an AWS organization. The
-// IPAM owns the public and private default scopes (`publicDefaultScopeId` /
-// `privateDefaultScopeId`), is allowed to manage CIDRs only in its declared
-// `operatingRegions`, and may be on the Free or Advanced `tier`. Traverse
-// `scopes()` and `pools()` to walk the address-space hierarchy down to
-// individual CIDR allocations on resources.
+// Account-wide controller that allocates, audits, and monitors IPv4/IPv6
+// CIDR space across an AWS organization. The IPAM owns the public and private
+// default scopes (`publicDefaultScopeId` / `privateDefaultScopeId`), is
+// allowed to manage CIDRs only in its declared `operatingRegions`, and may be
+// on the Free or Advanced `tier`. The `scopes` and `pools` collections walk
+// the address-space hierarchy down to individual CIDR allocations on
+// resources.
 private aws.ec2.ipam @defaults("id region tier state") {
   // ID of the IPAM
   id string
@@ -24416,7 +26060,7 @@ private aws.ec2.ipam @defaults("id region tier state") {
   ownerId string
   // User-supplied description for the IPAM
   description string
-  // IPAM tier: free or advanced — the advanced tier unlocks public-scope features and resource discovery
+  // IPAM tier: free or advanced (the advanced tier unlocks public-scope features and resource discovery)
   tier string
   // State of the IPAM
   //
@@ -24452,12 +26096,11 @@ private aws.ec2.ipam @defaults("id region tier state") {
 
 // Amazon VPC IPAM scope
 //
-// Examine a scope, the top-level container of IPAM address space. A scope
-// represents the IP space for a single network — the built-in `private` and
-// `public` scopes are flagged by `isDefault`, and additional scopes can be
-// added to model unconnected networks that reuse address ranges. The
-// `poolCount` summarizes how many pools live in the scope; iterate
-// `aws.ec2.ipam.pools()` and filter by `ipamScopeArn` to walk them.
+// Top-level container of IPAM address space. A scope represents the IP space
+// for a single network: the built-in `private` and `public` scopes are
+// flagged by `isDefault`, and additional scopes can be added to model
+// unconnected networks that reuse address ranges. The `poolCount` summarizes
+// how many pools live in the scope, each selectable by its `ipamScopeArn`.
 private aws.ec2.ipam.scope @defaults("id type isDefault region") {
   // ID of the scope
   id string
@@ -24485,14 +26128,14 @@ private aws.ec2.ipam.scope @defaults("id type isDefault region") {
 
 // Amazon VPC IPAM pool
 //
-// Examine a pool, the level of IPAM that actually hands out CIDR blocks
-// to resources. The `addressFamily` distinguishes IPv4 from IPv6 pools,
-// `publicIpSource` distinguishes Amazon-provided from BYOIP space, and
-// `publiclyAdvertisable` flags pools whose IPv6 space is advertised on the
-// public internet. `locale` constrains where the pool can hand out
-// allocations, and `awsService` (when set) restricts which AWS service can
-// use the pool. Traverse `allocations()` to see every CIDR currently
-// handed out by the pool, including the resource that holds it.
+// Level of IPAM that actually hands out CIDR blocks to resources. The
+// `addressFamily` distinguishes IPv4 from IPv6 pools, `publicIpSource`
+// distinguishes Amazon-provided from BYOIP space, and `publiclyAdvertisable`
+// flags pools whose IPv6 space is advertised on the public internet. `locale`
+// constrains where the pool can hand out allocations, and `awsService` (when
+// set) restricts which AWS service can use the pool. The `allocations`
+// collection lists every CIDR currently handed out by the pool, including the
+// resource that holds it.
 private aws.ec2.ipam.pool @defaults("id addressFamily state region") {
   // ID of the pool
   id string
@@ -24548,12 +26191,12 @@ private aws.ec2.ipam.pool @defaults("id addressFamily state region") {
 
 // Amazon VPC IPAM pool allocation
 //
-// Examine a single CIDR that an IPAM pool has handed to a resource. The
-// `cidr` is the address range, `resourceType` and `resourceId` identify
-// the holder (a VPC, subnet, EC2 public-IPv4 pool, etc.), and
-// `resourceOwner` plus `resourceRegion` show which account and Region the
-// holder lives in — handy for spotting cross-account IPv4/IPv6
-// allocations that fall outside the IPAM owner's account.
+// Single CIDR that an IPAM pool has handed to a resource. The `cidr` is the
+// address range, `resourceType` and `resourceId` identify the holder (a VPC,
+// subnet, EC2 public-IPv4 pool, etc.), and `resourceOwner` plus
+// `resourceRegion` show which account and Region the holder lives in, which
+// helps spot cross-account IPv4/IPv6 allocations that fall outside the IPAM
+// owner's account.
 private aws.ec2.ipam.pool.allocation @defaults("cidr resourceType resourceId") {
   // ID of the allocation
   id string
@@ -24573,14 +26216,14 @@ private aws.ec2.ipam.pool.allocation @defaults("cidr resourceType resourceId") {
 
 // AWS Step Functions (sfn)
 //
-// Use the `sfn` namespace to enumerate Step Functions state machines and
-// activity workers in the account. Iterate `stateMachines()` for every
-// state machine across enabled regions (with its type — STANDARD or
-// EXPRESS — definition, IAM execution role, logging configuration,
-// X-Ray tracing setting, and creation time), and `activities()` for the
-// long-poll worker activities that state machines can invoke. The
-// related `aws.stepfunctions` namespace surfaces the same service with a
-// slightly different schema; both are kept for backward compatibility.
+// Step Functions state machines and activity workers in the account. The
+// stateMachines field lists every state machine across enabled regions,
+// including its type (STANDARD or EXPRESS), Amazon States Language
+// definition, IAM execution role, logging configuration, X-Ray tracing
+// setting, and encryption configuration. The activities field lists the
+// long-poll worker tasks that state machines can invoke. The related
+// aws.stepfunctions namespace surfaces the same service with a slightly
+// different schema; both are kept for backward compatibility.
 aws.sfn @defaults("stateMachines") {
   // List of Step Functions state machines
   stateMachines() []aws.sfn.stateMachine
@@ -24589,6 +26232,14 @@ aws.sfn @defaults("stateMachines") {
 }
 
 // AWS Step Functions state machine
+//
+// A single Step Functions workflow. State machines coordinate
+// distributed application components through an Amazon States Language
+// definition and run under an IAM execution role, so auditing them
+// covers the workflow logic, the permissions it assumes, the depth of
+// CloudWatch Logs logging, X-Ray tracing, and encryption at rest. The
+// type field distinguishes STANDARD (durable, exactly-once) from EXPRESS
+// (high-volume, at-least-once) workflows.
 private aws.sfn.stateMachine @defaults("arn name type status") {
   // ARN of the state machine
   arn string
@@ -24646,13 +26297,12 @@ private aws.sfn.stateMachine @defaults("arn name type status") {
 
 // AWS Step Functions state machine version
 //
-// Examine a single published version of a Step Functions state machine —
-// each version is an immutable snapshot of the definition and
-// configuration as of the time it was published, and is selected by an
-// ARN of the form `<stateMachineArn>:<versionNumber>`. The `revisionId`
-// links the version back to the configuration revision it was published
-// from, which is useful when correlating alias routing
-// (`RoutingConfigurationListItem`) to specific revisions or when
+// A single published version of a Step Functions state machine. Each
+// version is an immutable snapshot of the definition and configuration
+// as of the time it was published, selected by an ARN of the form
+// <stateMachineArn>:<versionNumber>. The revisionId links the version
+// back to the configuration revision it was published from, which is
+// useful when correlating alias routing to specific revisions or when
 // comparing versions during a rollout.
 private aws.sfn.stateMachineVersion @defaults("arn revisionId") {
   // ARN of the state machine version, in the form <stateMachineArn>:<versionNumber>
@@ -24666,6 +26316,12 @@ private aws.sfn.stateMachineVersion @defaults("arn revisionId") {
 }
 
 // AWS Step Functions activity
+//
+// A task performed by a worker that runs outside AWS and polls Step
+// Functions for work, then reports results back. An activity has no
+// definition of its own, so this resource records the identity of each
+// worker task (its arn, name, region, and creation time) for
+// inventorying the external integrations a workflow depends on.
 private aws.sfn.activity @defaults("arn name") {
   // ARN of the activity
   arn string
@@ -24679,20 +26335,27 @@ private aws.sfn.activity @defaults("arn name") {
 
 // AWS Resource Access Manager (RAM)
 //
-// Use the RAM namespace to enumerate cross-account resource shares the
-// account owns. Iterate `resourceShares()` for every share across
-// enabled regions — each row surfaces the principals invited to the
-// share, the resources attached to it (transit gateways, subnets,
-// licenses, Resolver rules, and so on), the share status, the
-// allow-external-principals flag, the associated permissions, and the
-// owning organization or organizational unit when the share is bound to
-// AWS Organizations.
+// Cross-account resource shares owned by this account. Resource Access
+// Manager shares AWS resources (transit gateways, subnets, licenses,
+// Resolver rules, and more) with other accounts, organizational units,
+// or an entire organization. The resourceShares field lists every share
+// across enabled regions, each carrying the principals invited to it, the
+// resources attached, the share status, and the allowExternalPrincipals
+// flag that governs whether principals outside the organization may be
+// added.
 aws.ram @defaults("resourceShares") {
   // List of resource shares owned by this account
   resourceShares() []aws.ram.resourceShare
 }
 
 // AWS RAM resource share
+//
+// Single Resource Access Manager share that grants other principals
+// access to a set of AWS resources. The allowExternalPrincipals flag
+// reveals shares reachable from outside the organization, principals
+// lists who has been granted access, and resources lists what is exposed.
+// The status field reports whether the share is ACTIVE or in a
+// transitional or failed state.
 private aws.ram.resourceShare @defaults("arn name status") {
   // ARN of the resource share
   arn string
@@ -24711,18 +26374,29 @@ private aws.ram.resourceShare @defaults("arn name status") {
   // Tags for the resource share
   tags map[string]string
   // Principals associated with the resource share
+  //
+  // Each entry is a dict with `id` (the principal, an account ID,
+  // organization ARN, or organizational unit ARN), `resourceShareArn`
+  // (the ARN of the share the principal is associated with), and
+  // `external` (true when the principal is outside the account's
+  // organization).
   principals() []dict
   // Resources associated with the resource share
+  //
+  // Each entry is a dict with `arn` (the ARN of the shared resource),
+  // `type` (the resource type, for example `ec2:Subnet` or
+  // `ec2:TransitGateway`), `resourceShareArn` (the ARN of the share), and
+  // `status` (the resource's availability in the share, one of AVAILABLE,
+  // ZONAL_RESOURCE_INACCESSIBLE, LIMIT_EXCEEDED, UNAVAILABLE, or PENDING).
   resources() []dict
 }
 
 // AWS Storage Gateway
 //
-// Use the Storage Gateway namespace to enumerate hybrid cloud storage
-// gateways that connect on-premises environments to AWS storage. Iterate
-// `gateways()` for every File, Volume, and Tape gateway in the account,
-// then traverse into each gateway's `fileShares()` and `volumes()` to
-// audit encryption, logging, and access configuration.
+// Hybrid cloud storage gateways that connect on-premises environments to
+// AWS storage. The `gateways` list covers every File, Volume, and Tape
+// gateway in the account; each gateway exposes its `fileShares` and
+// `volumes` for auditing encryption, logging, and access configuration.
 aws.storagegateway {
   // List of Storage Gateway gateways across all regions
   gateways() []aws.storagegateway.gateway
@@ -24730,13 +26404,13 @@ aws.storagegateway {
 
 // Storage Gateway gateway
 //
-// Examine a single hybrid storage gateway, selected by `arn` — for example
+// Single hybrid storage gateway, selected by `arn`, for example
 // `aws.storagegateway.gateways.where(arn == "arn:aws:storagegateway:us-east-1:123456789012:gateway/sgw-12A3456B")`.
 // Summary fields (type, operational state, host environment, software
 // version) come from the gateway list; detail fields (endpoint type,
 // CloudWatch log group, VPC endpoint, network interfaces, capacity, and
 // software-update dates) describe the gateway's configuration and patch
-// posture. Traverse `fileShares()` and `volumes()` for the storage exposed
+// posture. The `fileShares` and `volumes` fields reach the storage exposed
 // through the gateway.
 private aws.storagegateway.gateway @defaults("name type operationalState region") {
   // Gateway ARN
@@ -24801,13 +26475,12 @@ private aws.storagegateway.gateway @defaults("name type operationalState region"
 
 // Storage Gateway file share
 //
-// Examine a single NFS or SMB file share backed by an S3 bucket, selected
-// by `arn`. Summary fields (type, status) come from the file-share list;
-// detail fields describe how data is encrypted (`kmsEncrypted`,
-// `encryptionType`, `kmsKey()`), the S3 location it maps to
-// (`locationArn`, `bucketRegion`), the access posture (`readOnly`,
-// `requesterPays`, `objectAcl`), and the IAM role the gateway assumes
-// (`iamRole()`).
+// Single NFS or SMB file share backed by an S3 bucket, selected by `arn`.
+// Summary fields (type, status) come from the file-share list; detail
+// fields describe how data is encrypted (`kmsEncrypted`, `encryptionType`,
+// `kmsKey`), the S3 location it maps to (`locationArn`, `bucketRegion`),
+// the access posture (`readOnly`, `requesterPays`, `objectAcl`), and the
+// IAM role the gateway assumes (`iamRole`).
 private aws.storagegateway.fileShare @defaults("id type status region") {
   // File share ARN
   arn string
@@ -24851,10 +26524,10 @@ private aws.storagegateway.fileShare @defaults("id type status region") {
 
 // Storage Gateway iSCSI volume
 //
-// Examine a single cached or stored iSCSI volume exposed by a Volume
-// Gateway, selected by `arn`. Summary fields (type, size, attachment
-// state) come from the volume list; detail fields describe the volume's
-// status, source snapshot, and encryption key (`encrypted`, `kmsKey()`).
+// Single cached or stored iSCSI volume exposed by a Volume Gateway,
+// selected by `arn`. Summary fields (type, size, attachment state) come
+// from the volume list; detail fields describe the volume's status, source
+// snapshot, and encryption key (`encrypted`, `kmsKey`).
 private aws.storagegateway.volume @defaults("id type sizeInBytes region") {
   // Volume ARN
   arn string
@@ -24886,14 +26559,13 @@ private aws.storagegateway.volume @defaults("id type sizeInBytes region") {
 
 // AWS Transfer Family
 //
-// Use the Transfer Family namespace to enumerate the file-transfer
-// service in the account. Iterate `servers()` for SFTP, FTP, FTPS, and
-// AS2 server endpoints (with their identity provider, endpoint type,
-// host-key fingerprint, S3/EFS storage backing, structured-logging role,
-// and security policy), `connectors()` for outbound AS2 and SFTP
-// connectors used to push files to partners, `webApps()` for web-portal
-// access fronts, and `workflows()` for the post-upload processing
-// workflows triggered after a file lands.
+// Managed file-transfer service in the account. The servers field lists
+// SFTP, FTP, FTPS, and AS2 server endpoints (with their identity
+// provider, endpoint type, host-key fingerprint, S3 or EFS storage
+// backing, structured-logging role, and security policy); connectors
+// lists outbound AS2 and SFTP connectors used to push files to partners;
+// webApps lists web-portal access fronts; and workflows lists the
+// post-upload processing workflows triggered after a file lands.
 aws.transfer @defaults("servers") {
   // List of Transfer Family servers
   servers() []aws.transfer.server
@@ -24963,9 +26635,20 @@ private aws.transfer.workflow @defaults("arn workflowId description") {
   region string
   // Description for the workflow
   description string
-  // Steps that run on workflow execution (each is a dict shaped like the SDK WorkflowStep)
+  // Steps that run on workflow execution
+  //
+  // Each entry is a dict keyed on Type (COPY, CUSTOM, TAG, DELETE, or
+  // DECRYPT) plus the matching detail block for that type: CopyStepDetails,
+  // CustomStepDetails, TagStepDetails, DeleteStepDetails, or
+  // DecryptStepDetails. Each detail block carries the step Name and the
+  // SourceFileLocation it operates on.
   steps() []dict
-  // Steps that run when an exception is encountered (each is a dict shaped like the SDK WorkflowStep)
+  // Steps that run when an exception is encountered
+  //
+  // Each entry has the same shape as steps: a dict keyed on Type (COPY,
+  // CUSTOM, TAG, DELETE, or DECRYPT) with the matching detail block
+  // (CopyStepDetails, CustomStepDetails, TagStepDetails, DeleteStepDetails,
+  // or DecryptStepDetails).
   onExceptionSteps() []dict
   // Tags for the workflow
   tags() map[string]string
@@ -25007,12 +26690,11 @@ private aws.transfer.server @defaults("arn serverId endpointType protocols") {
 
 // AWS App Mesh
 //
-// Use the App Mesh namespace to enumerate service-mesh control-plane
-// configuration in the account. Iterate `meshes()` for every App Mesh
-// mesh — each row surfaces the egress filter type (DROP_ALL or
-// ALLOW_ALL), the IP preference for service-discovery, the mesh owner
-// (for shared meshes), and the virtual nodes, virtual services, virtual
-// routers, and routes that compose the mesh topology.
+// Service-mesh control-plane configuration in the account. Each mesh in
+// `meshes` surfaces the egress filter type (DROP_ALL or ALLOW_ALL), the
+// IP preference for service discovery, the mesh owner (for shared
+// meshes), and the virtual nodes, virtual services, virtual routers, and
+// routes that compose the mesh topology.
 aws.appmesh @defaults("meshes") {
   // List of App Mesh meshes
   meshes() []aws.appmesh.mesh
@@ -25110,7 +26792,7 @@ private aws.appmesh.virtualNode @defaults("arn name") {
   status() string
   // Number of backend services
   //
-  // Deprecated in favor of `backendServices()`.
+  // Deprecated in favor of `backendServices`.
   backends() @maturity("deprecated") int
   // Backend services this node communicates with, including per-backend client policy
   backendServices() []dict
@@ -25141,7 +26823,7 @@ private aws.appmesh.virtualNode @defaults("arn name") {
   serviceDiscovery() @maturity("deprecated") dict
   // File path for access logs written by the Envoy proxy
   loggingAccessLogPath() string
-  // Format of access log entries — entries describe either the JSON key/value pairs or the text format string
+  // Format of access log entries, describing either the JSON key/value pairs or the text format string
   loggingAccessLogFormat() []dict
 }
 
@@ -25199,7 +26881,7 @@ private aws.appmesh.route @defaults("name") {
   lastUpdatedAt() time
   // Status: ACTIVE, INACTIVE, DELETED
   status() string
-  // Priority for the route — lower numbers match before higher numbers
+  // Priority for the route, where lower numbers match before higher numbers
   priority() int
   // Route specification (match, action, retry policy, timeout) including http/http2/tcp/grpc variants
   spec() dict
@@ -25217,13 +26899,12 @@ private aws.appmesh.route @defaults("name") {
 
 // AWS App Mesh virtual gateway
 //
-// Examine a virtual gateway that routes traffic from outside the mesh to
-// resources inside the mesh. Each gateway exposes one listener (port,
-// protocol, health check, TLS, connection pool), an optional default
-// client policy used for backend traffic, and optional access logging.
-// Use the `arn` field to select a specific gateway —
-// `aws.appmesh.virtualGateway(arn: "arn:aws:appmesh:...")` — or iterate
-// `aws.appmesh.mesh.virtualGateways` to walk every gateway in a mesh.
+// Virtual gateway that routes traffic from outside the mesh to resources
+// inside the mesh. Each gateway exposes one listener (port, protocol,
+// health check, TLS, connection pool), an optional default client policy
+// used for backend traffic, and optional access logging. The `arn` field
+// selects a specific gateway, for example
+// `aws.appmesh.virtualGateway(arn: "arn:aws:appmesh:...")`.
 private aws.appmesh.virtualGateway @defaults("arn name meshName") {
   // ARN of the virtual gateway
   arn string
@@ -25257,13 +26938,13 @@ private aws.appmesh.virtualGateway @defaults("arn name meshName") {
 
 // AWS IAM Identity Center
 //
-// Use the Identity Center namespace (formerly AWS SSO) to enumerate the
-// workforce identity service in the organization. Iterate `instances()`
-// for every Identity Center instance attached to the account — each
-// instance surfaces the identity store backing it (the source of users
-// and groups), the configured permission sets, the AWS-account
-// assignments those permission sets are deployed against, and the
-// trusted token issuers used by application assignments.
+// Workforce identity service (formerly AWS SSO) for the organization.
+// The `instances` field returns every Identity Center instance attached
+// to the account. Each instance surfaces the identity store backing it
+// (the source of users and groups), the configured permission sets, the
+// AWS-account assignments those permission sets are deployed against, and
+// the applications configured for single sign-on access. Audit this to
+// review who can assume which permissions in which member accounts.
 aws.identitycenter @defaults("instances") {
   // List of Identity Center instances
   instances() []aws.identitycenter.instance
@@ -25356,10 +27037,22 @@ private aws.identitycenter.permissionSet @defaults("arn name") {
   // Inline policy document (JSON string, empty if none)
   inlinePolicy() string
   // AWS managed policies attached to the permission set
+  //
+  // Each entry has the keys `arn` (the managed policy ARN) and `name` (the
+  // managed policy name).
   managedPolicies() []dict
   // Customer managed policies attached to the permission set
+  //
+  // Each entry has the keys `name` (the policy name) and `path` (the IAM
+  // path prefix the policy is created under in each member account).
   customerManagedPolicies() []dict
   // Permissions boundary attached to the permission set
+  //
+  // The maximum permissions the permission set can grant. The keys are
+  // `ManagedPolicyArn` (the ARN of an AWS managed policy used as the
+  // boundary) and `CustomerManagedPolicyReference` (a customer managed
+  // policy given by its nested `Name` and `Path`). Null when no boundary
+  // is attached.
   permissionsBoundary() dict
   // Tags for the permission set
   tags() map[string]string
@@ -25394,6 +27087,9 @@ private aws.identitycenter.group @defaults("displayName") {
   // Description of the group
   description() string
   // External IDs from the identity provider
+  //
+  // Each entry has the keys `issuer` (the identity provider that issued the
+  // ID) and `id` (the identifier for the group in that provider).
   externalIds() []dict
 }
 
@@ -25408,26 +27104,43 @@ private aws.identitycenter.user @defaults("userName displayName") {
   // When the user was created
   createdAt time
   // Email addresses associated with the user
+  //
+  // Each entry has the keys `value` (the email address), `type` (the label
+  // such as work or home), and `primary` (whether this is the primary
+  // address).
   emails() []dict
   // External IDs from the identity provider
+  //
+  // Each entry has the keys `issuer` (the identity provider that issued the
+  // ID) and `id` (the identifier for the user in that provider).
   externalIds() []dict
 }
 
 // AWS Private Certificate Authority (PCA)
 //
-// Use the Private CA namespace to enumerate AWS Private CA (formerly ACM
-// PCA) deployments in the account. Iterate `certificateAuthorities()`
-// for each CA across enabled regions — every entry surfaces the CA type
-// (ROOT or SUBORDINATE), key algorithm and signing algorithm, validity
-// window, status (ACTIVE, DISABLED, PENDING_CERTIFICATE, EXPIRED, etc.),
-// CRL and OCSP revocation configuration, the issuer chain, and the
-// resource policy that controls which principals can issue certificates.
+// Private certificate authorities managed by AWS Private CA (formerly
+// ACM PCA) across the account's enabled regions. The
+// certificateAuthorities field surfaces each CA's type (ROOT or
+// SUBORDINATE), key and signing algorithms, validity window, status
+// (ACTIVE, DISABLED, PENDING_CERTIFICATE, EXPIRED, and others), CRL and
+// OCSP revocation configuration, the issuer chain, and the resource
+// policy that controls which principals can issue certificates. Audit
+// this to confirm root CAs are appropriately scoped and protected and
+// that revocation is configured.
 aws.privateca {
   // List of private certificate authorities
   certificateAuthorities() []aws.privateca.certificateAuthority
 }
 
 // AWS Private Certificate Authority
+//
+// Single private CA in AWS Private CA, selected by its arn. Reports the
+// CA type (ROOT or SUBORDINATE), usage mode, key and signing algorithms,
+// key storage security standard, validity window, and lifecycle status,
+// along with the CRL and OCSP revocation configuration, the PEM-encoded
+// certificate and chain, and the resource-based policy governing
+// certificate issuance. Query it to verify that CAs are active,
+// correctly scoped, and have revocation and access controls in place.
 private aws.privateca.certificateAuthority @defaults("arn status type") {
   // ARN of the certificate authority
   arn string
@@ -25445,9 +27158,22 @@ private aws.privateca.certificateAuthority @defaults("arn status type") {
   keyAlgorithm string
   // Signing algorithm used by the CA
   signingAlgorithm string
-  // Subject information for the CA
+  // Subject distinguished name of the CA certificate
+  //
+  // Distinguished-name components present on the CA. Keys include
+  // CommonName, Organization, OrganizationalUnit, Country, State,
+  // Locality, and SerialNumber, plus less common fields such as Title,
+  // GivenName, Surname, Initials, Pseudonym,
+  // DistinguishedNameQualifier, GenerationQualifier, and
+  // CustomAttributes.
   subject dict
-  // Revocation configuration for the CA (CRL and OCSP settings)
+  // Revocation configuration for the CA
+  //
+  // Two nested blocks. CrlConfiguration holds Enabled, CrlType,
+  // ExpirationInDays, CustomCname, CustomPath, S3BucketName, S3ObjectAcl,
+  // and CrlDistributionPointExtensionConfiguration for certificate
+  // revocation lists. OcspConfiguration holds Enabled and OcspCustomCname
+  // for online certificate status checks.
   revocationConfiguration dict
   // Key storage security standard (e.g., FIPS_140_2_LEVEL_3_OR_HIGHER)
   keyStorageSecurityStandard string
@@ -25475,14 +27201,12 @@ private aws.privateca.certificateAuthority @defaults("arn status type") {
 
 // AWS Security Lake
 //
-// Use the Security Lake namespace to enumerate the centralized OCSF
-// security data lake deployment for the account. Iterate `dataLakes()`
-// for the per-region data-lake configurations (with their KMS
-// encryption, S3 storage classes, replication regions, and lifecycle
-// settings), and `subscribers()` for downstream consumers granted
-// access — each subscriber surfaces its source identifiers, access type
-// (S3 or Lake Formation), notification configuration, and the subset of
-// log sources it can read.
+// Centralized OCSF security data lake deployment for the account.
+// `dataLakes` returns the per-region data-lake configurations with
+// their KMS encryption, S3 storage classes, replication regions, and
+// lifecycle settings. `subscribers` returns the downstream consumers
+// granted access, each surfacing its source identifiers, access type
+// (S3 or Lake Formation), and the subset of log sources it can read.
 aws.securitylake {
   // List of Security Lake data lakes
   dataLakes() []aws.securitylake.dataLake
@@ -25501,12 +27225,21 @@ private aws.securitylake.dataLake @defaults("dataLakeArn region createStatus") {
   // KMS key used for encryption
   encryptionKmsKey() aws.kms.key
   // Lifecycle configuration for the data lake
+  //
+  // Object-lifecycle rules governing how long collected data is
+  // retained and when it moves to colder S3 storage. Keys: `Expiration`
+  // (object with `Days` before data expires) and `Transitions` (array
+  // of objects with `Days` and the target `StorageClass`).
   lifecycleConfiguration dict
   // Replication configuration for the data lake
+  //
+  // Cross-region rollup settings for the data lake. Keys: `Regions`
+  // (the centralized rollup Regions that receive replicated objects)
+  // and `RoleArn` (the IAM role Security Lake uses to replicate).
   replicationConfiguration dict
   // S3 bucket ARN for the data lake
   //
-  // Deprecated in favor of `s3Bucket()`.
+  // Deprecated in favor of `s3Bucket`.
   s3BucketArn @maturity("deprecated") string
   // S3 bucket for the data lake
   s3Bucket() aws.s3.bucket
@@ -25521,8 +27254,18 @@ private aws.securitylake.subscriber @defaults("subscriberArn subscriberName subs
   // Name of the subscriber
   subscriberName string
   // Identity of the subscriber (principal and external ID)
+  //
+  // AWS identity granted read access to the data lake. Keys:
+  // `Principal` (the AWS account, IAM role, or service principal) and
+  // `ExternalId` (the external ID used to establish the trust
+  // relationship).
   subscriberIdentity dict
   // Log and event sources
+  //
+  // Log and event source types the subscriber is allowed to consume.
+  // Each element wraps the source under a `Value` key holding
+  // `SourceName` and `SourceVersion`; custom sources also carry
+  // `Attributes` (Glue crawler and database ARNs) and `Provider`.
   sources []dict
   // Access types: LAKEFORMATION or S3
   accessTypes []string
@@ -25530,13 +27273,13 @@ private aws.securitylake.subscriber @defaults("subscriberArn subscriberName subs
   subscriberStatus string
   // IAM role ARN used by the subscriber
   //
-  // Deprecated in favor of `iamRole()`.
+  // Deprecated in favor of `iamRole`.
   roleArn @maturity("deprecated") string
   // IAM role used by the subscriber
   iamRole() aws.iam.role
   // S3 bucket ARN for the subscriber
   //
-  // Deprecated in favor of `s3Bucket()`.
+  // Deprecated in favor of `s3Bucket`.
   s3BucketArn @maturity("deprecated") string
   // S3 bucket for the subscriber
   s3Bucket() aws.s3.bucket
@@ -25546,15 +27289,15 @@ private aws.securitylake.subscriber @defaults("subscriberArn subscriberName subs
 
 // AWS Verified Access
 //
-// Use the Verified Access namespace to enumerate the zero-trust private
-// application access deployment in the account. Iterate `instances()`
-// for the per-region Verified Access instances (with their attached
-// trust providers and FIPS support), `trustProviders()` for the
-// identity and device trust providers (OIDC, IAM Identity Center,
-// CrowdStrike, Jamf, JumpCloud), `groups()` for the access groups that
-// share an access policy, and `endpoints()` for the application
-// endpoints (load balancer, network interface, RDS, or CIDR) that
-// Verified Access fronts.
+// Zero-trust private application access deployment in the account,
+// which grants access to applications based on identity and device
+// posture instead of network location. The `instances` field lists
+// the per-region Verified Access instances with their attached trust
+// providers and FIPS support, `trustProviders` the identity and device
+// trust providers (OIDC, IAM Identity Center, CrowdStrike, Jamf,
+// JumpCloud), `groups` the access groups that share an access policy,
+// and `endpoints` the application endpoints (load balancer, network
+// interface, RDS, or CIDR) that Verified Access fronts.
 aws.verifiedaccess {
   // List of Verified Access instances
   instances() []aws.verifiedaccess.instance
@@ -25577,6 +27320,11 @@ private aws.verifiedaccess.instance @defaults("verifiedAccessInstanceId descript
   // Whether FIPS is enabled
   fipsEnabled bool
   // Trust providers associated with this instance
+  //
+  // One entry per attached trust provider. Each dict carries
+  // `VerifiedAccessTrustProviderId`, `TrustProviderType` (user or
+  // device), `UserTrustProviderType`, `DeviceTrustProviderType`, and
+  // `Description`.
   trustProviders []dict
   // Time when the instance was created
   createdAt time
@@ -25603,8 +27351,17 @@ private aws.verifiedaccess.trustProvider @defaults("verifiedAccessTrustProviderI
   // Policy reference name used in Cedar policies
   policyReferenceName string
   // OIDC options configuration
+  //
+  // OpenID Connect settings for an OIDC user trust provider, with keys
+  // `Issuer`, `AuthorizationEndpoint`, `TokenEndpoint`,
+  // `UserInfoEndpoint`, `ClientId`, `ClientSecret`, and `Scope`. Null
+  // for device and IAM Identity Center trust providers.
   oidcOptions dict
-  // SSE specification (KMS encryption)
+  // Server-side encryption specification
+  //
+  // KMS encryption settings for the trust provider, with keys
+  // `CustomerManagedKeyEnabled` (true when a customer managed key is in
+  // use) and `KmsKeyArn`.
   sseSpecification dict
   // Tags for the trust provider
   tags map[string]string
@@ -25620,7 +27377,11 @@ private aws.verifiedaccess.group @defaults("verifiedAccessGroupId verifiedAccess
   region string
   // Verified Access instance ID the group belongs to
   verifiedAccessInstanceId string
-  // SSE specification (KMS encryption)
+  // Server-side encryption specification
+  //
+  // KMS encryption settings for the group, with keys
+  // `CustomerManagedKeyEnabled` (true when a customer managed key is in
+  // use) and `KmsKeyArn`.
   sseSpecification dict
   // Owner of the group
   owner string
@@ -25653,10 +27414,17 @@ private aws.verifiedaccess.endpoint @defaults("verifiedAccessEndpointId applicat
   // Domain certificate presented by the endpoint
   domainCertificate() aws.acm.certificate
   // Status of the endpoint
+  //
+  // Provisioning state of the endpoint, with keys `Code` (one of
+  // pending, active, updating, deleting, deleted) and `Message`.
   status dict
   // Security groups associated with the endpoint
   securityGroups() []aws.ec2.securitygroup
-  // SSE specification (KMS encryption)
+  // Server-side encryption specification
+  //
+  // KMS encryption settings for the endpoint, with keys
+  // `CustomerManagedKeyEnabled` (true when a customer managed key is in
+  // use) and `KmsKeyArn`.
   sseSpecification dict
   // Tags for the endpoint
   tags map[string]string
@@ -25673,23 +27441,34 @@ private aws.verifiedaccess.instanceLoggingConfiguration @defaults("verifiedAcces
   // Log version
   logVersion string
   // CloudWatch Logs configuration
+  //
+  // Access-log delivery to CloudWatch Logs, with keys `Enabled`,
+  // `LogGroup` (the destination log group ID), and `DeliveryStatus`.
   cloudWatchLogs dict
   // Kinesis Data Firehose configuration
+  //
+  // Access-log delivery to Kinesis Data Firehose, with keys `Enabled`,
+  // `DeliveryStream` (the destination stream ID), and `DeliveryStatus`.
   kinesisDataFirehose dict
   // S3 configuration
+  //
+  // Access-log delivery to Amazon S3, with keys `Enabled`,
+  // `BucketName`, `BucketOwner` (account that owns the bucket),
+  // `Prefix`, and `DeliveryStatus`.
   s3 dict
 }
 
 // AWS Control Tower
 //
-// Use the Control Tower namespace to enumerate the multi-account
-// landing-zone deployment for the AWS Organizations management account.
-// Iterate `landingZones()` for the deployed landing zones — each zone
-// surfaces its version, the home and governed regions, the drift
-// status, and the manifest that describes the configured baselines and
-// guardrails. Iterate `enabledBaselines()` for the baseline templates
-// applied to organizational units (the customizations Control Tower
-// applies to each enrolled OU).
+// Multi-account landing-zone governance for the AWS Organizations
+// management account. The landingZones collection covers each deployed
+// landing zone with its version, home and governed regions, drift
+// status, and the manifest describing the configured baselines and
+// guardrails. The enabledBaselines collection covers the baseline
+// templates applied to organizational units, the configuration Control
+// Tower enforces on each enrolled OU. Query these to confirm the
+// landing zone is in sync and that governance baselines are enabled
+// where expected.
 aws.controltower {
   // List of Control Tower landing zones
   landingZones() []aws.controltower.landingZone
@@ -25725,33 +27504,40 @@ private aws.controltower.enabledBaseline @defaults("arn baselineIdentifier") {
   targetIdentifier string
   // Version of the baseline
   baselineVersion string
-  // Status of the enabled baseline
+  // Enablement status of the baseline
+  //
+  // One of SUCCEEDED, FAILED, or UNDER_CHANGE.
   status string
   // Drift status summary of the enabled baseline
+  //
+  // Inheritance-drift summary, populated when the baseline applies at
+  // the OU level. Shape: `Types.Inheritance.Status`, where `Status` is
+  // `IN_SYNC` or `DRIFTED`. Drift occurs when a member account in the
+  // target OU no longer matches the baseline configuration defined on
+  // that OU.
   driftStatus dict
 }
 
 // Amazon Bedrock
 //
-// Use the Bedrock namespace to enumerate the foundation-model service
-// configuration in the account. Iterate `foundationModels()` for the
-// catalog of foundation models offered by Bedrock providers (with their
-// modalities, customization support, and inference types),
-// `customModels()` for fine-tuned or continued-pretraining models the
-// account owns, `guardrails()` for the content-policy guardrails (with
-// their topic, content, sensitive-information, and word-policy
-// filters), `provisionedModelThroughputs()` for committed
-// model-throughput allocations, and
-// `modelInvocationLoggingConfigurations()` for the per-region delivery
-// of model invocation logs to S3 and CloudWatch. For generative-AI
-// applications built on Bedrock, iterate `agents()` for Bedrock Agents
-// (with their foundation model, instructions, IAM service role, and
-// linked action groups and knowledge bases), `knowledgeBases()` for
+// Foundation-model service configuration in the account. The
+// foundationModels list is the catalog of models offered by Bedrock
+// providers, with their modalities, customization support, and
+// inference types. customModels are the fine-tuned or
+// continued-pretraining models the account owns, guardrails are the
+// content-policy guardrails (with their topic, content,
+// sensitive-information, and word-policy filters),
+// provisionedModelThroughputs are committed model-throughput
+// allocations, and modelInvocationLoggingConfigurations capture the
+// per-region delivery of model invocation logs to S3 and CloudWatch.
+// For generative-AI applications built on Bedrock, agents are Bedrock
+// Agents (with their foundation model, instructions, IAM service role,
+// and linked action groups and knowledge bases), knowledgeBases are
 // retrieval-augmented-generation data stores (with their vector-store
-// backend, embedding model, and data sources), and `flows()` for
-// authored generative-AI workflows. Iterate `evaluationJobs()` for
-// model-evaluation jobs, `modelImportJobs()` for custom-model imports,
-// and `batchInferenceJobs()` for batch model-invocation jobs.
+// backend, embedding model, and data sources), and flows are authored
+// generative-AI workflows. evaluationJobs cover model-evaluation jobs,
+// modelImportJobs cover custom-model imports, and batchInferenceJobs
+// cover batch model-invocation jobs.
 aws.bedrock {
   // Foundation models available in Bedrock
   foundationModels() []aws.bedrock.foundationModel
@@ -25789,16 +27575,16 @@ aws.bedrock {
 
 // Amazon Bedrock AgentCore
 //
-// Use the AgentCore namespace to enumerate the agentic-AI infrastructure
-// in the account: gateways that expose tools to agents over the Model
-// Context Protocol (MCP), hosted agent runtimes, short- and long-term
-// memory stores, the browser and code-interpreter sandboxes agents use
-// as built-in tools, and the Identity credential providers and workload
-// identities that govern how agents authenticate to external services.
-// Iterate `gateways()` for MCP servers, `runtimes()` for deployed agents,
-// and `memories()`, `browsers()`, `codeInterpreters()`,
-// `oauth2CredentialProviders()`, `apiKeyCredentialProviders()`, and
-// `workloadIdentities()` for the supporting infrastructure.
+// Agentic-AI infrastructure in the account: gateways that expose tools
+// to agents over the Model Context Protocol (MCP), hosted agent
+// runtimes, short- and long-term memory stores, the browser and
+// code-interpreter sandboxes agents use as built-in tools, and the
+// Identity credential providers and workload identities that govern how
+// agents authenticate to external services. The gateways list holds MCP
+// servers and runtimes holds deployed agents, while memories, browsers,
+// codeInterpreters, oauth2CredentialProviders,
+// apiKeyCredentialProviders, and workloadIdentities hold the supporting
+// infrastructure.
 private aws.bedrock.agentCore {
   // MCP gateways in the account
   gateways() []aws.bedrock.agentCore.gateway
@@ -25824,9 +27610,9 @@ private aws.bedrock.agentCore {
 // Protocol (MCP). Examine the endpoint URL agents connect to, the
 // protocol type, the inbound authorizer that controls which callers may
 // invoke the gateway, the IAM role the gateway assumes, and the
-// customer-managed encryption key. Iterate `targets()` for the individual
-// tool targets (Lambda functions, OpenAPI or Smithy APIs) federated
-// through the gateway.
+// customer-managed encryption key. The targets list holds the
+// individual tool targets (Lambda functions, OpenAPI or Smithy APIs)
+// federated through the gateway.
 private aws.bedrock.agentCore.gateway @defaults("name status protocolType") {
   // ARN of the gateway
   arn() string
@@ -25867,11 +27653,11 @@ private aws.bedrock.agentCore.gateway @defaults("name status protocolType") {
 // Amazon Bedrock AgentCore gateway target
 //
 // A gateway target is a single tool source federated through an MCP
-// gateway — a Lambda function, an OpenAPI or Smithy API, or another
-// backend. Examine the target's backing configuration and the credential
-// provider configurations that determine how the gateway authenticates
-// outbound to the target. The `name` field selects a target within its
-// gateway.
+// gateway: a Lambda function, an OpenAPI or Smithy API, or another
+// backend. The targetConfiguration holds the target's backing
+// configuration and the credentialProviderConfigurations determine how
+// the gateway authenticates outbound to the target. The `name` field
+// selects a target within its gateway.
 private aws.bedrock.agentCore.gatewayTarget @defaults("name status") {
   // Unique identifier of the target
   targetId string
@@ -25903,8 +27689,8 @@ private aws.bedrock.agentCore.gatewayTarget @defaults("name status") {
 // An agent runtime is a deployed agent hosted by AgentCore. Examine the
 // IAM role the runtime assumes, the network mode (public or VPC), the
 // inbound authorizer controlling who may invoke the agent, and the
-// environment variables configured for the agent. Iterate `endpoints()`
-// for the addressable endpoints that serve agent invocations.
+// environment variables configured for the agent. The endpoints list
+// holds the addressable endpoints that serve agent invocations.
 private aws.bedrock.agentCore.runtime @defaults("name version status") {
   // Unique identifier of the agent runtime
   id string
@@ -26163,7 +27949,7 @@ private aws.bedrock.customModel @defaults("modelArn modelName") {
   baseModel() aws.bedrock.foundationModel
   // ARN of the base model used for customization
   //
-  // Deprecated in favor of `baseModel()`.
+  // Deprecated in favor of baseModel.
   baseModelArn @maturity("deprecated") string
   // Customization type: FINE_TUNING or CONTINUED_PRE_TRAINING
   customizationType string
@@ -26192,12 +27978,25 @@ private aws.bedrock.guardrail @defaults("id name status") {
   // KMS key used for encryption
   kmsKey() aws.kms.key
   // Content filtering policy configuration
+  //
+  // Keys: `Filters` (each configured content-filter type with its input
+  // and output filter strengths) and `Tier` (the content-filter tier).
   contentPolicy() dict
   // Sensitive information policy (PII detection)
+  //
+  // Keys: `PiiEntities` (the PII entity types the guardrail detects and
+  // the action taken on each) and `Regexes` (custom regular-expression
+  // patterns and their action).
   sensitiveInformationPolicy() dict
   // Topic policy configuration (denied topics)
+  //
+  // Keys: `Topics` (each denied topic with its name, definition, and
+  // examples) and `Tier` (the denied-topic tier).
   topicPolicy() dict
   // Word policy configuration (blocked words)
+  //
+  // Keys: `Words` (custom blocked words) and `ManagedWordLists` (managed
+  // word lists, such as profanity, that the guardrail blocks).
   wordPolicy() dict
 }
 
@@ -26206,8 +28005,15 @@ private aws.bedrock.modelInvocationLoggingConfiguration @defaults("region textDa
   // Region for this logging configuration
   region string
   // CloudWatch logging configuration
+  //
+  // Keys: `LogGroupName`, `RoleArn` (role the log delivery assumes), and
+  // `LargeDataDeliveryS3Config` (S3 overflow location for large
+  // payloads). Null when CloudWatch delivery is not configured.
   cloudWatchConfig dict
   // S3 logging configuration
+  //
+  // Keys: `BucketName` and `KeyPrefix`. Null when S3 delivery is not
+  // configured.
   s3Config dict
   // Whether text data delivery is enabled
   textDataDeliveryEnabled bool
@@ -26233,7 +28039,7 @@ private aws.bedrock.provisionedModelThroughput @defaults("provisionedModelName m
   foundationModel() aws.bedrock.foundationModel
   // ARN of the foundation model
   //
-  // Deprecated in favor of `foundationModel()`.
+  // Deprecated in favor of foundationModel.
   foundationModelArn @maturity("deprecated") string
   // Number of model units provisioned
   modelUnits int
@@ -26251,8 +28057,9 @@ private aws.bedrock.provisionedModelThroughput @defaults("provisionedModelName m
 // groups (Lambda-backed tools) and consult knowledge bases for
 // retrieval-augmented generation. Each row exposes the orchestration
 // foundation model, the long-form instruction prompt, the session
-// idle-timeout, the customer-managed encryption key, and lazy-loaded
-// `actionGroups()` and `knowledgeBases()` lists.
+// idle-timeout, the customer-managed encryption key, and the
+// actionGroups and knowledgeBases attached to the agent's DRAFT
+// version.
 private aws.bedrock.agent @defaults("name status foundationModel") {
   // Unique identifier of the agent
   id string
@@ -26330,8 +28137,8 @@ private aws.bedrock.agent.alias @defaults("name status") {
 // retrieve-and-generate flows. Each row exposes the IAM role used for
 // ingestion and retrieval, the vector-store backing configuration
 // (OpenSearch Serverless, Pinecone, RDS, Redis Enterprise Cloud, or
-// MongoDB Atlas), the embedding-model configuration, and lazy-loaded
-// `dataSources()`.
+// MongoDB Atlas), the embedding-model configuration, and the
+// dataSources connected to the knowledge base.
 private aws.bedrock.knowledgeBase @defaults("name status") {
   // Unique identifier of the knowledge base
   id string
@@ -26803,19 +28610,27 @@ private aws.bedrock.prompt @defaults("name version") {
 
 // AWS Step Functions
 //
-// Use the Step Functions namespace to enumerate state machines in the
-// account. Iterate `stateMachines()` for every state machine across
-// enabled regions — each row surfaces the type (STANDARD or EXPRESS),
-// the Amazon States Language definition, the IAM execution role,
-// logging and X-Ray tracing configuration, and creation time. The
-// related `aws.sfn` namespace exposes the same service with an extra
-// `activities()` accessor.
+// Serverless workflow orchestration in the account. The `stateMachines`
+// collection lists every state machine across enabled regions, exposing
+// the workflow type (STANDARD or EXPRESS), the Amazon States Language
+// definition, the IAM execution role, logging and X-Ray tracing
+// configuration, and creation time. Auditing state machines surfaces
+// over-privileged execution roles and workflows running without logging
+// or tracing. The related `aws.sfn` namespace covers the same service
+// with an additional `activities` collection.
 aws.stepfunctions @defaults("stateMachines") {
   // List of state machines across all regions
   stateMachines() []aws.stepfunctions.stateMachine
 }
 
 // AWS Step Functions state machine
+//
+// Single Step Functions workflow, identified by its `arn`. Covers the
+// workflow type (STANDARD or EXPRESS), the Amazon States Language
+// definition, the IAM execution role assumed at runtime, and the
+// logging and tracing configuration. Reviewing a state machine reveals
+// over-broad execution-role permissions and workflows running without
+// logging or X-Ray tracing enabled.
 private aws.stepfunctions.stateMachine @defaults("arn name") {
   // ARN of the state machine
   arn string
@@ -26848,22 +28663,26 @@ private aws.stepfunctions.stateMachine.loggingConfiguration @defaults("level") {
   // Whether execution data is included in log events
   includeExecutionData bool
   // CloudWatch Logs log group destinations
+  //
+  // One entry per configured log target. Each entry holds a
+  // `CloudWatchLogsLogGroup` object whose `LogGroupArn` names the
+  // CloudWatch Logs log group that receives execution log events.
   destinations []dict
 }
 
 // AWS Firewall Manager
 //
-// Examine the organization-wide Firewall Manager configuration that
-// centrally enforces WAF, Shield Advanced, security group, Network
-// Firewall, DNS Firewall, and third-party firewall policies across member
-// accounts. Read `defaultAdminAccount` and `adminAccounts()` to see who
-// administers Firewall Manager, `policies()` for the policies in effect
-// (including per-account compliance status), `notificationChannel` for the
-// SNS topic that receives activity events, and `appsLists()`,
-// `protocolsLists()`, and `resourceSets()` for the reusable building
+// Organization-wide Firewall Manager configuration that centrally
+// enforces WAF, Shield Advanced, security group, Network Firewall, DNS
+// Firewall, and third-party firewall policies across member accounts.
+// The `defaultAdminAccount` and `adminAccounts` fields show who
+// administers Firewall Manager, `policies` returns the policies in effect
+// (including per-account compliance status), `notificationChannel`
+// resolves the SNS topic that receives activity events, and `appsLists`,
+// `protocolsLists`, and `resourceSets` expose the reusable building
 // blocks referenced by policies. Firewall Manager administration runs
-// against `us-east-1`; this namespace surfaces data only when the scanned
-// account is the organization's Firewall Manager administrator.
+// against `us-east-1`, and this namespace surfaces data only when the
+// scanned account is the organization's Firewall Manager administrator.
 aws.fms @defaults("defaultAdminAccount") {
   // ID of the account configured as the Firewall Manager default administrator
   defaultAdminAccount() string
@@ -26927,7 +28746,13 @@ private aws.fms.policy @defaults("name resourceType securityServiceType") {
   //
   // One of: WAF, WAFV2, SHIELD_ADVANCED, SECURITY_GROUPS_COMMON, SECURITY_GROUPS_CONTENT_AUDIT, SECURITY_GROUPS_USAGE_AUDIT, NETWORK_FIREWALL, DNS_FIREWALL, IMPORT_NETWORK_FIREWALL, NETWORK_ACL_COMMON, or THIRD_PARTY_FIREWALL.
   securityServiceType string
-  // Service-specific managed configuration (parsed from the SDK's ManagedServiceData JSON string)
+  // Service-specific managed configuration
+  //
+  // Contents depend on `securityServiceType`: a WAF or WAFV2 policy
+  // carries its managed rule groups and default action, a NETWORK_FIREWALL
+  // policy carries the firewall policy and endpoint placement, a
+  // SHIELD_ADVANCED policy carries the automatic response configuration,
+  // and so on. Empty when the policy defines no managed configuration.
   securityServiceManagedServiceData dict
   // Accounts and organizational units the policy applies to, keyed by ACCOUNT or ORG_UNIT
   includeMap map[string][]string
@@ -26998,16 +28823,17 @@ private aws.fms.resourceSet @defaults("name id status") {
 
 // AWS DataSync
 //
-// Use the DataSync namespace to enumerate the managed data-transfer
-// service in the account. Iterate `tasks()` for each transfer job (its
-// status, task mode, source and destination locations, CloudWatch
-// logging destination, data-integrity verification mode, and schedule),
-// `locations()` for the storage endpoints that tasks read from and write
-// to (each keyed by its ARN, with the URI that identifies the backing S3
-// bucket, file system, or on-premises host, such as
-// `s3://my-bucket/prefix`), and `agents()` for the on-premises agents
-// that connect source storage to the service, including whether an agent
-// reaches the service over the public internet or PrivateLink.
+// Managed data-transfer service that moves file data between on-premises
+// storage, AWS storage services, and other clouds. The `tasks` list
+// describes each transfer job (its status, task mode, source and
+// destination locations, CloudWatch logging destination, data-integrity
+// verification mode, and schedule), `locations` covers the storage
+// endpoints that tasks read from and write to (each keyed by its ARN,
+// with the URI that identifies the backing S3 bucket, file system, or
+// on-premises host, such as s3://my-bucket/prefix), and `agents` covers
+// the on-premises agents that connect source storage to the service,
+// including whether an agent reaches the service over the public
+// internet or PrivateLink.
 aws.datasync @defaults("tasks") {
   // List of DataSync tasks
   tasks() []aws.datasync.task
@@ -27081,16 +28907,14 @@ private aws.datasync.agent @defaults("arn name status") {
 
 // AWS AppFlow
 //
-// Use the AppFlow namespace to enumerate the managed integration service
-// that transfers data between software-as-a-service applications and AWS
-// services. Iterate `flows()` for each configured transfer (its status,
-// source and destination connector types, trigger type, the principal
-// that created it, and the customer-managed KMS key that encrypts its
-// data), and `connectorProfiles()` for the stored connection
-// configurations that flows authenticate through, each keyed by ARN with
-// its connector type, the connection mode that determines whether traffic
-// leaves over the public internet or PrivateLink, and the Secrets Manager
-// secret that holds its credentials.
+// Managed integration service that transfers data between
+// software-as-a-service applications (Salesforce, Marketo, Zendesk, and
+// others) and AWS services. The `flows` collection holds each configured
+// transfer, and the `connectorProfiles` collection holds the stored
+// connection configurations that flows authenticate through. Together
+// they let you audit which external systems are wired to your account,
+// how those connections are encrypted, and whether their traffic leaves
+// over the public internet or stays on PrivateLink.
 aws.appflow @defaults("flows") {
   // List of AppFlow flows
   flows() []aws.appflow.flow
@@ -27099,6 +28923,14 @@ aws.appflow @defaults("flows") {
 }
 
 // AWS AppFlow flow
+//
+// Single data transfer between a software-as-a-service application and an
+// AWS service. The `flowStatus` field reports whether the flow is active
+// or has errored, `sourceConnectorType` and `destinationConnectorType`
+// identify the systems being connected, and `triggerType` distinguishes
+// on-demand, scheduled, and event-driven runs. The `kmsKey` field
+// resolves the customer-managed key that encrypts the transferred data,
+// which is null when an AWS-owned key is used.
 private aws.appflow.flow @defaults("arn name flowStatus") {
   // ARN of the flow
   arn string
@@ -27129,6 +28961,13 @@ private aws.appflow.flow @defaults("arn name flowStatus") {
 }
 
 // AWS AppFlow connector profile
+//
+// Stored connection configuration that flows authenticate through when
+// reaching a source or destination system. The `connectionMode` field
+// reports whether the profile connects over the public internet or
+// PrivateLink (Public or Private), `connectorType` identifies the target
+// system, and `credentials` resolves the Secrets Manager secret that
+// holds the profile's authentication material.
 private aws.appflow.connectorProfile @defaults("arn name connectorType connectionMode") {
   // ARN of the connector profile
   arn string


### PR DESCRIPTION
## What

A broad documentation pass over `aws.lr`, extending the pattern established for **S3** (#9146) to the rest of the provider. The doc-comments here are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content that teaches what each resource is, what's queryable, and why the data matters for auditing.

**~97 services, 719 edits.**

## Changes

- **Descriptions on user-queryable resources that were title-only** — lead with the noun and convey audit/security significance (e.g. what makes a resource worth querying), *without* re-listing the field table the website already renders beneath.
- **Documented dict/map key shapes** — raw `dict`/`map` fields now describe their actual keys, verified against the Go implementations and SDK structs, instead of shipping an opaque type to the docs page.
- **Security-field derivations and enum values** — explain how computed booleans are derived and enumerate string enum values.
- **Style-rule cleanup at scale** — removed verb-led descriptions (`Examine`/`Use`/`Iterate`), em dashes, call-form `foo()` in prose, mechanism leaks (`lazy-loaded`, leaked SDK/API names), and parent-navigation hints; fixed a handful of title/type mismatches and deprecation-phrasing issues.

## The pattern (same as #9146)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation. A field is named in prose only when it adds semantics the table can't.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn (verified — an intermediate agent slip that dropped three `ssm.patchBaseline` fields was caught via the generated-code diff and restored).
- Automated checks on the added lines: 0 em dashes, no mechanism-leak phrases, no call-form accessors in prose.
- Every doc-comment is structurally valid (the parser enforces the title/blank-separator/150-char rules; regeneration succeeded).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.

Part of a provider-wide sweep; Azure, GCP, OCI, DigitalOcean, STACKIT, and Hetzner follow in their own PRs.
