### PR TITLE
📄 azure: enrich resource and field documentation across services

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -6,32 +6,26 @@ option go_package = "go.mondoo.com/mql/v13/providers/azure/resources"
 
 // Microsoft Azure
 //
-// Use the Azure root namespace as the entry point for the Azure
-// provider. The active subscription is exposed as `azure.subscription`,
-// and every Azure service-specific accessor (Compute, Storage,
-// Network, Key Vault, Cosmos DB, Monitor, Defender for Cloud, AKS,
-// and so on) is reached through that subscription.
+// Root namespace and entry point for the Azure provider. The active
+// subscription is exposed as `azure.subscription`, and every Azure
+// service-specific accessor (Compute, Storage, Network, Key Vault,
+// Cosmos DB, Monitor, Defender for Cloud, AKS, and so on) is reached
+// through that subscription.
 azure {
 }
 
 // Azure subscription
 //
-// Examine an Azure subscription — the billing, identity, and policy
-// container that owns every Azure resource accessible to the provider.
-// Surfaces the subscription ID, tenant ID, display name, state,
-// authorization source, applied tags, the managing tenants, and the
-// `subscriptionsPolicies` block. Iterate `resourceGroups()` for the
-// resource-group containers and `resources()` for every resource in
-// the subscription. Service-specific entry points hang off the
-// subscription as accessor methods — `compute()`, `network()`,
-// `storage()`, `web()`, `sql()`, `mySql()`, `postgreSql()`,
-// `cosmosDb()`, `keyVault()`, `iam()` (Authorization), `monitor()`,
-// `cloudDefender()`, `aks()`, `advisor()`, `policy`, `iot()`,
-// `cache()`, `dataFactory()`, `synapse()`, `containerRegistry()`,
-// `recoveryServices()`, `functions()`, `serviceBus()`, `eventHub()`,
-// `dns()`, `frontDoor()`, `containerApp()`, `containerInstance()`,
-// `logic()`, `batch()`, and `databricks()` — letting you traverse from
-// a subscription into every modeled Azure service.
+// Billing, identity, and policy container that owns every Azure
+// resource accessible to the provider, and the top of the resource
+// hierarchy for auditing an Azure tenant. Exposes the subscription
+// state, authorization source, applied tags, managing tenants, and the
+// placement, quota, and spending-limit settings in subscriptionsPolicies.
+// Resource groups, individual resources, and deployments are reachable
+// from here, along with per-service accessors for compute, network,
+// storage, identity, Key Vault, Defender for Cloud, and every other
+// modeled Azure service, letting you traverse from a subscription into
+// any resource it contains.
 azure.subscription @defaults ("name") {
   // Full resource identifier of the subscription
   id string
@@ -46,10 +40,17 @@ azure.subscription @defaults ("name") {
   // Subscription tags
   tags map[string]string
   // Subscription state
+  //
+  // One of Enabled, Warned, PastDue, Disabled, or Deleted.
   state string
   // Subscription authorization source
   authorizationSource string
-  // Subscription policies
+  // Subscription placement and spending policies
+  //
+  // Policy settings scoped to the subscription. Keys: `locationPlacementId`
+  // (the group of regions the subscription may deploy into), `quotaId`
+  // (the offer or quota tier), and `spendingLimit` (one of On, Off, or
+  // CurrentPeriodOff).
   subscriptionsPolicies dict
   // All resources in a subscription
   resources() []azure.subscription.resource
@@ -125,7 +126,8 @@ azure.subscription @defaults ("name") {
   apiManagement() azure.subscription.apiManagementService
   // Microsoft Purview resources in the subscription
   //
-  // The data-governance and sensitive-data-discovery service (the Azure analog of AWS Macie / GCP Cloud DLP).
+  // Data-governance accounts that classify, map, and monitor sensitive
+  // data across the subscription.
   purview() azure.subscription.purviewService
   // Azure AI Search resources in the subscription
   search() azure.subscription.searchService
@@ -168,6 +170,16 @@ private azure.subscription.webService.function @defaults("name type") {
 }
 
 // Azure resource group
+//
+// Logical container that holds related Azure resources and defines a
+// shared location, tag set, and lifecycle boundary for them. Resource
+// groups anchor governance and access control: tags drive cost and
+// ownership policy, location constrains where child resources may live,
+// and provisioningState reports the outcome of the last management
+// operation. A non-empty managedBy marks a group created and owned by
+// another service (for example a managed application or cluster), which
+// should not be modified directly. The deployments field lists the
+// Azure Resource Manager deployments run into the group.
 private azure.subscription.resourcegroup @defaults("name location") {
   // Resource group ID
   id string
@@ -188,6 +200,14 @@ private azure.subscription.resourcegroup @defaults("name location") {
 }
 
 // Azure resource
+//
+// Generic Azure Resource Manager inventory record for a single resource in a
+// subscription, covering resources of every type (compute, storage, networking,
+// and so on) in one uniform shape. Useful for cross-cutting audits: locating
+// resources by tags, location, or type, checking provisioningState, or reviewing
+// the managed identity attached through identity. Deep, type-specific properties
+// are not populated on this record; query the dedicated resource for a given type
+// when you need those.
 private azure.subscription.resource @defaults("id name location") {
   // Resource ID
   id string
@@ -204,10 +224,21 @@ private azure.subscription.resource @defaults("id name location") {
   // ID of the resource that manages this resource
   managedBy string
   // Resource SKU
+  //
+  // Billing and capacity tier of the resource, with keys name, tier, size,
+  // family, model, and capacity.
   sku dict
   // Resource plan
+  //
+  // Azure Marketplace purchase plan for resources deployed from a Marketplace
+  // offer, with keys name (plan ID), product (offer ID), publisher,
+  // promotionCode, and version.
   plan dict
   // Resource identity
+  //
+  // Managed identity assigned to the resource, with keys type, principalId,
+  // tenantId, and userAssignedIdentities. The type is one of None,
+  // SystemAssigned, UserAssigned, or "SystemAssigned, UserAssigned".
   identity dict
   // Resource provisioning state
   provisioningState string
@@ -221,11 +252,11 @@ private azure.subscription.resource @defaults("id name location") {
 
 // Azure Resource Manager system metadata
 //
-// Examine the creation and last-modification provenance that Azure Resource
-// Manager records for a resource: the identity that created it, the identity
-// that last modified it, the type of each identity, and the corresponding
-// timestamps. Use this to answer "who created this resource and when" across
-// the resources that report system metadata.
+// Creation and last-modification provenance that Azure Resource Manager
+// records for a resource: the identity that created it, the identity that
+// last modified it, the type of each identity, and the corresponding
+// timestamps. Answers "who created this resource and when" across the
+// resources that report system metadata.
 private azure.subscription.systemData @defaults("createdBy createdAt lastModifiedBy lastModifiedAt") {
   // Identity that created the resource (object ID, user principal name, or application ID)
   createdBy string
@@ -247,12 +278,12 @@ private azure.subscription.systemData @defaults("createdBy createdAt lastModifie
 
 // Azure Resource Manager deployment
 //
-// Examine an Azure Resource Manager template deployment, the unit that
-// provisions or updates a set of resources from a template. The deployment
-// reports its provisioning state and completion timestamp, the deployment
-// mode, the template and parameters used, the resources it produced through
+// Azure Resource Manager template deployment, the unit that provisions or
+// updates a set of resources from a template. The deployment reports its
+// provisioning state and completion timestamp, the deployment mode, the
+// template and parameters used, the resources it produced through
 // `outputResources`, and the `correlationId` that links it to the activity
-// log events it generated. Use this to trace which deployment created or
+// log events it generated. Query this to trace which deployment created or
 // last changed a group of resources.
 private azure.subscription.deployment @defaults("name provisioningState timestamp") {
   // Deployment ID
@@ -286,14 +317,29 @@ private azure.subscription.deployment @defaults("name provisioningState timestam
   // URI of the linked parameters file, when the deployment used one
   parametersLink string
   // Parameters supplied to the deployment
+  //
+  // Keys are parameter names. Each value is an object holding either a
+  // `value` with the supplied value, or a `reference` pointing at a Key
+  // Vault secret (with `keyVault` and `secretName`) for secure parameters.
   parameters dict
   // Output values produced by the deployment
+  //
+  // Keys are output names as declared in the template's outputs section.
+  // Each value is an object with a `type` and the resolved `value`.
   outputs dict
   // Resource providers used by the deployment
+  //
+  // Each entry describes a registered Azure resource provider, with `id`,
+  // `namespace`, `registrationState`, `registrationPolicy`, and a
+  // `resourceTypes` list of the provider's resource types.
   providers []dict
   // IDs of the resources provisioned or updated by the deployment
   outputResources []string
   // Error details when the deployment failed
+  //
+  // Null on a successful deployment. When present, an object with `code`,
+  // `message`, `target`, a nested `details` list of the same shape, and
+  // `additionalInfo` entries carrying `type` and `info`.
   error dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
@@ -329,15 +375,14 @@ private azure.subscription.computeService {
 
 // Azure virtual machine
 //
-// Examine an Azure Compute Engine VM and the security-relevant
-// configuration around it. Surfaces the VM size, OS profile, storage
-// profile (OS and data disks), network profile and attached
-// `interfaces()`, identity assignments, applied tags, the
-// availability/zone/proximity-placement-group placement, the boot
-// diagnostics and security profile (TrustedLaunch / ConfidentialVM,
-// SecureBoot, vTPM), the `extensions()` installed on the VM, OS
-// patching state, and the deployed extensions for ASC, Defender, and
-// guest configuration.
+// Virtual machine and the security-relevant configuration around it:
+// the VM size, OS profile, storage profile (OS and data disks), network
+// profile and attached network interfaces, identity assignments, applied
+// tags, the availability/zone/proximity-placement-group placement, the
+// boot diagnostics and security profile (TrustedLaunch / ConfidentialVM,
+// SecureBoot, vTPM), the extensions installed on the VM, OS patching
+// state, and the deployed extensions for ASC, Defender, and guest
+// configuration.
 azure.subscription.computeService.vm @defaults("name location properties.hardwareProfile.vmSize properties.storageProfile.osDisk.osType") {
   // VM ID
   id string
@@ -365,7 +410,7 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
   bootDiagnosticsStorageUri string
   // Base64-encoded user data passed to the VM at provisioning time (cloud-init equivalent)
   //
-  // Empty when user data is not set. Treat as sensitive — secrets and bootstrap credentials are sometimes embedded here.
+  // Empty when user data is not set. Treat as sensitive: secrets and bootstrap credentials are sometimes embedded here.
   userData string
   // VM extension
   extensions() []dict
@@ -482,8 +527,8 @@ azure.subscription.computeService.vm @defaults("name location properties.hardwar
 
 // Azure VM image reference
 //
-// Examine the image a VM was deployed from. For marketplace images
-// the `publisher`, `offer`, `sku`, and `version` are populated. For
+// Image a VM was deployed from. For marketplace images the `publisher`,
+// `offer`, `sku`, and `version` are populated. For
 // shared / community / direct gallery images, `imageId`,
 // `sharedGalleryImageId`, or `communityGalleryImageId` carries the
 // gallery resource path. `exactVersion` resolves the concrete version
@@ -511,8 +556,8 @@ private azure.subscription.computeService.vm.imageReference @defaults("publisher
 
 // Azure Arc-enabled server
 //
-// Examine an Azure Arc-enabled server (Microsoft.HybridCompute/machines)
-// — an on-premises or other-cloud machine projected into Azure for
+// Azure Arc-enabled server (Microsoft.HybridCompute/machines), an
+// on-premises or other-cloud machine projected into Azure for
 // management. Surfaces the agent status (Connected, Disconnected,
 // Expired), agent version, OS name and version, last status check,
 // machine identity, attached extensions, private link scope, and the
@@ -627,7 +672,7 @@ private azure.subscription.computeService.hybridMachine.extension @defaults("nam
 
 // Azure managed disk
 //
-// Examine an Azure managed disk attached to a VM, scale set, or
+// Managed disk attached to a VM, scale set, or
 // available for attachment. Surfaces the disk SKU and tier, OS type,
 // disk size and IOPS, the disk state (Unattached, Attached, Reserved,
 // ActiveSAS, ReadyToUpload, ActiveUpload), encryption settings
@@ -718,7 +763,7 @@ azure.subscription.computeService.disk @defaults("name location properties.osTyp
 
 // Azure disk encryption set
 //
-// Examine a customer-managed key configuration that managed disks and
+// Customer-managed key configuration that managed disks and
 // snapshots reference for envelope encryption. Surfaces the
 // `encryptionType` (EncryptionAtRestWithCustomerKey,
 // EncryptionAtRestWithPlatformAndCustomerKeys, or
@@ -757,7 +802,7 @@ azure.subscription.computeService.diskEncryptionSet @defaults("name location enc
 
 // Azure disk access resource
 //
-// Examine a private-endpoint configuration that managed disks and
+// Private-endpoint configuration that managed disks and
 // snapshots can be exported and imported through. Surfaces the
 // `provisioningState`, the `extendedLocation` if the resource lives in
 // an Azure Edge Zone, and the time the access was created and last
@@ -787,7 +832,7 @@ azure.subscription.computeService.diskAccess @defaults("name location") {
 
 // Azure managed disk snapshot
 //
-// Examine a point-in-time snapshot of an Azure managed disk. Surfaces
+// Point-in-time snapshot of an Azure managed disk. Surfaces
 // the snapshot SKU and tier, OS type, allocated and used size, the
 // `diskState`, the source resource the snapshot was created from, the
 // `incremental` flag (incremental vs full), encryption settings
@@ -862,14 +907,14 @@ azure.subscription.computeService.snapshot @defaults("name location diskSizeByte
 
 // Azure Virtual Machine Scale Set
 //
-// Examine a Virtual Machine Scale Set — the abstraction Azure uses to
+// Virtual Machine Scale Set, the abstraction Azure uses to
 // deploy and manage a group of identical VMs. Surfaces the
 // `orchestrationMode` (Uniform or Flexible), the SKU and capacity, the
 // network and OS profiles applied to instances, upgrade policy
 // (Manual, Automatic, Rolling), automatic-OS-upgrade and rolling
 // upgrade policy, the spot priority and eviction settings, identity
 // assignments, the VM-extension profile, the platform-fault-domain
-// count, and the per-instance `instances()` currently provisioned.
+// count, and the per-instance `instances` currently provisioned.
 azure.subscription.computeService.vmScaleSet @defaults("name location orchestrationMode sku") {
   // VMSS ARM resource ID
   id string
@@ -956,7 +1001,7 @@ azure.subscription.computeService.vmScaleSet @defaults("name location orchestrat
 
 // Azure scale set VM instance
 //
-// Examine a single VM instance inside a Virtual Machine Scale Set.
+// Single VM instance inside a Virtual Machine Scale Set.
 // Surfaces the per-instance ARM resource ID, the scale-set
 // `instanceId`, applied availability zones, the
 // `latestModelApplied` flag (whether the instance is on the current
@@ -997,11 +1042,11 @@ azure.subscription.computeService.vmScaleSet.instance @defaults("name instanceId
 
 // Azure Dedicated Host Group
 //
-// Examine a single-tenant placement scope for Azure Dedicated Hosts.
+// Single-tenant placement scope for Azure Dedicated Hosts.
 // Surfaces the platform-fault-domain count, the supported
 // availability zones, the `supportAutomaticPlacement` flag, and any
-// ultraSSD support exposed by the group. Use the `hosts()` collection
-// for the individual physical servers reserved through this group.
+// ultraSSD support exposed by the group. The `hosts` collection lists
+// the individual physical servers reserved through this group.
 azure.subscription.computeService.dedicatedHostGroup @defaults("name location platformFaultDomainCount") {
   // Dedicated host group ARM resource ID
   id string
@@ -1033,7 +1078,7 @@ azure.subscription.computeService.dedicatedHostGroup @defaults("name location pl
 
 // Azure Dedicated Host
 //
-// Examine a physical server reserved for a single tenant inside an
+// Physical server reserved for a single tenant inside an
 // Azure Dedicated Host Group. Surfaces the SKU, fault domain, license
 // type, host's auto-replace-on-failure setting, the VMs currently
 // placed on the host, the `instanceView` reporting allocation status
@@ -1075,7 +1120,7 @@ azure.subscription.computeService.dedicatedHost @defaults("name sku.name provisi
 
 // Azure Proximity Placement Group
 //
-// Examine a co-location scope for Azure compute resources. Surfaces
+// Co-location scope for Azure compute resources. Surfaces
 // the placement-group type (Standard or Ultra), the supported
 // availability zones, the colocation status, and the lists of VMs,
 // virtual-machine scale sets, and availability sets currently bound to
@@ -1091,7 +1136,7 @@ azure.subscription.computeService.proximityPlacementGroup @defaults("name locati
   tags map[string]string
   // Proximity placement group resource type
   type string
-  // Availability zones (Ultra type only — Standard does not support zones)
+  // Availability zones (Ultra type only, Standard does not support zones)
   zones []string
   // Unmodeled resource properties returned by the Azure API
   properties dict
@@ -1111,13 +1156,12 @@ azure.subscription.computeService.proximityPlacementGroup @defaults("name locati
 
 // Azure managed image
 //
-// Examine a custom VM image stored as a single Azure resource.
+// Custom VM image stored as a single Azure resource.
 // Surfaces the storage profile (OS disk and data disks), the
 // `hyperVGeneration` (V1 or V2), the source virtual machine the image
 // was generalized from, and the provisioning state. Compute Galleries
-// (`gallery()`) are the preferred mechanism for versioned image
-// distribution; managed images remain useful for single-resource
-// captures.
+// are the preferred mechanism for versioned image distribution;
+// managed images remain useful for single-resource captures.
 azure.subscription.computeService.image @defaults("name location hyperVGeneration provisioningState") {
   // Image ARM resource ID
   id string
@@ -1147,11 +1191,11 @@ azure.subscription.computeService.image @defaults("name location hyperVGeneratio
 
 // Azure Compute Gallery
 //
-// Examine a Compute Gallery (formerly Shared Image Gallery) — the
+// Compute Gallery (formerly Shared Image Gallery), the
 // versioned image-distribution scope inside a subscription. Surfaces
 // the gallery description, identifier, the
 // `sharingProfile` (private, community, or groups), the soft-delete
-// state, and the `images()` defined in the gallery so audits can
+// state, and the image definitions in the gallery so audits can
 // traverse from gallery to image definition to image version.
 azure.subscription.computeService.gallery @defaults("name location description") {
   // Gallery ARM resource ID
@@ -1172,7 +1216,7 @@ azure.subscription.computeService.gallery @defaults("name location description")
   uniqueName string
   // Provisioning state
   provisioningState string
-  // Sharing profile — Private, Groups, or Community
+  // Sharing profile (Private, Groups, or Community)
   sharingProfile dict
   // Soft-delete policy
   softDeletePolicy dict
@@ -1186,11 +1230,11 @@ azure.subscription.computeService.gallery @defaults("name location description")
 
 // Azure Compute Gallery image definition
 //
-// Examine a versioned VM image definition inside a Compute Gallery.
+// Versioned VM image definition inside a Compute Gallery.
 // Surfaces the OS type (Linux or Windows), OS state (Generalized vs
 // Specialized), `hyperVGeneration` (V1 or V2), architecture, supported
 // VM features, the publisher/offer/SKU identifiers, end-of-life date,
-// recommended VM configuration, and the `versions()` published under
+// recommended VM configuration, and the versions published under
 // the definition.
 azure.subscription.computeService.gallery.image @defaults("name osType osState hyperVGeneration") {
   // Image definition ARM resource ID
@@ -1215,7 +1259,7 @@ azure.subscription.computeService.gallery.image @defaults("name osType osState h
   hyperVGeneration string
   // Architecture (x64, Arm64)
   architecture string
-  // Image identifier — publisher, offer, sku
+  // Image identifier (publisher, offer, sku)
   identifier dict
   // Recommended hardware (vCPUs, memory)
   recommended dict
@@ -1243,7 +1287,7 @@ azure.subscription.computeService.gallery.image @defaults("name osType osState h
 
 // Azure Compute Gallery image version
 //
-// Examine a concrete versioned image inside a Compute Gallery image
+// Concrete versioned image inside a Compute Gallery image
 // definition. Surfaces the storage profile (OS disk image, data disk
 // images, and the source the version was created from), the
 // publishing-profile target regions and replication options, the
@@ -1288,13 +1332,12 @@ private azure.subscription.batchService {
 
 // Azure Batch account
 //
-// Examine an Azure Batch account — the resource-pool and job-scheduling
-// container for HPC and parallel workloads. Surfaces the account's
-// public network access state, the linked auto-storage account, the
-// poolAllocationMode (BatchService or UserSubscription), key vault
-// reference, encryption settings, network profile, the configured
-// node-communication mode, and the batch `pools()` deployed in the
-// account.
+// Resource-pool and job-scheduling container for high-performance and
+// parallel compute workloads. Audit an account for its public network
+// access state, allowed authentication modes, the pool allocation mode
+// (BatchService or UserSubscription), customer-managed-key encryption,
+// linked auto-storage account, and the compute pools deployed under it.
+// The account is selected by its ARM resource id.
 azure.subscription.batchService.account @defaults("id name location") {
   // Batch account ID
   id string
@@ -1314,7 +1357,12 @@ azure.subscription.batchService.account @defaults("id name location") {
   principalId string
   // User-assigned managed identities attached to the Batch account
   userAssignedIdentities() []azure.subscription.managedIdentity
-  // Batch account properties
+  // Raw account property bag
+  //
+  // Full ARM property object for the account. Most values are also
+  // exposed as flattened fields (poolAllocationMode, publicNetworkAccess,
+  // the core-quota fields, and the encryption and auto-storage settings);
+  // prefer those for audits.
   properties dict
   // Batch account endpoint
   accountEndpoint string
@@ -1332,7 +1380,10 @@ azure.subscription.batchService.account @defaults("id name location") {
   dedicatedCoreQuota int
   // Whether dedicated core quota per VM family is enforced
   dedicatedCoreQuotaPerVmFamilyEnforced bool
-  // Batch account dedicated core quota per VM family
+  // Dedicated core quota per VM family
+  //
+  // One entry per virtual machine family. Keys: `name` (the VM family)
+  // and `coreQuota` (the dedicated core limit granted to that family).
   dedicatedCoreQuotaPerVmFamily []dict
   // Batch account low priority core quota
   lowPriorityCoreQuota int
@@ -1358,9 +1409,18 @@ azure.subscription.batchService.account @defaults("id name location") {
   keyVault() azure.subscription.keyVaultService.vault
   // Key Vault key used to encrypt Batch account data with a customer-managed key
   encryptionKey() azure.subscription.keyVaultService.key
-  // Batch account network profile
+  // Network access profile
+  //
+  // Endpoint access rules for the account. Keys: `accountAccess` (data
+  // plane API) and `nodeManagementAccess` (compute-node management),
+  // each with `defaultAction` (Allow or Deny) and `ipRules` (a list of
+  // {action, value} allowed source ranges).
   networkProfile dict
-  // Batch account private endpoint connections
+  // Private endpoint connections
+  //
+  // One entry per private endpoint connection. Keys: `id`, `name`,
+  // `type`, `etag`, and `properties` (with `groupIds`, `privateEndpoint`,
+  // `privateLinkServiceConnectionState`, and `provisioningState`).
   privateEndpointConnections []dict
   // Batch account pools
   pools() []azure.subscription.batchService.account.pool
@@ -1374,12 +1434,12 @@ azure.subscription.batchService.account @defaults("id name location") {
 
 // Azure Batch pool
 //
-// Examine a compute pool inside an Azure Batch account. Surfaces the
-// VM size and image, the deployment configuration (cloud-services or
-// VM-based), scale settings (fixed or auto), per-node start tasks,
-// network configuration, allocation state, target dedicated and
-// low-priority node counts, and the certificates and applications
-// installed on pool nodes.
+// Compute pool inside an Azure Batch account, holding the VM size and
+// image, deployment configuration, scale settings (fixed or auto),
+// per-node start tasks, network configuration, and the disk-encryption
+// and confidential-computing security posture of its nodes. Audit a
+// pool for whether customer-managed disk encryption is enabled, its
+// host endpoint protection mode, and its provisioning state.
 azure.subscription.batchService.account.pool @defaults("id name") {
   // Pool resource ID
   id string
@@ -1389,7 +1449,10 @@ azure.subscription.batchService.account.pool @defaults("id name") {
   type string
   // Pool etag
   etag string
-  // Pool identity configuration
+  // Managed identity configuration
+  //
+  // Keys: `type` (None or UserAssigned) and `userAssignedIdentities`
+  // (a map of identity resource id to {clientId, principalId}).
   identity dict
   // Pool configuration settings including scale, network, and task scheduling options
   properties dict
@@ -1397,9 +1460,16 @@ azure.subscription.batchService.account.pool @defaults("id name") {
   provisioningState string
   // Pool virtual machine size
   vmSize string
-  // Pool deployment configuration
+  // Node deployment configuration
+  //
+  // Key: `virtualMachineConfiguration`, the VM-based node setup that is
+  // also exposed directly as virtualMachineConfiguration.
   deploymentConfiguration dict
-  // Pool virtual machine configuration
+  // Virtual machine node configuration
+  //
+  // VM-based node setup. Keys include `imageReference` (publisher,
+  // offer, sku, version), `nodeAgentSkuId`, `diskEncryptionConfiguration`,
+  // `securityProfile`, `osDisk`, and `dataDisks`.
   virtualMachineConfiguration dict
   // Whether customer-managed keys are used for disk encryption
   diskCustomerManagedKeyEnabled bool
@@ -1427,13 +1497,13 @@ private azure.subscription.databricksService {
 
 // Azure Databricks workspace
 //
-// Examine an Azure Databricks workspace — the analytics platform's
-// per-environment control plane. Surfaces the workspace SKU
-// (Standard, Premium, Trial), public network access state, the
-// managed resource group ID, the linked virtual network when VNet
-// injection is configured, the encryption settings (managed services
-// key and managed disks key), authorization settings, and the
-// `requiredNsgRules` posture used by the data plane.
+// Analytics platform workspace and its per-environment control plane.
+// A workspace is the security boundary for Databricks compute and data,
+// so query it to audit network isolation (public network access, Secure
+// Cluster Connectivity, and VNet injection into a custom virtual network),
+// customer-managed key encryption for managed services and managed disks,
+// and the Compliance Security Profile posture. The requiredNsgRules value
+// selects which network security group rules the data plane relies on.
 azure.subscription.databricksService.workspace @defaults("id name location publicNetworkAccess") {
   // Workspace ID
   id string
@@ -1445,9 +1515,18 @@ azure.subscription.databricksService.workspace @defaults("id name location publi
   tags map[string]string
   // Workspace type
   type string
-  // Workspace properties
+  // Raw workspace properties
+  //
+  // Workspace properties object as returned by Azure Resource Manager.
+  // Most values are also surfaced as dedicated fields on this resource
+  // (publicNetworkAccess, requiredNsgRules, the managed-disk and
+  // managed-services encryption settings, and the Compliance Security
+  // Profile fields); prefer those for audits.
   properties dict
-  // Workspace SKU
+  // Workspace pricing SKU
+  //
+  // SKU object with keys `name` (Standard, Premium, or Trial) and `tier`,
+  // identifying the Databricks plan the workspace runs under.
   sku dict
   // Public network access setting ("Enabled" or "Disabled")
   publicNetworkAccess string
@@ -1814,7 +1893,7 @@ azure.subscription.networkService.ipGroup @defaults("id name location") {
 
 // Azure VPN/ExpressRoute gateway
 //
-// Examine a virtual network gateway used for VPN, ExpressRoute, or
+// Virtual network gateway used for VPN, ExpressRoute, or
 // LocalGateway connectivity. Surfaces the gateway type, VPN type
 // (RouteBased or PolicyBased), generation, SKU, IP configuration,
 // BGP settings (ASN, peering address), VPN client configuration
@@ -1874,8 +1953,8 @@ azure.subscription.networkService.virtualNetworkGateway @defaults("id name locat
   connections() []azure.subscription.networkService.virtualNetworkGateway.connection
   // Custom IPsec/IKE policies negotiated for point-to-site VPN clients
   //
-  // Iterate the custom cryptographic policies applied to point-to-site
-  // client connections, each surfacing the IKE Phase 1 and Phase 2
+  // Custom cryptographic policies applied to point-to-site client
+  // connections, each surfacing the key-exchange and data-channel
   // algorithms, Diffie-Hellman groups, and security-association
   // lifetimes. Empty when the gateway has no point-to-site configuration
   // or uses Azure default cryptography.
@@ -1904,7 +1983,7 @@ azure.subscription.networkService.virtualNetworkGateway @defaults("id name locat
 
 // Azure application security group
 //
-// Examine an application security group (ASG) — the logical grouping
+// Application security group (ASG), the logical grouping
 // used inside Network Security Group rules so traffic can be allowed
 // or denied based on application identity rather than IP. Surfaces
 // the resource GUID and the provisioning state of the group.
@@ -1927,7 +2006,7 @@ azure.subscription.networkService.appSecurityGroup @defaults("id name location")
 
 // Azure Firewall
 //
-// Examine an Azure Firewall instance — the L4/L7 stateful service
+// Azure Firewall instance, the L4/L7 stateful service
 // firewall deployed at the network edge. Surfaces the firewall SKU
 // (Standard, Premium, or Basic), threat-intel mode, attached firewall
 // policy, IP configurations and management IP, application/network/NAT
@@ -2053,7 +2132,7 @@ private azure.subscription.networkService.firewall.natRule @defaults("name actio
 
 // Azure Firewall policy
 //
-// Examine a reusable Azure Firewall policy — the rule-set parent that
+// Reusable Azure Firewall policy, the rule-set parent that
 // firewall instances reference. Surfaces the policy SKU, threat-intel
 // mode and allow-list, DNS settings, intrusion detection settings,
 // TLS inspection certificate, the explicit-proxy configuration, the
@@ -2158,7 +2237,7 @@ private azure.subscription.networkService.firewallPolicy.idpsBypassRule @default
 
 // Azure DDoS protection plan
 //
-// Examine a DDoS Network Protection plan that virtual networks bind to
+// DDoS Network Protection plan that virtual networks bind to
 // for enhanced volumetric and protocol DDoS mitigation. Surfaces the
 // plan resource GUID, the public IP addresses currently protected by
 // the plan, and the linked virtual networks subscribing to its
@@ -2186,7 +2265,7 @@ azure.subscription.networkService.ddosProtectionPlan @defaults("name location") 
 
 // Azure service endpoint policy
 //
-// Examine a service-endpoint policy that restricts which Azure service
+// Service-endpoint policy that restricts which Azure service
 // resources can be reached from a subnet using service endpoints.
 // Surfaces the policy's service-endpoint-policy definitions (the
 // allowed Azure resource IDs), the contextual service alias, the
@@ -2302,12 +2381,12 @@ private azure.subscription.networkService.virtualNetworkGateway.connection @defa
 
 // IPsec/IKE policy of a virtual network gateway
 //
-// Examine a single custom IPsec/IKE cryptographic policy applied to a
+// Custom IPsec/IKE cryptographic policy applied to a
 // virtual network gateway. This covers both site-to-site connection
 // policies (from `virtualNetworkGateway.connections.ipsecPolicies`) and
 // point-to-site client policies (from
-// `virtualNetworkGateway.vpnClientIpsecPolicies`). Surfaces the IKE Phase
-// 1 and Phase 2 algorithms, `ikeEncryption` and `ikeIntegrity` for IKE,
+// `virtualNetworkGateway.vpnClientIpsecPolicies`). Surfaces the key-exchange
+// and data-channel algorithms, `ikeEncryption` and `ikeIntegrity` for IKE,
 // `ipsecEncryption` and `ipsecIntegrity` for IPsec, together with the
 // `dhGroup` and `pfsGroup` Diffie-Hellman groups and the
 // security-association lifetime (`saLifeTimeSeconds`) and payload size
@@ -2316,29 +2395,33 @@ private azure.subscription.networkService.virtualNetworkGateway.connection @defa
 private azure.subscription.networkService.virtualNetworkGateway.connection.ipsecPolicy @defaults("ikeEncryption ipsecEncryption dhGroup pfsGroup") {
   // Policy ID (connection ID + positional index; not stable if policy ordering changes server-side)
   id string
-  // IKE encryption algorithm for IKE Phase 1 (one of: "DES", "DES3", "AES128", "AES192", "AES256", "GCMAES128", "GCMAES256")
+  // IKE encryption algorithm for the key-exchange negotiation (one of: "DES", "DES3", "AES128", "AES192", "AES256", "GCMAES128", "GCMAES256")
   ikeEncryption string
-  // IKE integrity algorithm for IKE Phase 1 (one of: "MD5", "SHA1", "SHA256", "SHA384", "GCMAES128", "GCMAES256")
+  // IKE integrity algorithm for the key-exchange negotiation (one of: "MD5", "SHA1", "SHA256", "SHA384", "GCMAES128", "GCMAES256")
   ikeIntegrity string
-  // IPsec encryption algorithm for IKE Phase 2 (one of: "None", "DES", "DES3", "AES128", "AES192", "AES256", "GCMAES128", "GCMAES192", "GCMAES256")
+  // IPsec encryption algorithm for the data channel
+  //
+  // One of: "None", "DES", "DES3", "AES128", "AES192", "AES256", "GCMAES128", "GCMAES192", "GCMAES256".
   ipsecEncryption string
-  // IPsec integrity algorithm for IKE Phase 2 (one of: "MD5", "SHA1", "SHA256", "GCMAES128", "GCMAES192", "GCMAES256")
+  // IPsec integrity algorithm for the data channel (one of: "MD5", "SHA1", "SHA256", "GCMAES128", "GCMAES192", "GCMAES256")
   ipsecIntegrity string
-  // Diffie-Hellman group used in IKE Phase 1 (one of: "None", "DHGroup1", "DHGroup2", "DHGroup14", "DHGroup24", "DHGroup2048", "ECP256", "ECP384")
+  // Diffie-Hellman group used in the key-exchange negotiation
+  //
+  // One of: "None", "DHGroup1", "DHGroup2", "DHGroup14", "DHGroup24", "DHGroup2048", "ECP256", "ECP384".
   dhGroup string
-  // Diffie-Hellman group used for perfect forward secrecy in IKE Phase 2
+  // Diffie-Hellman group used for perfect forward secrecy in the data channel
   //
   // One of: "None", "PFS1", "PFS2", "PFS14", "PFS24", "PFS2048", "PFSMM", "ECP256", "ECP384".
   pfsGroup string
-  // IPsec security association (Phase 2) lifetime, in seconds
+  // IPsec security association lifetime, in seconds
   saLifeTimeSeconds int
-  // IPsec security association (Phase 2) payload size, in kilobytes
+  // IPsec security association payload size, in kilobytes
   saDataSizeKilobytes int
 }
 
 // Azure local network gateway
 //
-// Examine a local network gateway — the Azure resource that represents
+// Local network gateway, the Azure resource that represents
 // an on-premises network endpoint paired with a virtual network gateway
 // to form a site-to-site VPN. Surfaces the on-premises device IP
 // (`gatewayIpAddress`) or `fqdn`, the address prefixes that describe
@@ -2404,7 +2487,7 @@ private azure.subscription.networkService.bgpSettings.ipConfigurationBgpPeeringA
 
 // Azure NAT gateway
 //
-// Examine a NAT gateway that provides outbound SNAT for resources in
+// NAT gateway that provides outbound SNAT for resources in
 // one or more subnets. Surfaces the SKU and zone placement, the
 // configured idle-timeout, the public IP addresses and prefixes
 // allocated for outbound translation, the subnets currently consuming
@@ -2436,7 +2519,7 @@ azure.subscription.networkService.natGateway @defaults("id name location") {
 
 // Azure VNet subnet
 //
-// Examine a subnet inside an Azure Virtual Network. Surfaces the IPv4
+// Subnet inside an Azure Virtual Network. Surfaces the IPv4
 // and IPv6 address prefixes, the attached network security group and
 // route table, NAT gateway, service endpoints and service-endpoint
 // policies, delegations to PaaS services, the
@@ -2489,7 +2572,7 @@ azure.subscription.networkService.subnet @defaults("id name addressPrefix") {
 
 // Azure subnet service endpoint
 //
-// Examine a single service endpoint configured on a subnet. Service
+// Single service endpoint configured on a subnet. Service
 // endpoints route traffic from the subnet to a PaaS service over the
 // Azure backbone instead of the public internet, scoped to the
 // service and optionally to specific locations. Audit queries
@@ -2507,7 +2590,7 @@ private azure.subscription.networkService.subnet.serviceEndpoint @defaults("serv
 
 // Azure subnet service delegation
 //
-// Examine a single service delegation on a subnet. Delegations grant a
+// Single service delegation on a subnet. Delegations grant a
 // PaaS service (for example, Azure Container Instances or App Service
 // VNet integration) permission to inject managed resources directly
 // into the subnet. Audit queries flag unexpected delegations such as a
@@ -2526,7 +2609,7 @@ private azure.subscription.networkService.subnet.delegation @defaults("name serv
 
 // Azure Virtual Network (VNet)
 //
-// Examine an Azure Virtual Network and its connectivity surface.
+// Azure Virtual Network and its connectivity surface.
 // Surfaces the IPv4 and IPv6 address spaces, configured DNS servers,
 // the linked DDoS protection plan, encryption settings, BGP
 // communities, the `enableVmProtection` and `enableDdosProtection`
@@ -2575,7 +2658,7 @@ azure.subscription.networkService.virtualNetwork @defaults("id name location") {
 
 // Azure VNet peering
 //
-// Examine a peering between two Azure Virtual Networks. Surfaces the
+// Peering between two Azure Virtual Networks. Surfaces the
 // peering state (Initiated, Connected, Disconnected), the remote
 // virtual network reference, allow-virtual-network-access /
 // allow-forwarded-traffic / allow-gateway-transit / use-remote-gateways
@@ -2623,7 +2706,7 @@ private azure.subscription.networkService.virtualNetwork.dhcpOptions {
 
 // Azure Load Balancer
 //
-// Examine an Azure Load Balancer and the front-end / back-end
+// Azure Load Balancer and the front-end / back-end
 // configuration that determines how traffic is distributed. Surfaces
 // the SKU (Basic, Standard, Gateway), tier (Regional or Global), the
 // `frontendIPConfigurations`, `backendAddressPools`,
@@ -2783,7 +2866,7 @@ private azure.subscription.networkService.outboundRule @defaults("id name") {
 
 // Azure network interface
 //
-// Examine an Azure network interface (NIC) attached to a VM, scale
+// Azure network interface (NIC) attached to a VM, scale
 // set, or private endpoint. Surfaces the IP configurations (private
 // IP allocation, public IP, subnet binding), MAC address, the
 // associated network security group, accelerated-networking and
@@ -3171,7 +3254,7 @@ private azure.subscription.networkService.watcher.flowlog @defaults("name locati
 
 // Network Watcher packet capture session
 //
-// Examine a packet-capture session configured on a Network Watcher.
+// Packet-capture session configured on a Network Watcher.
 // Surfaces the `target` resource being captured (a VM or VMSS, with
 // `targetType` distinguishing them), the `bytesToCapturePerPacket`
 // truncation, the `timeLimitInSeconds` and `totalBytesPerSession`
@@ -3212,7 +3295,7 @@ private azure.subscription.networkService.watcher.packetCapture @defaults("name 
 
 // Network Watcher connection monitor
 //
-// Examine a connection-monitor instance — Network Watcher's
+// Connection-monitor instance, Network Watcher's
 // continuous reachability and latency check between source and
 // destination endpoints. Surfaces the `endpoints` (each carrying a
 // resource ID or address), the `testConfigurations` (protocol, port,
@@ -3263,7 +3346,7 @@ private azure.subscription.networkService.watcher.connectionMonitor @defaults("n
 
 // Azure Application Gateway
 //
-// Examine an Azure Application Gateway — the regional L7 load
+// Azure Application Gateway, the regional L7 load
 // balancer that fronts web workloads. Surfaces the SKU and tier
 // (Standard_v2, WAF_v2), TLS settings (frontend/backend TLS,
 // certificates, root certs), HTTP listeners, request-routing rules,
@@ -3340,7 +3423,7 @@ private azure.subscription.networkService.applicationGateway.gatewayIpConfig @de
 
 // Azure Application Gateway frontend IP configuration
 //
-// Examine a single frontend IP configuration on an Application Gateway. A
+// Single frontend IP configuration on an Application Gateway. A
 // configuration bound to a `subnetId` is an internal (private) frontend; one
 // with a `publicIpAddressId` is internet-facing. Use this to audit whether a
 // gateway exposes a public entry point.
@@ -3365,7 +3448,7 @@ private azure.subscription.networkService.applicationGateway.frontendIpConfig @d
 
 // Azure Application Gateway HTTP listener
 //
-// Examine a single HTTP/HTTPS listener configured on an Application
+// Single HTTP/HTTPS listener configured on an Application
 // Gateway. Surfaces the `protocol` (Http / Https) and `port` the
 // listener binds to, the `hostName` (or `hostNames` wildcard list),
 // whether SNI is required (`requireServerNameIndication`), and the
@@ -3402,7 +3485,7 @@ private azure.subscription.networkService.applicationGateway.listener @defaults(
 
 // Azure Application Gateway SSL certificate
 //
-// Examine a single SSL certificate uploaded to or referenced from
+// Single SSL certificate uploaded to or referenced from
 // Key Vault by an Application Gateway. Surfaces the source: when
 // `keyVaultSecretId` is non-empty, the certificate is referenced from
 // a Key Vault secret (the recommended path); when empty, the
@@ -3430,7 +3513,7 @@ private azure.subscription.networkService.applicationGateway.sslCertificate @def
 
 // Azure Application Gateway backend HTTP settings
 //
-// Examine a single backend HTTP settings collection on an Application
+// Single backend HTTP settings collection on an Application
 // Gateway, which controls how the gateway connects to its backend pool.
 // A `protocol` of Https means the gateway re-encrypts traffic to the
 // backend for end-to-end TLS. `validateCertChainAndExpiry` and
@@ -3471,7 +3554,7 @@ private azure.subscription.networkService.applicationGateway.backendHttpSettings
 
 // Azure Application Gateway SSL profile
 //
-// Examine a single SSL profile on an Application Gateway, which defines
+// Single SSL profile on an Application Gateway, which defines
 // the TLS policy and mutual-TLS client authentication for the listeners
 // bound to it. `sslPolicyType`, `sslPolicyName`, `sslMinProtocolVersion`,
 // and `sslCipherSuites` describe the negotiated TLS parameters.
@@ -3507,7 +3590,7 @@ private azure.subscription.networkService.applicationGateway.sslProfile @default
 
 // Azure Application Gateway trusted root certificate
 //
-// Examine a single trusted root certificate on an Application Gateway,
+// Single trusted root certificate on an Application Gateway,
 // used to validate the backend server certificate for end-to-end TLS.
 // The certificate is sourced either from inline `data` (base64-encoded
 // public certificate) or from a Key Vault secret resolved through
@@ -3527,7 +3610,7 @@ private azure.subscription.networkService.applicationGateway.trustedRootCertific
 
 // Azure Application Gateway trusted client certificate
 //
-// Examine a single trusted client certificate authority on an Application
+// Single trusted client certificate authority on an Application
 // Gateway, used to validate client certificates presented during mutual
 // TLS. `data` holds the base64-encoded certificate chain, `clientCertIssuerDN`
 // the issuer distinguished name, and `validatedCertData` the validated
@@ -3549,7 +3632,7 @@ private azure.subscription.networkService.applicationGateway.trustedClientCertif
 
 // Azure Application Gateway WAF config
 //
-// Examine the legacy WAF configuration attached directly to an
+// Legacy WAF configuration attached directly to an
 // Application Gateway (used by older v1 SKUs). Surfaces the WAF
 // `mode` (Detection / Prevention), the rule set type and version,
 // firewall mode flags, the `enabled` state, request-body limits, and
@@ -3570,7 +3653,7 @@ azure.subscription.networkService.wafConfig @defaults("id name type") {
 
 // Azure Web Application Firewall (WAF) policy
 //
-// Examine a reusable WAF policy that Application Gateway, Front Door,
+// Reusable WAF policy that Application Gateway, Front Door,
 // or other PaaS endpoints reference for L7 protection. Surfaces the
 // `policySettings` (mode, request body limits, file upload limits,
 // state, log scrubbing), the `customRules` list, the `managedRules`
@@ -3796,7 +3879,7 @@ private azure.subscription.networkService.route @defaults("name addressPrefix ne
 
 // Azure Traffic Manager profile
 //
-// Examine a Traffic Manager profile — the DNS-level global load
+// Traffic Manager profile, the DNS-level global load
 // balancer that resolves a single hostname to one of many backends
 // based on a routing method. Surfaces the `trafficRoutingMethod`
 // (Performance, Weighted, Priority, Geographic, MultiValue, Subnet),
@@ -3843,7 +3926,7 @@ azure.subscription.networkService.trafficManagerProfile @defaults("id name locat
 
 // Traffic Manager endpoint
 //
-// Examine a single endpoint inside a Traffic Manager profile —
+// Single endpoint inside a Traffic Manager profile,
 // either an Azure resource (`AzureEndpoints`), an external FQDN/IP
 // (`ExternalEndpoints`), or a child profile (`NestedEndpoints`).
 // Surfaces the `target` or `targetResourceId`, the `status` of the
@@ -3901,7 +3984,7 @@ private azure.subscription.networkService.trafficManagerProfile.endpoint @defaul
 
 // Azure Virtual WAN
 //
-// Examine a Virtual WAN — the global transit-network construct that
+// Virtual WAN, the global transit-network construct that
 // stitches together Virtual Hubs across regions, on-premises sites,
 // and ExpressRoute circuits. Surfaces the
 // `allowBranchToBranchTraffic` and `allowVnetToVnetTraffic`
@@ -3946,7 +4029,7 @@ azure.subscription.networkService.virtualWan @defaults("id name location virtual
 
 // Azure Virtual Hub
 //
-// Examine a Virtual Hub — the regional core of a Virtual WAN
+// Virtual Hub, the regional core of a Virtual WAN
 // deployment that provides routing, transit, and gateway hosting.
 // Surfaces the `addressPrefix` CIDR carved out for the hub, the
 // `sku` and `kind` (regular hub or Route Server), the
@@ -4006,7 +4089,7 @@ azure.subscription.networkService.virtualHub @defaults("id name location sku") {
 
 // Virtual Hub route table
 //
-// Examine a route table inside a Virtual Hub — the construct that
+// Route table inside a Virtual Hub, the construct that
 // stores user-defined routes for connections that select this table.
 // Surfaces the `routes` (each with `destinationType`, `destinations`,
 // `nextHopType`, `nextHop`), the `labels` that connections use to
@@ -4038,7 +4121,7 @@ private azure.subscription.networkService.virtualHub.routeTable @defaults("id na
 
 // Virtual Hub VNet connection
 //
-// Examine a connection between a Virtual Hub and a spoke virtual
+// Connection between a Virtual Hub and a spoke virtual
 // network. Surfaces the `enableInternetSecurity` flag (whether the
 // secured hub firewalls Internet egress for the spoke), the linked
 // `remoteVirtualNetwork()`, the `routingConfiguration` (associated
@@ -4064,7 +4147,7 @@ private azure.subscription.networkService.virtualHub.vnetConnection @defaults("i
 
 // Azure Virtual WAN VPN site
 //
-// Examine a VPN site — the registered on-prem branch endpoint that
+// VPN site, the registered on-prem branch endpoint that
 // terminates a site-to-site IPsec tunnel into a Virtual WAN's VPN
 // gateway. Surfaces the `ipAddress` (the public IP the gateway peers
 // with), the `addressPrefixes` advertised by the branch, the BGP
@@ -4124,7 +4207,7 @@ azure.subscription.networkService.vpnSite @defaults("id name location") {
 
 // Azure ExpressRoute circuit
 //
-// Examine an ExpressRoute circuit — the dedicated private link
+// ExpressRoute circuit, the dedicated private link
 // between an on-prem network and Microsoft's backbone, provisioned
 // either through a connectivity provider or on a customer-owned
 // ExpressRoute port. Surfaces the SKU triplet
@@ -4197,15 +4280,15 @@ azure.subscription.networkService.expressRouteCircuit @defaults("id name locatio
 
 // ExpressRoute circuit peering
 //
-// Examine a BGP peering inside an ExpressRoute circuit. The
+// BGP peering inside an ExpressRoute circuit. The
 // `peeringType` field distinguishes the three peering kinds:
 // `AzurePrivatePeering` (traffic to Azure VNets), `AzurePublicPeering`
-// (deprecated — public Azure services), and `MicrosoftPeering`
+// (deprecated, public Azure services), and `MicrosoftPeering`
 // (Microsoft 365 and Azure public services). Surfaces the BGP state
 // machine fields (`azureAsn`, `peerAsn`, `state`), the IPv4 BGP
 // substrate (`primaryPeerAddressPrefix`, `secondaryPeerAddressPrefix`,
 // `primaryAzurePort`, `secondaryAzurePort`, `vlanId`), `sharedKeySet`
-// (whether an MD5 shared key is configured — the key itself is not
+// (whether an MD5 shared key is configured, the key itself is not
 // exposed), the `microsoftPeeringConfig` (advertised public
 // prefixes, customer ASN, routing-registry name, IPv4 community
 // advertisement) when `peeringType` is `MicrosoftPeering`, the
@@ -4255,7 +4338,7 @@ private azure.subscription.networkService.expressRouteCircuit.peering @defaults(
 
 // ExpressRoute circuit authorization
 //
-// Examine a connection authorization issued on an ExpressRoute
+// Connection authorization issued on an ExpressRoute
 // circuit. Each authorization carries a redeemable key that a
 // downstream subscription owner can use to attach a virtual network
 // gateway to this circuit. The key itself is not exposed; surfaces
@@ -4884,7 +4967,13 @@ private azure.subscription.storageService.account @defaults("id name location") 
   tags map[string]string
   // Storage account type
   type string
-  // Storage account properties
+  // Raw storage account properties
+  //
+  // Serialized Azure Resource Manager property bag for the account. Most
+  // individual settings are also exposed as fields on this resource
+  // (accessTier, minimumTlsVersion, allowBlobPublicAccess, the networkRule
+  // fields, the encryption fields, and so on); prefer those over reading
+  // raw keys here.
   properties dict
   // Storage account identity
   //
@@ -4901,6 +4990,9 @@ private azure.subscription.storageService.account @defaults("id name location") 
   // User-assigned managed identity used to access the customer-managed encryption key; null when account-level encryption identity is not configured
   encryptionIdentity() azure.subscription.managedIdentity
   // Storage account SKU
+  //
+  // Dict with keys `name` (e.g. "Standard_LRS", "Standard_GRS",
+  // "Premium_LRS") and `tier` ("Standard" or "Premium").
   sku dict
   // Storage account kind
   kind string
@@ -5037,7 +5129,7 @@ private azure.subscription.storageService.account.queue @defaults("id name") {
   name string
   // Application-defined name/value pairs stored on the queue
   metadata map[string]string
-  // Approximate number of messages in the queue (fetched on demand via Get)
+  // Approximate number of messages in the queue
   approximateMessageCount() int
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
@@ -5191,11 +5283,25 @@ private azure.subscription.storageService.account.managementPolicy.rule @default
   filterBlobTypes []string
   // Prefix patterns for matching
   filterPrefixMatch []string
-  // Base blob actions (tiering and deletion thresholds)
+  // Lifecycle actions applied to current blob versions
+  //
+  // Dict with optional keys `delete`, `tierToCool`, `tierToCold`,
+  // `tierToArchive`, `tierToHot`, and `enableAutoTierToHotFromCool`. Each
+  // tier or delete value is an object carrying the age threshold that
+  // triggers it: `daysAfterModificationGreaterThan` or
+  // `daysAfterLastAccessTimeGreaterThan`.
   baseBlobActions dict
-  // Snapshot actions
+  // Lifecycle actions applied to blob snapshots
+  //
+  // Dict with optional keys `delete`, `tierToCool`, `tierToCold`,
+  // `tierToArchive`, and `tierToHot`. Each value is an object carrying the
+  // age threshold `daysAfterCreationGreaterThan` that triggers it.
   snapshotActions dict
-  // Version actions
+  // Lifecycle actions applied to previous blob versions
+  //
+  // Dict with optional keys `delete`, `tierToCool`, `tierToCold`,
+  // `tierToArchive`, and `tierToHot`. Each value is an object carrying the
+  // age threshold `daysAfterCreationGreaterThan` that triggers it.
   versionActions dict
 }
 
@@ -5229,11 +5335,12 @@ private azure.subscription.storageService.account.service.blobProperties @defaul
 
 // Static website hosting configuration on a storage account
 //
-// Examine whether $web is being served as a static site and which
-// documents the account returns for the root, subdirectory index, and
-// 404 responses. Enabled accounts expose an HTTPS-reachable web
-// endpoint without any access control on the served files, so the
-// presence of static hosting is itself an audit signal.
+// Static website hosting settings for the account's `$web` container:
+// whether the site is served and which documents the account returns for
+// the root, subdirectory index, and 404 responses. An enabled account
+// exposes an HTTPS-reachable web endpoint with no access control on the
+// served files, so the presence of static hosting is itself an audit
+// signal.
 private azure.subscription.storageService.account.staticWebsiteConfig @defaults("enabled indexDocument errorDocument404Path") {
   // Whether static website hosting is enabled on the account
   enabled bool
@@ -5286,6 +5393,12 @@ private azure.subscription.storageService.account.service.properties.logging @de
 }
 
 // Azure Storage container
+//
+// Blob container within a storage account, keyed by ARM id. Fields cover
+// the anonymous access level (`publicAccess`), immutability and legal-hold
+// state, default encryption scope, lease state, and soft-delete status,
+// making it the unit for auditing whether stored blobs can be reached
+// anonymously or altered under a retention policy.
 private azure.subscription.storageService.account.container @defaults("id name") {
   // Storage container ID
   id string
@@ -5295,7 +5408,12 @@ private azure.subscription.storageService.account.container @defaults("id name")
   type string
   // Storage container etag
   etag string
-  // Storage container properties
+  // Raw storage container properties
+  //
+  // Serialized Azure Resource Manager property bag for the container. Most
+  // individual settings are also exposed as fields on this resource
+  // (publicAccess, hasImmutabilityPolicy, hasLegalHold, leaseState,
+  // metadata, and so on); prefer those over reading raw keys here.
   properties dict
   // Public access level for the container (None, Blob, Container)
   publicAccess string
@@ -5339,10 +5457,10 @@ private azure.subscription.storageService.account.container @defaults("id name")
 
 // Azure Storage file share
 //
-// Examine a single Azure Files share hosted on a storage account.
-// Selectable by ARM id; fields cover the share protocol (SMB or NFS),
-// access tier, provisioned quota, and the presence of stored access
-// policies (signed identifiers).
+// Single Azure Files share hosted on a storage account. Selectable by
+// ARM id; fields cover the share protocol (SMB or NFS), access tier,
+// provisioned quota, and the presence of stored access policies (signed
+// identifiers).
 private azure.subscription.storageService.account.fileShare @defaults("name enabledProtocols accessTier shareQuotaGiB") {
   // ARM resource ID
   id string
@@ -5390,9 +5508,9 @@ private azure.subscription.storageService.account.fileShare @defaults("name enab
 
 // Azure Storage private endpoint connection
 //
-// Examine a private endpoint connection on a storage account. Selectable
-// by ARM id; fields expose the consumer-side endpoint reference and the
-// approval status governing traffic between consumer and storage.
+// Private endpoint connection on a storage account. Selectable by ARM id;
+// fields expose the consumer-side endpoint reference and the approval
+// status governing traffic between consumer and storage.
 private azure.subscription.storageService.account.privateEndpointConnection @defaults("name status provisioningState") {
   // ARM resource ID
   id string
@@ -5424,8 +5542,8 @@ private azure.subscription.storageService.account.privateEndpointConnection @def
 
 // Azure Storage object replication policy
 //
-// Examine an object replication policy linking a source storage account
-// to a destination account. Selectable by ARM id; fields expose the
+// Object replication policy linking a source storage account to a
+// destination account. Selectable by ARM id; fields expose the
 // source/destination pair, when replication was enabled, and the
 // container-to-container rules with optional prefix and creation-time
 // filters.
@@ -5454,11 +5572,11 @@ private azure.subscription.storageService.account.objectReplicationPolicy @defau
 
 // Network Security Perimeter configuration of an Azure Storage account
 //
-// Examine how a storage account is associated with an Azure Network Security
+// Association between a storage account and an Azure Network Security
 // Perimeter, including the enforcement mode that decides whether perimeter
 // access rules are logged only or actually blocked. Select a configuration by
-// its `id`. The `accessMode` field reports "Learning", "Audit", or "Enforced" —
-// only "Enforced" blocks traffic that violates the perimeter rules.
+// its `id`. The `associationAccessMode` field reports "Learning", "Audit", or
+// "Enforced"; only "Enforced" blocks traffic that violates the perimeter rules.
 // `accessRules` lists the inbound and outbound rules in effect,
 // `enabledLogCategories` the categories shipped to diagnostics, and
 // `provisioningIssues` any errors that prevented the configuration from
@@ -5511,8 +5629,8 @@ private azure.subscription.storageService.account.networkSecurityPerimeterConfig
 
 // Azure Storage blob inventory policy
 //
-// Examine the (singleton) blob inventory policy on a storage account.
-// Used to audit whether the account has cataloging enabled and what
+// Blob inventory policy on a storage account (a single policy named
+// "default"). Reports whether the account has cataloging enabled and what
 // inventory rules are defined (destination container, schema, schedule,
 // per-rule filters).
 private azure.subscription.storageService.account.blobInventoryPolicy @defaults("enabled lastModifiedTime") {
@@ -5534,7 +5652,7 @@ private azure.subscription.storageService.account.blobInventoryPolicy @defaults(
 
 // Microsoft Defender for Storage configuration for a single storage account
 //
-// Examine the per-account Defender for Storage settings. `isEnabled` reports
+// Per-account Defender for Storage settings. `isEnabled` reports
 // whether Defender for Storage is on for this account, and
 // `sensitiveDataDiscoveryEnabled` reflects whether the Microsoft Purview-backed
 // sensitive data classification engine scans blob containers and surfaces
@@ -5607,15 +5725,16 @@ private azure.subscription.webService.appRuntimeStack @defaults("preferredOs run
 
 // Azure App Service site
 //
-// Examine an App Service / Function App / Web App site. Surfaces the
-// app's runtime stack, SKU and App Service Plan binding, the
-// `siteConfig` (always-on, HTTP/2, TLS minimum version,
-// FTPS/HTTP-only state, IP restrictions, CORS), HTTPS-only flag,
-// client-cert and client-affinity settings, the configured custom
-// hostnames and SSL bindings, identity assignments, the deployed
-// `slots()`, app settings and connection strings, the linked storage
-// accounts, and the `webDiagnostics` (Application Insights / log
-// streaming) configuration.
+// App Service, Function App, or Web App hosted in the subscription,
+// with the security and network surface that governs how it is exposed
+// and authenticated. The configuration covers the runtime stack, the
+// App Service Plan binding, HTTPS-only enforcement, client-certificate
+// requirements, minimum TLS version, FTPS and remote-debugging state,
+// IP restrictions and CORS, public network access, managed-identity
+// assignments, custom hostnames and SSL bindings, private endpoint
+// connections, and regional VNet integration. Deployment slots, app
+// settings, connection strings, and diagnostic settings are queryable
+// for auditing configuration drift and credential exposure.
 azure.subscription.webService.appsite @defaults("id name location") {
   // App site ID
   id string
@@ -5750,8 +5869,19 @@ private azure.subscription.privateEndpointConnection @defaults("id name type") {
   // Private link service connection state details
   privateLinkServiceConnectionState azure.subscription.privateEndpointConnection.connectionState
   // Provisioning state of the private endpoint connection
+  //
+  // Lifecycle state of the connection, typically one of Succeeded,
+  // Creating, Updating, Deleting, or Failed.
   provisioningState string
-  // privateEndpointConnection properties
+  // Raw private endpoint connection properties
+  //
+  // Unmodified properties object from the Azure API. Keys include
+  // `privateEndpoint` (an object whose `id` is the linked private
+  // endpoint resource ID), `privateLinkServiceConnectionState` (an
+  // object with `status`, `description`, and `actionsRequired`), and
+  // `provisioningState`. These same values are exposed as the typed
+  // privateEndpoint, privateLinkServiceConnectionState, and
+  // provisioningState fields on this resource.
   properties dict
 }
 
@@ -5762,6 +5892,11 @@ private azure.subscription.privateEndpointConnection.connectionState @defaults("
   // Description of the private link service connection state
   description string
   // Status of the private link service connection
+  //
+  // Approval state of the connection request, one of Pending,
+  // Approved, Rejected, or Disconnected. A Pending or Rejected
+  // status means traffic over the private endpoint is not yet
+  // established.
   status string
 }
 
@@ -5909,9 +6044,13 @@ private azure.subscription.webService.appsiteconfig.ipSecurityRestriction @defau
   tag string
   // Virtual network subnet resource ID for VNet-based restrictions
   vnetSubnetResourceId string
-  // Service tag for service tag-based restrictions
+  // Subnet mask for the IP address range the restriction applies to
   subnetMask string
-  // HTTP headers for header-based restrictions
+  // HTTP header match conditions for the restriction
+  //
+  // Keys are HTTP header names that further scope the rule (for example
+  // X-Forwarded-Host, X-Forwarded-For, X-Azure-FDID, X-FD-HealthProbe);
+  // each value is the list of header values the rule matches on.
   headers dict
 }
 
@@ -6047,17 +6186,17 @@ private azure.subscription.webService.certificate @defaults("id name") {
 
 // Azure Static Web App
 //
-// Examine an Azure Static Web App — a managed service that hosts static
-// content (HTML/CSS/JS), serverless API routes, and global content
-// distribution from a source repository (typically GitHub or Azure
-// DevOps). Surfaces the SKU and tier (Free, Standard, Dedicated), the
-// default and custom hostnames, the source repository URL and branch,
-// the publishing provider, the public network access toggle, the
-// `allowConfigFileUpdates` flag, the staging-environment policy
-// (preview deployments per pull request), the enterprise-grade CDN
-// status, the identity assignment used for Key Vault references, and
-// counts for private endpoint connections, user-provided function
-// apps, linked backends, and database connections.
+// Managed service that hosts static content (HTML/CSS/JS), serverless
+// API routes, and globally distributed assets built from a source
+// repository (typically GitHub or Azure DevOps). The SKU and tier
+// (Free, Standard, Dedicated), default and custom hostnames, source
+// repository URL and branch, publishing provider, public network
+// access toggle, `allowConfigFileUpdates` flag, staging-environment
+// policy (preview deployments per pull request), enterprise-grade CDN
+// status, and Key Vault reference identity govern how the app is
+// built, exposed, and authenticated. Counts for private endpoint
+// connections, user-provided function apps, linked backends, and
+// database connections summarize its integration surface.
 private azure.subscription.webService.staticSite @defaults("name defaultHostname") {
   // Resource ID of the static web app
   id string
@@ -6169,9 +6308,9 @@ private azure.subscription.sqlService.server @defaults("name location properties
   properties dict
   // SQL Database server minimum TLS version
   minimalTlsVersion string
-  // Whether public network access is enabled for the SQL server
+  // Public network access state ("Enabled" or "Disabled")
   publicNetworkAccess string
-  // Whether outbound network access is restricted
+  // Outbound network access restriction state ("Enabled" or "Disabled")
   restrictOutboundNetworkAccess string
   // SQL server version
   version string
@@ -6191,21 +6330,21 @@ private azure.subscription.sqlService.server @defaults("name location properties
   connectionPolicy() @maturity("deprecated") dict
   // Raw server auditing policy
   //
-  // Deprecated in favor of `blobAuditingPolicy()`.
+  // Deprecated in favor of `blobAuditingPolicy`.
   auditingPolicy() @maturity("deprecated") dict
   // SQL Database server administrator login
   administratorLogin string
   // Raw server security alert policy
   //
-  // Deprecated in favor of `securityAlertPolicyConfig()`.
+  // Deprecated in favor of `securityAlertPolicyConfig`.
   securityAlertPolicy() @maturity("deprecated") dict
   // Raw server encryption protector
   //
-  // Deprecated in favor of `encryptionProtectorConfig()`.
+  // Deprecated in favor of `encryptionProtectorConfig`.
   encryptionProtector() @maturity("deprecated") dict
   // Legacy preview threat detection policy
   //
-  // Deprecated in favor of `securityAlertPolicyConfig()` and `advancedThreatProtectionSetting()`.
+  // Deprecated in favor of `securityAlertPolicyConfig` and `advancedThreatProtectionSetting`.
   threatDetectionPolicy() @maturity("deprecated") dict
   // SQL Database server vulnerability assessment settings
   vulnerabilityAssessmentSettings() azure.subscription.sqlService.server.vulnerabilityassessmentsettings
@@ -6241,7 +6380,7 @@ private azure.subscription.sqlService.server @defaults("name location properties
   // Whether the SQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to the entire public internet — a rule whose range spans
+  // opens the server to the entire public internet, a rule whose range spans
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
@@ -6349,19 +6488,24 @@ private azure.subscription.sqlService.database @defaults("name edition zoneRedun
   //
   // Deprecated in favor of `transparentDataEncryptionEnabled`.
   transparentDataEncryption() @maturity("deprecated") dict
-  // SQL database advisor
+  // Automatic tuning advisors for the database
+  //
+  // Raw Database Advisor objects returned by Azure SQL. Each entry has
+  // `id`, `name`, `type`, and a `properties` object whose
+  // `recommendedActions` list holds the index and query-plan
+  // recommendations Azure SQL generated for the database.
   advisor() []dict
   // Legacy preview threat detection policy
   //
-  // Deprecated in favor of `securityAlertPolicy()`.
+  // Deprecated in favor of `securityAlertPolicy`.
   threatDetectionPolicy() @maturity("deprecated") dict
   // Legacy per-database connection policy
   //
-  // Deprecated, please use `azure.subscription.sqlService.server.connectionType` — Azure SQL DB has no per-database connection policy.
+  // Deprecated, please use `azure.subscription.sqlService.server.connectionType`. Azure SQL DB has no per-database connection policy.
   connectionPolicy() @maturity("deprecated") dict
   // Raw database auditing policy
   //
-  // Deprecated in favor of `blobAuditingPolicy()`.
+  // Deprecated in favor of `blobAuditingPolicy`.
   auditingPolicy() @maturity("deprecated") dict
   // SQL database advanced threat protection settings
   advancedThreatProtection() azure.subscription.sqlService.database.advancedthreatprotection
@@ -6796,6 +6940,12 @@ private azure.subscription.sqlService.database.geoBackupPolicy @defaults("state"
 }
 
 // Azure Database for PostgreSQL
+//
+// Managed PostgreSQL databases in a subscription, covering both the current
+// Flexible Server deployment model (flexibleServers) and the earlier Single
+// Server model (servers) that Azure is retiring. Use it to enumerate every
+// managed PostgreSQL instance and audit their network exposure,
+// authentication mode, encryption, and backup posture.
 private azure.subscription.postgreSqlService {
   // Subscription identifier
   subscriptionId string
@@ -6806,6 +6956,14 @@ private azure.subscription.postgreSqlService {
 }
 
 // Azure Database for PostgreSQL flexible server
+//
+// PostgreSQL Flexible Server instance, the current deployment model for
+// managed PostgreSQL on Azure. Reports the network-exposure controls
+// (publicNetworkAccess, firewallRules, internetReachable), authentication
+// modes (activeDirectoryAuth, passwordAuth), data-at-rest encryption
+// (dataEncryptionType, with optional customer-managed Key Vault keys),
+// backup retention, and Microsoft Defender threat-protection state that
+// together determine the server's security posture.
 private azure.subscription.postgreSqlService.flexibleServer @defaults("name location properties.version properties.state properties.fullyQualifiedDomainName") {
   // PostgreSQL server ID
   id string
@@ -6817,7 +6975,16 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   tags map[string]string
   // PostgreSQL server type
   type string
-  // PostgreSQL server properties
+  // Raw Azure Resource Manager properties of the PostgreSQL flexible server
+  //
+  // Full ServerProperties object as returned by Azure Resource Manager, keyed
+  // by fields such as `administratorLogin`, `version`, `minorVersion`,
+  // `state`, `fullyQualifiedDomainName`, `availabilityZone`, `storage`,
+  // `backup`, `network`, `highAvailability`, `maintenanceWindow`,
+  // `authConfig`, and `dataEncryption`. The security-relevant values are also
+  // surfaced as typed fields (version, activeDirectoryAuth, passwordAuth,
+  // dataEncryptionType, publicNetworkAccess, geoRedundantBackup,
+  // backupRetentionDays).
   properties dict
   // PostgreSQL flexible server engine version
   version string
@@ -6827,9 +6994,9 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   databases() []azure.subscription.postgreSqlService.database
   // PostgreSQL server firewall rules
   firewallRules() []azure.subscription.sqlService.firewallrule
-  // Whether Microsoft Entra (Active Directory) authentication is enabled ("Enabled" or "Disabled")
+  // Microsoft Entra (Active Directory) authentication state ("Enabled" or "Disabled")
   activeDirectoryAuth string
-  // Whether password-based authentication is enabled ("Enabled" or "Disabled")
+  // Password-based authentication state ("Enabled" or "Disabled")
   passwordAuth string
   // Data encryption type ("SystemManaged" or "AzureKeyVault")
   dataEncryptionType string
@@ -6837,7 +7004,7 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   primaryEncryptionKeyStatus string
   // Status of the geo-backup encryption key
   geoBackupEncryptionKeyStatus string
-  // Whether public network access is enabled ("Enabled" or "Disabled")
+  // Public network access state ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Key Vault key used for primary data encryption (null if system-managed)
   dataEncryptionKey() azure.subscription.keyVaultService.key
@@ -6845,7 +7012,7 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   geoBackupEncryptionKey() azure.subscription.keyVaultService.key
   // Backup retention period in days
   backupRetentionDays int
-  // Whether geo-redundant backup is enabled
+  // Geo-redundant backup state ("Enabled" or "Disabled")
   geoRedundantBackup string
   // Microsoft Defender for Cloud advanced threat protection state ("Enabled", "Disabled", or "New")
   threatProtectionState() string
@@ -6854,7 +7021,7 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
   // Whether the PostgreSQL flexible server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to the entire public internet — a rule whose range spans
+  // opens the server to the entire public internet, a rule whose range spans
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
@@ -6873,6 +7040,12 @@ private azure.subscription.postgreSqlService.flexibleServer @defaults("name loca
 }
 
 // Azure Database for PostgreSQL server
+//
+// PostgreSQL Single Server instance, the earlier managed-PostgreSQL
+// deployment model that Azure is retiring in favor of Flexible Server.
+// Reports SSL enforcement, minimum TLS version, infrastructure (double)
+// encryption, public network access, firewall rules, and backup
+// configuration for auditing legacy servers still in production.
 private azure.subscription.postgreSqlService.server @defaults("id name location") {
   // PostgreSQL server ID
   id string
@@ -6884,13 +7057,22 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   tags map[string]string
   // PostgreSQL server type
   type string
-  // PostgreSQL server properties
+  // Raw Azure Resource Manager properties of the PostgreSQL server
+  //
+  // Full ServerProperties object as returned by Azure Resource Manager, keyed
+  // by fields such as `administratorLogin`, `version`, `userVisibleState`,
+  // `fullyQualifiedDomainName`, `sslEnforcement`, `minimalTlsVersion`,
+  // `publicNetworkAccess`, `infrastructureEncryption`, `earliestRestoreDate`,
+  // and `storageProfile`. The security-relevant values are also surfaced as
+  // typed fields (sslEnforcement, minimalTlsVersion, publicNetworkAccess,
+  // infrastructureEncryption, version, backupRetentionDays,
+  // geoRedundantBackup).
   properties dict
   // Whether SSL enforcement is enabled
   sslEnforcement bool
   // Minimum TLS version enforced on the server
   minimalTlsVersion string
-  // Whether public network access is enabled for the server
+  // Public network access state for the server ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Whether infrastructure encryption is enabled (double encryption)
   infrastructureEncryption bool
@@ -6898,7 +7080,7 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   version string
   // Backup retention period in days
   backupRetentionDays int
-  // Whether geo-redundant backup is enabled ("Enabled" or "Disabled")
+  // Geo-redundant backup state ("Enabled" or "Disabled")
   geoRedundantBackup string
   // PostgreSQL server configuration
   configuration() []azure.subscription.sqlService.configuration
@@ -6909,13 +7091,17 @@ private azure.subscription.postgreSqlService.server @defaults("id name location"
   // Whether the PostgreSQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to the entire public internet — a rule whose range spans
+  // opens the server to the entire public internet, a rule whose range spans
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
 }
 
 // Azure Database for PostgreSQL database
+//
+// Individual database hosted on a PostgreSQL single server or flexible
+// server, including its character set and collation. Use it to inventory
+// the databases present on a managed PostgreSQL instance.
 private azure.subscription.postgreSqlService.database @defaults("id name") {
   // PostgreSQL database ID
   id string
@@ -6981,15 +7167,16 @@ private azure.subscription.sqlService.virtualNetworkRule @defaults("id name") {
 
 // Azure SQL Managed Instance
 //
-// Examine an Azure SQL Managed Instance — a fully-managed SQL Server
-// deployed inside a virtual network. Surfaces the SKU and tier
-// (GeneralPurpose, BusinessCritical), vCore count, storage size, license
-// type, the subnet the instance is joined to, FQDN, the administrator
-// login name, the minimum TLS version enforced, the proxy/connection
-// override, whether the public data endpoint is enabled, zone
-// redundancy, current vs requested backup storage redundancy, the
-// identity and customer-managed-key configuration, the maintenance
-// configuration, and the `databases()` hosted on the instance.
+// Fully-managed SQL Server instance deployed inside a virtual network,
+// pairing broad SQL Server engine compatibility with platform-managed
+// backups, patching, and high availability. Exposes the security-relevant
+// posture of the instance: the minimum TLS version enforced, whether the
+// public data endpoint is reachable from outside the virtual network, the
+// connection type override, zone redundancy, current and requested backup
+// storage redundancy, and the managed identity and customer-managed-key
+// encryption configuration. The subnet the instance is joined to is
+// reachable through subnet, and the managed databases it hosts through
+// databases.
 azure.subscription.sqlService.managedInstance @defaults("name location state vCores skuName") {
   // Resource ID of the managed instance
   id string
@@ -7111,7 +7298,7 @@ private azure.subscription.mySqlService.server @defaults("id name location") {
   sslEnforcement bool
   // Minimum TLS version enforced on the server
   minimalTlsVersion string
-  // Whether public network access is enabled for the server
+  // Public network access state ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Whether infrastructure encryption is enabled (double encryption)
   infrastructureEncryption bool
@@ -7130,7 +7317,7 @@ private azure.subscription.mySqlService.server @defaults("id name location") {
   // Whether the MySQL server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to the entire public internet — a rule whose range spans
+  // opens the server to the entire public internet: a rule whose range spans
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
@@ -7168,7 +7355,7 @@ private azure.subscription.mySqlService.flexibleServer @defaults("name location 
   version string
   // Whether SSL enforcement is enabled (queries the require_secure_transport server parameter)
   sslEnforcement() bool
-  // Whether public network access is allowed
+  // Public network access state ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Key Vault key used for data encryption (null if system-managed)
   dataEncryptionKey() azure.subscription.keyVaultService.key
@@ -7193,7 +7380,7 @@ private azure.subscription.mySqlService.flexibleServer @defaults("name location 
   // Whether the MySQL flexible server is reachable from the public internet
   //
   // True when `publicNetworkAccess` is enabled AND at least one firewall rule
-  // opens the server to the entire public internet — a rule whose range spans
+  // opens the server to the entire public internet: a rule whose range spans
   // 0.0.0.0-255.255.255.255. The special "allow all Azure services" rule
   // (0.0.0.0-0.0.0.0) does not count, since it admits only Azure-internal IPs.
   internetReachable() bool
@@ -7255,6 +7442,12 @@ private azure.subscription.mySqlService.flexibleServer.administrator @defaults("
 }
 
 // Azure Cosmos DB
+//
+// Entry point to Azure Cosmos DB resources in a subscription. Lists the
+// classic multi-model Cosmos DB accounts, the Cosmos DB for MongoDB (vCore)
+// clusters, and the Cosmos DB for PostgreSQL (Citus) clusters, each a
+// distinct Azure resource type with its own configuration and security
+// posture.
 private azure.subscription.cosmosDbService {
   // Subscription identifier
   subscriptionId string
@@ -7268,22 +7461,27 @@ private azure.subscription.cosmosDbService {
 
 // Azure Cosmos DB account
 //
-// Examine a Cosmos DB account — the multi-model NoSQL service's
-// top-level resource. Surfaces the account `kind` (GlobalDocumentDB,
-// MongoDB, Parse), the API offering, default consistency policy,
-// configured locations and failover priorities, public network access,
-// network ACL bypass for Azure services, IP rules, virtual-network
-// rules, the encryption settings (key URI, identity used to access
-// Key Vault), local authentication state, the
-// `disableLocalAuth` flag, the
-// `analyticalStorageConfiguration`, backup policy, capabilities, and
-// the `sqlDatabases()` exposed by the account.
+// Top-level resource of the Azure Cosmos DB multi-model NoSQL service. The
+// account `kind` (GlobalDocumentDB, MongoDB, or Parse) selects which API
+// surface the account serves. Audit an account for its network exposure
+// (public network access, IP firewall rules, virtual-network rules, and
+// network ACL bypass for Azure services), its default consistency level, its
+// encryption posture (customer-managed key and the identity used to reach
+// Key Vault), whether local key-based authentication is disabled in favor of
+// Entra ID, the backup policy, and the data-plane RBAC role definitions and
+// assignments granted across the SQL, Cassandra, Gremlin, Table, and MongoDB
+// managed-instance APIs.
 azure.subscription.cosmosDbService.account @defaults("name kind location") {
   // Cosmos DB account ID
   id string
   // Cosmos DB account name
   name string
   // Cosmos DB account properties
+  //
+  // The full DatabaseAccountGetProperties payload as returned by Azure
+  // Resource Manager. Most values are also surfaced as typed sibling fields
+  // (for example defaultConsistencyLevel, publicNetworkAccess, ipRangeFilter,
+  // and the backup* fields); use this dict for values not otherwise modeled.
   properties dict
   // Cosmos DB account location
   location string
@@ -7385,14 +7583,12 @@ private azure.subscription.cosmosDbService.account.virtualNetworkRule @defaults(
 
 // Azure Cosmos DB for MongoDB (vCore) cluster
 //
-// Examine the configuration of a Cosmos DB for MongoDB (vCore) cluster
-// (`Microsoft.DocumentDB/mongoClusters`). Covers the compute tier and
-// data-disk size, shard count, high availability mode, MongoDB server
-// version, allowed authentication modes, Mongo Data API access, public
-// network access, customer-managed encryption key, and replication role
-// and state. vCore clusters are distinct Azure resources from classic
-// Cosmos DB accounts and are listed separately via
-// `cosmosDbService.mongoClusters`.
+// Cosmos DB for MongoDB (vCore) cluster (`Microsoft.DocumentDB/mongoClusters`),
+// a distinct Azure resource from a classic Cosmos DB account. Audit the
+// compute tier and data-disk size, shard count, high availability mode,
+// MongoDB server version, allowed authentication modes, Mongo Data API
+// access, public network access, the customer-managed encryption key, and
+// the replication role and state.
 private azure.subscription.cosmosDbService.mongoCluster @defaults("computeTier serverVersion provisioningState") {
   // MongoDB vCore cluster resource ID
   id string
@@ -7450,14 +7646,13 @@ private azure.subscription.cosmosDbService.mongoCluster @defaults("computeTier s
 
 // Azure Cosmos DB for PostgreSQL cluster
 //
-// Examine the configuration of a Cosmos DB for PostgreSQL (Citus) cluster
-// (`Microsoft.DBforPostgreSQL/serverGroupsv2`). Covers the PostgreSQL and
-// Citus versions, coordinator and worker-node compute (vCores, storage
-// quota, server edition), worker node count, high availability, public IP
-// access on the coordinator and worker nodes, the maintenance window,
-// read-replica topology, and the server names in the cluster. PostgreSQL
-// clusters are distinct Azure resources from classic Cosmos DB accounts
-// and are listed separately via `cosmosDbService.postgresqlClusters`.
+// Cosmos DB for PostgreSQL (Citus) cluster
+// (`Microsoft.DBforPostgreSQL/serverGroupsv2`), a distinct Azure resource
+// from a classic Cosmos DB account. Audit the PostgreSQL and Citus versions,
+// coordinator and worker-node compute (vCores, storage quota, server
+// edition), worker node count, high availability, public IP access on the
+// coordinator and worker nodes, the maintenance window, and the read-replica
+// topology.
 private azure.subscription.cosmosDbService.postgresqlCluster @defaults("postgresqlVersion nodeCount provisioningState") {
   // PostgreSQL cluster resource ID
   id string
@@ -7510,8 +7705,15 @@ private azure.subscription.cosmosDbService.postgresqlCluster @defaults("postgres
   // Resource IDs of read-replica clusters
   readReplicas []string
   // Maintenance window of the cluster
+  //
+  // Keys: `customWindow` (whether a custom maintenance window is enabled),
+  // `dayOfWeek` (preferred day of the week, 0 to 6), `startHour`, and
+  // `startMinute`.
   maintenanceWindow dict
   // Server names in the cluster
+  //
+  // Each entry has keys `name` (the server name) and
+  // `fullyQualifiedDomainName` (the server's fully qualified domain name).
   serverNames []dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
@@ -7717,13 +7919,11 @@ private azure.subscription.cosmosDbService.account.mongoMIRoleAssignment @defaul
 
 // Azure Cosmos DB SQL API database
 //
-// Examine a SQL-API (Core) database hosted on a Cosmos DB account.
-// Selectable by ARM id; surfaces the database-level throughput posture
-// (manual provisioned vs autoscale ceiling, with `throughputPerContainer`
-// distinguishing the case where throughput is configured per-container
-// rather than at the database level) and exposes the contained
-// containers as a typed sub-resource. Throughput fields are lazy and
-// share a single GetSQLDatabaseThroughput call.
+// SQL-API (Core) database hosted on a Cosmos DB account, selectable by its
+// ARM resource id. The throughput posture distinguishes manually provisioned
+// RU/s from an autoscale ceiling, and `throughputPerContainer` marks the case
+// where throughput is set per-container rather than at the database level.
+// The contained containers are exposed as a sub-resource.
 private azure.subscription.cosmosDbService.account.sqlDatabase @defaults("name throughputPerContainer autoscaleEnabled manualThroughput") {
   // ARM resource ID
   id string
@@ -7755,12 +7955,10 @@ private azure.subscription.cosmosDbService.account.sqlDatabase @defaults("name t
 
 // Azure Cosmos DB SQL API container
 //
-// Examine a SQL-API container within a Cosmos DB database. Selectable
-// by ARM id; surfaces the partition key, default TTL, indexing policy
-// mode, conflict resolution policy, unique-key constraints, and the
-// throughput posture (manual / autoscale / inherited from the parent
-// database). Throughput fields are lazy and share a single
-// GetSQLContainerThroughput call.
+// SQL-API container within a Cosmos DB database, selectable by its ARM
+// resource id. Audit the partition key, default TTL, indexing policy mode,
+// conflict resolution policy, unique-key constraints, and the throughput
+// posture (manual, autoscale, or inherited from the parent database).
 private azure.subscription.cosmosDbService.account.sqlDatabase.container @defaults("name partitionKeyPaths defaultTtl") {
   // ARM resource ID
   id string
@@ -7822,12 +8020,14 @@ private azure.subscription.keyVaultService {
 
 // Azure Managed HSM pool
 //
-// Examine a Managed HSM pool — the FIPS 140-2 Level 3 hardware
-// security module offering separate from regular Key Vaults. Surfaces
-// the pool SKU, `tenantId`, the `initialAdminObjectIds` granted local
-// HSM admin, the deployment status and provisioning state, public
-// network access, network ACLs, soft-delete and purge-protection
-// settings, and the public/private endpoint connection list.
+// Single-tenant, FIPS 140-2 Level 3 validated hardware security module
+// pool for cryptographic key storage, provisioned separately from
+// standard Key Vaults. Query it to audit who holds local HSM admin
+// rights (initialAdminObjectIds), whether soft-delete and
+// purge-protection guard against key loss, and how network reach is
+// restricted (publicNetworkAccess and networkAcls). Data-plane key
+// access is governed by Managed HSM local RBAC, distinct from the
+// management-plane permission that lists the pool.
 azure.subscription.keyVaultService.managedHsm @defaults("name location") {
   // Managed HSM ID
   id string
@@ -7855,7 +8055,12 @@ azure.subscription.keyVaultService.managedHsm @defaults("name location") {
   softDeleteRetentionInDays int
   // Public network access setting
   publicNetworkAccess string
-  // Network ACLs
+  // Inbound network rule set
+  //
+  // Keys: `bypass` ("AzureServices" or "None"), `defaultAction`
+  // ("Allow" or "Deny", applied when no rule matches), `ipRules` (a
+  // list of `{value}` allowed CIDR ranges), `virtualNetworkRules` (a
+  // list of `{id}` allowed subnet resource IDs), and `serviceTags`.
   networkAcls dict
   // Provisioning state
   provisioningState string
@@ -7869,15 +8074,24 @@ azure.subscription.keyVaultService.managedHsm @defaults("name location") {
   systemMetadata() azure.subscription.systemData
   // Cryptographic keys stored in the Managed HSM pool
   //
-  // Iterate the keys held in the hardware security module, each exposing
-  // its key type, key size, and elliptic curve. Reading keys requires
+  // Keys held in the hardware security module, each exposing its key
+  // type, key size, and elliptic curve. Reading keys requires
   // data-plane access to the HSM (a Managed HSM local RBAC role such as
   // "Managed HSM Crypto User"), which is separate from the
-  // management-plane permission that lists the pool itself.
+  // management-plane permission that lists the pool.
   keys() []azure.subscription.keyVaultService.key
 }
 
 // Azure Key Vault vault
+//
+// Managed store for cryptographic keys, secrets, and certificates that
+// backs application encryption and TLS across Azure workloads. Query it
+// to audit the authorization model (rbacAuthorizationEnabled versus
+// accessPolicies), data-protection guarantees (enableSoftDelete,
+// enablePurgeProtection, and softDeleteRetentionInDays), network
+// exposure (publicNetworkAccess and networkAcls), and the keys,
+// secrets, and certificates it holds. The skuName distinguishes
+// standard vaults from premium, where premium adds HSM-backed keys.
 private azure.subscription.keyVaultService.vault @defaults("vaultName type vaultUri location") {
   // Vault ID
   id string
@@ -7891,7 +8105,16 @@ private azure.subscription.keyVaultService.vault @defaults("vaultName type vault
   tags map[string]string
   // Vault URL
   vaultUri() string
-  // Vault properties
+  // Raw vault properties
+  //
+  // The unprocessed vault property bag from Azure Resource Manager,
+  // with keys including `sku`, `tenantId`, `enableRbacAuthorization`,
+  // `enableSoftDelete`, `enablePurgeProtection`, `enabledForDeployment`,
+  // `enabledForDiskEncryption`, `enabledForTemplateDeployment`,
+  // `publicNetworkAccess`, `networkAcls`, and `accessPolicies`. Most
+  // values are also exposed as dedicated fields on this resource
+  // (skuName, rbacAuthorizationEnabled, accessPolicies, networkAcls);
+  // prefer those for audits.
   properties() dict
   // Whether RBAC access to the vault is enabled
   rbacAuthorizationEnabled() bool
@@ -7901,7 +8124,7 @@ private azure.subscription.keyVaultService.vault @defaults("vaultName type vault
   enablePurgeProtection() bool
   // Number of days that deleted vaults and vault objects are retained
   softDeleteRetentionInDays() int
-  // Whether the vault is accessible from public networks
+  // Public network access setting ("Enabled" or "Disabled")
   publicNetworkAccess() string
   // Whether the vault can be used for Azure Resource Manager deployment
   enabledForDeployment() bool
@@ -8016,8 +8239,17 @@ private azure.subscription.keyVaultService.key @defaults("kid keyName") {
 // Azure Key Vault key rotation policy
 private azure.subscription.keyVaultService.key.rotationPolicyObject @defaults("enabled") {
   // Lifetime actions for the rotation policy
+  //
+  // Each entry has `action` (`{type}`, where type is "Rotate" or
+  // "Notify") and `trigger` (`{timeAfterCreate, timeBeforeExpiry}`,
+  // ISO 8601 durations such as "P90D" that schedule the action relative
+  // to key creation or expiry).
   lifetimeActions []dict
-  // Attributes of the rotation policy (e.g., expiryTime)
+  // Attributes of the rotation policy
+  //
+  // Keys: `expiryTime` (ISO 8601 duration giving the lifetime of newly
+  // rotated key versions, such as "P90D"), `created`, and `updated`
+  // (timestamps for the policy itself).
   attributes dict
   // Whether automatic key rotation is enabled (true if rotationPolicy exists with Rotate action)
   enabled bool
@@ -8167,10 +8399,10 @@ private azure.subscription.monitorService.activityLog @defaults("alerts") {
   alerts() []azure.subscription.monitorService.activityLog.alert
   // Management events recorded over the last seven days
   //
-  // Examine the management-plane operations Azure recorded for the
-  // subscription: who performed each operation, when, against which
-  // resource, and whether it succeeded. The list covers the most recent
-  // seven days, the practical window for change attribution.
+  // Management-plane operations Azure recorded for the subscription: who
+  // performed each operation, when, against which resource, and whether
+  // it succeeded. The list covers the most recent seven days, the
+  // practical window for change attribution.
   entries() []azure.subscription.monitorService.activityLog.entry
 }
 
@@ -8217,12 +8449,20 @@ private azure.subscription.monitorService.activityLog.alert @defaults("name type
   // Description of the activity log alert
   description string
   // Conditions for the activity log alert, all of which must be met
+  //
+  // Each entry has keys: fieldName; equals; containsAny (list of accepted
+  // values); and anyOf (nested leaf conditions, each with its own
+  // fieldName, equals, and containsAny) forming a match-any group.
   conditions []dict
   // Location of the alert
   location string
   // Tags of the alert
   tags map[string]string
   // Actions that activate when the conditions are met
+  //
+  // Each entry has keys: actionGroupId (ARM ID of the action group to
+  // notify) and webhookProperties (custom key/value pairs sent to the
+  // action group's webhook receivers).
   actions []dict
   // List of resource IDs that must be present to trigger the alert
   scopes []string
@@ -8232,11 +8472,11 @@ private azure.subscription.monitorService.activityLog.alert @defaults("name type
 
 // Azure Monitor activity log event
 //
-// Examine a single management-plane event from the subscription activity
-// log. Each event records the operation that was performed, the identity
-// that initiated it through `caller`, the affected resource, the outcome,
-// and the `correlationId` that ties together all events belonging to one
-// operation — for example every event emitted by a single deployment.
+// Single management-plane event from the subscription activity log. Each
+// event records the operation that was performed, the identity that
+// initiated it through `caller`, the affected resource, the outcome, and
+// the `correlationId` that ties together all events belonging to one
+// operation (for example every event emitted by a single deployment).
 private azure.subscription.monitorService.activityLog.entry @defaults("operationName caller status eventTimestamp") {
   // Unique event data identifier
   id string
@@ -8348,13 +8588,12 @@ private azure.subscription.monitorService.diagnosticsetting @defaults("id name")
 
 // Azure Monitor diagnostic settings category
 //
-// Examine one log or metric category that a resource is capable of
-// emitting through diagnostic settings, independent of whether any
-// diagnostic setting currently collects it. Comparing the available
-// categories against the enabled categories on a resource's
-// `diagnosticSettings` surfaces telemetry a resource could emit but
-// isn't. The `name` field is the category name (for example
-// `AuditEvent` or `AllMetrics`).
+// One log or metric category that a resource is capable of emitting
+// through diagnostic settings, independent of whether any diagnostic
+// setting currently collects it. Comparing the available categories
+// against the enabled categories on a resource's `diagnosticSettings`
+// surfaces telemetry a resource could emit but isn't. The `name` field
+// is the category name (for example `AuditEvent` or `AllMetrics`).
 private azure.subscription.monitorService.diagnosticSettingsCategory @defaults("name categoryType") {
   // Diagnostic category name
   name string
@@ -8365,6 +8604,15 @@ private azure.subscription.monitorService.diagnosticSettingsCategory @defaults("
 }
 
 // Microsoft Defender for Cloud
+//
+// Microsoft Defender for Cloud posture and threat protection for the
+// subscription. Reports which Defender plans (servers, containers, storage,
+// databases, key vaults, App Service, Resource Manager, APIs, and CSPM) are
+// enabled and at what pricing tier, alongside security assessments, active
+// alerts, secure scores, regulatory compliance results, just-in-time VM
+// access policies, alert suppression rules, workspace settings, and security
+// contacts. Audit it to confirm the intended protections are turned on and to
+// review the subscription's overall security posture.
 private azure.subscription.cloudDefenderService @defaults("defenderForServers.enabled defenderForContainers.enabled"){
   // Subscription identifier
   subscriptionId string
@@ -8372,55 +8620,55 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers.en
   monitoringAgentAutoProvision() bool
   // List of Defender for Servers components and whether they are enabled
   //
-  // Deprecated in favor of `forServers()`.
+  // Deprecated in favor of `forServers`.
   defenderForServers() @maturity("deprecated") dict
   // List of Defender for Servers components and whether they are enabled
   forServers() azure.subscription.cloudDefenderService.defenderForServers
   // Microsoft Defender for App Service configuration
   //
-  // Deprecated in favor of `forAppServices()`.
+  // Deprecated in favor of `forAppServices`.
   defenderForAppServices() @maturity("deprecated") dict
   // Microsoft Defender for App Service configuration
   forAppServices() azure.subscription.cloudDefenderService.defenderForAppServices
   // Microsoft Defender for SQL servers on machines configuration
   //
-  // Deprecated in favor of `forSqlServersOnMachines()`.
+  // Deprecated in favor of `forSqlServersOnMachines`.
   defenderForSqlServersOnMachines() @maturity("deprecated") dict
   // Microsoft Defender for SQL servers on machines configuration
   forSqlServersOnMachines() azure.subscription.cloudDefenderService.defenderForSqlServersOnMachines
   // Microsoft Defender for Azure SQL Databases configuration
   //
-  // Deprecated in favor of `forSqlDatabases()`.
+  // Deprecated in favor of `forSqlDatabases`.
   defenderForSqlDatabases() @maturity("deprecated") dict
   // Microsoft Defender for Azure SQL Databases configuration
   forSqlDatabases() azure.subscription.cloudDefenderService.defenderForSqlDatabases
   // Microsoft Defender for open-source relational databases configuration
   //
-  // Deprecated in favor of `forOpenSourceDatabases()`.
+  // Deprecated in favor of `forOpenSourceDatabases`.
   defenderForOpenSourceDatabases() @maturity("deprecated") dict
   // Microsoft Defender for open-source relational databases configuration
   forOpenSourceDatabases() azure.subscription.cloudDefenderService.defenderForOpenSourceDatabases
   // Microsoft Defender for Azure Cosmos DB configuration
   //
-  // Deprecated in favor of `forCosmosDb()`.
+  // Deprecated in favor of `forCosmosDb`.
   defenderForCosmosDb() @maturity("deprecated") dict
   // Microsoft Defender for Azure Cosmos DB configuration
   forCosmosDb() azure.subscription.cloudDefenderService.defenderForCosmosDb
   // Microsoft Defender for Storage Accounts configuration
   //
-  // Deprecated in favor of `forStorageAccounts()`.
+  // Deprecated in favor of `forStorageAccounts`.
   defenderForStorageAccounts() @maturity("deprecated") dict
   // Microsoft Defender for Storage Accounts configuration
   forStorageAccounts() azure.subscription.cloudDefenderService.defenderForStorageAccounts
   // Microsoft Defender for Key Vault configuration
   //
-  // Deprecated in favor of `forKeyVaults()`.
+  // Deprecated in favor of `forKeyVaults`.
   defenderForKeyVaults() @maturity("deprecated") dict
   // Microsoft Defender for Key Vault configuration
   forKeyVaults() azure.subscription.cloudDefenderService.defenderForKeyVaults
   // Microsoft Defender for Resource Manager configuration
   //
-  // Deprecated in favor of `forResourceManager()`.
+  // Deprecated in favor of `forResourceManager`.
   defenderForResourceManager() @maturity("deprecated") dict
   // Microsoft Defender for Resource Manager configuration
   forResourceManager() azure.subscription.cloudDefenderService.defenderForResourceManager
@@ -8430,7 +8678,7 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers.en
   defenderCSPM() azure.subscription.cloudDefenderService.defenderCSPM
   // Defender for Containers components configuration
   //
-  // Deprecated in favor of `forContainers()`.
+  // Deprecated in favor of `forContainers`.
   defenderForContainers() @maturity("deprecated") dict
   // Defender for Containers components configuration
   forContainers() azure.subscription.cloudDefenderService.defenderForContainers
@@ -8454,7 +8702,7 @@ private azure.subscription.cloudDefenderService @defaults("defenderForServers.en
   alerts() []azure.subscription.cloudDefenderService.alert
   // Just-in-time network access policies (on-demand, time-bound VM port access)
   jitNetworkAccessPolicies() []azure.subscription.cloudDefenderService.jitNetworkAccessPolicy
-  // Alert suppression rules (which alerts are auto-dismissed — potential detection blind spots)
+  // Alert suppression rules (which alerts are auto-dismissed, a potential detection blind spot)
   alertSuppressionRules() []azure.subscription.cloudDefenderService.alertSuppressionRule
   // Workspace settings (where the subscription's security data is stored)
   workspaceSettings() []azure.subscription.cloudDefenderService.workspaceSetting
@@ -8631,6 +8879,14 @@ private azure.subscription.cloudDefenderService.regulatoryComplianceControl @def
 }
 
 // Microsoft Defender for Cloud security assessment
+//
+// A security recommendation evaluated against a resource, reporting whether
+// the resource is healthy, unhealthy, or not applicable, together with its
+// severity, Defender CSPM risk level, affected security categories, associated
+// MITRE ATT&CK tactics and techniques, and remediation guidance. Audit
+// unhealthy assessments to find the misconfigurations and exposures Microsoft
+// Defender for Cloud has flagged, and drill into subAssessments for the
+// per-CVE or per-check detail behind a finding.
 private azure.subscription.cloudDefenderService.assessment @defaults("displayName status severity riskLevel") {
   // Assessment resource ID
   id string
@@ -8758,6 +9014,12 @@ private azure.subscription.cloudDefenderService.assessment.subAssessment @defaul
 }
 
 // Microsoft Defender for Cloud security alert
+//
+// A threat detection raised by Microsoft Defender for Cloud describing
+// suspicious or malicious activity observed against a resource. Reports the
+// alert severity and status, the compromised entity, the kill-chain intent,
+// the time window of the activity, and manual remediation steps. Audit active
+// alerts to find in-progress or unresolved threats in the subscription.
 private azure.subscription.cloudDefenderService.alert @defaults("displayName severity status") {
   // Alert resource ID
   id string
@@ -8803,7 +9065,10 @@ private azure.subscription.cloudDefenderService.settings @defaults("name kind") 
   kind string
   // The settings type
   type string
-  // The properties dict (enabled)
+  // Setting configuration
+  //
+  // Carries the `enabled` boolean indicating whether the data export or alert
+  // sync setting is turned on.
   properties dict
 }
 
@@ -9193,9 +9458,17 @@ private azure.subscription.cloudDefenderService.securityContact @defaults("id na
   phone string
   // Emails that receive security alerts
   emails []string
-  // A collection of sources which evaluate the email notification
+  // Email notification sources and their thresholds
+  //
+  // Keyed by source type ("Alert" or "AttackPath"). Each value carries the
+  // source type and its minimum notification threshold: minimalSeverity for
+  // Alert sources and minimalRiskLevel for AttackPath sources.
   notificationSources dict
-  // Notifications by role settings
+  // Subscription roles that receive email notifications
+  //
+  // Carries state ("On" or "Off") and roles, the list of subscription RBAC
+  // roles whose members are notified (for example Owner, Contributor,
+  // ServiceAdmin, or AccountAdmin).
   notificationsByRole dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
@@ -9211,13 +9484,13 @@ private azure.subscription.authorizationService {
   roleAssignments() []azure.subscription.authorizationService.roleAssignment
   // Managed identities
   managedIdentities() []azure.subscription.managedIdentity
-  // Deny assignments — read-only deny rules that block actions even for owners (e.g., managed-app deny on resources)
+  // Deny assignments: read-only deny rules that block actions even for owners (e.g., managed-app deny on resources)
   denyAssignments() []azure.subscription.authorizationService.denyAssignment
-  // Classic (ASM) co-administrators — legacy admin grants that should normally be zero
+  // Classic (ASM) co-administrators: legacy admin grants that should normally be zero
   classicAdministrators() []azure.subscription.authorizationService.classicAdministrator
-  // PIM role eligibility schedules — who is eligible to activate which privileged role
+  // PIM role eligibility schedules: who is eligible to activate which privileged role
   roleEligibilitySchedules() []azure.subscription.authorizationService.roleEligibilitySchedule
-  // PIM role assignment schedules — currently active (including time-bound) privileged role assignments
+  // PIM role assignment schedules: currently active (including time-bound) privileged role assignments
   roleAssignmentSchedules() []azure.subscription.authorizationService.roleAssignmentSchedule
 }
 
@@ -9312,15 +9585,28 @@ private azure.subscription.authorizationService.denyAssignment @defaults("name d
   isSystemProtected bool
   // Scope of the deny assignment (subscription/resource group/resource)
   scope string
-  // Permissions denied (each: { actions, dataActions, notActions, notDataActions, condition })
+  // Denied permissions
+  //
+  // Each entry has keys `actions`, `dataActions`, `notActions`,
+  // `notDataActions`, `condition`, and `conditionVersion`.
   permissions []dict
-  // Principals subject to the deny ([{principalId, principalType}])
+  // Principals subject to the deny
+  //
+  // Each entry has keys `id`, `type`, `displayName`, and `email`.
   principals []dict
-  // Principals excluded from the deny ([{principalId, principalType}])
+  // Principals excluded from the deny
+  //
+  // Each entry has keys `id`, `type`, `displayName`, and `email`.
   excludePrincipals []dict
 }
 
-// Classic (ASM) administrator — legacy co-admin / service admin grants
+// Classic (ASM) administrator
+//
+// Legacy co-administrator or service administrator grant from the classic
+// (Azure Service Management) deployment model. These grants predate role-based
+// access control and carry broad subscription-wide access, so on a hardened
+// subscription the count should normally be zero. Select by the administrator's
+// resource ID.
 private azure.subscription.authorizationService.classicAdministrator @defaults("emailAddress role") {
   // Classic administrator ID
   id string
@@ -9385,10 +9671,22 @@ private azure.subscription.authorizationService.roleAssignment  @defaults("princ
 }
 
 // Azure managed identity
+//
+// Azure managed identity that a resource uses to authenticate to other
+// Azure services without an embedded secret, either system-assigned (tied
+// to a single resource's lifecycle) or user-assigned (a standalone identity
+// attachable to many resources). The `roleAssignments` show the privileges
+// granted to the identity across scopes, and `federatedIdentityCredentials`
+// reveal external OIDC issuers trusted to obtain tokens for it (workload
+// identity federation), a common privilege-escalation path worth auditing.
 private azure.subscription.managedIdentity @defaults("name") {
+  // Name of the managed identity
   name string
+  // Client ID (application ID) of the identity's service principal
   clientId string
+  // Object ID of the identity's service principal, referenced by role assignments
   principalId string
+  // Entra ID tenant that owns the identity
   tenantId string
   roleAssignments() []azure.subscription.authorizationService.roleAssignment
   // Federated identity credentials (workload identity federation)
@@ -9412,17 +9710,14 @@ private azure.subscription.aksService {
 
 // Azure Kubernetes Service (AKS) cluster
 //
-// Examine an AKS cluster's control-plane and managed-platform
-// configuration. Surfaces the Kubernetes version, DNS prefix, FQDN,
-// API server access profile (private cluster, authorized IP ranges),
-// network profile (network plugin, service/pod CIDR, load-balancer
-// SKU), identity (system-assigned or user-assigned, kubeletIdentity),
-// RBAC and Azure AD integration, OIDC issuer URL for workload
-// identity, the agent pool profiles, addon profiles (monitoring,
-// policy, ingress-app-routing), Azure Policy and Defender for Cloud
-// integration, image cleaner, cluster auto-upgrade channel, and the
-// security profile (workload identity, image integrity, defender,
-// node restriction, KMS encryption).
+// Managed Kubernetes cluster and its control-plane security posture:
+// the Kubernetes version, private-cluster and API server access
+// controls, network plugin and policy, RBAC and Azure AD integration,
+// workload identity federation through the OIDC issuer, KMS encryption
+// of cluster secrets, Microsoft Defender monitoring, the auto-upgrade
+// channel, and the node pools that back the cluster. The
+// `internetReachable` predicate reports whether the API server is
+// reachable from the public internet.
 azure.subscription.aksService.cluster @defaults("name location kubernetesVersion") {
   // ID of the AKS cluster
   id string
@@ -9448,21 +9743,54 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   fqdn string
   // The DNS prefix of the AKS cluster
   dnsPrefix string
-  // The storage profile of the AKS cluster
+  // CSI storage driver configuration for the cluster
+  //
+  // Keys: `blobCSIDriver`, `diskCSIDriver`, `fileCSIDriver`, and
+  // `snapshotController`, each an object with an `enabled` boolean. See
+  // diskCsiDriverEnabled for the disk-driver state as a boolean.
   storageProfile dict
   // Whether the Azure Disk CSI driver is enabled on the cluster
   diskCsiDriverEnabled bool
-  // The workload autoscaler profile of the AKS cluster
+  // Workload autoscaler add-on configuration
+  //
+  // Keys: `keda` (Kubernetes Event-driven Autoscaling) and
+  // `verticalPodAutoscaler`, each an object with an `enabled` boolean.
   workloadAutoScalerProfile dict
-  // The security profile of the AKS cluster
+  // Cluster security add-on configuration
+  //
+  // Keys: `azureKeyVaultKms` (`{enabled, keyId, keyVaultNetworkAccess,
+  // keyVaultResourceId}`), `defender` (`{logAnalyticsWorkspaceResourceId,
+  // securityMonitoring}`), `imageCleaner` (`{enabled, intervalHours}`),
+  // `workloadIdentity` (`{enabled}`), and `customCATrustCertificates`.
+  // Individual states are also exposed as the defenderEnabled,
+  // imageCleanerEnabled, workloadIdentityEnabled, and
+  // azureKeyVaultKmsEnabled fields.
   securityProfile dict
-  // The pod identity profile of the AKS cluster
+  // Azure AD pod-managed identity configuration
+  //
+  // Keys: `enabled`, `allowNetworkPluginKubenet`,
+  // `userAssignedIdentities`, and `userAssignedIdentityExceptions`.
   podIdentityProfile dict
-  // The network profile of the AKS cluster
+  // Cluster network configuration
+  //
+  // Keys include `networkPlugin`, `networkPluginMode`, `networkPolicy`,
+  // `networkDataplane`, `networkMode`, `outboundType`, `loadBalancerSku`,
+  // `loadBalancerProfile`, `natGatewayProfile`, `serviceCidr`(s),
+  // `podCidr`(s), `dnsServiceIP`, `ipFamilies`, and `advancedNetworking`.
+  // The networkPlugin and networkPolicy scalar fields expose the two
+  // most common values directly.
   networkProfile dict
-  // The HTTP proxy config of the AKS cluster
+  // Outbound HTTP proxy configuration for cluster nodes
+  //
+  // Keys: `enabled`, `httpProxy`, `httpsProxy`, `noProxy` (list of
+  // no-proxy hosts), and `trustedCa` (base64 CA certificate bundle).
   httpProxyConfig dict
-  // The add-on profiles of the AKS cluster
+  // Managed add-ons enabled on the cluster
+  //
+  // Each entry is a single-key object whose key is the add-on name (for
+  // example `omsagent`, `azurepolicy`, `azureKeyvaultSecretsProvider`,
+  // or `ingressApplicationGateway`) and whose value is an object with
+  // `enabled`, `config`, and `identity`.
   addonProfiles []dict
   // Raw agent pool profiles attached to the cluster
   //
@@ -9470,7 +9798,13 @@ azure.subscription.aksService.cluster @defaults("name location kubernetesVersion
   agentPoolProfiles @maturity("deprecated") []dict
   // Node pools (agent pools) attached to the cluster
   nodePools() []azure.subscription.aksService.cluster.nodePool
-  // The API server access profile
+  // Kubernetes API server access configuration
+  //
+  // Keys: `authorizedIPRanges`, `enablePrivateCluster`,
+  // `enablePrivateClusterPublicFQDN`, `enableVnetIntegration`,
+  // `privateDNSZone`, `disableRunCommand`, and `subnetId`. The same
+  // values are exposed as the apiServerAuthorizedIPRanges,
+  // enablePrivateCluster, privateDnsZone, and disableRunCommand fields.
   apiServerAccessProfile dict
   // FQDN subdomain for private DNS zone clusters
   fqdnSubdomain string
@@ -9597,9 +9931,9 @@ private azure.subscription.aksService.cluster.advancedNetworking @defaults("tran
 
 // Azure Kubernetes Service cluster identity binding
 //
-// Examine a binding between an external workload identity and an Azure
+// Binding between an external workload identity and an Azure
 // user-assigned managed identity on an AKS cluster. Each binding ties a
-// federated identity — selected by the `name` field — to a managed
+// federated identity, selected by the `name` field, to a managed
 // identity, letting in-cluster workloads authenticate as that identity
 // through the cluster's OIDC issuer. Surfaces the bound managed
 // identity's client, object, and tenant IDs, the OIDC issuer URL the
@@ -9719,6 +10053,13 @@ private azure.subscription.aksService.cluster.nodePool @defaults("name mode vmSi
 }
 
 // Azure Advisor
+//
+// Azure Advisor recommendations and category scores for a subscription.
+// Advisor analyzes resource configuration and usage telemetry and flags
+// improvements across cost, security, reliability, operational excellence,
+// and performance. The `recommendations` field enumerates individual
+// findings, while `scores` and the rolled-up `averageScore` track posture
+// per category over time.
 private azure.subscription.advisorService @defaults("averageScore recommendations.length scores.length") {
   // Subscription identifier
   subscriptionId string
@@ -9731,6 +10072,11 @@ private azure.subscription.advisorService @defaults("averageScore recommendation
 }
 
 // Azure Advisor recommendation
+//
+// Single Advisor finding for a subscription, describing a suggested
+// improvement and the resource it applies to. Each recommendation carries
+// a `category`, an `impact` rating, and a `risk` level, together with the
+// affected resource in `impactedResource`. The `id` selects the record.
 private azure.subscription.advisorService.recommendation @defaults("name category impact description impactedResource") {
   // Recommendation ID
   id string
@@ -9739,10 +10085,18 @@ private azure.subscription.advisorService.recommendation @defaults("name categor
   // Recommendation resource type
   type string
   // Recommendation category
+  //
+  // One of Cost, HighAvailability, OperationalExcellence, Performance, or
+  // Security.
   category string
   // Recommendation risk
+  //
+  // Potential risk of not implementing the recommendation. One of Error,
+  // Warning, or None.
   risk string
   // Recommendation impact
+  //
+  // Business impact of the recommendation. One of High, Medium, or Low.
   impact string
   // Recommendation description
   description string
@@ -9752,7 +10106,14 @@ private azure.subscription.advisorService.recommendation @defaults("name categor
   impactedResourceType string
   // The impacted resource
   impactedResource string
-  // Recommendation properties
+  // Full recommendation properties
+  //
+  // The complete Advisor recommendation record. Keys include `category`,
+  // `impact`, and `risk` (also surfaced as top-level fields), `impactedField`
+  // and `impactedValue` (the affected resource type and resource), plus
+  // `shortDescription`, `extendedProperties`, `metadata`, `resourceMetadata`,
+  // `recommendationTypeId`, `learnMoreLink`, `potentialBenefits`, `actions`,
+  // `remediation`, `label`, and `lastUpdated`.
   properties dict
 }
 
@@ -9799,6 +10160,12 @@ private azure.subscription.advisorService.securityScore {
 }
 
 // Azure Policy service
+//
+// Azure Policy governance for a subscription, covering the policy
+// assignments in effect, the definitions and initiatives they draw
+// from, the exemptions that suspend enforcement, and an aggregate
+// compliance summary. Use it to audit which governance controls are
+// applied and where resources fall out of compliance.
 private azure.subscription.policy @defaults("subscriptionId") {
   // Subscription identifier
   subscriptionId string
@@ -9815,6 +10182,13 @@ private azure.subscription.policy @defaults("subscriptionId") {
 }
 
 // Azure Policy assignment
+//
+// Assignment of a policy definition or initiative to a scope, which
+// puts the policy into effect. The enforcementMode field distinguishes
+// active enforcement from audit-only evaluation (Default vs
+// DoNotEnforce), and scope records whether the assignment is inherited
+// from a containing management group or applied directly to the
+// subscription.
 private azure.subscription.policy.assignment @defaults("name enforcementMode") {
   // Policy definition ID
   id string
@@ -9828,13 +10202,23 @@ private azure.subscription.policy.assignment @defaults("name enforcementMode") {
   description string
   // Policy enforcement Mode
   enforcementMode string
-  // Policy parameters
+  // Parameter values supplied to the assigned policy
+  //
+  // Keyed by parameter name, with each value an object holding a
+  // `value` field that carries the argument passed to the definition.
   parameters dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }
 
 // Azure Policy definition
+//
+// Single policy rule and the effect it produces (for example deny,
+// audit, append, or deployIfNotExists). The policyType field records
+// whether the definition ships with Azure or is custom, and policyRule
+// holds the if/then condition evaluated against resources. Selecting
+// definitions by their category metadata or effect helps audit which
+// controls are available to assign.
 private azure.subscription.policy.definition @defaults("name displayName policyType") {
   // Policy definition resource ID
   id string
@@ -9861,6 +10245,12 @@ private azure.subscription.policy.definition @defaults("name displayName policyT
 }
 
 // Azure Policy initiative
+//
+// Initiative (policy set) that groups multiple policy definitions under
+// a single assignable unit, so related controls are applied together.
+// The policyDefinitions field lists the grouped definitions and their
+// parameters, and policyType records whether the initiative ships with
+// Azure or is custom.
 private azure.subscription.policy.setDefinition @defaults("name displayName policyType") {
   // Policy set definition resource ID
   id string
@@ -9885,6 +10275,13 @@ private azure.subscription.policy.setDefinition @defaults("name displayName poli
 }
 
 // Azure Policy exemption
+//
+// Exemption that suspends policy enforcement for a resource, resource
+// group, or subscription, so an assignment stops flagging or blocking
+// the exempted scope. The exemptionCategory field records why it was
+// granted (Waiver or Mitigated) and expiresOn records when enforcement
+// resumes. Auditing exemptions surfaces intentional gaps in governance
+// coverage.
 private azure.subscription.policy.exemption @defaults("name exemptionCategory expiresOn") {
   // Policy exemption resource ID
   id string
@@ -9913,6 +10310,11 @@ private azure.subscription.policy.exemption @defaults("name exemptionCategory ex
 }
 
 // Azure Policy compliance summary
+//
+// Aggregate compliance rollup for the subscription, reporting how many
+// resources and policies are out of compliance along with per-state and
+// per-assignment breakdowns. Use it to gauge overall governance health
+// without enumerating individual policy states.
 private azure.subscription.policy.complianceSummary @defaults("nonCompliantResources nonCompliantPolicies") {
   // Subscription identifier
   subscriptionId string
@@ -9924,23 +10326,41 @@ private azure.subscription.policy.complianceSummary @defaults("nonCompliantResou
   resourceComplianceCounts() map[string]int
   // Policy counts keyed by compliance state
   policyComplianceCounts() map[string]int
-  // Per-assignment compliance breakdown with non-compliant resource and policy counts
+  // Per-assignment compliance breakdown
+  //
+  // One entry per policy assignment, each keyed with `policyAssignmentId`,
+  // `policySetDefinitionId`, `nonCompliantResources`, and
+  // `nonCompliantPolicies`.
   assignments() []dict
 }
 
 // Azure IoT Hub Service
+//
+// IoT Hub deployments across the subscription. IoT Hub is the managed service
+// that brokers bidirectional communication between IoT devices and Azure.
+// Query `iotHubs` to audit each hub's authentication policy (SAS-key
+// controls), TLS enforcement, public network exposure, outbound egress
+// restrictions, and managed identity assignment.
 private azure.subscription.iotService {
   // Subscription identifier
   subscriptionId string
   // Raw IoT hubs in the subscription
   //
-  // Deprecated in favor of `iotHubs()`.
+  // Deprecated in favor of `iotHubs`.
   hubs() @maturity("deprecated") []dict
   // Typed IoT hubs in the subscription
   iotHubs() []azure.subscription.iotService.iotHub
 }
 
 // Azure IoT hub
+//
+// Single IoT Hub instance, the cloud endpoint that authenticates devices and
+// ingests their telemetry. Security-relevant settings include the SAS-key
+// authentication policy (`disableLocalAuth`, `disableDeviceSAS`,
+// `disableModuleSAS`), `minTlsVersion`, `publicNetworkAccess`, outbound egress
+// restrictions via `restrictOutboundNetworkAccess` and `allowedFqdnList`, the
+// `networkRuleSet` IP filter, and managed identity assignment. The `id` field
+// is the full resource ID.
 private azure.subscription.iotService.iotHub @defaults("id name location") {
   // IoT hub resource ID
   id string
@@ -9953,6 +10373,10 @@ private azure.subscription.iotService.iotHub @defaults("id name location") {
   // Tags applied to the IoT hub
   tags map[string]string
   // SKU details
+  //
+  // Pricing and scale keyed by `name` (edition, one of F1, B1, B2, B3, S1, S2,
+  // or S3), `tier` (Free, Basic, or Standard), and `capacity` (number of
+  // provisioned units).
   sku dict
   // Provisioning state
   provisioningState string
@@ -10006,14 +10430,14 @@ private azure.subscription.cacheService @defaults("subscriptionId") {
 
 // Azure Cache for Redis instance
 //
-// Examine an Azure Cache for Redis instance. Surfaces the SKU and
-// tier (Basic, Standard, Premium, Enterprise), the Redis version,
-// host name and ports (SSL and non-SSL), the
-// `enableNonSslPort` flag, public network access, the configured
-// `redisConfiguration` (maxmemory policy, eviction, AOF/RDB
-// persistence), TLS minimum version, identity assignments, replicas
-// per master, shard count for clustered Premium tiers, and the
-// virtual-network or private-endpoint placement.
+// Managed Redis cache deployment and its exposure and hardening posture.
+// Covers the pricing tier and SKU, Redis version, and the settings that
+// determine reachability and transport security: publicNetworkAccess,
+// the enableNonSslPort flag that opens the plaintext 6379 port,
+// minimumTlsVersion, and the VNet injection or private-endpoint
+// placement. redisConfiguration carries persistence and authentication
+// settings, and the identity fields expose the cache's managed identity.
+// Premium and Enterprise tiers add clustering (shardCount) and replicas.
 azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   // ID of the Redis cache
   id string
@@ -10023,7 +10447,13 @@ azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   location string
   // Type of the Redis cache
   type string
-  // Properties of the Redis cache
+  // Raw Redis cache resource
+  //
+  // Unmodified Azure Resource Manager representation of the cache, keyed
+  // by the ARM property names (`id`, `name`, `location`, `properties`,
+  // `sku`, `identity`, `zones`, `tags`). Individual values are also
+  // surfaced as their own fields on this resource; prefer those (for
+  // example redisVersion, minimumTlsVersion) over reading this bag.
   properties dict
   // Specifies whether the non-ssl Redis server port (6379) is enabled
   enableNonSslPort bool
@@ -10045,11 +10475,24 @@ azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   replicasPerPrimary int
   // Minimum TLS version required by the Redis cache
   minimumTlsVersion string
-  // SKU information for the Redis cache
+  // Cache SKU
+  //
+  // Pricing tier and size, keyed by `name` (Basic, Standard, or
+  // Premium), `family` (C for Basic/Standard, P for Premium), and
+  // `capacity` (the size number within the family).
   sku dict
   // Tags of redis cache
   tags map[string]string
-  // Redis configuration settings (maxmemory-policy, persistence, auth, etc.)
+  // Redis configuration settings
+  //
+  // Server-side settings keyed by their ARM configuration names. Security
+  // and durability relevant keys include `authnotrequired` (when set,
+  // password auth is disabled), `aad-enabled` (Entra ID authentication),
+  // `maxmemory-policy` (eviction strategy), `rdb-backup-enabled` and
+  // `aof-backup-enabled` with their `rdb-storage-connection-string` /
+  // `aof-storage-connection-string-0` / `aof-storage-connection-string-1`
+  // persistence targets, and `preferred-data-persistence-auth-method`
+  // (SAS or ManagedIdentity).
   redisConfiguration dict
   // Number of shards (Premium Cluster Cache only)
   shardCount int
@@ -10061,7 +10504,14 @@ azure.subscription.cacheService.redisInstance @defaults("id hostName") {
   subnet() azure.subscription.networkService.subnet
   // Availability zones for the cache
   zones []string
-  // Managed identity information
+  // Managed identity assignment
+  //
+  // Managed identity block keyed by `type` (None, SystemAssigned,
+  // UserAssigned, or "SystemAssigned, UserAssigned"), `principalId` and
+  // `tenantId` of the system-assigned identity, and
+  // `userAssignedIdentities`. The system-assigned principal is also
+  // available as principalId, and the attached user-assigned identities
+  // as userAssignedIdentities.
   identity dict
   // Principal ID of the cache's system-assigned managed identity; empty when no system-assigned identity is enabled
   principalId string
@@ -10145,13 +10595,12 @@ private azure.subscription.dataFactoryService {
 
 // Azure Data Factory
 //
-// Examine an Azure Data Factory — the managed ETL/ELT and data
-// integration service. Surfaces the factory's identity assignments,
-// the linked Git repository configuration (Azure DevOps or GitHub
-// account, project, root folder, collaboration branch), public
-// network access, the `purviewConfiguration` for data-catalog
-// integration, encryption settings (customer-managed key reference),
-// global parameters, and the resource version.
+// Managed cloud ETL/ELT and data-integration service that orchestrates
+// pipelines across data stores. Auditing a factory surfaces its public
+// network access posture, source-control (Git) binding, customer-managed
+// key encryption, and the managed identities it uses to reach data
+// sources, along with its linked services, integration runtimes, and
+// managed virtual network.
 azure.subscription.dataFactoryService.factory @defaults("name location") {
   // Full resource ID
   id string
@@ -10167,13 +10616,23 @@ azure.subscription.dataFactoryService.factory @defaults("name location") {
   properties dict
   // Whether public network access is enabled ("Enabled" or "Disabled")
   publicNetworkAccess string
-  // Identity configuration
+  // Managed identity assigned to the factory
+  //
+  // Keys: type ("SystemAssigned", "UserAssigned", or
+  // "SystemAssigned,UserAssigned"), principalId, tenantId, and
+  // userAssignedIdentities (map keyed by identity resource ID). Null
+  // when no identity is configured.
   identity dict
   // Provisioning state
   provisioningState string
   // Version of the factory
   version string
-  // Repository configuration for source control
+  // Source-control (Git) binding for the factory
+  //
+  // Keys: type ("FactoryVSTSConfiguration" for Azure DevOps or
+  // "FactoryGitHubConfiguration" for GitHub), accountName, projectName
+  // (Azure DevOps only), repositoryName, collaborationBranch, rootFolder,
+  // and lastCommitId. Null when the factory is not bound to a repository.
   repoConfiguration dict
   // Encryption configuration
   //
@@ -10216,12 +10675,12 @@ azure.subscription.dataFactoryService.factory @defaults("name location") {
 
 // Azure Data Factory linked service
 //
-// Examine a single linked service — the configured connection from the
-// factory to an external system (Azure SQL, Storage, REST API, ...).
-// Selectable by ARM id; fields cover the linked-service type, the
-// integration runtime executing it, declared parameter names, and a
-// `usesKeyVaultReference` rollup that flags whether any credential
-// field in `typeProperties` resolves through Azure Key Vault.
+// Configured connection from the factory to an external system such as
+// Azure SQL, Blob Storage, or a REST API. Selectable by ARM id. The
+// serviceType field identifies the connector, integrationRuntimeName
+// names the runtime that executes it, and usesKeyVaultReference flags
+// whether any credential in typeProperties resolves through Azure Key
+// Vault rather than being stored inline, a common configuration audit.
 private azure.subscription.dataFactoryService.factory.linkedService @defaults("name serviceType integrationRuntimeName usesKeyVaultReference") {
   // ARM resource ID
   id string
@@ -10261,12 +10720,13 @@ private azure.subscription.dataFactoryService.factory.linkedService @defaults("n
 
 // Azure Data Factory integration runtime
 //
-// Examine a compute resource attached to the factory — either a
-// fully-managed Azure runtime (Azure Integration Runtime / Azure-SSIS)
-// or a Self-hosted runtime that runs on customer infrastructure.
-// Selectable by ARM id; fields cover the runtime type and the raw
-// type-specific properties (Managed exposes computeProperties /
-// ssisProperties; SelfHosted exposes nodes and version info).
+// Compute resource attached to the factory that executes pipeline
+// activities, either a fully-managed Azure Integration Runtime (or
+// Azure-SSIS) or a Self-hosted runtime running on customer
+// infrastructure. Selectable by ARM id. The runtimeType field selects
+// the variant and typeProperties carries the runtime-specific
+// configuration (Managed exposes compute and SSIS properties;
+// SelfHosted exposes node and version info).
 private azure.subscription.dataFactoryService.factory.integrationRuntime @defaults("name runtimeType") {
   // ARM resource ID
   id string
@@ -10286,10 +10746,11 @@ private azure.subscription.dataFactoryService.factory.integrationRuntime @defaul
 
 // Azure Data Factory managed virtual network
 //
-// Examine the (singleton) managed virtual network on a factory. Selectable
-// by ARM id; fields expose the alias and the underlying virtual-network
-// id, plus the managed private endpoints that route factory-side traffic
-// privately to other Azure resources.
+// Managed virtual network on a factory that isolates integration runtime
+// traffic and routes it privately to data sources. Selectable by ARM id.
+// Exposes the alias, the underlying virtual-network id, and the managed
+// private endpoints that carry factory-side traffic to other Azure
+// resources over Private Link.
 private azure.subscription.dataFactoryService.factory.managedVirtualNetwork @defaults("name alias") {
   // ARM resource ID
   id string
@@ -10309,10 +10770,10 @@ private azure.subscription.dataFactoryService.factory.managedVirtualNetwork @def
 
 // Azure Data Factory managed private endpoint
 //
-// Examine a managed private endpoint inside a factory's managed virtual
-// network — used to route factory traffic to a target Azure resource via
-// Private Link. Selectable by ARM id; fields expose the target resource,
-// the connection-approval state, and FQDNs assigned to the endpoint.
+// Managed private endpoint inside a factory's managed virtual network
+// that routes factory traffic to a target Azure resource over Private
+// Link. Selectable by ARM id. Exposes the target resource, the
+// connection-approval state, and the FQDNs assigned to the endpoint.
 private azure.subscription.dataFactoryService.factory.managedPrivateEndpoint @defaults("name groupId connectionStatus") {
   // ARM resource ID
   id string
@@ -10350,13 +10811,13 @@ private azure.subscription.synapseService {
 
 // Azure Synapse Analytics workspace
 //
-// Examine an Azure Synapse Analytics workspace. Surfaces the
-// workspace's default Data Lake Storage account, the SQL
+// Analytics workspace unifying data warehousing, big-data
+// processing, and data integration. The security-relevant surface
+// includes the default Data Lake Storage account, the SQL
 // administrator login, the managed virtual network configuration, the
 // public network access setting, customer-managed-key encryption
-// settings, identity assignments, the
-// `azureADOnlyAuthentication` flag, the workspace repository for Git
-// integration, and the configured trusted-service bypass list.
+// settings, identity assignments, the `azureADOnlyAuthentication`
+// flag, and the configured trusted-service bypass list.
 azure.subscription.synapseService.workspace @defaults("name location") {
   // Full resource ID
   id string
@@ -10368,15 +10829,32 @@ azure.subscription.synapseService.workspace @defaults("name location") {
   tags map[string]string
   // Resource type
   type string
-  // Unmodeled resource properties returned by the Azure API
+  // Complete workspace properties as returned by the Azure API
+  //
+  // Raw property bag for the workspace. Frequently audited values are
+  // also exposed as dedicated fields, including managedVirtualNetwork,
+  // publicNetworkAccess, encryption, sqlAdministratorLogin,
+  // defaultStorageFilesystem, and provisioningState.
   properties dict
-  // Identity configuration
+  // Managed identity configuration
+  //
+  // Identity block for the workspace. Keys include `type` (None,
+  // SystemAssigned, or "SystemAssigned,UserAssigned"), `principalId`
+  // and `tenantId` of the system-assigned identity, and
+  // `userAssignedIdentities` keyed by identity resource ID. The
+  // user-assigned identities are also available through
+  // userAssignedIdentities.
   identity dict
-  // Whether managed virtual network is enabled (set to "default" when enabled)
+  // Managed virtual network setting, set to "default" when enabled and empty when disabled
   managedVirtualNetwork string
   // Public network access setting ("Enabled" or "Disabled")
   publicNetworkAccess string
   // Encryption configuration
+  //
+  // Encryption settings for the workspace. Keys include `cmk` (the
+  // customer-managed key details, with `key`, `kekIdentity`, and
+  // `status`) and `doubleEncryptionEnabled`. The customer-managed key
+  // itself is also resolved through cmkKey.
   encryption dict
   // Name of the managed resource group
   managedResourceGroupName string
@@ -10410,14 +10888,15 @@ private azure.subscription.containerRegistryService {
 
 // Azure Container Registry
 //
-// Examine an Azure Container Registry — the managed Docker registry
-// service. Surfaces the SKU and tier (Basic, Standard, Premium), the
-// admin user state, public network access, the network rule set
-// (default action, IP rules, virtual-network rules), zone redundancy,
-// the encryption configuration and KMS reference, anonymous pull
-// access, data endpoint enabled state, the policies block (quarantine,
-// retention, trust, soft delete, export), and the configured
-// `webhooks()`, `replications()`, and `tasks()`.
+// Managed private Docker and OCI registry that stores and distributes
+// container images and artifacts. Auditing a registry surfaces its SKU
+// tier (Basic, Standard, Premium), whether the admin user and anonymous
+// pull are enabled, the public network access state and the network
+// rule set that restricts inbound traffic, the encryption configuration,
+// and the content-trust, retention, quarantine, and export policies that
+// govern image lifecycle and supply-chain controls. Sub-resources cover
+// geo-replications, webhooks, scope-map and token access, pull-through
+// cache rules, and connected edge registries.
 azure.subscription.containerRegistryService.registry @defaults("id name location skuName") {
   // Registry resource ID
   id string
@@ -10628,7 +11107,11 @@ private azure.subscription.containerRegistryService.registry.token @defaults("id
   provisioningState string
   // Scope map that defines token permissions
   scopeMap() azure.subscription.containerRegistryService.registry.scopeMap
-  // Token certificates
+  // Certificate credentials that authenticate the token
+  //
+  // Each entry carries `name` ("certificate1" or "certificate2"),
+  // `encodedPemCertificate` (base64-encoded public certificate in PEM
+  // format), `expiry`, and `thumbprint`.
   certificates []dict
   // Token password credentials
   //
@@ -10654,7 +11137,7 @@ private azure.subscription.containerRegistryService.registry.cacheRule @defaults
   targetRepository string
   // ARM resource ID of the credential set associated with the cache rule
   credentialSetResourceId string
-  // Typed reference to the credential set used by this cache rule
+  // Credential set used by this cache rule
   credentialSet() azure.subscription.containerRegistryService.registry.credentialSet
   // Cache rule creation date
   creationDate time
@@ -10674,9 +11157,19 @@ private azure.subscription.containerRegistryService.registry.credentialSet @defa
   type string
   // The upstream login server the credentials apply to (e.g. "docker.io")
   loginServer string
-  // Identity used to access the Key Vault holding the secrets
+  // Managed identity used to read the Key Vault secrets
+  //
+  // Carries `type` ("SystemAssigned", "UserAssigned", "SystemAssigned,
+  // UserAssigned", or "None"), `principalId`, `tenantId`, and
+  // `userAssignedIdentities` (map keyed by user-assigned identity
+  // resource ID).
   identity dict
-  // Authentication credentials (Key Vault secret URIs for username/password)
+  // Upstream authentication credentials
+  //
+  // Each entry carries `name` ("Credential1"), the Key Vault secret URIs
+  // `usernameSecretIdentifier` and `passwordSecretIdentifier` for the
+  // username and password, and `credentialHealth` describing the last
+  // validation status. Secret values are never returned.
   authCredentials []dict
   // Credential set creation date
   creationDate time
@@ -10740,14 +11233,14 @@ private azure.subscription.containerRegistryService.registry.connectedRegistry @
 
 // Azure Log Analytics workspace
 //
-// Examine a Log Analytics workspace — the underlying log/data store
-// for Azure Monitor, Microsoft Sentinel, and Defender for Cloud.
-// Surfaces the workspace SKU (PerGB2018, CapacityReservation, Free,
-// Standalone, etc.), retention period, daily-quota cap and reset
-// time, the public network access state for ingestion and query, the
-// linked Application Insights workspaces, the customer-managed-key
-// reference, identity assignments, and the `created`/`modified`
-// timestamps tying the workspace's lifecycle to its tenant.
+// Underlying log and data store for Azure Monitor, Microsoft Sentinel,
+// and Defender for Cloud. Surfaces the workspace SKU (PerGB2018,
+// CapacityReservation, Free, Standalone, etc.), retention period,
+// daily-quota cap and reset time, the public network access state for
+// ingestion and query, the linked Application Insights workspaces, the
+// customer-managed-key reference, identity assignments, and the
+// `created`/`modified` timestamps tying the workspace's lifecycle to
+// its tenant.
 azure.subscription.monitorService.workspace @defaults("id name location skuName") {
   // Workspace resource ID
   id string
@@ -10988,11 +11481,10 @@ private azure.subscription.monitorService.workspace.nspConfiguration @defaults("
 
 // Log Analytics QueryPack
 //
-// Examine a Log Analytics query pack — the share-and-version unit for
-// curated KQL queries. Surfaces the query-pack `queryPackId`, the
-// `provisioningState`, time created and modified, and the resource
-// tags applied. The queries inside the pack are accessed through the
-// per-pack collection accessor on the parent monitor service.
+// Share-and-version unit for curated KQL queries. Surfaces the query-pack
+// `queryPackId`, the `provisioningState`, time created and modified, and
+// the resource tags applied. The saved queries inside the pack are
+// available through `queries`.
 azure.subscription.monitorService.queryPack @defaults("id name location queryPackId") {
   // QueryPack resource ID
   id string
@@ -11056,14 +11548,15 @@ private azure.subscription.recoveryServicesService {
 
 // Azure Recovery Services vault
 //
-// Examine a Recovery Services vault — the storage container for Azure
-// Backup and Azure Site Recovery. Surfaces the vault SKU, the
-// soft-delete and immutability state, public network access, identity
-// assignments, the customer-managed-key encryption reference,
-// cross-region restore configuration, the `monitoringSettings` for
-// classic alerts and Azure Monitor alerts, the redundancy mode
-// (LRS, GRS, ZRS, GZRS), and the
-// `securitySettings` (multi-user authorization, soft delete).
+// Storage container for Azure Backup and Azure Site Recovery that holds
+// backup policies, protected items, and the encryption, redundancy, and
+// network configuration governing how backup data is stored and reached.
+// Query a vault to audit whether soft delete and immutability protect
+// backups from tampering, whether public network access is disabled,
+// whether customer-managed keys encrypt the data, and whether multi-user
+// authorization guards destructive operations. The securitySettings,
+// encryption, redundancySettings, and monitoringSettings sub-resources
+// carry the detailed state.
 azure.subscription.recoveryServicesService.vault @defaults("id name location skuName") {
   // Vault resource ID
   id string
@@ -11075,7 +11568,14 @@ azure.subscription.recoveryServicesService.vault @defaults("id name location sku
   type string
   // Vault tags
   tags map[string]string
-  // Identity configuration
+  // Managed identity configuration
+  //
+  // Managed identity block of the vault, with keys `type` (one of
+  // "SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned", or
+  // "None"), `principalId` and `tenantId` for the system-assigned identity,
+  // and `userAssignedIdentities` mapping each assigned identity resource ID
+  // to its client and principal IDs. See userAssignedIdentities for the
+  // resolved user-assigned identity resources.
   identity dict
   // User-assigned managed identities associated with the vault
   userAssignedIdentities() []azure.subscription.managedIdentity
@@ -11225,7 +11725,13 @@ private azure.subscription.recoveryServicesService.vault.backupPolicy @defaults(
   name string
   // Resource type
   type string
-  // Policy properties (polymorphic: IaaS VM, SQL, FileShare, etc.)
+  // Backup policy properties
+  //
+  // Raw policy definition whose shape is selected by the
+  // `backupManagementType` discriminator key (for example "AzureIaasVM",
+  // "AzureSql", "AzureStorage" for file shares, or "AzureWorkload" for SQL
+  // and SAP HANA in a VM). Along with the discriminator, common keys carry
+  // the schedule and retention rules that define the backup cadence.
   properties dict
 }
 
@@ -11237,7 +11743,14 @@ private azure.subscription.recoveryServicesService.vault.protectedItem @defaults
   name string
   // Resource type
   type string
-  // Item properties (polymorphic: VM, SQL, FileShare, SAP HANA, etc.)
+  // Protected item properties
+  //
+  // Raw protected-item definition whose shape is selected by the
+  // `protectedItemType` discriminator key (for example
+  // "Microsoft.Compute/virtualMachines", "AzureFileShareProtectedItem", or
+  // the SQL and SAP HANA workload types). Common keys include
+  // `backupManagementType`, `workloadType`, `policyId`, and the time and
+  // health status of the most recent backup.
   properties dict
 }
 
@@ -11253,15 +11766,15 @@ private azure.subscription.functionsService {
 
 // Azure Function App
 //
-// Examine a Function App — the Azure-Functions-flavored App Service
-// site that runs serverless functions. Surfaces the runtime stack,
-// SKU, App Service Plan binding, the `siteConfig` (TLS minimum
-// version, FTPS state, IP restrictions, CORS, always-on,
-// HTTPS-only), HTTPS-only flag, identity assignments, public network
-// access, the configured custom hostnames and SSL bindings, the
-// `appSettings()` (with the runtime version, AzureWebJobsStorage,
-// FUNCTIONS_WORKER_RUNTIME, etc.), `connectionStrings()`, deployment
-// slots, and per-function metadata.
+// Function App, an App Service site configured to run serverless
+// functions. Covers runtime state, HTTPS-only enforcement, client
+// certificate mode, managed-identity assignments, public network
+// access, and regional virtual-network integration. The site
+// configuration (minimum TLS version, FTPS state, IP restrictions,
+// CORS, always-on) is available through `configuration`, while
+// `appSettings` and `connectionStrings` report the configured
+// settings without exposing their values, so you can audit for
+// plaintext secrets and Azure Key Vault reference usage.
 azure.subscription.functionsService.functionApp @defaults("id name location") {
   // Function App resource ID
   id string
@@ -11305,7 +11818,13 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
   virtualNetworkSubnetId string
   // Subnet the function app is regionally VNet-integrated with; null when no regional VNet integration is configured
   virtualNetworkSubnet() azure.subscription.networkService.subnet
-  // Function App properties
+  // Raw Azure Resource Manager site properties
+  //
+  // Full SiteProperties object returned by ARM for the function app,
+  // including hosting-plan binding, host names, and site state. Many
+  // of these values are surfaced as top-level fields (state,
+  // defaultHostName, httpsOnly, publicNetworkAccess); use those for
+  // stable audits and this dict for keys not otherwise modeled.
   properties dict
   // Site configuration: minimum TLS version, FTPS state, HTTP/2, always-on, remote debugging, and IP restrictions
   configuration() azure.subscription.webService.appsiteconfig
@@ -11325,12 +11844,12 @@ azure.subscription.functionsService.functionApp @defaults("id name location") {
 
 // Azure Function App application setting
 //
-// Examine a single application setting on a function app. Selectable by
-// composite id; surfaces whether the value resolves through Azure Key
-// Vault, whether the setting is sticky on slot swaps, and a heuristic
-// flag (`isLikelySecret`) for setting names that suggest secret content
-// — useful for "any plaintext secret-like setting that is not a Key
-// Vault reference" audits.
+// Single application setting on a function app, selectable by its
+// composite id. Reports whether the value resolves through Azure Key
+// Vault (`hasKeyVaultReference`), whether the setting is sticky across
+// slot swaps (`slotSetting`), and a heuristic flag (`isLikelySecret`)
+// for setting names that suggest secret content, supporting audits for
+// any plaintext secret-like setting that is not a Key Vault reference.
 private azure.subscription.functionsService.functionApp.appSetting @defaults("name hasKeyVaultReference isLikelySecret slotSetting") {
   // Composite ID: <functionAppId>/config/appsettings/<name>
   id string
@@ -11358,7 +11877,12 @@ private azure.subscription.functionsService.functionApp.function @defaults("id n
   id string
   // Function name
   name string
-  // Function configuration
+  // Function configuration (function.json)
+  //
+  // Raw function.json content: the `bindings` array (trigger and
+  // input/output binding definitions with their type, direction, and
+  // name), the `disabled` flag, and script settings such as
+  // `scriptFile` and `entryPoint`.
   config dict
   // Function language
   language string
@@ -11371,6 +11895,11 @@ private azure.subscription.functionsService.functionApp.function @defaults("id n
 // ===== Azure Service Bus Service =====
 
 // Azure Service Bus service
+//
+// Service Bus messaging across the subscription. The `namespaces`
+// field lists every Service Bus namespace, each exposing its SKU and
+// tier, network access controls, encryption settings, and the queues,
+// topics, and subscriptions defined inside it.
 private azure.subscription.serviceBusService {
   // Subscription identifier
   subscriptionId string
@@ -11380,14 +11909,14 @@ private azure.subscription.serviceBusService {
 
 // Azure Service Bus namespace
 //
-// Examine a Service Bus namespace — the messaging entity scope that
-// owns queues, topics, and subscriptions. Surfaces the SKU and tier
-// (Basic, Standard, Premium), the messaging unit count (Premium
-// only), public network access, the `disableLocalAuth` flag,
-// minimum TLS version, identity assignments, the encryption settings
-// (customer-managed key reference), zone redundancy, and the
-// `queues()`, `topics()`, and `authorizationRules()` defined inside
-// the namespace.
+// Messaging scope that owns the queues, topics, and subscriptions of
+// a Service Bus deployment. The SKU and tier (Basic, Standard,
+// Premium) set the available feature set, while `disableLocalAuth`,
+// the customer-managed key encryption settings, and the network rule
+// set govern how clients authenticate and which networks may reach
+// the namespace. Query these to confirm SAS-key access is disabled,
+// public reachability is restricted, and encryption uses a managed
+// key.
 azure.subscription.serviceBusService.namespace @defaults("id name location") {
   // Namespace resource ID
   id string
@@ -11398,6 +11927,9 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   // Namespace tags
   tags map[string]string
   // SKU details
+  //
+  // Keys: `name` and `tier` (Basic, Standard, or Premium) plus
+  // `capacity` (messaging unit count, Premium only).
   sku dict
   // Namespace status
   status string
@@ -11414,6 +11946,9 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
   // Whether double encryption (infrastructure layer + CMK) is enabled
   requireInfrastructureEncryption bool
   // Customer-managed encryption keys (Key Vault references) configured for this namespace
+  //
+  // Each entry has keys `keyName`, `keyVaultUri`, `keyVersion`, and
+  // `identity` (the user-assigned identity used to reach the vault).
   cmkKeys []dict
   // Raw namespace network rule set
   //
@@ -11435,12 +11970,12 @@ azure.subscription.serviceBusService.namespace @defaults("id name location") {
 
 // Service Bus namespace network rule set
 //
-// Examine the namespace-level network access policy: the
-// `defaultAction` (Allow / Deny) applied to traffic that does not
-// match any rule, whether `publicNetworkAccess` is enabled at all,
-// whether `trustedServiceAccessEnabled` lets Microsoft-owned services
-// bypass the rule set, the list of `ipRules`, and the list of
-// `virtualNetworkRules` (each referencing a subnet).
+// Network access policy governing which traffic may reach a Service
+// Bus namespace. `defaultAction` (Allow or Deny) applies to traffic
+// that matches no rule, `publicNetworkAccess` toggles public
+// reachability, and `trustedServiceAccessEnabled` lets Microsoft-owned
+// services bypass the rule set. The `ipRules` and `virtualNetworkRules`
+// lists enumerate the allowed IP ranges and subnets.
 private azure.subscription.serviceBusService.namespace.networkRules @defaults("defaultAction publicNetworkAccess trustedServiceAccessEnabled") {
   // Default action for traffic that does not match any rule ("Allow" or "Deny")
   defaultAction string
@@ -11456,11 +11991,11 @@ private azure.subscription.serviceBusService.namespace.networkRules @defaults("d
 
 // Service Bus namespace virtual network rule
 //
-// Examine a single VNet rule attached to a Service Bus namespace.
-// Resolves to the referenced subnet, with the
-// `ignoreMissingVnetServiceEndpoint` flag indicating whether the
-// rule permits traffic from the subnet even when the subnet has not
-// yet enabled the `Microsoft.ServiceBus` service endpoint.
+// Single VNet rule attached to a Service Bus namespace, resolving to
+// the referenced `subnet`. The `ignoreMissingVnetServiceEndpoint`
+// flag indicates whether the rule permits traffic from the subnet
+// even when the subnet has not yet enabled the Microsoft.ServiceBus
+// service endpoint.
 private azure.subscription.serviceBusService.namespace.networkRules.virtualNetworkRule @defaults("ignoreMissingVnetServiceEndpoint") {
   // Subnet referenced by the rule
   subnet() azure.subscription.networkService.subnet
@@ -11469,6 +12004,13 @@ private azure.subscription.serviceBusService.namespace.networkRules.virtualNetwo
 }
 
 // Azure Service Bus queue
+//
+// First-in-first-out message queue within a Service Bus namespace,
+// selected by `name`. The `status` controls whether send and receive
+// are enabled, `messageCount` and `deadLetterMessageCount` report
+// backlog and poison-message volume, and `requiresSession`,
+// `requiresDuplicateDetection`, and `maxDeliveryCount` govern
+// delivery semantics.
 private azure.subscription.serviceBusService.namespace.queue @defaults("id name") {
   // Queue resource ID
   id string
@@ -11501,6 +12043,12 @@ private azure.subscription.serviceBusService.namespace.queue @defaults("id name"
 }
 
 // Azure Service Bus topic
+//
+// Publish-subscribe messaging entity within a Service Bus namespace,
+// selected by `name`. Messages sent to the topic fan out to its
+// `subscriptions`. The `status`, `enablePartitioning`,
+// `supportOrdering`, and `requiresDuplicateDetection` fields describe
+// its availability and delivery behavior.
 private azure.subscription.serviceBusService.namespace.topic @defaults("id name") {
   // Topic resource ID
   id string
@@ -11529,6 +12077,11 @@ private azure.subscription.serviceBusService.namespace.topic @defaults("id name"
 }
 
 // Azure Service Bus topic subscription
+//
+// Named subscription attached to a Service Bus topic, selected by
+// `name`, that receives a copy of the topic's messages. The `status`,
+// `messageCount`, `deadLetterMessageCount`, `maxDeliveryCount`, and
+// `requiresSession` fields describe its delivery state and semantics.
 private azure.subscription.serviceBusService.namespace.topic.subscription @defaults("id name") {
   // Subscription resource ID
   id string
@@ -11566,14 +12119,14 @@ private azure.subscription.eventHubService {
 
 // Azure Event Hubs namespace
 //
-// Examine an Event Hubs namespace — the streaming-ingestion entity
-// scope that owns Event Hubs and consumer groups. Surfaces the SKU
-// and tier (Basic, Standard, Premium, Dedicated), the throughput
-// units configured, auto-inflate state, Kafka-enabled flag, the
-// `disableLocalAuth` toggle, minimum TLS version, public network
-// access, network rule sets, identity assignments, customer-managed-key
-// encryption settings, and the `eventhubs()` defined inside the
-// namespace.
+// Streaming-ingestion entity scope that owns Event Hubs and their
+// consumer groups. The namespace determines the security posture of
+// everything inside it: SAS-key authentication can be disabled in
+// favor of Entra ID via disableLocalAuth, a minimum TLS version
+// enforced, public network access restricted, network rule sets
+// applied, and customer-managed keys used for encryption at rest.
+// Audit these settings to confirm a namespace is not reachable over
+// unauthenticated or plaintext paths.
 azure.subscription.eventHubService.namespace @defaults("id name location") {
   // Namespace resource ID
   id string
@@ -11583,7 +12136,10 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   location string
   // Namespace tags
   tags map[string]string
-  // SKU details
+  // SKU tier and capacity
+  //
+  // Keys: `name` and `tier` (one of Basic, Standard, or Premium), and
+  // `capacity` (the provisioned throughput or premium units).
   sku dict
   // Namespace status
   status string
@@ -11605,7 +12161,11 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
   cmkKeySource string
   // Whether double encryption (infrastructure layer + CMK) is enabled
   requireInfrastructureEncryption bool
-  // Customer-managed encryption keys (Key Vault references) configured for this namespace
+  // Customer-managed encryption keys
+  //
+  // Key Vault references used to encrypt data at rest. Each entry has
+  // `keyName`, `keyVaultUri`, `keyVersion`, and an `identity` used to
+  // reach the key.
   cmkKeys []dict
   // Raw namespace network rule set
   //
@@ -11625,12 +12185,13 @@ azure.subscription.eventHubService.namespace @defaults("id name location") {
 
 // Event Hubs namespace network rule set
 //
-// Examine the namespace-level network access policy: the
-// `defaultAction` (Allow / Deny) applied to traffic that does not
-// match any rule, whether `publicNetworkAccess` is enabled at all,
-// whether `trustedServiceAccessEnabled` lets Microsoft-owned services
-// bypass the rule set, the list of `ipRules`, and the list of
-// `virtualNetworkRules` (each referencing a subnet).
+// Namespace-level network access policy. The defaultAction (Allow or
+// Deny) applies to traffic that matches no rule, publicNetworkAccess
+// controls whether the public endpoint is reachable at all,
+// trustedServiceAccessEnabled lets Microsoft-owned services bypass
+// the rule set, and ipRules and virtualNetworkRules enumerate the
+// explicitly permitted sources. A defaultAction of Allow leaves the
+// namespace open to any network.
 private azure.subscription.eventHubService.namespace.networkRules @defaults("defaultAction publicNetworkAccess trustedServiceAccessEnabled") {
   // Default action for traffic that does not match any rule ("Allow" or "Deny")
   defaultAction string
@@ -11646,11 +12207,11 @@ private azure.subscription.eventHubService.namespace.networkRules @defaults("def
 
 // Event Hubs namespace virtual network rule
 //
-// Examine a single VNet rule attached to an Event Hubs namespace.
-// Resolves to the referenced subnet, with the
-// `ignoreMissingVnetServiceEndpoint` flag indicating whether the
-// rule permits traffic from the subnet even when the subnet has not
-// yet enabled the `Microsoft.EventHub` service endpoint.
+// Single virtual-network rule attached to an Event Hubs namespace,
+// resolving to the referenced subnet. The
+// ignoreMissingVnetServiceEndpoint flag indicates whether the rule
+// permits traffic from the subnet even when the subnet has not yet
+// enabled the Microsoft.EventHub service endpoint.
 private azure.subscription.eventHubService.namespace.networkRules.virtualNetworkRule @defaults("ignoreMissingVnetServiceEndpoint") {
   // Subnet referenced by the rule
   subnet() azure.subscription.networkService.subnet
@@ -11710,13 +12271,13 @@ private azure.subscription.eventGridService {
 
 // Azure Event Grid custom topic
 //
-// Examine an Event Grid custom topic — a user-created event ingestion
-// endpoint clients publish to. Surfaces the input schema, the
-// `disableLocalAuth` toggle, public network access state, inbound IP
-// rules, the minimum TLS version enforced on publishers, the data
-// residency boundary, the publishing endpoint, identity assignments,
-// the metric resource ID, and the count of private endpoint
-// connections.
+// User-created event ingestion endpoint that clients publish events to.
+// Custom topics are the primary control point for publish security:
+// `disableLocalAuth` governs whether key-based publishing is allowed,
+// `publicNetworkAccess` and `inboundIpRules` gate network reachability,
+// and `minimumTlsVersionAllowed` sets the transport floor for
+// publishers. Audit these together to confirm a topic is not publicly
+// writable over weak transport or shared access keys.
 azure.subscription.eventGridService.topic @defaults("name location publicNetworkAccess provisioningState") {
   // Topic resource ID
   id string
@@ -11754,12 +12315,13 @@ azure.subscription.eventGridService.topic @defaults("name location publicNetwork
 
 // Azure Event Grid system topic
 //
-// Examine an Event Grid system topic — auto-generated topics used by
-// Azure resources (storage accounts, key vaults, container registries,
-// etc.) to publish events. Surfaces the source resource, the topic
-// type, provisioning state, identity assignments, and the metric
-// resource ID. Use the `source` field as the typed pointer back to the
-// originating Azure resource.
+// Auto-generated topic through which an Azure resource (storage account,
+// key vault, container registry, and similar) publishes its own events.
+// The `source` field points back to the originating resource and
+// `topicType` identifies the publisher category (for example
+// "Microsoft.Storage.StorageAccounts" or "Microsoft.KeyVault.vaults"),
+// which together reveal which resources are wired into event routing and
+// under what identity.
 azure.subscription.eventGridService.systemTopic @defaults("name location topicType source provisioningState") {
   // System topic resource ID
   id string
@@ -11785,14 +12347,14 @@ azure.subscription.eventGridService.systemTopic @defaults("name location topicTy
 
 // Azure Event Grid domain
 //
-// Examine an Event Grid domain — a multi-tenant topic container that
-// scopes thousands of topics under a single endpoint. Surfaces the
-// input schema, the `disableLocalAuth` toggle, public network access
-// state, inbound IP rules, the minimum TLS version enforced on
-// publishers, the auto-create / auto-delete domain-topic toggles, the
-// data residency boundary, the publishing endpoint, identity
-// assignments, the metric resource ID, and the count of private
-// endpoint connections.
+// Multi-tenant topic container that scopes thousands of topics under a
+// single publishing endpoint. As with a custom topic, its publish
+// surface is governed by `disableLocalAuth`, `publicNetworkAccess`,
+// `inboundIpRules`, and `minimumTlsVersionAllowed`, while
+// `autoCreateTopicWithFirstSubscription` and
+// `autoDeleteTopicWithLastSubscription` control the lifecycle of the
+// domain topics beneath it. Audit these to confirm the shared endpoint
+// is not publicly writable over weak transport or shared access keys.
 azure.subscription.eventGridService.domain @defaults("name location publicNetworkAccess provisioningState") {
   // Domain resource ID
   id string
@@ -11846,12 +12408,12 @@ private azure.subscription.dnsService {
 
 // Azure public DNS zone
 //
-// Examine an Azure DNS public zone. Surfaces the zone's
-// `numberOfRecordSets` and `maxNumberOfRecordSets` cap, the assigned
-// authoritative name servers, the registration virtual networks (when
-// the zone is private DNS in another product), and the `recordSets()`
-// hosted in the zone. Use `azure.subscription.dnsService.privateZone`
-// for Azure Private DNS zones.
+// Public DNS zone that hosts authoritative records for a domain and
+// answers queries from the internet. Reports the assigned authoritative
+// name servers, the current record-set count against the
+// maxNumberOfRecordSets cap, and the individual recordSets hosted in
+// the zone. For internal-only zones resolved from linked virtual
+// networks, query azure.subscription.dnsService.privateZone.
 azure.subscription.dnsService.zone @defaults("id name") {
   // DNS zone resource ID
   id string
@@ -11884,17 +12446,24 @@ private azure.subscription.dnsService.zone.recordSet @defaults("id name type") {
   // Fully qualified domain name
   fqdn string
   // Record set properties
+  //
+  // Raw record-set properties keyed by record type. The type-specific
+  // record array present depends on the record type: aRecords,
+  // aaaaRecords, cnameRecord, mxRecords, nsRecords, ptrRecords,
+  // srvRecords, txtRecords, caaRecords, and soaRecord. Also carries
+  // fqdn, TTL, metadata, provisioningState, and targetResource.
   properties dict
 }
 
 // Azure Private DNS zone
 //
-// Examine an Azure Private DNS zone — a DNS zone resolved only from
-// linked virtual networks. Surfaces the `numberOfRecordSets` and the
-// `numberOfVirtualNetworkLinks` (with auto-registration counts), the
-// `provisioningState`, the maximum allowed record-set and
-// virtual-network-link counts, and the `recordSets()` hosted in the
-// zone.
+// Private DNS zone whose records resolve only from the virtual networks
+// linked to it, keeping internal name resolution off the public
+// internet. Reports the provisioning state, the current record-set and
+// virtual-network-link counts against their maximums, and the record
+// sets hosted in the zone. Linked virtual networks, including which
+// ones auto-register VM records, are reached through
+// virtualNetworkLinks.
 azure.subscription.dnsService.privateZone @defaults("id name") {
   // Private DNS zone resource ID
   id string
@@ -11946,15 +12515,13 @@ private azure.subscription.frontDoorService {
 
 // Azure Front Door / CDN profile
 //
-// Examine an Azure Front Door (Standard / Premium) or classic CDN
-// profile. Surfaces the SKU and tier (Standard_AzureFrontDoor,
-// Premium_AzureFrontDoor, Standard_Microsoft, Standard_Verizon,
-// Premium_Verizon, Standard_Akamai, Standard_ChinaCdn), the resource
-// state, identity assignments, the `originResponseTimeoutSeconds`,
-// the `logScrubbing` configuration, and the `endpoints()`,
-// `originGroups()`, `customDomains()`, `secrets()`, `rulesets()`,
-// `routes()`, `securityPolicies()`, and `firewallPolicies()` defined
-// inside the profile.
+// Azure Front Door (Standard / Premium) or classic CDN profile, the
+// top-level container for a content-delivery configuration. The `sku`
+// name selects the tier: Standard_AzureFrontDoor, Premium_AzureFrontDoor,
+// Standard_Microsoft, Standard_Verizon, Premium_Verizon, Standard_Akamai,
+// or Standard_ChinaCdn. Audit the profile to reach its endpoints, custom
+// domains, origin groups, and the security policies that bind Web
+// Application Firewall protection to its domains.
 azure.subscription.frontDoorService.profile @defaults("id name location") {
   // Profile resource ID
   id string
@@ -11964,7 +12531,11 @@ azure.subscription.frontDoorService.profile @defaults("id name location") {
   location string
   // Profile tags
   tags map[string]string
-  // SKU details
+  // Pricing tier
+  //
+  // Object with a single `name` key holding the pricing tier:
+  // Standard_AzureFrontDoor, Premium_AzureFrontDoor, Standard_Microsoft,
+  // Standard_Verizon, Premium_Verizon, Standard_Akamai, or Standard_ChinaCdn.
   sku dict
   // Profile kind (frontdoor, cdn)
   kind string
@@ -11996,7 +12567,11 @@ private azure.subscription.frontDoorService.profile.securityPolicy @defaults("id
   policyType string
   // ARM resource ID of the associated WAF policy (empty if none is associated)
   wafPolicyId string
-  // Domains and path patterns the WAF policy is associated with
+  // Domains and path patterns the WAF policy protects
+  //
+  // Each entry has `domains` (a list of domain references, each carrying an
+  // `id` and an `isActive` flag) and `patternsToMatch` (the URL path
+  // patterns the policy applies to).
   associations []dict
   // Provisioning state
   provisioningState string
@@ -12083,8 +12658,17 @@ private azure.subscription.frontDoorService.profile.originGroup @defaults("id na
   // Provisioning state
   provisioningState string
   // Health probe settings
+  //
+  // Object with `probePath` (path requested against each origin),
+  // `probeProtocol` (Http, Https, or NotSet), `probeRequestType` (GET or
+  // HEAD), and `probeIntervalInSeconds` (seconds between probes).
   healthProbeSettings dict
   // Load balancing settings
+  //
+  // Object with `sampleSize` (samples considered per load-balancing
+  // decision), `successfulSamplesRequired` (samples that must succeed for an
+  // origin to be considered healthy), and `additionalLatencyInMilliseconds`
+  // (latency band width used when grouping origins by latency).
   loadBalancingSettings dict
   // Origins in this origin group
   origins() []azure.subscription.frontDoorService.profile.originGroup.origin
@@ -12120,8 +12704,8 @@ private azure.subscription.frontDoorService.profile.originGroup.origin @defaults
 
 // Azure Container Apps
 //
-// Examine Azure Container Apps managed environments, the Container Apps
-// running in them, and Container Apps jobs. Use this resource to audit
+// Azure Container Apps managed environments, the container apps running
+// in them, and Container Apps jobs across the subscription. Covers
 // ingress posture, image pinning, identity-vs-secret registry auth,
 // Easy Auth configuration, and revision history.
 private azure.subscription.containerAppService {
@@ -12137,8 +12721,8 @@ private azure.subscription.containerAppService {
 
 // Azure Container Apps managed environment
 //
-// Examine the network, logging, and TLS boundary that hosts a set of
-// Container Apps. Selectable by ARM id; fields cover VNET delegation,
+// Network, logging, and TLS boundary that hosts a set of container
+// apps. Selectable by ARM id; fields cover VNET delegation,
 // public-network access, peer-traffic mTLS, zone redundancy, and the
 // linked Log Analytics workspace.
 azure.subscription.containerAppService.managedEnvironment @defaults("name location provisioningState internalLoadBalancerEnabled") {
@@ -12166,9 +12750,17 @@ azure.subscription.containerAppService.managedEnvironment @defaults("name locati
   internalLoadBalancerEnabled bool
   // Whether zone redundancy is enabled
   zoneRedundant bool
-  // Peer authentication (mTLS) configuration
+  // Peer authentication settings
+  //
+  // Mutual TLS between apps in the environment. The dict has a single
+  // key `mtls`, whose `enabled` bool reports whether app-to-app mTLS is
+  // enforced.
   peerAuthentication dict
-  // Peer traffic configuration (cluster-internal encryption)
+  // Peer traffic settings
+  //
+  // Cluster-internal traffic encryption. The dict has a single key
+  // `encryption`, whose `enabled` bool reports whether peer traffic is
+  // encrypted.
   peerTrafficConfiguration dict
   // Custom domain configuration (dnsSuffix + cert thumbprint)
   customDomainConfiguration dict
@@ -12220,9 +12812,9 @@ private azure.subscription.containerAppService.managedEnvironment.privateEndpoin
 
 // HTTP route config attached to a Container Apps managed environment
 //
-// Examine an env-scoped routing table that fans traffic across multiple
-// container apps by path/prefix. The `name` field selects the route
-// config within an environment.
+// Env-scoped routing table that fans traffic across multiple container
+// apps by path or prefix. The `name` field selects the route config
+// within an environment.
 private azure.subscription.containerAppService.managedEnvironment.httpRouteConfig @defaults("name fqdn provisioningState") {
   // ARM resource ID
   id string
@@ -12234,7 +12826,11 @@ private azure.subscription.containerAppService.managedEnvironment.httpRouteConfi
   provisioningState string
   // Custom domain bindings on this route config
   customDomains []dict
-  // Routing rules — each entry has `description`, `routes` (match + action), and `targets` (container apps / revisions / labels)
+  // Routing rules
+  //
+  // Each entry has `description`, `routes` (match and action), and
+  // `targets` (the container apps, revisions, or labels traffic is sent
+  // to).
   rules []dict
   // Errors encountered while reconciling routes
   provisioningErrors []dict
@@ -12244,10 +12840,10 @@ private azure.subscription.containerAppService.managedEnvironment.httpRouteConfi
 
 // Maintenance configuration on a Container Apps managed environment
 //
-// Examine the maintenance window schedule for a managed environment.
-// Container Apps applies infrastructure-level patches during the listed
-// scheduled entries. The `name` field selects the configuration; a
-// managed environment typically has at most one.
+// Maintenance window schedule for a managed environment. Container Apps
+// applies infrastructure-level patches during the listed scheduled
+// entries. The `name` field selects the configuration; a managed
+// environment typically has at most one.
 private azure.subscription.containerAppService.managedEnvironment.maintenanceConfiguration @defaults("name") {
   // ARM resource ID
   id string
@@ -12317,10 +12913,10 @@ private azure.subscription.containerAppService.managedEnvironment.certificate @d
 
 // Azure Container App
 //
-// Examine a single Container App workload. The resource exposes ingress
-// posture (external vs internal, transport, allowed origins, IP rules,
-// client-cert mode), revision strategy, scale bounds, secrets/registry
-// auth, and the per-container image and resource definitions.
+// Single Container App workload, exposing ingress posture (external vs
+// internal, transport, allowed origins, IP rules, client-cert mode),
+// revision strategy, scale bounds, secrets and registry auth, and the
+// per-container image and resource definitions.
 azure.subscription.containerAppService.containerApp @defaults("name location provisioningState ingressExternal httpsOnly") {
   // ARM resource ID
   id string
@@ -12354,11 +12950,11 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   ingressEnabled bool
   // External ingress (true) vs internal-only (false)
   //
-  // Only meaningful when `ingressEnabled == true` — defaults to false when ingress is disabled.
+  // Only meaningful when `ingressEnabled` is true; defaults to false when ingress is disabled.
   ingressExternal bool
   // Target port for ingress
   targetPort int
-  // Allowed transport ("Auto", "Http", "Http2", "Tcp" — Azure SDK casing)
+  // Allowed transport ("Auto", "Http", "Http2", "Tcp")
   transport string
   // Whether HTTPS-only is enforced (insecureAllowed == false)
   httpsOnly bool
@@ -12369,6 +12965,10 @@ azure.subscription.containerAppService.containerApp @defaults("name location pro
   // CORS allowed origins on ingress
   corsAllowedOrigins []string
   // IP security restrictions on ingress
+  //
+  // Each entry has `name`, `description`, `ipAddressRange` (CIDR), and
+  // `action` ("Allow" or "Deny"). A rule set is all-Allow or all-Deny;
+  // when Allow rules are present, every other source IP is denied.
   ipSecurityRestrictions []dict
   // Workload profile name in the parent environment ("Consumption" by default)
   workloadProfileName string
@@ -12434,7 +13034,10 @@ private azure.subscription.containerAppService.containerApp.container @defaults(
   command []string
   // Container start args
   args []string
-  // Environment variables — each entry has {name, value, secretRef}
+  // Environment variables
+  //
+  // Each entry has `name`, `value` (the inline value), and `secretRef`
+  // (name of a declared secret to pull the value from instead).
   env []dict
   // CPU cores (e.g., 0.25, 0.5, 1.0)
   cpuCores float
@@ -12496,14 +13099,12 @@ private azure.subscription.containerAppService.containerApp.authConfig @defaults
 
 // Azure Container Apps Job
 //
-// Examine a Container Apps Job — the run-to-completion sibling of
-// Azure Container Apps. Surfaces the `triggerType` (Manual,
-// Schedule, or Event), the configuration block (replica timeout,
-// retry limit, parallelism, replica completion count, registries,
-// secrets, identity), the per-trigger schedule or event-trigger
-// configuration, the template (containers, init containers, volumes),
-// the linked managed environment, and the workload profile the job
-// runs on.
+// Run-to-completion workload, the batch sibling of Azure Container
+// Apps. The `triggerType` field (Manual, Schedule, or Event) selects
+// how the job starts, and the resource surfaces the replica timeout and
+// retry limits, the schedule or event-trigger configuration, the
+// container template, registry and secret auth, the linked managed
+// environment, and the workload profile the job runs on.
 azure.subscription.containerAppService.job @defaults("name location triggerType provisioningState") {
   // ARM resource ID
   id string
@@ -12523,13 +13124,22 @@ azure.subscription.containerAppService.job @defaults("name location triggerType 
   triggerType string
   // Cron expression (when triggerType == "Schedule")
   cronExpression string
-  // Event-driven scaling rules (KEDA-based) when triggerType == "Event"
+  // Event-driven scaling configuration, set when triggerType is "Event"
+  //
+  // Keys: `parallelism`, `replicaCompletionCount`, and `scale`
+  // (`minExecutions`, `maxExecutions`, `pollingInterval`, and `rules`
+  // holding the KEDA trigger definitions).
   eventTriggerConfig dict
   // Replica timeout (seconds)
   replicaTimeoutSeconds int
   // Replica retry limit
   replicaRetryLimit int
-  // Identity (system + user-assigned)
+  // Managed identity
+  //
+  // Keys: `type` ("SystemAssigned", "UserAssigned", "SystemAssigned,
+  // UserAssigned", or "None"), `principalId` and `tenantId` of the
+  // system-assigned identity, and `userAssignedIdentities` keyed by
+  // resource ID.
   identity dict
   // Container definitions (image, env, resources, probes); flattened
   containers []dict
@@ -12547,10 +13157,11 @@ azure.subscription.containerAppService.job @defaults("name location triggerType 
 
 // Azure Container Instances
 //
-// Examine Azure Container Instances container groups and the containers
-// within them. Use this resource to audit OS type, restart policy, image
-// pinning, registry auth, VNET delegation, security context (privileged,
-// runAsUser), and confidential-ACI usage.
+// Container Instances (ACI) container groups in the subscription and the
+// containers within them. The auditable surface includes OS type, restart
+// policy, image pinning, registry authentication, VNET delegation,
+// container security context (privileged, runAsUser), and confidential-ACI
+// usage.
 private azure.subscription.containerInstanceService {
   // Subscription identifier
   subscriptionId string
@@ -12560,9 +13171,12 @@ private azure.subscription.containerInstanceService {
 
 // Azure Container Instances container group
 //
-// Examine a container group — the unit of deployment in ACI, holding one
-// or more containers that share lifecycle, network, and storage. Selectable
-// by ARM id.
+// Container group, the unit of deployment in ACI that holds one or more
+// containers sharing lifecycle, network, and storage. Exposes group-level
+// networking (public or private IP, exposed ports, subnet delegation), image
+// registry credentials, customer-managed-key encryption, and the
+// confidential-computing SKU. Selected by ARM resource id, for example
+// azure.subscription.containerInstanceService.containerGroup(id: "/subscriptions/.../containerGroups/mygroup").
 azure.subscription.containerInstanceService.containerGroup @defaults("name location osType sku ipAddressType") {
   // ARM resource ID
   id string
@@ -12584,7 +13198,12 @@ azure.subscription.containerInstanceService.containerGroup @defaults("name locat
   confidential bool
   // SHA-256 hash of the CCE policy (Confidential ACI only)
   ccePolicyHash string
-  // Identity block (system + user-assigned principal IDs)
+  // Managed identity assigned to the group
+  //
+  // Keys: type ("None", "SystemAssigned", "UserAssigned", or
+  // "SystemAssigned, UserAssigned"), principalId and tenantId of the
+  // system-assigned identity, and userAssignedIdentities keyed by identity
+  // resource ID.
   identity dict
   // IP address type ("Public", "Private", or null)
   ipAddressType string
@@ -12649,8 +13268,14 @@ private azure.subscription.containerInstanceService.containerGroup.container @de
   // Volume mounts (volumeName, mountPath, readOnly)
   volumeMounts []dict
   // Liveness probe
+  //
+  // Keys: exec, httpGet, initialDelaySeconds, periodSeconds,
+  // failureThreshold, successThreshold, and timeoutSeconds.
   livenessProbe dict
   // Readiness probe
+  //
+  // Keys: exec, httpGet, initialDelaySeconds, periodSeconds,
+  // failureThreshold, successThreshold, and timeoutSeconds.
   readinessProbe dict
   // Raw security context
   //
@@ -12680,10 +13305,10 @@ private azure.subscription.containerInstanceService.containerGroup.container @de
 
 // Azure Logic Apps
 //
-// Examine Azure Logic Apps Consumption-tier workflows in the subscription.
-// Use this resource to audit workflow state, access-control policies,
-// secret-typed parameters, and the trigger and action set defined in
-// each workflow's JSON definition.
+// Consumption-tier Logic Apps workflows in the subscription, enumerated
+// through `workflows`. Auditing these surfaces workflow state,
+// access-control policies, secret-typed parameters, and the trigger and
+// action set defined in each workflow's JSON definition.
 private azure.subscription.logicService {
   // Subscription identifier
   subscriptionId string
@@ -12693,8 +13318,9 @@ private azure.subscription.logicService {
 
 // Azure Logic Apps Consumption workflow
 //
-// Examine a single Consumption-tier Logic App. Selectable by ARM id;
-// fields cover lifecycle state, SKU, integration-account binding,
+// Single Consumption-tier Logic App, selectable by ARM id (for example
+// `azure.subscription.logicService.workflow(id: "/subscriptions/.../workflows/my-flow")`).
+// Fields cover lifecycle state, SKU, integration-account binding,
 // access-control policies (per-policy IP allow lists and OAuth
 // authentication policies), parameters (with secure-string detection),
 // and the trigger and action lists parsed from the workflow definition.
@@ -12717,7 +13343,11 @@ azure.subscription.logicService.workflow @defaults("name location state provisio
   version string
   // Public access endpoint, when ingress is exposed
   accessEndpoint string
-  // Identity (system + user-assigned)
+  // Managed identity
+  //
+  // Has `type` ("SystemAssigned", "UserAssigned", or "None"), `principalId`,
+  // `tenantId`, and `userAssignedIdentities` (map keyed by the identity's ARM
+  // resource id).
   identity dict
   // ARM id of the linked integration account, if any
   integrationAccountId string
@@ -12727,17 +13357,30 @@ azure.subscription.logicService.workflow @defaults("name location state provisio
   createdTime time
   // Last changed time
   changedTime time
-  // Outgoing connector / workflow / access-endpoint IPs reported for the workflow
+  // Connector and workflow endpoint IP ranges
+  //
+  // Has `connector` and `workflow`, each with `accessEndpointIpAddresses` and
+  // `outgoingIpAddresses` (lists of `{address}` entries). Use these to build
+  // network allow lists for traffic the workflow originates or receives.
   endpointsConfiguration dict
   // Access-control policy for inbound triggers
   //
   // Has `allowedCallerIpAddresses []` and `openAuthenticationPolicies {}`. Empty IP list means no IP restriction.
   accessControlTriggers dict
   // Access-control policy for reading workflow run contents
+  //
+  // Same shape as `accessControlTriggers`: `allowedCallerIpAddresses []` and
+  // `openAuthenticationPolicies {}`. Empty IP list means no IP restriction.
   accessControlContents dict
   // Access-control policy for invoking workflow actions
+  //
+  // Same shape as `accessControlTriggers`: `allowedCallerIpAddresses []` and
+  // `openAuthenticationPolicies {}`. Empty IP list means no IP restriction.
   accessControlActions dict
   // Access-control policy for workflow management operations
+  //
+  // Same shape as `accessControlTriggers`: `allowedCallerIpAddresses []` and
+  // `openAuthenticationPolicies {}`. Empty IP list means no IP restriction.
   accessControlWorkflowManagement dict
   // Whether at least one access-control policy has an IP allow list configured
   hasIpRestrictions bool
@@ -12766,12 +13409,12 @@ azure.subscription.logicService.workflow @defaults("name location state provisio
 
 // Azure API Management
 //
-// Use this namespace to enumerate the API Management gateway instances
-// configured in the subscription via `services()`. The returned
-// `azure.subscription.apiManagementService.service` resources expose
-// SKU, virtual-network integration mode, public network access,
-// gateway TLS / cipher policy, identity, endpoints, and private
-// endpoint connection state.
+// API Management gateway instances configured in the subscription.
+// Each entry in `services` is a multi-tenant API gateway that fronts
+// backend APIs, exposing its SKU, virtual-network integration mode,
+// public network access posture, gateway TLS and cipher policy,
+// managed identity, endpoint URLs, and private endpoint connection
+// state.
 private azure.subscription.apiManagementService {
   // Subscription identifier
   subscriptionId string
@@ -12781,19 +13424,15 @@ private azure.subscription.apiManagementService {
 
 // Azure API Management service instance
 //
-// Examine an API Management gateway service — the multi-tenant API
-// gateway that fronts backend APIs with auth, rate limiting, transforms,
-// and a developer portal. Surfaces the SKU and capacity, virtual-network
-// integration mode (None / External / Internal), public network access
-// state, the NAT gateway toggle, gateway / management / portal /
-// developer-portal / SCM endpoint URLs, the `disableGateway` flag, the
-// `enableClientCertificate` flag for Consumption SKU mTLS, status of
-// the developer and legacy portals, platform version, the custom
-// properties map that encodes the gateway TLS / cipher policy
-// (`Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10`
-// etc.), publisher email and name, identity, public / private /
-// outbound IP addresses, the count of private endpoint connections, and
-// the availability zones.
+// Multi-tenant API gateway that fronts backend APIs with authentication,
+// rate limiting, request and response transforms, and a developer portal.
+// The service's network and transport posture is queryable here: the
+// virtual-network integration mode (None, External, or Internal), public
+// network access state, and the gateway TLS and cipher policy encoded in
+// `customProperties` and surfaced as the `tls10Enabled`, `ssl30Enabled`,
+// and `tripleDesEnabled` booleans. Also exposes whether client
+// certificates are required, the managed identity, and the private
+// endpoint connections that reach the service.
 azure.subscription.apiManagementService.service @defaults("name location skuName provisioningState") {
   // Resource ID of the API Management service
   id string
@@ -12903,13 +13542,13 @@ azure.subscription.apiManagementService.service @defaults("name location skuName
 
 // Microsoft Purview
 //
-// Use the Purview namespace to enumerate the Microsoft Purview accounts
-// in the subscription. Each account is a tenant-scoped data-governance
-// and sensitive-data-discovery hub that catalogs data assets across
-// Azure (Storage, SQL, Synapse, Cosmos DB, Power BI) and external clouds.
-// Iterate `accounts()` for the per-region Purview accounts and inspect
-// their public-network-access posture, managed-resource-group bindings,
-// SKU, and public endpoints.
+// Microsoft Purview accounts in the subscription. Each account is a
+// tenant-scoped data-governance and sensitive-data-discovery hub that
+// catalogs data assets across Azure (Storage, SQL, Synapse, Cosmos DB,
+// Power BI) and external clouds. The `accounts` list holds the
+// per-region Purview accounts, where their public-network-access
+// posture, managed-resource-group bindings, SKU, and public endpoints
+// are queryable.
 private azure.subscription.purviewService {
   // Subscription identifier
   subscriptionId string
@@ -12919,14 +13558,14 @@ private azure.subscription.purviewService {
 
 // Microsoft Purview account
 //
-// Examine a single Purview account — the tenant-scoped governance hub
-// that hosts the data catalog, scanning, classification, and lineage
-// surfaces. Use `publicNetworkAccess` to confirm whether the account is
-// reachable from the public internet; `managedResourceGroupName` and
-// `managedResources` to find the Purview-managed Storage and Event Hub
-// resources backing the account; `endpoints` for the catalog/scan/guardian
-// URIs; and `privateEndpointConnections` for the approved private-link
-// bindings.
+// Single Purview account, the tenant-scoped governance hub that hosts
+// the data catalog, scanning, classification, and lineage surfaces. The
+// `publicNetworkAccess` field confirms whether the account is reachable
+// from the public internet; `managedResourceGroupName` and
+// `managedResources` locate the Purview-managed Storage and Event Hub
+// resources backing the account; `endpoints` gives the catalog, scan,
+// and guardian URIs; and `privateEndpointConnections` lists the approved
+// private-link bindings.
 private azure.subscription.purviewService.account @defaults("name location publicNetworkAccess provisioningState") {
   // Full resource ID
   id string
@@ -12944,9 +13583,9 @@ private azure.subscription.purviewService.account @defaults("name location publi
   identity dict
   // Friendly display name for the account
   friendlyName string
-  // Provisioning state: Succeeded, Failed, Creating, Deleting, Moving, Unknown
+  // Provisioning state: Succeeded, Failed, Canceled, Creating, Deleting, Moving, SoftDeleting, SoftDeleted, or Unknown
   provisioningState string
-  // Whether the account is reachable from the public internet: Enabled, NotConfigured, or Disabled
+  // Public network access state: Enabled, Disabled, or NotSpecified
   publicNetworkAccess string
   // Name of the Purview-managed resource group that backs this account
   managedResourceGroupName string
@@ -12955,6 +13594,12 @@ private azure.subscription.purviewService.account @defaults("name location publi
   // Public endpoints of the account, with keys `catalog`, `guardian`, `scan`
   endpoints dict
   // Approved private-endpoint connections for the account
+  //
+  // Each entry carries `id`, `name`, `type`, and a `properties` object
+  // holding `privateEndpoint.id`, `provisioningState`, and a
+  // `privateLinkServiceConnectionState` with `status` (Approved, Pending,
+  // Rejected, Disconnected, or Unknown), `description`, and
+  // `actionsRequired`.
   privateEndpointConnections []dict
   // Cloud connectors for external (AWS) scanning, with the externally surfaced AWS external ID
   cloudConnectors dict
@@ -12972,12 +13617,10 @@ private azure.subscription.purviewService.account @defaults("name location publi
 
 // Azure AI Search
 //
-// Use the search namespace to enumerate the Azure AI Search services in
-// the subscription. Each service hosts search indexes that frequently
-// hold sensitive or business-critical content, so the namespace is the
-// entry point for auditing their public-network exposure, customer-managed-key
-// encryption, and authentication posture. Iterate `services()` for the
-// per-service records.
+// Azure AI Search services in the subscription. Each service hosts
+// search indexes that frequently hold sensitive or business-critical
+// content, making this the entry point for auditing their public-network
+// exposure, customer-managed-key encryption, and authentication posture.
 private azure.subscription.searchService {
   // Subscription identifier
   subscriptionId string
@@ -12987,15 +13630,14 @@ private azure.subscription.searchService {
 
 // Azure AI Search service
 //
-// Examine a single Azure AI Search service — the managed service that
-// hosts search indexes, indexers, and data sources. Use `publicNetworkAccess`
-// to confirm whether the service is reachable from the public internet,
-// `cmkEnforcement` for the customer-managed-key compliance policy and
-// `cmkEncryptionComplianceStatus` for whether any indexes remain
-// platform-encrypted, `disableLocalAuth` for whether API-key authentication
-// is turned off in favor of Microsoft Entra ID, `replicaCount` and
-// `partitionCount` for the provisioned capacity, `hostingMode` for the
-// high-density option, and `networkRuleSet` for the IP firewall rules.
+// Single Azure AI Search service, the managed service that hosts search
+// indexes, indexers, and data sources. Because the indexes it serves often
+// contain sensitive or business-critical content, its exposure and
+// encryption posture matter: `publicNetworkAccess` and `networkRuleSet`
+// govern reachability from the public internet, `cmkEnforcement` and
+// `cmkEncryptionComplianceStatus` cover customer-managed-key encryption of
+// indexes, and `disableLocalAuth` reports whether API-key authentication
+// is turned off in favor of Microsoft Entra ID.
 azure.subscription.searchService.service @defaults("id name location publicNetworkAccess") {
   // Search service resource ID
   id string
@@ -13007,7 +13649,12 @@ azure.subscription.searchService.service @defaults("id name location publicNetwo
   tags map[string]string
   // SKU details (name: free, basic, standard, standard2, standard3, storage_optimized_l1, storage_optimized_l2)
   sku dict
-  // Identity configuration (SystemAssigned, UserAssigned, principalId, tenantId)
+  // Managed identity configuration
+  //
+  // Keys: `type` ("None", "SystemAssigned", "UserAssigned", or
+  // "SystemAssigned, UserAssigned"), `userAssignedIdentities` (map of
+  // user-assigned identity resource IDs), and the read-only `principalId`
+  // and `tenantId` of the system-assigned identity.
   identity dict
   // Whether the service is reachable from the public internet ("enabled" or "disabled")
   publicNetworkAccess string
@@ -13029,7 +13676,13 @@ azure.subscription.searchService.service @defaults("id name location publicNetwo
   provisioningState string
   // Operational status of the service ("running", "provisioning", "deleting", "degraded", "disabled", "error", or "stopped")
   status string
-  // Network rule set: IP firewall rules and the bypass setting governing public access
+  // IP firewall rules governing public access
+  //
+  // Keys: `bypass` ("AzureServices" lets requests from Azure trusted
+  // services skip the IP rules, "None" allows no origin to bypass them) and
+  // `ipRules`, a list of `{value}` entries where each value is a single
+  // IPv4 address or a CIDR range permitted to reach the service endpoint.
+  // These rules apply only when `publicNetworkAccess` is "enabled".
   networkRuleSet dict
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
@@ -13043,9 +13696,9 @@ azure.subscription.searchService.service @defaults("id name location publicNetwo
 // receive; registration assignments attach those definitions to this
 // subscription or a resource group within it. A standing delegation grants an
 // outside tenant persistent access, so this namespace is the entry point for
-// detecting unexpected or overprivileged cross-tenant management. Iterate
-// `registrationDefinitions()` for the offers and `registrationAssignments()`
-// for the attachments in effect.
+// detecting unexpected or overprivileged cross-tenant management. The
+// `registrationDefinitions` field lists the offers and
+// `registrationAssignments` the attachments in effect.
 private azure.subscription.lighthouseService {
   // Subscription identifier
   subscriptionId string
@@ -13146,15 +13799,14 @@ azure.subscription.lighthouseService.registrationAssignment @defaults("name scop
 
 // Azure Machine Learning
 //
-// Use the Machine Learning namespace to enumerate the Azure Machine Learning
-// workspaces in the subscription, backed by the
-// `Microsoft.MachineLearningServices` resource provider. A workspace is the
-// top-level container for ML assets — experiments, models, compute, and
-// datastores — and binds to a Key Vault, Storage account, Application Insights
-// component, and Container Registry, so the namespace is the entry point for
-// auditing their public-network exposure, network isolation,
-// customer-managed-key encryption, and authentication posture. Iterate
-// `workspaces()` for the per-workspace records.
+// Machine Learning namespace covering the Azure Machine Learning workspaces in
+// the subscription, backed by the `Microsoft.MachineLearningServices` resource
+// provider. A workspace is the top-level container for ML assets (experiments,
+// models, compute, and datastores) and binds to a Key Vault, Storage account,
+// Application Insights component, and Container Registry, so the namespace is
+// the entry point for auditing their public-network exposure, network
+// isolation, customer-managed-key encryption, and authentication posture. The
+// `workspaces` field returns the per-workspace records.
 private azure.subscription.machineLearningService {
   // Subscription identifier
   subscriptionId string
@@ -13164,20 +13816,20 @@ private azure.subscription.machineLearningService {
 
 // Azure Machine Learning workspace
 //
-// Examine a single Azure Machine Learning workspace — the top-level container
-// for ML experiments, models, compute, and datastores. Use
-// `publicNetworkAccess` to confirm whether the workspace is reachable from the
-// public internet, `managedNetworkIsolationMode` for the managed-VNet outbound
-// policy, `hbiWorkspace` for whether it is flagged high-business-impact (which
-// restricts the diagnostic data Microsoft collects),
-// `allowPublicAccessWhenBehindVnet` for whether public access is permitted
-// despite a private endpoint, `v1LegacyMode` for whether the older v1 API
-// surface is still enabled, `encryptionKey` for the customer-managed key
-// encrypting workspace data (null when platform-managed), and `keyVault`,
-// `storageAccount`, `applicationInsights`, and `containerRegistry` for the
-// linked resources whose own posture the workspace inherits. Select a
-// workspace by `name` — for example
-// `azure.subscription.machineLearning.workspaces.where(name == "my-ws")`.
+// Single Azure Machine Learning workspace, the top-level container for ML
+// experiments, models, compute, and datastores, selected by `name` (for
+// example
+// `azure.subscription.machineLearningService.workspaces.where(name == "my-ws")`).
+// `publicNetworkAccess` confirms whether the workspace is reachable from the
+// public internet, `managedNetworkIsolationMode` reports the managed-VNet
+// outbound policy, `hbiWorkspace` flags whether it is high-business-impact
+// (which restricts the diagnostic data Microsoft collects),
+// `allowPublicAccessWhenBehindVnet` reports whether public access is permitted
+// despite a private endpoint, `v1LegacyMode` reports whether the older v1 API
+// surface is still enabled, and `encryptionKey` resolves the customer-managed
+// key encrypting workspace data (null when platform-managed). The `keyVault`,
+// `storageAccount`, `applicationInsights`, and `containerRegistry` references
+// resolve the linked resources whose own posture the workspace inherits.
 azure.subscription.machineLearningService.workspace @defaults("id name location publicNetworkAccess") {
   // Workspace resource ID
   id string
@@ -13222,6 +13874,11 @@ azure.subscription.machineLearningService.workspace @defaults("id name location 
   // Whether workspace data is encrypted with a customer-managed key ("Enabled") or a Microsoft-managed key ("Disabled")
   encryptionStatus string
   // Private endpoint connections to the workspace
+  //
+  // Each entry carries `id`, `name`, `type`, and a `properties` object holding
+  // `provisioningState`, `privateEndpoint` (with the connected private
+  // endpoint's `id`), and `privateLinkServiceConnectionState` (with `status`,
+  // `description`, and `actionsRequired`).
   privateEndpointConnections []dict
   // Customer-managed Key Vault key encrypting workspace data (null when Microsoft-managed)
   encryptionKey() azure.subscription.keyVaultService.key
@@ -13255,13 +13912,13 @@ azure.subscription.machineLearningService.workspace @defaults("id name location 
 
 // Real-time inference endpoint in an Azure Machine Learning workspace
 //
-// Examine a single online endpoint — the HTTPS endpoint that serves one
-// or more model deployments for real-time scoring, selected by `name`.
-// Use `authMode` to see how callers authenticate ("Key" or "AMLToken"),
-// `scoringUri` for the inference URL, `publicNetworkAccess` for whether
-// the endpoint is reachable from the public internet, `traffic` for how
-// live traffic is split across deployments, and `deployments` for the
-// model deployments behind the endpoint.
+// Single online endpoint, the HTTPS endpoint that serves one or more model
+// deployments for real-time scoring, selected by `name`. `authMode` reports
+// how callers authenticate ("Key" or "AMLToken"), `scoringUri` gives the
+// inference URL, `publicNetworkAccess` reports whether the endpoint is
+// reachable from the public internet, `traffic` shows how live traffic is
+// split across deployments, and `deployments` returns the model deployments
+// behind the endpoint.
 azure.subscription.machineLearningService.workspace.onlineEndpoint @defaults("name authMode provisioningState publicNetworkAccess") {
   // Online endpoint resource ID
   id string
@@ -13301,14 +13958,13 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint @defaults("na
 
 // Model deployment behind an online endpoint
 //
-// Examine a single online deployment — the model, environment, and
-// compute that serve a share of an online endpoint's traffic, selected
-// by `name`. Use `model` for the registered model being served,
-// `instanceType` and `skuCapacity` for the compute size and instance
-// count, `endpointComputeType` for the hosting type ("Managed",
-// "Kubernetes", or "AzureMLCompute"), `environmentId` for the inference
-// environment, and `egressPublicNetworkAccess` for whether the container
-// has unrestricted outbound network access.
+// Single online deployment, the model, environment, and compute that serve a
+// share of an online endpoint's traffic, selected by `name`. `model` names the
+// registered model being served, `instanceType` and `skuCapacity` give the
+// compute size and instance count, `endpointComputeType` reports the hosting
+// type ("Managed", "Kubernetes", or "AzureMLCompute"), `environmentId`
+// identifies the inference environment, and `egressPublicNetworkAccess`
+// reports whether the container has unrestricted outbound network access.
 azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment @defaults("name model instanceType provisioningState") {
   // Online deployment resource ID
   id string
@@ -13344,13 +14000,13 @@ azure.subscription.machineLearningService.workspace.onlineEndpoint.deployment @d
 
 // Serverless (Models-as-a-Service) endpoint in an Azure Machine Learning workspace
 //
-// Examine a single serverless endpoint — a pay-as-you-go model API
-// consumed without provisioning compute, selected by `name`. Use
-// `modelId` for the model being served, `inferenceUri` for the inference
-// URL, `authMode` and `endpointState` for the authentication mode and
-// lifecycle state, `marketplaceSubscriptionId` for the backing
-// Marketplace subscription, and `contentSafetyStatus` for whether
-// content safety filtering is enabled.
+// Single serverless endpoint, a pay-as-you-go model API consumed without
+// provisioning compute, selected by `name`. `modelId` names the model being
+// served, `inferenceUri` gives the inference URL, `authMode` and
+// `endpointState` report the authentication mode and lifecycle state,
+// `marketplaceSubscriptionId` identifies the backing Marketplace subscription,
+// and `contentSafetyStatus` reports whether content safety filtering is
+// enabled.
 azure.subscription.machineLearningService.workspace.serverlessEndpoint @defaults("name modelId endpointState provisioningState") {
   // Serverless endpoint resource ID
   id string
@@ -13382,14 +14038,13 @@ azure.subscription.machineLearningService.workspace.serverlessEndpoint @defaults
 
 // Compute target in an Azure Machine Learning workspace
 //
-// Examine a single compute target — the cluster, instance, or attached
-// resource that runs jobs and model deployments, selected by `name`. Use
-// `computeType` for the kind of compute ("AmlCompute", "ComputeInstance",
-// "Kubernetes", "AKS", and others), `disableLocalAuth` for whether SSH /
-// local authentication is turned off in favor of Microsoft Entra ID,
-// `isAttachedCompute` for whether the resource was brought from outside
-// the workspace, and `resourceId` for the underlying ARM compute it maps
-// to.
+// Single compute target, the cluster, instance, or attached resource that runs
+// jobs and model deployments, selected by `name`. `computeType` reports the
+// kind of compute ("AmlCompute", "ComputeInstance", "Kubernetes", "AKS", and
+// others), `disableLocalAuth` reports whether SSH / local authentication is
+// turned off in favor of Microsoft Entra ID, `isAttachedCompute` reports
+// whether the resource was brought from outside the workspace, and
+// `resourceId` identifies the underlying ARM compute it maps to.
 azure.subscription.machineLearningService.workspace.compute @defaults("name computeType provisioningState disableLocalAuth") {
   // Compute resource ID
   id string
@@ -13427,11 +14082,11 @@ azure.subscription.machineLearningService.workspace.compute @defaults("name comp
 
 // Registered model in an Azure Machine Learning workspace
 //
-// Examine a single registered model container — the named entry that
-// groups all versions of a model, selected by `name`. Use `latestVersion`
-// for the most recent registered version, `nextVersion` for the version
-// the next registration will receive, `isArchived` for whether the model
-// is archived, and `description`/`tags` for the model's metadata.
+// Single registered model container, the named entry that groups all versions
+// of a model, selected by `name`. `latestVersion` gives the most recent
+// registered version, `nextVersion` gives the version the next registration
+// will receive, `isArchived` reports whether the model is archived, and
+// `description` and `tags` carry the model's metadata.
 azure.subscription.machineLearningService.workspace.model @defaults("name latestVersion provisioningState") {
   // Model container resource ID
   id string
@@ -13455,13 +14110,11 @@ azure.subscription.machineLearningService.workspace.model @defaults("name latest
 
 // App Configuration
 //
-// Use the App Configuration namespace to enumerate the App Configuration
-// stores in the subscription. Each store centralizes application settings
-// and feature flags — content that routinely includes references to
-// secrets — so the namespace is the entry point for auditing their
-// public-network exposure, customer-managed-key encryption, and
-// authentication posture. Iterate `configurationStores()` for the
-// per-store records.
+// App Configuration stores in the subscription, each centralizing
+// application settings and feature flags. That content routinely
+// includes references to secrets, so this namespace is the entry
+// point for auditing per-store public-network exposure,
+// customer-managed-key encryption, and authentication posture.
 private azure.subscription.appConfigurationService {
   // Subscription identifier
   subscriptionId string
@@ -13471,14 +14124,14 @@ private azure.subscription.appConfigurationService {
 
 // App Configuration store
 //
-// Examine a single App Configuration store — the managed key-value service
-// that holds application settings and feature flags. Use `publicNetworkAccess`
-// to confirm whether the store is reachable from the public internet,
-// `disableLocalAuth` for whether access-key authentication is turned off in
-// favor of Microsoft Entra ID, `cmkKeyIdentifier` for the customer-managed
-// key encrypting the store (empty when Microsoft-managed keys are used),
-// `softDeleteRetentionInDays` and `enablePurgeProtection` for the
-// data-recovery guarantees, and `endpoint` for the data-plane URL.
+// Single App Configuration store, the managed key-value service that holds
+// application settings and feature flags. `publicNetworkAccess` confirms
+// whether the store is reachable from the public internet, `disableLocalAuth`
+// whether access-key authentication is turned off in favor of Microsoft
+// Entra ID, `cmkKeyIdentifier` the customer-managed key encrypting the store
+// (empty when Microsoft-managed keys are used), `softDeleteRetentionInDays`
+// and `enablePurgeProtection` the data-recovery guarantees, and `endpoint`
+// the data-plane URL.
 azure.subscription.appConfigurationService.configurationStore @defaults("id name location publicNetworkAccess") {
   // Configuration store resource ID
   id string
@@ -13490,7 +14143,11 @@ azure.subscription.appConfigurationService.configurationStore @defaults("id name
   tags map[string]string
   // SKU details (name: free or standard)
   sku dict
-  // Identity configuration (SystemAssigned, UserAssigned, principalId, tenantId)
+  // Managed identity configuration
+  //
+  // Keys: `type` (None, SystemAssigned, UserAssigned, or
+  // "SystemAssigned, UserAssigned"), `userAssignedIdentities`,
+  // `principalId`, and `tenantId`.
   identity dict
   // Whether the store is reachable from the public internet ("Enabled" or "Disabled")
   publicNetworkAccess string
@@ -13522,14 +14179,14 @@ azure.subscription.appConfigurationService.configurationStore @defaults("id name
 
 // Azure AI Services
 //
-// Use the Cognitive Services namespace to enumerate the Azure AI Services
-// (formerly Cognitive Services) accounts in the subscription, backed by the
-// `Microsoft.CognitiveServices` resource provider. Each account exposes AI
-// APIs — OpenAI, Speech, Vision, Language, and others — whose prompts and
-// responses can carry sensitive data, so the namespace is the entry point
-// for auditing their public-network exposure, network ACLs, customer-managed-key
-// encryption, and authentication posture. Iterate `accounts()` for the
-// per-account records.
+// Azure AI Services (formerly Cognitive Services) accounts in the
+// subscription, backed by the `Microsoft.CognitiveServices` resource
+// provider. Each account exposes AI APIs (OpenAI, Speech, Vision,
+// Language, and others) whose prompts and responses can carry sensitive
+// data, so this namespace is the entry point for auditing their
+// public-network exposure, network ACLs, customer-managed-key
+// encryption, and authentication posture. The `accounts` field holds
+// the per-account records.
 private azure.subscription.cognitiveServicesService {
   // Subscription identifier
   subscriptionId string
@@ -13539,17 +14196,17 @@ private azure.subscription.cognitiveServicesService {
 
 // Azure AI Services account
 //
-// Examine a single Azure AI Services account — the resource that exposes
-// one or more AI APIs identified by `kind` (for example "OpenAI",
-// "SpeechServices", or "CognitiveServices"). Use `publicNetworkAccess` to
-// confirm whether the account is reachable from the public internet,
-// `networkAcls` for the IP and virtual-network firewall rules,
-// `disableLocalAuth` for whether API-key authentication is turned off in
-// favor of Microsoft Entra ID, `restrictOutboundNetworkAccess` for
-// data-exfiltration controls, `cmkKeyName` and `cmkKeyVaultUri` for the
-// customer-managed key encrypting the account, and `customSubDomainName`
-// for the subdomain required by token-based authentication and private
-// endpoints.
+// Single Azure AI Services account, the resource that exposes one or
+// more AI APIs identified by `kind` (for example "OpenAI",
+// "SpeechServices", or "CognitiveServices"). `publicNetworkAccess`
+// reports whether the account is reachable from the public internet,
+// `networkAcls` holds the IP and virtual-network firewall rules,
+// `disableLocalAuth` reports whether API-key authentication is turned
+// off in favor of Microsoft Entra ID, `restrictOutboundNetworkAccess`
+// covers data-exfiltration controls, `cmkKeyName` and `cmkKeyVaultUri`
+// describe the customer-managed key encrypting the account, and
+// `customSubDomainName` is the subdomain required by token-based
+// authentication and private endpoints.
 azure.subscription.cognitiveServicesService.account @defaults("id name location kind publicNetworkAccess") {
   // Account resource ID
   id string
@@ -13699,19 +14356,19 @@ private azure.subscription.cognitiveServicesService.account.networkInjection @de
 
 // Model deployment on an Azure AI Services account
 //
-// Examine a single model deployment — the concrete model an application
-// calls through the account, identified by `name` (for example
+// Single model deployment, the concrete model an application calls
+// through the account, identified by `name` (for example
 // `azure.subscription.cognitiveServices.accounts.where(kind == "OpenAI")[0].deployments.where(name == "gpt-4o")`).
-// Use `modelName` and `modelVersion` to confirm which model and version
-// is served (and `modelFormat`/`modelPublisher` for non-OpenAI models),
-// `versionUpgradeOption` to audit whether the deployment is pinned to a
-// version that may be retiring or set to auto-upgrade, `skuName` for the
-// deployment type (for example "Standard", "GlobalStandard", or
-// "ProvisionedManaged") and `skuCapacity`/`currentCapacity` for the
-// provisioned throughput, `raiPolicyName` (resolved by `raiPolicy`) for
-// the content-filter policy applied to the model, `dynamicThrottlingEnabled`
-// for automatic throughput throttling, and `capabilities` for the
-// model's advertised features.
+// `modelName` and `modelVersion` confirm which model and version is
+// served (and `modelFormat`/`modelPublisher` for non-OpenAI models),
+// `versionUpgradeOption` reports whether the deployment is pinned to a
+// version that may be retiring or set to auto-upgrade, `skuName` gives
+// the deployment type (for example "Standard", "GlobalStandard", or
+// "ProvisionedManaged") and `skuCapacity`/`currentCapacity` the
+// provisioned throughput, `raiPolicyName` (resolved by `raiPolicy`) the
+// content-filter policy applied to the model, `dynamicThrottlingEnabled`
+// automatic throughput throttling, and `capabilities` the model's
+// advertised features.
 azure.subscription.cognitiveServicesService.account.deployment @defaults("name modelName modelVersion skuName versionUpgradeOption") {
   // Deployment resource ID
   id string
@@ -13757,12 +14414,12 @@ azure.subscription.cognitiveServicesService.account.deployment @defaults("name m
 
 // Azure AI Foundry project
 //
-// Examine a single Azure AI Foundry project — a workspace under an AI
-// Services account that scopes agents, deployments, and connections for
-// a team or application, selected by `name`. Use `isDefault` to identify
-// the account's default project, `displayName` and `description` for the
-// human-facing labels, `endpoints` for the project's data-plane URLs,
-// and `connections` for the project-scoped links to model providers,
+// Single Azure AI Foundry project, a workspace under an AI Services
+// account that scopes agents, deployments, and connections for a team
+// or application, selected by `name`. `isDefault` identifies the
+// account's default project, `displayName` and `description` carry the
+// human-facing labels, `endpoints` holds the project's data-plane URLs,
+// and `connections` lists the project-scoped links to model providers,
 // data sources, and tool (MCP) servers an agent can reach.
 azure.subscription.cognitiveServicesService.account.project @defaults("name displayName isDefault provisioningState") {
   // Project resource ID
@@ -13793,16 +14450,16 @@ azure.subscription.cognitiveServicesService.account.project @defaults("name disp
 
 // Connection on an Azure AI Foundry project
 //
-// Examine a single project-scoped connection — the link an agent or
-// application uses to reach an external resource, identified by `name`.
-// Use `category` to see what the connection points to (for example
-// "AzureOpenAI", "CognitiveSearch", "Serverless", "ManagedOnlineEndpoint",
-// or "CustomKeys" — the category used for Model Context Protocol tool
-// servers), `target` for the endpoint URL, `authType` for how the
-// connection authenticates, `isSharedToAll` for whether every member can
-// use it, `useWorkspaceManagedIdentity` for managed-identity access,
-// `peRequirement`/`peStatus` for private-endpoint posture, and `metadata`
-// for connection-specific settings (an MCP connection records its server
+// Single project-scoped connection, the link an agent or application
+// uses to reach an external resource, identified by `name`. `category`
+// shows what the connection points to (for example "AzureOpenAI",
+// "CognitiveSearch", "Serverless", "ManagedOnlineEndpoint", or
+// "CustomKeys", the category used for Model Context Protocol tool
+// servers), `target` gives the endpoint URL, `authType` how the
+// connection authenticates, `isSharedToAll` whether every member can
+// use it, `useWorkspaceManagedIdentity` managed-identity access,
+// `peRequirement`/`peStatus` private-endpoint posture, and `metadata`
+// connection-specific settings (an MCP connection records its server
 // label and URL here).
 private azure.subscription.cognitiveServicesService.account.project.connection @defaults("name category authType target") {
   // Connection resource ID
@@ -13841,17 +14498,17 @@ private azure.subscription.cognitiveServicesService.account.project.connection @
 
 // Connection on an Azure AI Services account
 //
-// Examine a single account-scoped connection — the link, shared across
-// the account's projects, used to reach an external resource, identified
-// by `name`. Use `category` to see what the connection points to (for
-// example "AzureOpenAI", "CognitiveSearch", "Serverless",
-// "ManagedOnlineEndpoint", or "CustomKeys" — the category used for Model
-// Context Protocol tool servers), `target` for the endpoint URL,
-// `authType` for how the connection authenticates, `isSharedToAll` for
-// whether every member can use it, `useWorkspaceManagedIdentity` for
-// managed-identity access, `peRequirement`/`peStatus` for private-endpoint
-// posture, and `metadata` for connection-specific settings (an MCP
-// connection records its server label and URL here).
+// Single account-scoped connection, the link (shared across the
+// account's projects) used to reach an external resource, identified by
+// `name`. `category` shows what the connection points to (for example
+// "AzureOpenAI", "CognitiveSearch", "Serverless", "ManagedOnlineEndpoint",
+// or "CustomKeys", the category used for Model Context Protocol tool
+// servers), `target` gives the endpoint URL, `authType` how the
+// connection authenticates, `isSharedToAll` whether every member can
+// use it, `useWorkspaceManagedIdentity` managed-identity access,
+// `peRequirement`/`peStatus` private-endpoint posture, and `metadata`
+// connection-specific settings (an MCP connection records its server
+// label and URL here).
 private azure.subscription.cognitiveServicesService.account.connection @defaults("name category authType target") {
   // Connection resource ID
   id string
@@ -13889,11 +14546,11 @@ private azure.subscription.cognitiveServicesService.account.connection @defaults
 
 // Responsible AI content-filter policy on a Cognitive Services account
 //
-// Examine the policy mode, the content filters it enforces (per category
-// and source), the custom blocklists it references, and the custom RAI
-// topics it applies. Use this to audit which accounts have content
-// filtering active, whether filters block or only warn, and at what
-// severity threshold each category trips.
+// Responsible AI policy covering the filter mode, the content filters it
+// enforces (per category and source), the custom blocklists it
+// references, and the custom RAI topics it applies. Audit this to see
+// which accounts have content filtering active, whether filters block or
+// only warn, and at what severity threshold each category trips.
 private azure.subscription.cognitiveServicesService.account.raiPolicy @defaults("name mode policyType") {
   // ARM resource ID
   id string
@@ -13917,11 +14574,11 @@ private azure.subscription.cognitiveServicesService.account.raiPolicy @defaults(
 
 // Content filter on a Responsible AI policy
 //
-// Examine a single content-filter rule keyed by content category and
-// source. Rules describe which severity threshold trips the filter,
-// whether the filter is active, and whether matches block the request
-// or only flag it. Audit queries typically scope by (name, source) to
-// confirm coverage of sensitive categories.
+// Single content-filter rule keyed by content category and source. Each
+// rule describes which severity threshold trips the filter, whether the
+// filter is active, and whether matches block the request or only flag
+// it. Audit queries typically scope by (name, source) to confirm
+// coverage of sensitive categories.
 private azure.subscription.cognitiveServicesService.account.raiPolicy.contentFilter @defaults("name source enabled blocking severityThreshold") {
   // Content category name (e.g., "Hate", "Sexual", "Violence", "Selfharm", "Jailbreak", "ProtectedMaterialText", "ProtectedMaterialCode")
   name string
@@ -13937,10 +14594,10 @@ private azure.subscription.cognitiveServicesService.account.raiPolicy.contentFil
 
 // Custom RAI topic reference on a Responsible AI policy
 //
-// Examine the link between a policy and a custom topic registered on
-// the same account. Carries the per-attachment scalars (source the
-// topic applies to, whether matches block) and resolves to the
-// underlying [[azure.subscription.cognitiveServicesService.account.raiTopic]].
+// Link between a policy and a custom topic registered on the same
+// account. Carries the per-attachment scalars (source the topic applies
+// to, whether matches block) and resolves to the underlying
+// [[azure.subscription.cognitiveServicesService.account.raiTopic]].
 private azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef @defaults("topicName source blocking") {
   // Name of the custom topic
   topicName string
@@ -13954,9 +14611,9 @@ private azure.subscription.cognitiveServicesService.account.raiPolicy.topicRef @
 
 // Responsible AI custom topic on a Cognitive Services account
 //
-// Examine a custom RAI topic and its lifecycle: status, sample data
-// location, creation/last-modified times, and a failure reason when the
-// topic has failed to train. Topics referenced by an [[azure.subscription.cognitiveServicesService.account.raiPolicy]]
+// Custom RAI topic and its lifecycle: status, sample data location,
+// creation/last-modified times, and a failure reason when the topic has
+// failed to train. Topics referenced by an [[azure.subscription.cognitiveServicesService.account.raiPolicy]]
 // add custom blocked-content detection beyond the built-in categories.
 private azure.subscription.cognitiveServicesService.account.raiTopic @defaults("name status topicName") {
   // ARM resource ID
@@ -13989,7 +14646,7 @@ private azure.subscription.cognitiveServicesService.account.raiTopic @defaults("
 
 // Microsoft Sentinel
 //
-// Examine Microsoft Sentinel onboarding and analytics surface in a
+// Microsoft Sentinel onboarding and analytics surface in a
 // subscription. Sentinel is layered on a Log Analytics workspace via
 // the SecurityInsights solution; a Log Analytics workspace appears
 // under `workspaces` only when Sentinel has been onboarded on it. Use
@@ -14005,11 +14662,10 @@ private azure.subscription.sentinelService @defaults("subscriptionId") {
 
 // Microsoft Sentinel onboarded Log Analytics workspace
 //
-// Examine a Log Analytics workspace that has Sentinel enabled.
-// Surfaces the workspace identity plus the analytics rules and data
-// connectors configured on it. The underlying Log Analytics workspace
-// is reachable via `workspace()` for retention, network, and access
-// settings.
+// Log Analytics workspace with Microsoft Sentinel enabled. Surfaces
+// the workspace identity plus the analytics rules and data connectors
+// configured on it. The underlying Log Analytics workspace is reachable
+// via `workspace` for retention, network, and access settings.
 private azure.subscription.sentinelService.workspace @defaults("name resourceGroup subscriptionId") {
   // ARM resource ID of the underlying Log Analytics workspace
   id string
@@ -14033,12 +14689,12 @@ private azure.subscription.sentinelService.workspace @defaults("name resourceGro
 
 // Microsoft Sentinel analytics rule
 //
-// Examine a single Sentinel analytics rule. Rules detect threats by
-// running KQL queries on workspace data (Scheduled), correlating
-// alerts across data sources (Fusion), or forwarding alerts from
-// other Microsoft security products (MicrosoftSecurityIncidentCreation).
-// Use `kind` to filter by rule type and `enabled` to identify active
-// detection coverage. Kind-specific configuration (KQL query, trigger
+// Single Sentinel analytics rule. Rules detect threats by running KQL
+// queries on workspace data (Scheduled), correlating alerts across
+// data sources (Fusion), or forwarding alerts from other Microsoft
+// security products (MicrosoftSecurityIncidentCreation). Use `kind` to
+// filter by rule type and `enabled` to identify active detection
+// coverage. Kind-specific configuration (KQL query, trigger
 // thresholds, source product filters) is in `properties`.
 private azure.subscription.sentinelService.alertRule @defaults("name kind enabled severity displayName") {
   // ARM resource ID
@@ -14065,9 +14721,11 @@ private azure.subscription.sentinelService.alertRule @defaults("name kind enable
 
 // Azure SignalR Service
 //
-// Use this namespace to iterate the Azure SignalR Service instances in
-// the subscription. SignalR provides real-time messaging (WebSockets)
-// for applications; each instance is reached through `instances()`.
+// Real-time messaging (WebSockets) service instances in the
+// subscription, each available through `instances`. SignalR delivers
+// server-to-client push messaging for applications. Auditing the
+// instances surfaces public network exposure and the authentication
+// methods enabled on each.
 private azure.subscription.signalRService {
   // Subscription identifier
   subscriptionId string
@@ -14077,13 +14735,13 @@ private azure.subscription.signalRService {
 
 // Azure SignalR Service instance
 //
-// Examine a single Azure SignalR Service instance. Use
-// `publicNetworkAccess` to confirm whether the instance is reachable
-// from the public internet, `disableLocalAuth` and `disableAadAuth` for
-// the enabled authentication methods, `clientCertEnabled` for whether
-// mutual TLS client certificates are required, and
-// `networkAclsDefaultAction` for the default network rule applied when
-// no ACL matches.
+// Single Azure SignalR Service instance providing real-time WebSocket
+// messaging. The `publicNetworkAccess` field confirms whether the
+// instance is reachable from the public internet, `disableLocalAuth`
+// and `disableAadAuth` report which authentication methods are enabled,
+// `clientCertEnabled` reports whether mutual TLS client certificates are
+// required, and `networkAclsDefaultAction` is the default network rule
+// applied when no ACL matches.
 azure.subscription.signalRService.signalR @defaults("id name location publicNetworkAccess") {
   // SignalR resource ID
   id string
@@ -14095,9 +14753,17 @@ azure.subscription.signalRService.signalR @defaults("id name location publicNetw
   tags map[string]string
   // Service mode kind ("SignalR" or "RawWebSockets")
   kind string
-  // SKU details (name, tier, capacity)
+  // SKU details
+  //
+  // Pricing tier of the instance with keys `name` (e.g. Standard_S1,
+  // Free_F1), `tier` (Free, Basic, Standard, or Premium), `capacity`
+  // (unit count), `family`, and `size`.
   sku dict
-  // Identity configuration (SystemAssigned, UserAssigned, principalId, tenantId)
+  // Identity configuration
+  //
+  // Managed identity assigned to the instance with keys `type` (None,
+  // SystemAssigned, or UserAssigned), `userAssignedIdentities`,
+  // `principalId`, and `tenantId`.
   identity dict
   // Public hostname clients connect to
   hostName string
@@ -14125,10 +14791,11 @@ azure.subscription.signalRService.signalR @defaults("id name location publicNetw
 
 // Azure Web PubSub Service
 //
-// Use this namespace to iterate the Azure Web PubSub Service instances
-// in the subscription. Web PubSub provides real-time publish/subscribe
-// messaging over WebSockets; each instance is reached through
-// `instances()`.
+// Web PubSub Service instances in the subscription, each providing
+// real-time publish/subscribe messaging over WebSockets. Query the
+// instances to audit public network exposure, the enabled
+// authentication methods, and network access rules across the
+// subscription.
 private azure.subscription.webPubSubService {
   // Subscription identifier
   subscriptionId string
@@ -14138,13 +14805,14 @@ private azure.subscription.webPubSubService {
 
 // Azure Web PubSub Service instance
 //
-// Examine a single Azure Web PubSub Service instance. Use
-// `publicNetworkAccess` to confirm whether the instance is reachable
-// from the public internet, `disableLocalAuth` and `disableAadAuth` for
-// the enabled authentication methods, `clientCertEnabled` for whether
-// mutual TLS client certificates are required, and
-// `networkAclsDefaultAction` for the default network rule applied when
-// no ACL matches.
+// Single Web PubSub Service instance providing real-time
+// publish/subscribe messaging over WebSockets. The security-relevant
+// fields confirm whether the instance is reachable from the public
+// internet (publicNetworkAccess), which authentication methods are
+// enabled (disableLocalAuth and disableAadAuth), whether mutual TLS
+// client certificates are required (clientCertEnabled), and the
+// default rule applied when no network ACL matches
+// (networkAclsDefaultAction).
 azure.subscription.webPubSubService.webPubSub @defaults("id name location publicNetworkAccess") {
   // Web PubSub resource ID
   id string
@@ -14186,8 +14854,10 @@ azure.subscription.webPubSubService.webPubSub @defaults("id name location public
 
 // Azure Data Explorer (Kusto)
 //
-// Use this namespace to iterate the Azure Data Explorer clusters in the
-// subscription. Each cluster is reached through `clusters()`.
+// Azure Data Explorer (Kusto) clusters in the subscription. Enumerate
+// `clusters` to audit real-time analytics deployments for public
+// network exposure, encryption at rest, and the principals granted
+// access.
 private azure.subscription.kustoService {
   // Subscription identifier
   subscriptionId string
@@ -14197,15 +14867,16 @@ private azure.subscription.kustoService {
 
 // Azure Data Explorer cluster
 //
-// Examine a single Azure Data Explorer (Kusto) cluster. Use
-// `publicNetworkAccess` and `publicIpType` to confirm internet exposure,
-// `restrictOutboundNetworkAccess` for data-exfiltration control,
-// `allowedIpRangeList`/`allowedFqdnList` for the inbound/outbound
-// allow-lists, `enableDiskEncryption` and `enableDoubleEncryption` for
-// encryption at rest, `cmkKeyName`/`cmkKeyVaultUri` for the
-// customer-managed key, `trustedExternalTenants` for which external
-// Microsoft Entra tenants may authenticate, and `enablePurge` for
-// whether hard-delete is allowed.
+// Single Azure Data Explorer (Kusto) cluster, the compute and storage
+// unit that hosts databases for fast analytics over large data volumes.
+// The `publicNetworkAccess` and `publicIpType` fields confirm internet
+// exposure, `restrictOutboundNetworkAccess` covers data-exfiltration
+// control, `allowedIpRangeList` and `allowedFqdnList` give the inbound
+// and outbound allow-lists, `enableDiskEncryption` and
+// `enableDoubleEncryption` cover encryption at rest, `cmkKeyName` and
+// `cmkKeyVaultUri` carry the customer-managed key, `trustedExternalTenants`
+// lists which external Microsoft Entra tenants may authenticate, and
+// `enablePurge` reports whether hard-delete is allowed.
 azure.subscription.kustoService.cluster @defaults("id name location publicNetworkAccess state") {
   // Cluster resource ID
   id string
@@ -14271,14 +14942,14 @@ azure.subscription.kustoService.cluster @defaults("id name location publicNetwor
 
 // Azure Data Explorer database
 //
-// Examine a single database hosted on an Azure Data Explorer cluster. Use
-// `kind` to distinguish a read-write database from a read-only follower,
-// `hotCachePeriod` and `softDeletePeriod` for the cache and retention
-// windows, `cmkKeyName`/`cmkKeyVaultUri` for a database-scoped
+// Single database hosted on an Azure Data Explorer cluster. The `kind`
+// field distinguishes a read-write database from a read-only follower,
+// `hotCachePeriod` and `softDeletePeriod` give the cache and retention
+// windows, `cmkKeyName` and `cmkKeyVaultUri` carry a database-scoped
 // customer-managed encryption key, and `leaderClusterResourceId` with
-// `originalDatabaseName` to trace a follower back to its source. Iterate
-// `principalAssignments` to audit who can read or administer the database
-// and `dataConnections` to see which external sources feed ingestion.
+// `originalDatabaseName` trace a follower back to its source.
+// `principalAssignments` reveals who can read or administer the database
+// and `dataConnections` shows which external sources feed ingestion.
 azure.subscription.kustoService.cluster.database @defaults("name kind hotCachePeriod softDeletePeriod") {
   // Database resource ID
   id string
@@ -14316,11 +14987,11 @@ azure.subscription.kustoService.cluster.database @defaults("name kind hotCachePe
 
 // Azure Data Explorer cluster principal assignment
 //
-// Examine a Microsoft Entra principal granted cluster-wide access to an
-// Azure Data Explorer cluster. Use `role` to see the level of access
+// Microsoft Entra principal granted cluster-wide access to an Azure
+// Data Explorer cluster. The `role` field gives the level of access
 // (`AllDatabasesAdmin`, `AllDatabasesViewer`, or `AllDatabasesMonitor`),
-// `principalType` for whether the principal is an `App`, `Group`, or
-// `User`, and `principalId`/`principalName` to identify it.
+// `principalType` reports whether the principal is an `App`, `Group`, or
+// `User`, and `principalId` with `principalName` identify it.
 private azure.subscription.kustoService.cluster.principalAssignment @defaults("principalName role principalType") {
   // Assignment resource ID
   id string
@@ -14344,11 +15015,12 @@ private azure.subscription.kustoService.cluster.principalAssignment @defaults("p
 
 // Azure Data Explorer database principal assignment
 //
-// Examine a Microsoft Entra principal granted access to a single Azure
-// Data Explorer database. Use `role` for the database-scoped permission
-// (`Admin`, `Ingestor`, `Monitor`, `UnrestrictedViewer`, `User`, or
-// `Viewer`), `principalType` for whether the principal is an `App`,
-// `Group`, or `User`, and `principalId`/`principalName` to identify it.
+// Microsoft Entra principal granted access to a single Azure Data
+// Explorer database. The `role` field gives the database-scoped
+// permission (`Admin`, `Ingestor`, `Monitor`, `UnrestrictedViewer`,
+// `User`, or `Viewer`), `principalType` reports whether the principal is
+// an `App`, `Group`, or `User`, and `principalId` with `principalName`
+// identify it.
 private azure.subscription.kustoService.cluster.database.principalAssignment @defaults("principalName role principalType") {
   // Assignment resource ID
   id string
@@ -14372,13 +15044,13 @@ private azure.subscription.kustoService.cluster.database.principalAssignment @de
 
 // Azure Data Explorer cluster callout policy
 //
-// Examine an outbound callout policy that governs which external endpoints
-// an Azure Data Explorer cluster may reach from queries and plugins. Use
-// `calloutType` for the external service category (for example `kusto`,
-// `sql`, `cosmosdb`, `azure_openai`, `webapi`, or `external_data`),
-// `calloutUriRegex` for the destination pattern the policy matches, and
-// `outboundAccess` for whether matching calls are allowed or denied —
-// the key control for limiting data exfiltration paths.
+// Outbound callout policy that governs which external endpoints an
+// Azure Data Explorer cluster may reach from queries and plugins. The
+// `calloutType` field gives the external service category (for example
+// `kusto`, `sql`, `cosmosdb`, `azure_openai`, `webapi`, or
+// `external_data`), `calloutUriRegex` the destination pattern the policy
+// matches, and `outboundAccess` whether matching calls are allowed or
+// denied, the key control for limiting data exfiltration paths.
 private azure.subscription.kustoService.cluster.calloutPolicy @defaults("calloutType outboundAccess calloutUriRegex") {
   // Identifier of the callout policy
   calloutId string
@@ -14396,11 +15068,10 @@ private azure.subscription.kustoService.cluster.calloutPolicy @defaults("callout
 
 // Azure Data Explorer cluster private endpoint connection
 //
-// Examine a private endpoint connection terminating on an Azure Data
-// Explorer cluster. Use `status` for the approval state (`Approved`,
-// `Pending`, or `Rejected`), `groupId` for the targeted sub-resource, and
-// `privateEndpointId` for the resource ID of the connecting private
-// endpoint.
+// Private endpoint connection terminating on an Azure Data Explorer
+// cluster. The `status` field gives the approval state (`Approved`,
+// `Pending`, or `Rejected`), `groupId` the targeted sub-resource, and
+// `privateEndpoint` the connecting private endpoint.
 private azure.subscription.kustoService.cluster.privateEndpointConnection @defaults("name status groupId") {
   // Connection resource ID
   id string
@@ -14422,11 +15093,11 @@ private azure.subscription.kustoService.cluster.privateEndpointConnection @defau
 
 // Azure Data Explorer cluster managed private endpoint
 //
-// Examine a managed private endpoint created by an Azure Data Explorer
-// cluster to reach another Azure resource over a private link. Use
-// `privateLinkResourceId` for the target resource, `groupId` for the
-// sub-resource it connects to, and `requestMessage` for the approval
-// message sent to the resource owner.
+// Managed private endpoint created by an Azure Data Explorer cluster to
+// reach another Azure resource over a private link. The
+// `privateLinkResourceId` field gives the target resource, `groupId` the
+// sub-resource it connects to, and `requestMessage` the approval message
+// sent to the resource owner.
 private azure.subscription.kustoService.cluster.managedPrivateEndpoint @defaults("name groupId provisioningState") {
   // Managed private endpoint resource ID
   id string
@@ -14448,12 +15119,12 @@ private azure.subscription.kustoService.cluster.managedPrivateEndpoint @defaults
 
 // Azure Data Explorer database data connection
 //
-// Examine an ingestion data connection feeding an Azure Data Explorer
-// database. Use `kind` for the source type (`EventHub`, `EventGrid`,
-// `IotHub`, or `CosmosDb`), `sourceResourceId` for the Azure resource
-// supplying the data, `tableName`/`dataFormat`/`mappingRuleName` for the
-// ingestion target and shape, and `managedIdentityResourceId` for the
-// identity used to authenticate to the source.
+// Ingestion data connection feeding an Azure Data Explorer database. The
+// `kind` field gives the source type (`EventHub`, `EventGrid`, `IotHub`,
+// or `CosmosDb`), `sourceResourceId` the Azure resource supplying the
+// data, `tableName`, `dataFormat`, and `mappingRuleName` the ingestion
+// target and shape, and `managedIdentity` the identity used to
+// authenticate to the source.
 private azure.subscription.kustoService.cluster.database.dataConnection @defaults("name kind tableName") {
   // Data connection resource ID
   id string
@@ -14476,7 +15147,7 @@ private azure.subscription.kustoService.cluster.database.dataConnection @default
   consumerGroup string
   // How ingestion routes across databases, one of "Single" or "Multi"
   databaseRouting string
-  // Resource ID of the source feeding ingestion — the Event Hub, IoT Hub, Event Grid topic, or Cosmos DB account, depending on kind
+  // Resource ID of the source feeding ingestion: the Event Hub, IoT Hub, Event Grid topic, or Cosmos DB account, depending on kind
   sourceResourceId string
   // Managed identity used to authenticate to the source, if any
   managedIdentity() azure.subscription.managedIdentity
@@ -14488,8 +15159,12 @@ private azure.subscription.kustoService.cluster.database.dataConnection @default
 
 // Azure Automation
 //
-// Use this namespace to iterate the Azure Automation accounts in the
-// subscription. Each account is reached through `accounts()`.
+// Entry point for the Azure Automation accounts in the subscription,
+// available through `accounts`. Automation accounts host runbooks, DSC
+// configurations, and shared assets (variables, credentials, and
+// certificates), so this is the starting point for auditing how a
+// subscription automates operations and what secrets that automation
+// stores.
 private azure.subscription.automationService {
   // Subscription identifier
   subscriptionId string
@@ -14499,13 +15174,14 @@ private azure.subscription.automationService {
 
 // Azure Automation account
 //
-// Examine a single Azure Automation account. Use `publicNetworkAccess`
-// to confirm internet exposure, `disableLocalAuth` for whether key-based
-// authentication is disabled in favor of Microsoft Entra ID,
-// `cmkKeySource`/`cmkKeyName` for customer-managed-key encryption, and
-// iterate `variables`, `credentials`, and `certificates` to audit the
-// secrets the account stores (for example unencrypted variables, or
-// expiring or exportable certificates).
+// Single Azure Automation account, the container for runbooks, DSC
+// configurations, and shared assets. `publicNetworkAccess` reports
+// internet exposure, `disableLocalAuth` reports whether key-based
+// authentication is disabled in favor of Microsoft Entra ID, and
+// `cmkKeySource`, `cmkKeyName`, and `cmkKeyVaultUri` describe
+// customer-managed-key encryption. The `variables`, `credentials`, and
+// `certificates` collections expose the secrets the account stores, for
+// example unencrypted variables or expiring or exportable certificates.
 azure.subscription.automationService.account @defaults("id name location publicNetworkAccess") {
   // Account resource ID
   id string
@@ -14515,9 +15191,17 @@ azure.subscription.automationService.account @defaults("id name location publicN
   location string
   // Account tags
   tags map[string]string
-  // SKU details (name)
+  // SKU
+  //
+  // Pricing tier of the account. Keys: `name` (either "Free" or
+  // "Basic"), `capacity`, and `family`.
   sku dict
-  // Identity configuration (SystemAssigned, UserAssigned, principalId, tenantId)
+  // Managed identity configuration
+  //
+  // Keys: `type` (one of "None", "SystemAssigned", "UserAssigned", or
+  // "SystemAssigned, UserAssigned"), `userAssignedIdentities` (map keyed
+  // by user-assigned identity resource ID), `principalId`, and
+  // `tenantId`.
   identity dict
   // Account lifecycle state ("Ok", "Unavailable", "Suspended")
   state string
@@ -14603,8 +15287,11 @@ private azure.subscription.automationService.account.certificate @defaults("name
 
 // Azure Virtual Desktop
 //
-// Use this namespace to iterate the Azure Virtual Desktop host pools in
-// the subscription. Each host pool is reached through `hostPools()`.
+// Azure Virtual Desktop deployment in the subscription and the entry
+// point for auditing virtual desktop infrastructure. The `hostPools`
+// field lists every host pool, each of which governs RDP redirection
+// settings, session limits, public network exposure, and single sign-on
+// for the session hosts that deliver desktops and applications to users.
 private azure.subscription.desktopVirtualizationService {
   // Subscription identifier
   subscriptionId string
@@ -14614,13 +15301,14 @@ private azure.subscription.desktopVirtualizationService {
 
 // Azure Virtual Desktop host pool
 //
-// Examine a single Azure Virtual Desktop host pool. Use
-// `customRdpProperty` to audit the RDP session settings (clipboard,
-// drive, and device redirection), `validationEnvironment` for whether
-// the pool receives pre-release agent updates, `startVMOnConnect` and
-// `maxSessionLimit` for session behavior, `loadBalancerType` and
-// `hostPoolType` for the pool model, and `ssoadfsAuthority` for the
-// single-sign-on configuration.
+// Group of session hosts that deliver virtual desktops and remote
+// applications to users, and the primary control point for the pool's
+// security posture. The raw `customRdpProperty` string carries the RDP
+// redirection rules (clipboard, drive, and device access) that decide how
+// data can move between the session host and the client, while
+// `publicNetworkAccess` and `ssoSecretType` govern network reachability
+// and how the single sign-on secret is stored. Audit these to confirm a
+// pool does not leak data through unrestricted redirection or exposure.
 azure.subscription.desktopVirtualizationService.hostPool @defaults("id name location hostPoolType") {
   // Host pool resource ID
   id string
@@ -14630,7 +15318,11 @@ azure.subscription.desktopVirtualizationService.hostPool @defaults("id name loca
   location string
   // Host pool tags
   tags map[string]string
-  // Identity configuration (SystemAssigned, UserAssigned, principalId, tenantId)
+  // Managed identity assigned to the host pool
+  //
+  // Keys: `type` (the identity model, currently always "SystemAssigned"),
+  // `principalId` (the object ID of the system-assigned identity), and
+  // `tenantId` (the Entra tenant that owns the identity).
   identity dict
   // Host pool type ("Personal", "Pooled", or "BYODesktop")
   hostPoolType string
@@ -14652,7 +15344,11 @@ azure.subscription.desktopVirtualizationService.hostPool @defaults("id name loca
   ssoadfsAuthority string
   // Update ring the host pool belongs to
   ring int
-  // Whether the host pool is reachable from the public internet ("Enabled", "Disabled", "EnabledForSessionHostsOnly", or "EnabledForClientsOnly")
+  // Public network access setting
+  //
+  // Controls whether the host pool is reachable from the public internet.
+  // One of "Enabled", "Disabled", "EnabledForSessionHostsOnly", or
+  // "EnabledForClientsOnly".
   publicNetworkAccess string
   // How the single-sign-on secret is stored ("SharedKey", "Certificate", "SharedKeyInKeyVault", or "CertificateInKeyVault")
   ssoSecretType string


### PR DESCRIPTION
## What

A broad documentation pass over `azure.lr`, extending the pattern from **S3** (#9146) and **AWS** (#9151) to the Azure provider. These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**53 services, ~353 edits.**

## Changes

- **Descriptions on user-queryable resources that were title-only** — lead with the noun and convey audit/security significance, *without* re-listing the field table the website already renders.
- **Documented dict/map key shapes** — `identity`, `sku`, `networkProfile`, `securityProfile`, `redisConfiguration`, and many others now describe their real keys, verified against the `armXxx` SDK structs.
- **Security-field derivations and enum values** — explain how computed fields are derived and enumerate string enum values.
- **Style-rule cleanup at scale** — removed verb-led descriptions (`Examine`/`Use`/`Iterate`), em dashes, call-form `foo()` in prose, mechanism leaks (`typed`, `lazy-loaded`), and cross-cloud analogies; corrected a VM description that used the GCP term "Compute Engine VM"; fixed title/type mismatches; and split two IPsec enum titles that exceeded the 150-char cap into title + description.

## The pattern (same as #9146 / #9151)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation. A field is named in prose only when it adds semantics the table can't.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, 0 titles over the 150-char cap, no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds; the parser enforces the title/blank-separator/150-char rules).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and SDK struct), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.

Part of a provider-wide sweep; GCP, OCI, DigitalOcean, STACKIT, and Hetzner follow in their own PRs.
