### PR TITLE
📄 gcp: enrich resource and field documentation across services

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -35,17 +35,17 @@ alias gcp.memorystore = gcp.project.memorystoreService
 
 // Google Cloud organization
 //
-// Examine the Cloud Resource Manager organization that contains the
-// account's folders, projects, IAM policy, and Security Command Center
+// Cloud Resource Manager organization that contains the account's
+// folders, projects, IAM policy, and Security Command Center
 // configuration. Surfaces the organization ID, name, lifecycle state,
 // the IAM `iamPolicy` and `auditConfig` bindings, the `orgPolicies`
 // applied across the org tree, the access-approval settings, and the
-// child `folders()` and `projects()`. The Security Command Center
+// child `folders` and `projects`. The Security Command Center
 // accessors (`sccSources`, `sccFindings`, `sccNotificationConfigs`,
 // `sccMuteConfigs`, `sccBigQueryExports`, `sccOrganizationSettings`)
-// expose SCC posture across all sources, `accessPolicies()` returns
+// expose SCC posture across all sources, `accessPolicies` returns
 // the VPC Service Controls access policies bound to the org, and
-// `customConstraints()` lists the custom Organization Policy constraints
+// `customConstraints` lists the custom Organization Policy constraints
 // defined on it.
 gcp.organization @defaults("name") {
   // Organization ID
@@ -106,9 +106,9 @@ gcp.organization @defaults("name") {
 
 // Google Cloud (GCP) IAM custom role defined at the organization level
 //
-// Examine a custom IAM role defined on the organization rather than on
-// an individual project — its title, description, launch stage
-// (`ALPHA`, `BETA`, `GA`, `DEPRECATED`, `DISABLED`), the full list of
+// Custom IAM role defined on the organization rather than on an
+// individual project: its title, description, launch stage (`ALPHA`,
+// `BETA`, `GA`, `DEPRECATED`, `DISABLED`), the full list of
 // permissions it grants, and whether it has been soft-deleted.
 // Organization-level custom roles are reusable across every project in
 // the org, so an overly broad permission set has a wider blast radius
@@ -134,20 +134,20 @@ private gcp.organization.role @defaults("title name") {
   //
   // True when any included permission is iam.serviceAccounts.actAs,
   // getAccessToken, signBlob, signJwt, getOpenIdToken, or
-  // implicitDelegation — the permissions that enable acting as a service
+  // implicitDelegation, the permissions that enable acting as a service
   // account and escalating privilege.
   grantsServiceAccountImpersonation() bool
 }
 
 // Network Security profile for an organization
 //
-// Examine a Network Security profile that defines a reusable set of
-// threat-detection and traffic-handling behavior referenced by
-// firewall policy rules: `threatPreventionProfile` configures
-// intrusion prevention severity overrides, `urlFilteringProfile`
-// configures URL filtering, and the intercept and mirroring profiles
-// configure packet handling. The `type` field records which behavior
-// the profile carries. Selected by the full resource name.
+// Reusable set of threat-detection and traffic-handling behavior
+// referenced by firewall policy rules: `threatPreventionProfile`
+// configures intrusion prevention severity overrides,
+// `urlFilteringProfile` configures URL filtering, and the intercept
+// and mirroring profiles configure packet handling. The `type` field
+// records which behavior the profile carries. Selected by the full
+// resource name.
 private gcp.organization.networkSecurityProfile @defaults("name type") {
   // Full resource name of the security profile
   name string
@@ -155,13 +155,30 @@ private gcp.organization.networkSecurityProfile @defaults("name type") {
   description string
   // Profile type (THREAT_PREVENTION, CUSTOM_MIRRORING, CUSTOM_INTERCEPT, URL_FILTERING)
   type string
-  // Threat prevention configuration, including per-severity and per-threat overrides
+  // Threat prevention configuration
+  //
+  // Dict with keys `severityOverrides` (list of {severity, action}),
+  // `threatOverrides` (list of {threatId, type, action}), and
+  // `antivirusOverrides` (list of {protocol, action}). Each override's
+  // action is one of DEFAULT_ACTION, ALLOW, ALERT, or DENY.
   threatPreventionProfile dict
-  // URL filtering configuration applied by the profile
+  // URL filtering configuration
+  //
+  // Dict with a `urlFilters` key: a list of {urls, priority,
+  // filteringAction} entries where filteringAction is ALLOW or DENY for
+  // connections whose URL matches any string in urls.
   urlFilteringProfile dict
-  // Custom packet-mirroring configuration applied by the profile
+  // Custom packet-mirroring configuration
+  //
+  // Dict with a single `mirroringEndpointGroup` key holding the
+  // resource name of the mirroring endpoint group that receives
+  // mirrored traffic.
   customMirroringProfile dict
-  // Custom packet-intercept configuration applied by the profile
+  // Custom packet-intercept configuration
+  //
+  // Dict with a single `interceptEndpointGroup` key holding the
+  // resource name of the intercept endpoint group that receives
+  // intercepted traffic.
   customInterceptProfile dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -175,12 +192,11 @@ private gcp.organization.networkSecurityProfile @defaults("name type") {
 
 // Network Security profile group for an organization
 //
-// Examine a Network Security profile group, which bundles individual
-// security profiles so that a single firewall policy rule can apply
-// threat prevention, URL filtering, mirroring, and intercept behavior
-// together. Each field references the full resource name of the
-// security profile that supplies that behavior. Selected by the full
-// resource name.
+// Bundle of individual security profiles so that a single firewall
+// policy rule can apply threat prevention, URL filtering, mirroring,
+// and intercept behavior together. Each field references the full
+// resource name of the security profile that supplies that behavior.
+// Selected by the full resource name.
 private gcp.organization.networkSecurityProfileGroup @defaults("name") {
   // Full resource name of the security profile group
   name string
@@ -204,12 +220,12 @@ private gcp.organization.networkSecurityProfileGroup @defaults("name") {
 
 // Google Cloud Identity group
 //
-// Examine a Cloud Identity or Google Workspace group: the `email`
-// that identifies it, its `displayName` and `description`, the
-// `labels` that classify it as a security group or discussion forum,
-// and its `memberships` — the users, service accounts, and nested
-// groups that belong to it. Use it to expand an IAM binding granted
-// to a group into the concrete principals the binding reaches.
+// Cloud Identity or Google Workspace group, identified by its `email`
+// and `id`. The `labels` classify the group as a security group or a
+// discussion forum, and `memberships` enumerates the users, service
+// accounts, and nested groups that belong to it. Use this to expand an
+// IAM binding granted to a group into the concrete principals it reaches
+// and to audit the membership of privileged security groups.
 private gcp.cloudIdentity.group @defaults("displayName email") {
   // Resource name of the group (groups/{groupId})
   name string
@@ -221,7 +237,13 @@ private gcp.cloudIdentity.group @defaults("displayName email") {
   displayName string
   // Human-readable description of the group
   description string
-  // Labels classifying the group, such as security group or discussion forum
+  // Group classification labels
+  //
+  // Well-known label keys with empty values:
+  // cloudidentity.googleapis.com/groups.security marks a security
+  // group (usable in IAM bindings), and
+  // cloudidentity.googleapis.com/groups.discussion_forum marks a
+  // Google Groups discussion forum.
   labels map[string]string
   // Time the group was created
   created time
@@ -231,11 +253,12 @@ private gcp.cloudIdentity.group @defaults("displayName email") {
 
 // Google Cloud Identity group membership
 //
-// Examine a single membership in a Cloud Identity group: `memberKey`
-// identifies the member, `type` distinguishes a user from a service
-// account or a nested group, `roles` lists the roles the member holds
-// in the group (MEMBER, MANAGER, OWNER), and `deliverySetting`
-// records how group mail reaches the member.
+// Single membership in a Cloud Identity group. The `memberKey`
+// identifies the member and `type` distinguishes a user from a service
+// account or a nested group, while `roles` lists the roles the member
+// holds in the group (MEMBER, MANAGER, OWNER) and `deliverySetting`
+// records how group mail reaches the member. Use this to audit who holds
+// OWNER or MANAGER rights over a group whose membership grants access.
 private gcp.cloudIdentity.membership @defaults("memberKey type") {
   // Resource name of the membership (groups/{groupId}/memberships/{membershipId})
   name string
@@ -262,11 +285,11 @@ private gcp.folders {
 
 // Google Cloud (GCP) Memorystore for Redis
 //
-// Use this resource as the entry point for Memorystore for Redis in the
-// project. It hosts the managed-Redis `instances` and the newer `clusters`
-// (sharded Memorystore for Redis Cluster deployments) — each exposing auth
-// mode, transit encryption, authorized network, and maintenance settings
-// for cache-tier audits.
+// Managed Redis service (Memorystore) in the project, covering both the
+// classic managed-Redis `instances` and the newer sharded `clusters`
+// (Memorystore for Redis Cluster deployments). Each exposes auth mode,
+// transit encryption, authorized network, and maintenance settings for
+// cache-tier security and configuration audits.
 private gcp.project.redisService {
   // Project ID
   projectId string
@@ -278,15 +301,14 @@ private gcp.project.redisService {
 
 // Google Cloud (GCP) Memorystore for Redis instance
 //
-// Examine a managed Redis instance — its version, tier, memory
-// size, and network placement (`authorizedNetwork`, `connectMode`).
-// Surfaces authentication posture (`authEnabled`,
-// `transitEncryptionMode`), replica topology (`replicaCount`,
-// `readReplicasMode`, `readEndpoint`), the customer-managed
-// encryption key via `kmsKey()`, persistence and maintenance
-// configuration, and the list of `serverCaCerts` used for TLS
-// connections. The `state` and `statusMessage` fields reflect the
-// current operational condition of the instance.
+// Managed Redis instance, including its version, tier, memory size, and
+// network placement (`network`, `connectMode`). Surfaces the
+// authentication posture (`authEnabled`, `transitEncryptionMode`), replica
+// topology (`replicaCount`, `readReplicasMode`, `readEndpoint`), the
+// customer-managed encryption key through `kmsKey`, persistence and
+// maintenance configuration, and the `serverCaCerts` used for TLS
+// connections. The `state` and `statusMessage` fields reflect the current
+// operational condition of the instance.
 private gcp.project.redisService.instance @defaults("name") {
   // Unique name of the resource in this scope including project and location
   name string
@@ -365,11 +387,20 @@ private gcp.project.redisService.instance @defaults("name") {
   alternativeLocationId string
   // The reasons the instance has been suspended
   suspensionReasons []string
-  // The persistence configuration of the instance
+  // Data-persistence configuration of the instance
+  //
+  // Keys: `persistenceMode` (DISABLED or RDB), `rdbSnapshotPeriod` (the RDB
+  // snapshot frequency), `rdbNextSnapshotTime`, and `rdbSnapshotStartTime`.
   persistenceConfig dict
-  // The maintenance policy of the instance
+  // Maintenance policy of the instance
+  //
+  // Keys: `createTime`, `updateTime`, `description`, and
+  // `weeklyMaintenanceWindow`, a list of windows each with `day`,
+  // `startTime` (HH:MM:SS), and `duration`.
   maintenancePolicy dict
-  // The upcoming maintenance schedule
+  // Upcoming maintenance schedule
+  //
+  // Keys: `startTime`, `endTime`, and `scheduleDeadlineTime`.
   maintenanceSchedule dict
   // List of server CA certificates for the instance
   serverCaCerts []gcp.project.redisService.instance.serverCaCert
@@ -409,17 +440,15 @@ private gcp.project.redisService.instance.serverCaCert @defaults("serialNumber s
 
 // Google Cloud (GCP) Memorystore for Redis Cluster
 //
-// Examine a sharded Memorystore for Redis Cluster deployment.
-// Surfaces the cluster `state`, shard and replica counts,
-// `nodeType`, total memory size (`sizeGb`, `preciseSizeGb`),
-// authorization and transit-encryption modes, deletion protection,
-// the customer-managed encryption key via `cryptoKey()`, and
-// operational metadata such as `maintenancePolicy`,
-// `maintenanceSchedule`, `persistenceConfig`, and
-// `automatedBackupConfig`. The `pscConfigs`, `pscConnections`,
-// `clusterEndpoints`, and `discoveryEndpoints` describe the Private
-// Service Connect topology. Use `backups()` to enumerate
-// point-in-time cluster backups.
+// Sharded Memorystore for Redis Cluster deployment, including the cluster
+// `state`, shard and replica counts, `nodeType`, total memory size
+// (`sizeGb`, `preciseSizeGb`), authorization and transit-encryption modes,
+// deletion protection, the customer-managed encryption key through
+// `cryptoKey`, and operational metadata such as `maintenancePolicy`,
+// `maintenanceSchedule`, `persistenceConfig`, and `automatedBackupConfig`.
+// The `pscConfigs`, `pscConnections`, `clusterEndpoints`, and
+// `discoveryEndpoints` describe the Private Service Connect topology, and
+// `backups` enumerates point-in-time cluster backups.
 private gcp.project.redisService.cluster @defaults("name") {
   // Unique name of the resource
   name string
@@ -459,19 +488,42 @@ private gcp.project.redisService.cluster @defaults("name") {
   backupCollection string
   // Redis configuration parameters
   redisConfigs map[string]string
-  // The persistence configuration of the cluster
+  // Data-persistence configuration of the cluster
+  //
+  // Keys: `mode` (DISABLED, RDB, or AOF); `rdbConfig` with
+  // `rdbSnapshotPeriod` and `rdbSnapshotStartTime`; and `aofConfig` with
+  // `appendFsync`.
   persistenceConfig dict
-  // The zone distribution configuration of the cluster
+  // Zone distribution configuration of the cluster
+  //
+  // Keys: `mode` (MULTI_ZONE or SINGLE_ZONE) and `zone`.
   zoneDistributionConfig dict
-  // The maintenance policy of the cluster
+  // Maintenance policy of the cluster
+  //
+  // Keys: `createTime`, `updateTime`, and `weeklyMaintenanceWindow`, a list
+  // of windows each with `day` and `startTime` (HH:MM:SS).
   maintenancePolicy dict
-  // The upcoming maintenance schedule
+  // Upcoming maintenance schedule
+  //
+  // Keys: `startTime` and `endTime`.
   maintenanceSchedule dict
-  // Encryption information of the cluster
+  // At-rest encryption state of the cluster
+  //
+  // Keys: `encryptionType` (GOOGLE_DEFAULT_ENCRYPTION or
+  // CUSTOMER_MANAGED_ENCRYPTION), `kmsKeyVersions`, `kmsKeyPrimaryState`,
+  // and `lastUpdateTime`.
   encryptionInfo dict
-  // The automated backup configuration of the cluster
+  // Automated backup configuration of the cluster
+  //
+  // Keys: `automatedBackupMode` (DISABLED or ENABLED), `retention` (backup
+  // retention duration), and `fixedFrequencySchedule` with `startTime`
+  // (HH:MM:SS).
   automatedBackupConfig dict
-  // The cross-cluster replication configuration
+  // Cross-cluster replication configuration
+  //
+  // Keys: `clusterRole` (NONE, PRIMARY, or SECONDARY); `primaryCluster`
+  // and `secondaryClusters` entries each with `cluster` (resource name)
+  // and `uid`; and `updateTime`.
   crossClusterReplicationConfig dict
   // The PSC configurations
   pscConfigs []gcp.project.redisService.cluster.pscConfig
@@ -487,7 +539,10 @@ private gcp.project.redisService.cluster @defaults("name") {
   serverCaMode string
   // The CA pool resource for customer-managed CAS
   serverCaPool string
-  // PSC service attachments
+  // Private Service Connect service attachments the cluster exposes
+  //
+  // Each entry has `serviceAttachment` (the service attachment resource)
+  // and `connectionType`.
   pscServiceAttachments []dict
 }
 
@@ -545,12 +600,11 @@ private gcp.project.redisService.cluster.pscConnection @defaults("pscConnectionI
 
 // Google Cloud (GCP) Memorystore for Redis Cluster backup
 //
-// Examine a point-in-time backup of a Redis Cluster. Surfaces the
-// backup `name`, `state`, `backupType` (ON_DEMAND or AUTOMATED),
-// creation and expiry timestamps, total size, the engine version
-// and cluster topology (node type, shard and replica counts) at
-// backup time, encryption information, and the list of constituent
-// `backupFiles`.
+// Point-in-time backup of a Redis Cluster, including the backup `name`,
+// `state`, `backupType` (ON_DEMAND or AUTOMATED), creation and expiry
+// timestamps, total size, the engine version and cluster topology (node
+// type, shard and replica counts) captured at backup time, encryption
+// information, and the constituent `backupFiles`.
 private gcp.project.redisService.cluster.backup @defaults("name state") {
   // Project ID
   projectId string
@@ -580,7 +634,11 @@ private gcp.project.redisService.cluster.backup @defaults("name state") {
   backupType string
   // The current state of the backup
   state string
-  // Encryption information of the backup
+  // At-rest encryption state of the backup
+  //
+  // Keys: `encryptionType` (GOOGLE_DEFAULT_ENCRYPTION or
+  // CUSTOMER_MANAGED_ENCRYPTION), `kmsKeyVersions`, `kmsKeyPrimaryState`,
+  // and `lastUpdateTime`.
   encryptionInfo dict
   // The list of backup files
   backupFiles []gcp.project.redisService.cluster.backup.backupFile
@@ -640,12 +698,14 @@ private gcp.project.redisService.cluster.connectionDetail @defaults("pscConnecti
 
 // Google Cloud (GCP) folder
 //
-// Examine a Cloud Resource Manager folder — a node in the org
-// hierarchy between the organization and its projects. Surfaces
-// the folder `id`, `name`, `parentId`, lifecycle `state`, creation
-// and update timestamps, and the timestamp when deletion was
-// requested. Use `folders()` to enumerate immediate child folders
-// and `projects()` to list the projects directly under this folder.
+// Cloud Resource Manager folder, a node in the organization hierarchy
+// that sits between the organization and its projects. Folders group
+// projects and other folders into business units or environments, and
+// each folder carries its own IAM policy, organization policies, audit
+// logging configuration, and Essential Contacts, so auditing a folder
+// reveals the access and governance controls inherited by everything
+// beneath it. Traverse the hierarchy downward through folders and
+// projects, and upward through parentFolder and parentOrganization.
 private gcp.folder @defaults("name") {
   // Folder ID
   id string
@@ -669,7 +729,10 @@ private gcp.folder @defaults("name") {
   // the folder's management resources. Null when the folder has no
   // management project.
   managementProjectRef() gcp.project
-  // Folder state
+  // Folder lifecycle state
+  //
+  // One of STATE_UNSPECIFIED, ACTIVE, or DELETE_REQUESTED (the folder
+  // has been marked for deletion by a user).
   state string
   // Timestamp when deletion was requested
   deleteTime time
@@ -700,23 +763,22 @@ private gcp.projects {
 
 // Google Cloud project
 //
-// Examine a Google Cloud project — the resource container that owns
-// every Compute, Storage, IAM, GKE, BigQuery, Cloud SQL, and other
-// service-specific deployment in the account. Surfaces the project ID
-// and number, lifecycle state, labels, parent organization or folder,
-// the IAM policy and audit-log configuration (with the
-// `hasPublicIamBinding`, `primitiveRoleBindings`, and
-// `dataAccessLoggingEnabled` predicates that drive CIS controls 1.x and
-// 2.1), enabled `services()`, recommendations, the project's
-// `essentialContacts` and `apiKeys`, and the access-approval settings.
-// Service-specific entry points hang off the project as accessor
-// methods — `compute()`, `gke()`, `storage()`, `sql()`, `dns()`,
-// `bigquery()`, `iam()`, `kms()`, `pubsub()`, `cloudFunctions()`,
-// `cloudRun()`, `dataproc()`, `dataflow()`, `firestore()`,
-// `spanner()`, `bigtable()`, `alloydb()`, `redis()`,
-// `secretmanager()`, `binaryAuthorization()`, `monitoring()`,
-// `logging()`, and many others — letting you traverse from a single
-// project into every modeled service it uses.
+// Resource container that owns every Compute, Storage, IAM, GKE,
+// BigQuery, Cloud SQL, and other service-specific deployment in the
+// account. Exposes the project ID and number, lifecycle state, labels,
+// and parent organization or folder, along with the IAM policy and
+// audit-log configuration. The `hasPublicIamBinding`,
+// `primitiveRoleBindings`, and `dataAccessLoggingEnabled` predicates
+// drive CIS controls 1.x and 2.1. Also surfaces enabled `services`,
+// `recommendations`, the project's `essentialContacts` and `apiKeys`,
+// and the access-approval settings. Service-specific entry points hang
+// off the project as accessors (`compute`, `gke`, `storage`, `sql`,
+// `dns`, `bigquery`, `iam`, `kms`, `pubsub`, `cloudFunctions`,
+// `cloudRun`, `dataproc`, `dataflow`, `firestore`, `spanner`,
+// `bigtable`, `alloydb`, `redis`, `secretmanager`,
+// `binaryAuthorization`, `monitoring`, `logging`, and many others),
+// letting you traverse from a single project into every modeled
+// service it uses.
 gcp.project @defaults("name number") {
   // Unique, user-assigned ID of the project
   id string
@@ -774,7 +836,13 @@ gcp.project @defaults("name number") {
   sql() gcp.project.sqlService
   // GCP IAM resources
   iam() gcp.project.iamService
-  // Common instance metadata for the project
+  // Project-wide Compute Engine instance metadata
+  //
+  // Key/value metadata applied to every VM in the project unless overridden
+  // per-instance. Holds user-defined keys plus security-relevant Google keys
+  // such as `enable-oslogin` (require OS Login for SSH access),
+  // `block-project-ssh-keys`, `serial-port-enable`, and `ssh-keys`
+  // (project-level SSH public keys).
   commonInstanceMetadata() map[string]string
   // GCP Cloud DNS
   dns() gcp.project.dnsService
@@ -902,11 +970,11 @@ gcp.project @defaults("name number") {
 
 // Google Cloud (GCP) Resource Manager lien
 //
-// Examine the encumbrances that block destructive operations on a project.
-// A lien names the operations it blocks through `restrictions` (e.g.
+// Encumbrance that blocks destructive operations on a project. A lien names
+// the operations it blocks through `restrictions` (e.g.
 // `resourcemanager.projects.delete`), the system that created it via
 // `origin`, and a human-readable `reason`. Liens are deletion-protection
-// controls — a project with a `resourcemanager.projects.delete` lien cannot
+// controls: a project with a `resourcemanager.projects.delete` lien cannot
 // be deleted until the lien is removed. Liens are selected by their
 // system-generated `name` (e.g. `liens/1234abcd`).
 private gcp.project.lien @defaults("name reason") {
@@ -924,12 +992,13 @@ private gcp.project.lien @defaults("name reason") {
 
 // Google Cloud (GCP) Resource Manager tag binding
 //
-// Examine the connection between a tag value and the project. A tag binding
+// Attachment of a tag value to a project (or other resource). A tag binding
 // applies a `tagValue` to the bound resource and all of its descendants, and
-// tags drive conditional IAM and organization-policy enforcement. The
-// `tagValueNamespacedName` gives the human-readable key/value path and
-// `resource` identifies the bound resource. Tag bindings are selected by
-// their `name`.
+// tags drive conditional IAM grants and organization-policy enforcement, so
+// auditing bindings reveals which conditional access and policy rules take
+// effect. The `tagValueNamespacedName` gives the human-readable key/value
+// path and `resource` identifies the bound resource. Tag bindings are
+// selected by their `name`.
 private gcp.project.tagBinding @defaults("tagValueNamespacedName resource") {
   // Name of the tag binding
   name string
@@ -943,13 +1012,13 @@ private gcp.project.tagBinding @defaults("tagValueNamespacedName resource") {
 
 // Google Cloud service API
 //
-// Examine a single Google Cloud service API (compute.googleapis.com,
-// iam.googleapis.com, etc.) and whether it is enabled for the parent
-// project. Surfaces the canonical service `name`, the `title` Google
-// uses for the service, the parent project, the service `state`, and
-// the `enabled` predicate that audits whether the API has been turned
-// on. The parent `gcp.project.services()` collection lists every
-// available and enabled service for a project.
+// Single Google Cloud service API, such as compute.googleapis.com or
+// iam.googleapis.com, and whether it is enabled for a project.
+// Auditing service APIs reveals which cloud capabilities are active on
+// a project, so you can confirm that sensitive or unused services are
+// turned off and that required ones are on. The `name` field selects
+// the service by its canonical API host, and `enabled` reports whether
+// the API has been turned on.
 gcp.service @defaults("name") {
   // Project ID
   projectId string
@@ -960,21 +1029,27 @@ gcp.service @defaults("name") {
   // Service title
   title string
   // Service state
+  //
+  // One of ENABLED, DISABLED, or STATE_UNSPECIFIED.
   state string
   // Whether the service is enabled
+  //
+  // True when state is ENABLED.
   enabled() bool
 }
 
 // Google Cloud recommendation
 //
-// Examine a single recommendation and the action Recommender suggests
-// taking. Surfaces the recommendation `id`, the `recommender` that
-// produced it (for example `google.compute.instance.IdleResourceRecommender`),
-// the recommendation `category` and `priority`, the proposed resource
-// changes in `content`, the `primaryImpact` and `additionalImpact`
-// projections (cost, security, performance, reliability, etc.), the
-// `lastRefreshTime`, and the lifecycle `state` reflecting whether the
-// recommendation is active, claimed, dismissed, or applied.
+// Single recommendation produced by the Recommender service, describing an
+// action to take on a resource (resize an idle instance, tighten an IAM
+// policy, purchase a committed-use discount, and so on). Select a
+// recommendation by `id`. The `recommender` names which analyzer generated
+// it (for example `google.compute.instance.IdleResourceRecommender`),
+// `category` and `priority` rank its urgency, `content` holds the proposed
+// resource changes, and `primaryImpact` with `additionalImpact` project the
+// cost, security, performance, reliability, and sustainability effects. The
+// `state` reflects whether the recommendation is active, claimed, succeeded,
+// failed, or dismissed.
 gcp.recommendation {
   // ID of recommendation
   id string
@@ -986,19 +1061,46 @@ gcp.recommendation {
   name string
   // ID of the recommender that produced this recommendation
   recommender string
-  // The primary impact that this recommendation can have
+  // Primary impact of applying this recommendation
+  //
+  // Keys: `category` (COST, SECURITY, PERFORMANCE, MANAGEABILITY,
+  // RELIABILITY, or SUSTAINABILITY), `service` (the affected Google Cloud
+  // service), and exactly one projection matching the category:
+  // `costProjection`, `securityProjection`, `sustainabilityProjection`, or
+  // `reliabilityProjection`. The `category` value is also exposed as the
+  // top-level `category` field.
   primaryImpact dict
-  // Optional set of additional impact that this recommendation can have
+  // Additional impacts beyond the primary one
+  //
+  // Each entry has the same shape as `primaryImpact`: a `category`, a
+  // `service`, and one matching projection (`costProjection`,
+  // `securityProjection`, `sustainabilityProjection`, or
+  // `reliabilityProjection`).
   additionalImpact []dict
   // Recommended changes to resources
+  //
+  // Keys: `operationGroups` (the groups of create, update, or remove
+  // operations to apply, executed atomically within each group) and
+  // `overview` (a free-form summary of the recommendation as a nested
+  // object).
   content dict
   // Category of primary impact
+  //
+  // One of COST, SECURITY, PERFORMANCE, MANAGEABILITY, RELIABILITY, or
+  // SUSTAINABILITY.
   category string
   // Recommendation's priority
+  //
+  // One of P1 (highest) through P4 (lowest), or PRIORITY_UNSPECIFIED when
+  // the recommender does not set one.
   priority string
   // Last time this recommendation was refreshed
   lastRefreshTime time
-  // State and metadata of recommendation
+  // Lifecycle state and metadata of the recommendation
+  //
+  // Keys: `state` (ACTIVE, CLAIMED, SUCCEEDED, FAILED, or DISMISSED) and
+  // `stateMetadata` (a string-to-string map of user-supplied metadata about
+  // the state).
   state dict
 }
 
@@ -1061,7 +1163,7 @@ private gcp.project.computeService {
   firewalls() []gcp.project.computeService.firewall
   // Google Compute Engine VPC network in a project
   networks() []gcp.project.computeService.network
-  // Whether the project still has the auto-created `default` VPC network — true when a network named "default" exists
+  // Whether the project still has the auto-created `default` VPC network (true when a network named "default" exists)
   hasDefaultNetwork() bool
   // Logical partition of a VPC network
   subnetworks() []gcp.project.computeService.subnetwork
@@ -1131,21 +1233,21 @@ private gcp.project.computeService {
   publicAdvertisedPrefixes() []gcp.project.computeService.publicAdvertisedPrefix
   // Instance templates
   instanceTemplates() []gcp.project.computeService.instanceTemplate
-  // Whether OS Login is enabled project-wide — project commonInstanceMetadata item 'enable-oslogin' is TRUE
+  // Whether OS Login is enabled project-wide (project commonInstanceMetadata item 'enable-oslogin' is TRUE)
   projectOsLoginEnabled() bool
-  // Whether project-wide SSH keys are blocked — project commonInstanceMetadata item 'block-project-ssh-keys' is TRUE
+  // Whether project-wide SSH keys are blocked (project commonInstanceMetadata item 'block-project-ssh-keys' is TRUE)
   projectBlockProjectSshKeys() bool
-  // Whether serial port access is enabled project-wide — project commonInstanceMetadata item 'serial-port-enable' is TRUE
+  // Whether serial port access is enabled project-wide (project commonInstanceMetadata item 'serial-port-enable' is TRUE)
   projectSerialPortEnabled() bool
 }
 
 // Google Cloud (GCP) Compute Engine static IP address
 //
-// Examine a reserved static IP address (external or internal).
+// Reserved static IP address (external or internal).
 // Surfaces the `address` value, `addressType`, `ipVersion`,
 // `purpose` (EXTERNAL, GCE_ENDPOINT, SHARED_LOADBALANCER_VIP, etc.),
 // `networkTier`, `status`, and `prefixLength` for IP-range
-// reservations. The typed `network()` and `subnetwork()` accessors
+// reservations. The `network` and `subnetwork` references
 // link to the VPC resources the address is scoped to, and
 // `resourceUrls` lists the compute resources currently using the
 // address.
@@ -1200,11 +1302,11 @@ private gcp.project.computeService.address @defaults("name address addressType")
 
 // Google Cloud (GCP) Compute Engine forwarding rule
 //
-// Examine a load-balancer forwarding rule that routes incoming
+// Load-balancer forwarding rule that routes incoming
 // traffic to a backend. Surfaces the `ipAddress`, `ipProtocol`,
 // `portRange`, `ports`, `loadBalancingScheme`, `networkTier`, and
-// `targetUrl` describing where traffic is sent. The typed
-// `network()` and `subnetwork()` accessors link to the VPC
+// `targetUrl` describing where traffic is sent. The
+// `network` and `subnetwork` references link to the VPC
 // resources the rule is scoped to. Audit Private Service Connect
 // posture via `pscConnectionStatus` and `allowPscGlobalAccess`, and
 // packet mirroring eligibility via `isMirroringCollector`.
@@ -1303,7 +1405,7 @@ private gcp.project.computeService.forwardingRule {
 
 // Google Cloud (GCP) Compute Engine region
 //
-// Examine a Compute Engine region and its capacity posture.
+// Compute Engine region and its capacity posture.
 // Surfaces the region `name`, `status`, creation timestamp,
 // per-resource `quotas` (CPU, disk, instances, etc.) as a
 // name-to-float map, deprecation status, and whether the region
@@ -1343,7 +1445,7 @@ private gcp.project.computeService.zone @defaults("name") {
 
 // Google Cloud (GCP) Compute Engine machine type
 //
-// Examine a Compute Engine machine type and its hardware
+// Compute Engine machine type and its hardware
 // specification. Surfaces the `name`, `guestCpus`, `memoryMb`,
 // `isSharedCpu`, maximum persistent-disk count and total size,
 // and the `zone` it belongs to. Used for auditing instance
@@ -1376,7 +1478,7 @@ private gcp.project.computeService.machineType @defaults("name") {
 
 // Google Cloud Compute Engine instance
 //
-// Examine a Compute Engine VM instance and the security-relevant
+// Compute Engine VM instance and the security-relevant
 // configuration around it. Surfaces the machine type and CPU platform,
 // the instance status and lifecycle, attached `disks` and
 // `networkInterfaces`, the boot image, applied `labels` and `metadata`,
@@ -1457,7 +1559,10 @@ gcp.project.computeService.instance @defaults("name id") {
   hasFullCloudPlatformScope() bool
   // Whether instance metadata 'block-project-ssh-keys' is true
   blockProjectSshKeysEnabled() bool
-  // Whether OS Login is enabled on this instance — checks instance metadata 'enable-oslogin', then falls back to project commonInstanceMetadata when unset
+  // Whether OS Login is enabled on this instance
+  //
+  // Reads the instance metadata `enable-oslogin`, falling back to the project
+  // `commonInstanceMetadata` value when the instance does not set it.
   osLoginEnabled() bool
   // Whether instance-level SSH keys are set in metadata ('ssh-keys'), which grant access outside OS Login / IAM and are unmanaged
   hasInstanceSshKeys() bool
@@ -1525,7 +1630,7 @@ gcp.project.computeService.instance @defaults("name id") {
   workloadIdentityConfig dict
   // Customer-supplied or KMS-backed encryption key for instance suspend state and Local SSDs
   //
-  // Examines the key material that protects suspended data and Local
+  // The key material that protects suspended data and Local
   // SSD storage attached to the instance: `kmsKeyName` for
   // customer-managed KMS keys, `kmsKeyServiceAccount` for the service
   // account used against the KMS key, `rawKey` / `rsaEncryptedKey` for
@@ -1598,7 +1703,7 @@ private gcp.project.computeService.instance.exposure @defaults("internetReachabl
 
 // Compute instance network interface
 //
-// Examine a single network interface (NIC) attached to a Compute Engine
+// Single network interface (NIC) attached to a Compute Engine
 // instance. Surfaces the internal `networkIP`, the `network` and `subnetwork`
 // the interface is attached to, the `accessConfigs` that assign external
 // (public) IPs, the `aliasIpRanges` used for alias IP / GKE Pod ranges, and the
@@ -1630,7 +1735,7 @@ private gcp.project.computeService.instance.networkInterface @defaults("name net
 
 // VM Manager OS inventory for a Compute Engine instance
 //
-// Examine the operating system and software state that the VM Manager
+// Operating system and software state that the VM Manager
 // OS Config agent reports for a single instance: `osInfo` carries the
 // detected OS name, version, and architecture, while `items` lists
 // every installed package and every available package update. Use it
@@ -1678,7 +1783,7 @@ private gcp.project.computeService.instance.osInventory @defaults("name updateTi
 
 // Inventory item on a Compute Engine instance
 //
-// Examine a single piece of OS inventory reported by the OS Config agent —
+// Single piece of OS inventory reported by the OS Config agent:
 // either an installed package or an available package update. The `type`
 // field distinguishes the two, `packageType` records the package manager
 // (apt, yum, zypper, googet, wua, qfe, cos, zypperPatch, or
@@ -1703,7 +1808,7 @@ private gcp.project.computeService.instance.osInventory.item @defaults("packageN
 
 // VM Manager vulnerability report for a Compute Engine instance
 //
-// Examine the vulnerabilities that VM Manager detects on a single
+// Vulnerabilities that VM Manager detects on a single
 // instance by correlating its OS inventory against vulnerability
 // feeds. Each entry in `vulnerabilities` records the affected
 // packages and the CVE details, and `highestUpgradableCveSeverity`
@@ -1732,7 +1837,7 @@ private gcp.project.computeService.instance.vulnerabilityReport @defaults("name 
 
 // Vulnerability detected by VM Manager on a Compute Engine instance
 //
-// Examine a single vulnerability that VM Manager correlated against the
+// Single vulnerability that VM Manager correlated against the
 // instance's OS inventory. The `cve` identifies the issue, `severity` and
 // `cvssV3Score` rank it, and `installedInventoryItemIds` /
 // `availableInventoryItemIds` link to the affected and fixing inventory
@@ -1762,7 +1867,7 @@ private gcp.project.computeService.instance.vulnerabilityReport.vulnerability @d
 
 // Google Cloud (GCP) Compute Engine confidential VM configuration
 //
-// Examine the Confidential Compute settings on a VM instance — whether
+// Confidential Compute settings on a VM instance: whether
 // confidential compute is enabled and, when it is, the underlying
 // technology used (AMD SEV, AMD SEV-SNP, or Intel TDX). Confidential
 // VMs encrypt memory at the hardware level and are the GCP control
@@ -1798,15 +1903,15 @@ private gcp.project.computeService.serviceaccount @defaults("email") {
 
 // Google Cloud (GCP) Compute Engine persistent disk
 //
-// Examine a Compute Engine persistent disk and its security
+// Compute Engine persistent disk and its security
 // configuration. Surfaces the disk `type` (pd-standard, pd-ssd,
 // pd-balanced, etc.), `sizeGb`, `status`, attached instance
 // `users`, and the `zone` or `region` of the disk. Audit
-// encryption posture via `diskEncryptionKey` and the typed
-// `kmsKey()` accessor for customer-managed keys, and
+// encryption posture via `diskEncryptionKey` and the
+// `kmsKey` reference for customer-managed keys, and
 // `enableConfidentialCompute` for Confidential VM disks. The
-// `sourceImage()` and `sourceSnapshot()` accessors identify what
-// the disk was created from, and `storagePool()` links to the
+// `sourceImage` and `sourceSnapshot` references identify what
+// the disk was created from, and `storagePool` links to the
 // provisioned storage pool when applicable.
 private gcp.project.computeService.disk @defaults("name") {
   // Unique identifier for the resource
@@ -1951,13 +2056,13 @@ private gcp.project.computeService.attachedDisk {
 
 // Google Cloud (GCP) Compute Engine persistent disk snapshot
 //
-// Examine a Compute Engine disk snapshot and its security posture.
+// Compute Engine disk snapshot and its security posture.
 // Surfaces the snapshot `name`, `status`, `snapshotType`,
 // `diskSizeGb`, storage consumption (`storageBytes`,
 // `storageLocations`), and `labels`. Audit access exposure via
-// `iamPolicy()` and the `public()` predicate that returns true
+// `iamPolicy` and the `public` predicate that returns true
 // when the snapshot is shared with `allUsers` or
-// `allAuthenticatedUsers`. The typed `kmsKey()` accessor links to
+// `allAuthenticatedUsers`. The `kmsKey` reference links to
 // the customer-managed encryption key when CMEK is used, and
 // `sourceDisk` identifies the disk the snapshot was taken from.
 private gcp.project.computeService.snapshot @defaults("name") {
@@ -2032,13 +2137,13 @@ private gcp.project.computeService.snapshot @defaults("name") {
 
 // Google Compute Engine custom or public machine image
 //
-// Examine a Compute Engine image's configuration, encryption posture, and
+// Compute Engine image configuration, encryption posture, and
 // access controls. Surfaces the image `family`, `architecture`, disk and
 // archive sizes, `status`, confidential-compute flag, Protected Zone
 // attributes, Cloud Storage `storageLocations`, source provenance
-// (`sourceDisk()`, `sourceImage()`, `sourceSnapshot()`), the CMEK key
-// protecting the image, the IAM policy — including any `allUsers` /
-// `allAuthenticatedUsers` grants that make the image `public()` — and
+// (`sourceDisk`, `sourceImage`, `sourceSnapshot`), the CMEK key
+// protecting the image, the IAM policy (including any `allUsers` /
+// `allAuthenticatedUsers` grants that make the image `public`), and
 // user-defined `labels`.
 private gcp.project.computeService.image @defaults("id name") {
   // Unique identifier
@@ -2102,13 +2207,13 @@ private gcp.project.computeService.image @defaults("id name") {
 
 // Google Compute Engine VPC firewall rule
 //
-// Examine a Compute Engine firewall rule's traffic-filtering configuration.
+// Compute Engine firewall rule traffic-filtering configuration.
 // Surfaces the rule `direction` (INGRESS / EGRESS), `priority`, `disabled`
 // state, `sourceRanges`, `destinationRanges`, target and source tags and
 // service accounts, `allowed` and `denied` protocol/port lists, and log
-// configuration. Derived predicates — `openToInternet()`,
-// `allowsSshFromInternet()`, and `allowsRdpFromInternet()` — flag the
-// most common exposure patterns. The `network()` reference links to the
+// configuration. Derived predicates (`openToInternet`,
+// `allowsSshFromInternet`, and `allowsRdpFromInternet`) flag the
+// most common exposure patterns. The `network` reference links to the
 // VPC the rule belongs to.
 private gcp.project.computeService.firewall @defaults("name") {
   // Unique identifier
@@ -2129,9 +2234,9 @@ private gcp.project.computeService.firewall @defaults("name") {
   sourceRanges []string
   // Whether this rule allows ingress traffic from the public internet (INGRESS, enabled, has allow rules, sourceRanges contains 0.0.0.0/0 or ::/0)
   openToInternet() bool
-  // Whether this rule permits SSH (tcp/22) from the public internet — narrower form of openToInternet for the SSH-specific port check
+  // Whether this rule permits SSH (tcp/22) from the public internet (narrower form of openToInternet for the SSH-specific port check)
   allowsSshFromInternet() bool
-  // Whether this rule permits RDP (tcp/3389) from the public internet — narrower form of openToInternet for the RDP-specific port check
+  // Whether this rule permits RDP (tcp/3389) from the public internet (narrower form of openToInternet for the RDP-specific port check)
   allowsRdpFromInternet() bool
   // Source service accounts
   sourceServiceAccounts []string
@@ -2173,14 +2278,14 @@ private gcp.project.computeService.firewall @defaults("name") {
 
 // Google Cloud VPC network
 //
-// Examine a Compute Engine VPC network and the structural posture
+// Compute Engine VPC network and the structural posture
 // around it. Surfaces the network `mode` (legacy, custom, or auto), the
 // `legacy` predicate, the `autoCreateSubnetworks` flag, the routing
 // mode, MTU, IPv6/ULA settings, the network-firewall enforcement order,
 // the attached firewall policy, peering configurations, and the
-// `subnetworks()` defined in the network.
+// `subnetworks` defined in the network.
 gcp.project.computeService.network @defaults("name") {
-  // Whether the network is a legacy (single-region, non-subnetted) network — derived from mode == "legacy"
+  // Whether the network is a legacy (single-region, non-subnetted) network, derived from mode == "legacy"
   legacy() bool
   // Unique identifier
   id string
@@ -2237,14 +2342,14 @@ gcp.project.computeService.network @defaults("name") {
 
 // Google Cloud VPC subnetwork
 //
-// Examine a regional VPC subnetwork inside a Compute Engine network.
+// Regional VPC subnetwork inside a Compute Engine network.
 // Surfaces the subnetwork's IPv4 and IPv6 CIDR ranges, the `purpose`
 // and `role` (private, regional-managed-proxy, internal-load-balancer,
 // global-managed-proxy, etc.), the `enableFlowLogs` flag and matching
 // `logConfig`, the `privateIpGoogleAccess` and
 // `privateIpv6GoogleAccess` settings that control reachability of
-// Google APIs from instances without external IPs, and typed
-// references to the `network()` and the `region()` the subnet
+// Google APIs from instances without external IPs, and references
+// to the `network` and the `region` the subnet
 // is bound to.
 gcp.project.computeService.subnetwork @defaults("name") {
   // Unique identifier
@@ -2332,11 +2437,11 @@ private gcp.project.computeService.subnetwork.logConfig @defaults("enable") {
 
 // Google Compute Engine Cloud Router
 //
-// Examine a Cloud Router's BGP configuration and NAT services. Surfaces
+// Cloud Router BGP configuration and NAT services. Surfaces
 // `bgp` session settings, `bgpPeers` for dynamic route exchange,
 // `encryptedInterconnectRouter` for HA VPN / Dedicated Interconnect
-// encryption enforcement, and the `natServices()` defining Cloud NAT
-// gateway configuration within the router. The `network()` reference
+// encryption enforcement, and the `natServices` defining Cloud NAT
+// gateway configuration within the router. The `network` reference
 // links to the VPC the router is attached to.
 private gcp.project.computeService.router @defaults("name")  {
   // Unique identifier
@@ -2365,13 +2470,13 @@ private gcp.project.computeService.router @defaults("name")  {
 
 // Google Compute Engine backend service
 //
-// Examine a load-balancer backend service's configuration and security
-// posture. Surfaces the `loadBalancingScheme`, `protocol`, `backends()`
+// Load-balancer backend service configuration and security
+// posture. Surfaces the `loadBalancingScheme`, `protocol`, `backends`
 // (instance groups or NEGs), `healthChecks`, session-affinity settings,
 // Cloud CDN policy (`cdnPolicy`), Identity-Aware Proxy configuration
-// (`iap`), and the attached Cloud Armor `securityPolicy()`. Derived
-// predicates `cloudArmorEnabled()` and `iapEnabled()` provide quick
-// posture checks. The `network()` reference links to the VPC the service
+// (`iap`), and the attached Cloud Armor `securityPolicy`. Derived
+// predicates `cloudArmorEnabled` and `iapEnabled` provide quick
+// posture checks. The `network` reference links to the VPC the service
 // is deployed in.
 private gcp.project.computeService.backendService @defaults("name") {
   // Unique identifier
@@ -2548,11 +2653,10 @@ private gcp.project.computeService.backendService.cdnPolicy {
 
 // Google Cloud (GCP) Cloud Storage
 //
-// Use this resource as the entry point for Cloud Storage in the project.
-// It hosts the project's `buckets`, each exposing its IAM policy, uniform
-// bucket-level access setting, public-access prevention, retention and
-// versioning policies, default encryption key, and lifecycle rules for
-// object-storage audits.
+// Cloud Storage for the project, the entry point to its `buckets`. Each
+// bucket exposes its IAM policy, uniform bucket-level access setting,
+// public-access prevention, retention and versioning policies, default
+// encryption key, and lifecycle rules for object-storage audits.
 private gcp.project.storageService {
   // Project ID
   projectId string
@@ -2562,17 +2666,16 @@ private gcp.project.storageService {
 
 // Google Cloud Storage bucket
 //
-// Examine a Cloud Storage bucket's configuration, access controls, and
-// data-protection settings. Surfaces the `storageClass`, `location` and
-// `locationType`, `labels`, `tags` (Resource Manager Tags bound to the bucket),
-// IAM policy (including `public()` which flags
-// any `allUsers` / `allAuthenticatedUsers` grant), `iamConfiguration`
-// (uniform bucket-level access, public access prevention), `retentionPolicy`
-// and `retentionPolicyLocked`, object `versioningEnabled`, default CMEK
-// encryption key (`defaultKmsKey()`), lifecycle management rules
-// (`lifecycle`), and soft-delete policy. The `loggingEnabled` predicate
-// indicates whether access logs are being exported to another bucket. Cloud
-// DLP integration surfaces the bucket's `dlpDataProfile()` when enabled.
+// Cloud Storage bucket configuration, access controls, and
+// data-protection settings, the core surface for object-storage audits.
+// Covers the IAM policy and ACLs (with `public` and
+// `publicAccessPrevention` flagging any `allUsers` or
+// `allAuthenticatedUsers` exposure), `iamConfiguration` for uniform
+// bucket-level access, `retentionPolicy` and object `versioningEnabled`,
+// the default CMEK encryption key, `lifecycle` management rules,
+// soft-delete policy, and access logging (`loggingEnabled` is the
+// is-it-on check). When Cloud DLP has profiled the bucket,
+// `dlpDataProfile` reports its sensitivity findings.
 private gcp.project.storageService.bucket @defaults("id") {
   // Bucket ID
   id string
@@ -2640,13 +2743,13 @@ private gcp.project.storageService.bucket @defaults("id") {
   metageneration int
   // Uniform bucket-level access configuration (enabled, lockedTime)
   uniformBucketLevelAccess dict
-  // Whether uniform bucket-level access is enabled — flat hoist of uniformBucketLevelAccess.enabled
+  // Whether uniform bucket-level access is enabled (hoist of uniformBucketLevelAccess.enabled)
   uniformBucketLevelAccessEnabled() bool
   // Soft delete policy (retentionDurationSeconds, effectiveTime)
   softDeletePolicy dict
   // Soft-delete retention duration in seconds (0 when no soft-delete policy is set)
   softDeleteRetentionDuration int
-  // Whether soft-delete is enabled — true when softDeletePolicy.retentionDurationSeconds > 0
+  // Whether soft-delete is enabled (true when softDeletePolicy.retentionDurationSeconds > 0)
   softDeletePolicyEnabled() bool
   // Object retention mode (Enabled or empty)
   objectRetentionMode string
@@ -2817,6 +2920,12 @@ private gcp.project.storageService.bucket.lifecycleRuleCondition @defaults("age 
 // engine and version, connection settings, automated backup configuration,
 // SSL/TLS enforcement, authorized networks, and database flags for
 // relational-database audits.
+// Google Cloud SQL service
+//
+// Entry point for Cloud SQL in the project. The instances collection lists
+// every managed MySQL, PostgreSQL, and SQL Server database instance, from
+// which their databases, users, SSL certificates, backup runs, and
+// per-instance settings are reachable.
 private gcp.project.sqlService {
   // Project ID
   projectId string
@@ -2826,16 +2935,18 @@ private gcp.project.sqlService {
 
 // Google Cloud SQL managed database instance
 //
-// Examine a Cloud SQL instance's configuration, connectivity, and security
-// posture. Surfaces the `databaseVersion`, `state`, `region`, `zone()`,
-// instance `settings` (backup configuration, IP configuration, database
-// flags, password policy, maintenance window), assigned `ipAddresses`,
-// CMEK disk-encryption key (`kmsKey()`), replica configuration, and
-// PSC / private networking attributes. Derived predicates include
-// `publicIpEnabled()`, `backupConfigurationEnabled()`,
-// `pointInTimeRecoveryEnabled()`, `hasBuiltInUsers()`, and
-// `localRootEnabled()`. Child collections expose `databases()`, `users()`,
-// `sslCerts()`, and `backupRuns()`.
+// Managed relational database instance (MySQL, PostgreSQL, or SQL Server)
+// with its full configuration, connectivity, and security posture. The
+// databaseVersion and state identify the engine and lifecycle; settings
+// carries the backup configuration, IP configuration, database flags,
+// password policy, and maintenance window; ipAddresses along with the PSC
+// and private-networking attributes describe reachability; and kmsKey names
+// the customer-managed encryption key when disk encryption is not
+// Google-managed. Derived predicates flag common hardening findings:
+// publicIpEnabled, internetReachable, backupConfigurationEnabled,
+// pointInTimeRecoveryEnabled, hasBuiltInUsers, and localRootEnabled. The
+// databases, users, sslCerts, and backupRuns collections expose the
+// instance contents.
 private gcp.project.sqlService.instance @defaults("name") {
   // Project ID
   projectId string
@@ -2851,13 +2962,22 @@ private gcp.project.sqlService.instance @defaults("name") {
   databaseInstalledVersion string
   // Database engine type and version
   databaseVersion string
-  // Disk encryption configuration
+  // Customer-managed disk encryption configuration (`{kmsKeyName}`)
+  //
+  // The kmsKeyName is the resource name of the Cloud KMS key used to encrypt
+  // the instance's data disk. See kmsKey for the resolved key.
   diskEncryptionConfiguration dict
-  // Disk encryption status
+  // Disk encryption status (`{kmsKeyVersionName}`)
+  //
+  // The kmsKeyVersionName is the specific Cloud KMS key version currently
+  // protecting the instance's data disk.
   diskEncryptionStatus dict
   // Customer-managed KMS key used for disk encryption (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
-  // Name and status of the failover replica
+  // Name and availability of the failover replica (`{name, available}`)
+  //
+  // The name identifies the standby instance and available reports whether it
+  // is ready to take over. See failoverReplicaRef for the resolved instance.
   failoverReplica dict
   // Standby instance designated as the high-availability failover target
   //
@@ -2996,18 +3116,25 @@ private gcp.project.sqlService.instance.database @defaults("name") {
   instance string
   // Name of the database
   name string
-  // SQL Server database details
+  // SQL Server database details (`{compatibilityLevel, recoveryModel}`)
+  //
+  // Populated only for SQL Server databases. compatibilityLevel is the SQL
+  // Server compatibility version and recoveryModel is the configured recovery
+  // model.
   sqlserverDatabaseDetails dict
 }
 
 // Google Cloud SQL database user
 //
-// Examine a Cloud SQL database user's authentication type and access
-// configuration. Surfaces the `name`, `host` (MySQL-specific connection
-// restriction), `type` (BUILT_IN, CLOUD_IAM_USER, CLOUD_IAM_SERVICE_ACCOUNT,
-// CLOUD_IAM_GROUP, CLOUD_IAM_GROUP_USER, CLOUD_IAM_GROUP_SERVICE_ACCOUNT),
-// `iamEmail` for Cloud IAM principals, `databaseRoles` (PostgreSQL and
-// SQL Server), `dualPasswordType`, and `passwordPolicy`.
+// Database user account on a Cloud SQL instance, with its authentication type
+// and access configuration. The type distinguishes built-in database accounts
+// from Cloud IAM principals (BUILT_IN, CLOUD_IAM_USER,
+// CLOUD_IAM_SERVICE_ACCOUNT, CLOUD_IAM_GROUP, CLOUD_IAM_GROUP_USER,
+// CLOUD_IAM_GROUP_SERVICE_ACCOUNT); host restricts where a MySQL user may
+// connect from; iamEmail identifies the Cloud IAM principal; databaseRoles
+// lists role memberships on PostgreSQL and SQL Server; and passwordPolicy and
+// dualPasswordType describe credential handling. Built-in users are a common
+// SQL hardening finding.
 private gcp.project.sqlService.instance.user @defaults("name type host") {
   // Project ID
   projectId string
@@ -3025,18 +3152,26 @@ private gcp.project.sqlService.instance.user @defaults("name type host") {
   databaseRoles []string
   // Dual password status
   dualPasswordType string
-  // Password validation policy
+  // Per-user password policy (`{allowedFailedAttempts, passwordExpirationDuration, enableFailedAttemptsCheck, enablePasswordVerification}`)
+  //
+  // allowedFailedAttempts and enableFailedAttemptsCheck govern account
+  // lockout, passwordExpirationDuration sets how long the password stays
+  // valid, and enablePasswordVerification requires the current password when
+  // changing it.
   passwordPolicy dict
 }
 
 // Google Cloud SQL backup run
 //
-// Examine a Cloud SQL backup run's status, timing, and storage configuration.
-// Surfaces the `backupKind` (SNAPSHOT or PHYSICAL), `status`
-// (ENQUEUED, RUNNING, FAILED, SUCCESSFUL, SKIPPED, DELETED), `startTime`,
-// `endTime`, `enqueuedTime`, `location`, `databaseVersion` at backup time,
-// disk-encryption configuration, and any `error` details for failed runs.
-// The `type` field distinguishes AUTOMATED, ON_DEMAND, and FINAL backups.
+// Single backup operation on a Cloud SQL instance, with its status, timing,
+// and storage configuration. The backupKind is SNAPSHOT or PHYSICAL; status
+// is one of ENQUEUED, RUNNING, FAILED, SUCCESSFUL, SKIPPED, or DELETED;
+// startTime, endTime, and enqueuedTime record the run timeline; location and
+// databaseVersion capture where the backup is stored and the engine version
+// at backup time; and error carries the failure details for a failed run. The
+// type field distinguishes AUTOMATED, ON_DEMAND, and FINAL backups. Auditing
+// backupRuns confirms that recovery points actually exist rather than merely
+// being configured.
 private gcp.project.sqlService.backupRun @defaults("id status type startTime") {
   // Project ID
   projectId string
@@ -3050,15 +3185,24 @@ private gcp.project.sqlService.backupRun @defaults("id status type startTime") {
   databaseVersion string
   // Description of the run (on-demand backups only)
   description string
-  // Backup-specific encryption configuration
+  // Backup-specific encryption configuration (`{kind, kmsKeyName}`)
+  //
+  // The kmsKeyName is the resource name of the Cloud KMS key used to encrypt
+  // this backup.
   diskEncryptionConfiguration dict
-  // Backup-specific encryption status
+  // Backup-specific encryption status (`{kind, kmsKeyVersionName}`)
+  //
+  // The kmsKeyVersionName is the specific Cloud KMS key version used to
+  // encrypt this backup.
   diskEncryptionStatus dict
   // Time the backup operation completed
   endTime time
   // Time the run was enqueued
   enqueuedTime time
-  // Error information if the run failed
+  // Error information if the run failed (`{code, kind, message}`)
+  //
+  // Populated only for a FAILED run: code identifies the specific error and
+  // message gives additional detail.
   error dict
   // Location where the backup is stored
   location string
@@ -3080,11 +3224,12 @@ private gcp.project.sqlService.backupRun @defaults("id status type startTime") {
 
 // Google Cloud SQL instance SSL/TLS client certificate
 //
-// Examine a Cloud SQL client certificate used for SSL/TLS mutual
-// authentication. Surfaces the `commonName`, `sha1Fingerprint`,
-// `certSerialNumber`, the PEM-encoded `cert` body, `createTime`, and
-// `expirationTime`. Use `expirationTime` to audit certificates approaching
-// their expiry.
+// Client certificate used for SSL/TLS mutual authentication against a Cloud
+// SQL instance. The commonName is the user-supplied certificate name;
+// sha1Fingerprint and certSerialNumber identify it; cert holds the
+// PEM-encoded body; and createTime and expirationTime bound its validity.
+// Compare expirationTime against the present to find certificates approaching
+// expiry.
 private gcp.project.sqlService.instance.sslCert @defaults("commonName sha1Fingerprint") {
   // Project ID
   projectId string
@@ -3153,11 +3298,20 @@ private gcp.project.sqlService.instance.settings {
   deletionProtectionEnabled bool
   // Deny maintenance periods
   denyMaintenancePeriods []gcp.project.sqlService.instance.settings.denyMaintenancePeriod
-  // Insights configuration
+  // Query Insights configuration (`{queryInsightsEnabled, queryPlansPerMinute, queryStringLength, recordApplicationTags, recordClientAddress}`)
+  //
+  // queryInsightsEnabled turns on Query Insights; queryStringLength and
+  // queryPlansPerMinute bound what is captured; and recordApplicationTags and
+  // recordClientAddress control whether application tags and client IP
+  // addresses are recorded alongside queries.
   insightsConfig dict
   // IP management settings
   ipConfiguration gcp.project.sqlService.instance.settings.ipConfiguration
-  // Location preference settings
+  // Location preference settings (`{zone, secondaryZone, followGaeApplication}`)
+  //
+  // zone and secondaryZone are the preferred Compute Engine zones for the
+  // primary and failover, and followGaeApplication names an App Engine
+  // application whose location the instance should follow.
   locationPreference dict
   // Maintenance window
   maintenanceWindow gcp.project.sqlService.instance.settings.maintenanceWindow
@@ -3169,7 +3323,12 @@ private gcp.project.sqlService.instance.settings {
   replicationType string
   // Instance settings version
   settingsVersion int
-  // SQL-server-specific audit configuration
+  // SQL Server audit configuration (`{bucket, retentionInterval, uploadInterval}`)
+  //
+  // bucket is the Cloud Storage bucket that receives audit logs;
+  // uploadInterval sets how often logs are written; and retentionInterval sets
+  // how long they are kept. An empty bucket means server auditing is not
+  // configured.
   sqlServerAuditConfig dict
   // Whether to increase storage size automatically
   storageAutoResize bool
@@ -3203,13 +3362,13 @@ private gcp.project.sqlService.instance.settings {
 
 // Google Cloud (GCP) SQL instance Entra ID / Active Directory configuration
 //
-// Examine the Active Directory (now Entra ID) binding on a Cloud SQL
-// for SQL Server instance. `domain` is the FQDN the instance is joined
-// to; `mode` selects between Google-managed (`MANAGED_ACTIVE_DIRECTORY`)
-// and customer-managed (`CUSTOMER_MANAGED_ACTIVE_DIRECTORY`) directory
-// services; `dnsServers` lists the domain controller IPv4 addresses
-// used to bootstrap the join. A SQL Server instance with no AD binding
-// (or a binding to an unexpected domain) is the audit hot spot.
+// Active Directory (now Entra ID) binding on a Cloud SQL for SQL Server
+// instance. The domain is the FQDN the instance is joined to; mode selects
+// between Google-managed (MANAGED_ACTIVE_DIRECTORY) and customer-managed
+// (CUSTOMER_MANAGED_ACTIVE_DIRECTORY) directory services; and dnsServers lists
+// the domain controller IPv4 addresses used to bootstrap the join. A SQL
+// Server instance with no AD binding, or a binding to an unexpected domain, is
+// the audit hot spot.
 private gcp.project.sqlService.instance.settings.activeDirectory @defaults("domain mode") {
   // Fully-qualified Active Directory / Entra ID domain (e.g., corp.example.com); empty when no binding is configured
   domain string
@@ -3227,7 +3386,10 @@ private gcp.project.sqlService.instance.settings.activeDirectory @defaults("doma
 private gcp.project.sqlService.instance.settings.backupconfiguration {
   // Internal ID for this resource
   id string
-  // Backup retention settings
+  // Backup retention settings (`{retainedBackups, retentionUnit}`)
+  //
+  // retainedBackups is the number of automated backups kept and retentionUnit
+  // is the unit it is counted in (COUNT).
   backupRetentionSettings dict
   // Whether binary log is enabled
   binaryLogEnabled bool
@@ -3271,7 +3433,12 @@ private gcp.project.sqlService.instance.settings.ipConfiguration {
   id string
   // Name of the allocated IP range for the private IP Cloud SQL instance
   allocatedIpRange string
-  // List of external networks that are allowed to connect to the instance using the IP
+  // External networks allowed to connect over the public IP (`{name, value, kind, expirationTime}`)
+  //
+  // Each entry is a CIDR allow-list rule: value is the authorized CIDR range,
+  // name is an optional label, and expirationTime, when set, is when the rule
+  // stops applying. An entry with value 0.0.0.0/0 exposes the instance to the
+  // entire internet. See hasOpenAuthorizedNetworks for that check.
   authorizedNetworks []dict
   // Whether any authorized network entry uses 0.0.0.0/0 or ::/0 (public internet)
   hasOpenAuthorizedNetworks() bool
@@ -3318,7 +3485,15 @@ private gcp.project.sqlService.instance.settings.ipConfiguration.pscConfig @defa
   pscEnabled bool
   // List of consumer projects that are allow-listed to create a PSC endpoint to the Cloud SQL instance
   allowedConsumerProjects []string
-  // Whether auto-creation of PSC DNS records for the Cloud SQL instance is enabled
+  // Consumer networks auto-connected via Private Service Connect
+  //
+  // Each entry has keys `consumerNetwork`, `consumerNetworkStatus`, `consumerProject`,
+  // `ipAddress`, `instanceAutoDnsStatus`, and `serviceConnectionPolicy`.
+  // Each entry describes a consumer VPC network with an automatically created
+  // PSC endpoint to this instance: consumerNetwork and consumerProject
+  // identify the network, ipAddress is the endpoint address, and
+  // consumerNetworkStatus and instanceAutoDnsStatus report the connection and
+  // DNS-provisioning state.
   pscAutoConnections []dict
 }
 
@@ -3354,10 +3529,10 @@ private gcp.project.sqlService.instance.settings.passwordValidationPolicy @defau
 
 // Google Cloud BigQuery service
 //
-// Use this resource as the entry point for BigQuery in the project. It
-// hosts the project's `datasets()` (with their tables, models, routines,
-// access entries, and CMEK encryption), `connections()` to external data
-// sources, and slot `reservations()` for capacity management audits.
+// BigQuery data warehouse for the project, the entry point to its
+// `datasets` (with their tables, models, routines, access entries, and
+// CMEK encryption), `connections` to external data sources, and slot
+// `reservations` for capacity-management audits.
 private gcp.project.bigqueryService @defaults("projectId") {
   // Project ID
   projectId string
@@ -3371,13 +3546,14 @@ private gcp.project.bigqueryService @defaults("projectId") {
 
 // Google BigQuery dataset
 //
-// Examine a BigQuery dataset's configuration, access controls, and
-// data-protection settings. Surfaces the `location`, `labels`, `tags`,
-// access entries (`access` and the `public()` predicate for any
-// `allUsers` / `allAuthenticatedUsers` grant), the CMEK encryption key
-// (`kmsKey()`), `defaultTableExpirationMs`, `maxTimeTravelHours`,
-// `storageBillingModel`, and case-sensitivity settings. Child collections
-// expose `tables()`, `models()`, and `routines()` within the dataset.
+// BigQuery dataset configuration, access controls, and data-protection
+// settings. The `location`, `labels`, and `tags` describe placement and
+// metadata; `access` lists the grants and `public` reports whether any
+// entry exposes the dataset to `allUsers` or `allAuthenticatedUsers`; and
+// `kmsKey` reports the customer-managed encryption key. The
+// `defaultTableExpirationMs`, `maxTimeTravelHours`, `storageBillingModel`,
+// and case-sensitivity settings round out the configuration, and child
+// collections expose `tables`, `models`, and `routines` within the dataset.
 private gcp.project.bigqueryService.dataset @defaults("id name") {
   // Dataset ID
   id string
@@ -3450,28 +3626,42 @@ private gcp.project.bigqueryService.dataset.accessEntry @defaults("role entity e
   datasetId string
   // Role of the entity
   role string
-  // Type of the entity
+  // Entity type
+  //
+  // One of USER_EMAIL, GROUP_EMAIL, DOMAIN, SPECIAL_GROUP, VIEW, IAM_MEMBER,
+  // ROUTINE, DATASET, or UNKNOWN. Selects which reference field is populated:
+  // VIEW sets viewRef, ROUTINE sets routineRef, and DATASET sets datasetRef.
   entityType string
   // Entity (individual or group) granted access
   entity string
-  // View granted access (entityType must be ViewEntity)
+  // View granted access
+  //
+  // Present when entityType is VIEW. Dict with `projectId`, `datasetId`,
+  // and `tableId` identifying the authorized view.
   viewRef dict
-  // Routine granted access (only UDF currently supported)
+  // Routine granted access
+  //
+  // Present when entityType is ROUTINE (only UDFs are currently supported).
+  // Dict with `projectId`, `datasetId`, and `tableId` identifying the
+  // authorized routine.
   routineRef dict
-  // Resources within a dataset granted access
+  // Dataset resources granted access
+  //
+  // Present when entityType is DATASET. Dict with `projectId` and
+  // `datasetId` identifying the authorized dataset, plus `targetTypes`
+  // listing which resource kinds in that dataset the grant covers.
   datasetRef dict
 }
 
 // Google BigQuery table
 //
-// Examine a BigQuery table's schema, partitioning, and data-protection
-// configuration. Surfaces the `type` (TABLE, VIEW, MATERIALIZED_VIEW,
-// EXTERNAL), `schema`, `location`, `labels`, size metrics (`numBytes`,
-// `numLongTermBytes`, `numRows`), time-based and range `timePartitioning`
-// and `rangePartitioning`, `clusteringFields`, `expirationTime`, CMEK
-// encryption key (`kmsKey()`), and external data configuration for
-// federated tables. Cloud DLP integration surfaces the table's
-// `dlpDataProfile()` when enabled.
+// BigQuery table schema, partitioning, and data-protection configuration.
+// The `type` distinguishes TABLE, VIEW, MATERIALIZED_VIEW, and EXTERNAL;
+// `schema`, `timePartitioning`, `rangePartitioning`, and `clusteringFields`
+// describe layout; `numBytes`, `numLongTermBytes`, and `numRows` report
+// size; and `kmsKey` reports the customer-managed encryption key. External
+// data configuration covers federated tables, and `dlpDataProfile` surfaces
+// the Cloud DLP sensitivity profile when discovery has profiled the table.
 private gcp.project.bigqueryService.table @defaults("id") {
   // Table ID
   id string
@@ -3522,16 +3712,36 @@ private gcp.project.bigqueryService.table @defaults("id") {
   // Query to use for a logical view
   viewQuery string
   // Data clustering configuration
+  //
+  // Ordered list of the columns the table is clustered by. Null when the
+  // table has no clustering configured.
   clusteringFields dict
   // Information about table stored outside of BigQuery.
   externalDataConfig dict
-  // Information for materialized views
+  // Materialized view definition
+  //
+  // Present for MATERIALIZED_VIEW tables. Dict with `Query` (the defining
+  // SQL), `EnableRefresh`, `RefreshInterval`, `LastRefreshTime`,
+  // `AllowNonIncrementalDefinition`, and `MaxStaleness`.
   materializedView dict
   // Integer-range-based partitioning on a table
+  //
+  // Dict with `Field` (the INT64 column partitioned on) and `Range`, itself
+  // a dict of `Start`, `End`, and `Interval` defining the partition
+  // boundaries. Null when the table is not range-partitioned.
   rangePartitioning dict
   // Time-based date partitioning on a table
+  //
+  // Dict with `Type` (HOUR, DAY, MONTH, or YEAR), `Field` (the TIMESTAMP or
+  // DATE column partitioned on, empty when partitioned by ingestion time),
+  // `Expiration` (per-partition retention), and `RequirePartitionFilter`.
+  // Null when the table is not time-partitioned.
   timePartitioning dict
   // Table schema
+  //
+  // One dict per column, each with `Name`, `Type` (STRING, INTEGER, RECORD,
+  // and other BigQuery types), `Description`, `Required`, `Repeated`, and a
+  // nested `Schema` list for RECORD fields.
   schema []dict
   // Cloud DLP table data profile for this table — sensitivity score, risk level, and predicted infoTypes. Null when discovery has not profiled this table
   dlpDataProfile() gcp.project.dlpService.tableDataProfile
@@ -3543,10 +3753,10 @@ private gcp.project.bigqueryService.table @defaults("id") {
 
 // Google BigQuery ML model
 //
-// Examine a BigQuery ML model's metadata and encryption configuration.
-// Surfaces the `type`, `location`, `labels`, `created` and `modified`
-// timestamps, `expirationTime`, and the CMEK encryption key (`kmsKey()`)
-// protecting the model artifacts.
+// BigQuery ML model metadata and encryption configuration. The `type`,
+// `location`, `labels`, `created` and `modified` timestamps, and
+// `expirationTime` describe the model, and `kmsKey` reports the
+// customer-managed key protecting the model artifacts.
 private gcp.project.bigqueryService.model @defaults("id") {
   // Model ID
   id string
@@ -3580,11 +3790,11 @@ private gcp.project.bigqueryService.model @defaults("id") {
 
 // Google BigQuery routine (UDF or stored procedure)
 //
-// Examine a BigQuery routine's definition and metadata. Surfaces the
-// `type` (SCALAR_FUNCTION, PROCEDURE, TABLE_VALUED_FUNCTION, etc.),
-// `language` (SQL, JAVASCRIPT, PYTHON, etc.), `body` containing the
-// routine's implementation, `description`, and `created` / `modified`
-// timestamps.
+// BigQuery routine definition and metadata. The `type` distinguishes
+// SCALAR_FUNCTION, PROCEDURE, TABLE_VALUED_FUNCTION, and other routine
+// kinds; `language` reports the implementation language (SQL, JAVASCRIPT,
+// PYTHON, and others); and `body` holds the routine's source, alongside
+// `description` and `created` / `modified` timestamps.
 private gcp.project.bigqueryService.routine @defaults("id") {
   // Routine ID
   id string
@@ -3608,12 +3818,11 @@ private gcp.project.bigqueryService.routine @defaults("id") {
 
 // Google BigQuery external data source connection
 //
-// Examine a BigQuery connection used to query data residing outside
-// BigQuery. Surfaces the connection `type` (CLOUD_SQL, AWS, AZURE,
-// CLOUD_SPANNER, CLOUD_RESOURCE, SPARK, SALESFORCE_DATA_CLOUD, or
-// UNKNOWN), `location`, type-specific `properties` (credentials,
-// endpoint, database), and `hasCredential` to verify that authentication
-// material is configured.
+// BigQuery connection used to query data residing outside BigQuery. The
+// `type` distinguishes CLOUD_SQL, AWS, AZURE, CLOUD_SPANNER, CLOUD_RESOURCE,
+// SPARK, SALESFORCE_DATA_CLOUD, and UNKNOWN; `properties` carries the
+// type-specific credential, endpoint, and database settings; and
+// `hasCredential` reports whether authentication material is configured.
 private gcp.project.bigqueryService.connection @defaults("name friendlyName type") {
   // Full resource name of the connection: projects/{project}/locations/{location}/connections/{id}
   name string
@@ -3639,11 +3848,12 @@ private gcp.project.bigqueryService.connection @defaults("name friendlyName type
 
 // Google BigQuery slot reservation
 //
-// Examine a BigQuery capacity reservation's slot allocation and autoscaling
-// configuration. Surfaces the `slotCapacity` baseline, `autoscale` settings,
-// `concurrency` limit, `edition` (STANDARD, ENTERPRISE, ENTERPRISE_PLUS),
-// `ignoreIdleSlots` isolation flag, and managed disaster-recovery location
-// attributes (`primaryLocation`, `secondaryLocation`, `originalPrimaryLocation`).
+// BigQuery capacity reservation's slot allocation and autoscaling
+// configuration. The `slotCapacity` baseline, `autoscale` settings, and
+// `concurrency` limit describe capacity; `edition` reports the service tier
+// (STANDARD, ENTERPRISE, ENTERPRISE_PLUS); `ignoreIdleSlots` controls slot
+// isolation; and `primaryLocation`, `secondaryLocation`, and
+// `originalPrimaryLocation` describe managed disaster-recovery placement.
 private gcp.project.bigqueryService.reservation @defaults("name slotCapacity edition") {
   // Full resource name of the reservation: projects/{project}/locations/{location}/reservations/{id}
   name string
@@ -3656,6 +3866,10 @@ private gcp.project.bigqueryService.reservation @defaults("name slotCapacity edi
   // If true, reservation will not use idle slots from sibling reservations
   ignoreIdleSlots bool
   // Autoscale configuration
+  //
+  // Dict with `maxSlots` (the ceiling autoscaling may add above the
+  // baseline) and `currentSlots` (slots currently added by autoscaling).
+  // Null when autoscaling is not configured.
   autoscale dict
   // Soft upper bound on the number of concurrent jobs in this reservation (0 = system-managed)
   concurrency int
@@ -3675,10 +3889,10 @@ private gcp.project.bigqueryService.reservation @defaults("name slotCapacity edi
 
 // Google Cloud Domains
 //
-// Use this resource as the entry point for Cloud Domains in the project.
-// It hosts the `registrations` — the domain names registered through Cloud
-// Domains — and `enabled` reports whether the Cloud Domains API is turned
-// on for the project.
+// Cloud Domains registration service for the project, covering the domain
+// names registered through Cloud Domains. The `registrations` list holds
+// each registered domain and its security posture, and `enabled` reports
+// whether the Cloud Domains API is turned on for the project.
 private gcp.project.cloudDomainsService @defaults("projectId") {
   // Project ID
   projectId string
@@ -3690,11 +3904,10 @@ private gcp.project.cloudDomainsService @defaults("projectId") {
 
 // Google Cloud Domains registration
 //
-// Examine a domain registered through Cloud Domains. Surfaces the
-// `domainName`, lifecycle `state`, `expireTime`, and the configuration
-// that matters for domain security: the `transferLockState` (protection
-// against unauthorized transfers), the authoritative `nameServers` and
-// which `dnsProvider` serves them, the DNSSEC `dnssecState` and signing
+// Domain registered through Cloud Domains, with the configuration that
+// matters for domain security: the `transferLockState` (protection against
+// unauthorized transfers), the authoritative `nameServers` and which
+// `dnsProvider` serves them, the DNSSEC `dnssecState` and signing
 // `dsRecords`, the `renewalMethod`, the WHOIS `contactPrivacy` level, and
 // any open `issues`. Selected by its full resource name, for example
 // `projects/my-project/locations/global/registrations/example-com`.
@@ -3767,10 +3980,10 @@ private gcp.project.cloudDomainsService.registration @defaults("domainName state
 
 // Google Cloud (GCP) Cloud DNS
 //
-// Use this resource as the entry point for Cloud DNS in the project. It
-// hosts the `managedZones` (public and private DNS zones, including their
-// DNSSEC state and record sets) and the `policies` that govern inbound and
-// outbound DNS resolution for the project's VPC networks.
+// Cloud DNS configuration for the project. Hosts the `managedZones` (public
+// and private DNS zones, including their DNSSEC state and record sets) and
+// the `policies` that govern inbound and outbound DNS resolution for the
+// project's VPC networks.
 private gcp.project.dnsService {
   // Project ID
   projectId string
@@ -3784,14 +3997,12 @@ private gcp.project.dnsService {
 
 // Google Cloud DNS managed zone
 //
-// Examine a Cloud DNS managed zone's configuration and security posture.
-// Surfaces the `dnsName`, `visibility` (public or private), `dnssecConfig`
-// (DNSSEC enablement and key-signing algorithm), the `cloudLoggingEnabled`
-// flag, `privateVisibilityConfig` for VPC-scoped private zones,
-// `nameServers`, `nameServerSet`, `labels`, and IAM policy bindings.
-// Derived predicates `dnssecEnabled` and `dnsSecAlgorithmWeak()` flag
-// DNSSEC posture issues. Child `recordSets()` expose the DNS records
-// within the zone.
+// DNS zone hosting record sets for a domain within the project, along with
+// its `visibility` (public or private), DNSSEC posture, and query-logging
+// state. Private zones expose the VPC networks and GKE clusters authorized to
+// resolve against them and any outbound forwarding or peering targets. The
+// `dnssecEnabled` and `dnsSecAlgorithmWeak` predicates flag absent or weak
+// DNSSEC signing, and `recordSets` expose the DNS records within the zone.
 private gcp.project.dnsService.managedzone @defaults("name") {
   // Managed zone ID
   id string
@@ -3802,6 +4013,11 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   // User-friendly description of the resource
   description string
   // DNSSEC configuration
+  //
+  // Dict with `state` (DNSSEC signing state: "on", "off", or "transfer"),
+  // `nonExistence` (proof-of-nonexistence mode: "nsec" or "nsec3"), and
+  // `defaultKeySpecs`, a list of `{algorithm, keyLength, keyType}` entries
+  // describing the zone's default key-signing and zone-signing keys.
   dnssecConfig dict
   // DNS name of this managed zone
   dnsName string
@@ -3825,7 +4041,12 @@ private gcp.project.dnsService.managedzone @defaults("name") {
   dnsSecAlgorithmWeak() bool
   // DNSSEC signing algorithms of the zone's default key specs (e.g. rsasha256, ecdsap256sha256, rsasha1)
   dnssecDefaultKeyAlgorithms []string
-  // Authorized VPC networks and GKE clusters for a private zone (empty for public zones)
+  // Authorized VPC networks and GKE clusters for a private zone
+  //
+  // Empty for public zones. Dict with `networks`, a list of `{networkUrl}`
+  // entries naming the VPC networks permitted to query this private zone, and
+  // `gkeClusters`, a list of `{gkeClusterName}` entries for the authorized GKE
+  // clusters. See `authorizedNetworks` for the resolved network references.
   privateVisibilityConfig dict
   // Authorized VPC networks for a private zone
   //
@@ -3854,10 +4075,10 @@ private gcp.project.dnsService.managedzone @defaults("name") {
 
 // Google Cloud DNS record set
 //
-// Examine a Cloud DNS resource record set within a managed zone. Surfaces
-// the record `name`, `type` (A, AAAA, CNAME, MX, TXT, NS, SOA, etc.),
-// `ttl`, `rrdatas` (the actual record data as defined in RFC 1035 / 1034),
-// and `signatureRrdatas` (DNSSEC signatures as defined in RFC 4034).
+// Resource record set within a managed zone, keyed by its `name` and `type`
+// (A, AAAA, CNAME, MX, TXT, NS, SOA, and others). The `rrdatas` field holds
+// the record data as defined in RFC 1035 and RFC 1034, and `signatureRrdatas`
+// holds the DNSSEC signatures as defined in RFC 4034.
 private gcp.project.dnsService.recordset @defaults("name") {
   // Project ID
   projectId string
@@ -3875,11 +4096,11 @@ private gcp.project.dnsService.recordset @defaults("name") {
 
 // Google Cloud DNS policy
 //
-// Examine a Cloud DNS policy applied to one or more VPC networks. Surfaces
-// `enableInboundForwarding` (whether on-premises resolvers can send queries
-// to Cloud DNS), `enableLogging` for DNS query audit trails, and
-// `networkNames` / `networks()` listing the VPC networks the policy
-// governs.
+// DNS policy applied to one or more VPC networks. The
+// `enableInboundForwarding` flag controls whether on-premises resolvers can
+// send queries to Cloud DNS, `enableLogging` controls DNS query audit trails,
+// and `networkNames` / `networks` list the VPC networks the policy governs.
+// Outbound queries can be forwarded to the `alternativeNameServers` targets.
 private gcp.project.dnsService.policy @defaults("name") {
   // Project ID
   projectId string
@@ -3903,13 +4124,12 @@ private gcp.project.dnsService.policy @defaults("name") {
 
 // Google Cloud DNS response policy
 //
-// Examine a Cloud DNS response policy that overrides DNS answers for queries
-// made against one or more VPC networks. Because a response policy can
-// redirect or rewrite resolved addresses, surfacing its bindings matters for
-// security review. Surfaces the server-assigned `id`, the user-assigned
-// `responsePolicyName`, `description`, `networkUrls` / `networks()` listing
-// the VPC networks the policy is attached to, and `gkeClusters` naming any
-// bound GKE clusters.
+// Response policy that overrides DNS answers for queries made against one or
+// more VPC networks. Because a response policy can redirect or rewrite
+// resolved addresses, its bindings matter for security review. Selected by
+// the user-assigned `responsePolicyName`, it exposes the bound VPC networks
+// through `networkUrls` / `networks` and any bound GKE clusters through
+// `gkeClusters`.
 private gcp.project.dnsService.responsePolicy @defaults("responsePolicyName") {
   // Project ID
   projectId string
@@ -3942,11 +4162,11 @@ private gcp.project.gkeService {
 
 // Google Kubernetes Engine (GKE) cluster
 //
-// Examine a GKE cluster's full configuration and security posture — node
-// pools, networking, control-plane version and release channel, workload
-// identity, binary authorization, shielded nodes, database encryption,
-// security posture scanning, and maintenance policy. Select a cluster by
-// name and location, for example
+// Full configuration and security posture of a GKE cluster: node pools,
+// networking, control-plane version and release channel, workload identity,
+// binary authorization, shielded nodes, database encryption, security
+// posture scanning, and maintenance policy. Select a cluster by name and
+// location, for example
 // `gcp.project.gkeService.clusters.one(name == "my-cluster")`.
 private gcp.project.gkeService.cluster @defaults("name description location status currentMasterVersion") {
   // Project ID
@@ -4097,14 +4317,13 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   masterGlobalAccessEnabled @maturity("deprecated") bool
   // Control plane endpoints configuration
   //
-  // Examine the modern, structured access-control configuration for the
-  // cluster's control plane — both DNS and IP endpoints. The
-  // `ipEndpointsConfig` sub-dict exposes the authorized-networks list,
-  // whether the public IP endpoint is enabled, and whether private endpoint
-  // global access is enabled. The `dnsEndpointConfig` sub-dict exposes the
-  // managed DNS endpoint URL and whether it is allowed. Replaces the legacy
-  // `masterAuthorizedNetworksConfig` and the access-related fields of
-  // `privateClusterConfig`.
+  // Structured access-control configuration for the cluster's control plane,
+  // covering both DNS and IP endpoints. The `ipEndpointsConfig` sub-dict
+  // exposes the authorized-networks list, whether the public IP endpoint is
+  // enabled, and whether private endpoint global access is enabled. The
+  // `dnsEndpointConfig` sub-dict exposes the managed DNS endpoint URL and
+  // whether it is allowed. Replaces the legacy `masterAuthorizedNetworksConfig`
+  // and the access-related fields of `privateClusterConfig`.
   controlPlaneEndpointsConfig dict
   // Whether the control plane is reachable through a public IP endpoint
   //
@@ -4138,13 +4357,13 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   controlPlaneInternetReachable() bool
   // Logging components enabled on the control plane
   //
-  // The members of `loggingConfig.componentConfig.enableComponents` —
+  // The members of `loggingConfig.componentConfig.enableComponents`:
   // `SYSTEM_COMPONENTS`, `WORKLOADS`, `APISERVER`, `SCHEDULER`, and
   // `CONTROLLER_MANAGER`. An empty list means cluster logging is disabled.
   controlPlaneLoggingComponents []string
   // Monitoring components enabled on the control plane
   //
-  // The members of `monitoringConfig.componentConfig.enableComponents` —
+  // The members of `monitoringConfig.componentConfig.enableComponents`:
   // `SYSTEM_COMPONENTS`, `APISERVER`, `SCHEDULER`, `CONTROLLER_MANAGER`,
   // `STORAGE`, `HPA`, `POD`, `DAEMONSET`, `DEPLOYMENT`, `STATEFULSET`,
   // `CADVISOR`, `KUBELET`, `DCGM`, and `JOBSET`. An empty list means cluster
@@ -4152,30 +4371,30 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   controlPlaneMonitoringComponents []string
   // Logging configuration
   //
-  // Examine which logging components are enabled for the cluster. The
+  // Which logging components are enabled for the cluster. The
   // `componentConfig.enableComponents` list contains members of
   // `SYSTEM_COMPONENTS`, `WORKLOADS`, `APISERVER`, `SCHEDULER`, and
   // `CONTROLLER_MANAGER`. Replaces the legacy `loggingService` string.
   loggingConfig dict
   // Monitoring configuration
   //
-  // Examine which monitoring components are enabled for the cluster plus the
-  // managed Prometheus configuration. The `componentConfig.enableComponents`
-  // list contains members of `SYSTEM_COMPONENTS`, `APISERVER`, `SCHEDULER`,
+  // Which monitoring components are enabled for the cluster, plus the managed
+  // Prometheus configuration. The `componentConfig.enableComponents` list
+  // contains members of `SYSTEM_COMPONENTS`, `APISERVER`, `SCHEDULER`,
   // `CONTROLLER_MANAGER`, `STORAGE`, `HPA`, `POD`, `DAEMONSET`, `DEPLOYMENT`,
   // `STATEFULSET`, `CADVISOR`, `KUBELET`, `DCGM`, and `JOBSET`. Replaces the
   // legacy `monitoringService` string.
   monitoringConfig dict
   // Secret Manager configuration
   //
-  // Configuration for the Secret Manager CSI driver — exposes whether the
+  // Configuration for the Secret Manager CSI driver. Exposes whether the
   // driver is `enabled` and the optional `rotationConfig` (enable flag plus
   // rotation interval) used to refresh synced secrets.
   secretManagerConfig dict
   // User-managed keys configuration
   //
   // Customer-managed encryption-key (CMEK) references for cluster control
-  // plane storage and certificate authorities — cluster CA, etcd API CA,
+  // plane storage and certificate authorities: cluster CA, etcd API CA,
   // etcd peer CA, aggregation CA, service-account signing/verification keys,
   // the control-plane disk encryption key, and the GKE-ops etcd backup
   // encryption key.
@@ -4188,7 +4407,7 @@ private gcp.project.gkeService.cluster @defaults("name description location stat
   anonymousAuthenticationConfig dict
   // Fleet configuration
   //
-  // Fleet membership information for the cluster — `project` (the fleet host
+  // Fleet membership information for the cluster: `project` (the fleet host
   // project), `membership` (the full fleet membership resource name), and
   // `preRegistered` (whether the cluster was registered through the fleet
   // API).
@@ -4324,10 +4543,10 @@ private gcp.project.gkeService.cluster.securityPostureConfig {
 
 // Google Kubernetes Engine (GKE) cluster network policy configuration
 //
-// Examine whether a Kubernetes network policy provider (such as Calico) is
-// enabled on the cluster. An `enabled: false` result means pod-to-pod traffic
-// is unrestricted by Kubernetes NetworkPolicy objects — a common CIS
-// benchmark finding.
+// Whether a Kubernetes network policy provider (such as Calico) is enabled on
+// the cluster. An `enabled: false` result means pod-to-pod traffic is
+// unrestricted by Kubernetes NetworkPolicy objects, a common CIS benchmark
+// finding.
 private gcp.project.gkeService.cluster.networkPolicy @defaults("enabled provider") {
   // Internal ID
   id string
@@ -4399,10 +4618,10 @@ private gcp.project.gkeService.cluster.ipAllocationPolicy @defaults("stackType c
 
 // Google Kubernetes Engine (GKE) cluster network config
 //
-// Examine the VPC network and subnetwork the cluster is attached to, along
-// with datapath provider, intra-node visibility, L4 internal load-balancer
-// subsetting, IPv6 access settings, DNS configuration, and restrictions on
-// services with external IPs.
+// VPC network and subnetwork the cluster is attached to, along with datapath
+// provider, intra-node visibility, L4 internal load-balancer subsetting, IPv6
+// access settings, DNS configuration, and restrictions on services with
+// external IPs.
 private gcp.project.gkeService.cluster.networkConfig @defaults("networkPath") {
   // Internal ID for this resource
   id string
@@ -4438,12 +4657,11 @@ private gcp.project.gkeService.cluster.networkConfig @defaults("networkPath") {
 
 // Google Kubernetes Engine (GKE) cluster node pool
 //
-// Examine a node pool's VM configuration, autoscaling bounds, auto-upgrade
-// and auto-repair settings, Kubernetes version, pod CIDR size, upgrade
-// strategy, and the managed instance groups that back it. Each node pool
-// contains a `config` sub-resource covering machine type, disk, service
-// account, image type, shielded-instance settings, and workload metadata
-// mode.
+// A node pool's VM configuration, autoscaling bounds, auto-upgrade and
+// auto-repair settings, Kubernetes version, pod CIDR size, upgrade strategy,
+// and the managed instance groups that back it. Each node pool contains a
+// `config` sub-resource covering machine type, disk, service account, image
+// type, shielded-instance settings, and workload metadata mode.
 private gcp.project.gkeService.cluster.nodepool @defaults("name") {
   // Internal ID for this resource
   id string
@@ -4508,10 +4726,10 @@ private gcp.project.gkeService.cluster.nodepool.upgradeSettings @defaults("strat
 
 // Google Kubernetes Engine (GKE) node pool autoscaling configuration
 //
-// Examine whether autoscaling is enabled on a node pool and the minimum and
-// maximum node count bounds — both per-location and total across all
-// locations. The `autoprovisioned` flag indicates the pool was created by
-// Node Auto-Provisioning rather than configured directly.
+// Whether autoscaling is enabled on a node pool and the minimum and maximum
+// node count bounds, both per-location and total across all locations. The
+// `autoprovisioned` flag indicates the pool was created by Node
+// Auto-Provisioning rather than configured directly.
 private gcp.project.gkeService.cluster.nodepool.autoscaling @defaults( "enabled" ) {
   // Is autoscaling enabled for this node pool.
   enabled bool
@@ -4559,13 +4777,12 @@ private gcp.project.gkeService.cluster.nodepool.networkConfig.performanceConfig 
 
 // Google Kubernetes Engine (GKE) node pool configuration
 //
-// Examine the per-node VM settings for a node pool — machine type, disk
-// size and type, service account (and whether it is the default Compute
-// Engine account or carries the broad cloud-platform OAuth scope), image
-// type, workload metadata mode, Kubernetes labels and taints, shielded
-// instance settings, sandbox type (gVisor), confidential nodes, and
-// accelerator configuration. This resource is the primary surface for CIS
-// GKE node-security benchmarks.
+// Per-node VM settings for a node pool: machine type, disk size and type,
+// service account (and whether it is the default Compute Engine account or
+// carries the broad cloud-platform OAuth scope), image type, workload
+// metadata mode, Kubernetes labels and taints, shielded instance settings,
+// sandbox type (gVisor), confidential nodes, and accelerator configuration.
+// This resource is the primary surface for CIS GKE node-security benchmarks.
 private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType diskSizeGb") {
   // Internal ID for this resource
   id string
@@ -4651,7 +4868,7 @@ private gcp.project.gkeService.cluster.nodepool.config @defaults("machineType di
   // Surfaces the containerd settings applied to nodes. Keys:
   // `privateRegistryAccessConfig` (CA-domain configuration for pulling from
   // private registries, including GCP Secret Manager certificate references),
-  // `writableCgroups`, and `registryHosts` — a list of per-server registry
+  // `writableCgroups`, and `registryHosts`, a list of per-server registry
   // host configurations (each containerd `hosts.toml`). Every registry host
   // entry carries a `server`, plus `hosts` with their `capabilities`
   // (HOST_CAPABILITY_PULL, HOST_CAPABILITY_RESOLVE, HOST_CAPABILITY_PUSH),
@@ -4705,10 +4922,10 @@ private gcp.project.gkeService.cluster.nodepool.config.sandboxConfig @defaults("
 
 // Google Kubernetes Engine (GKE) node pool shielded instance configuration
 //
-// Examine whether Secure Boot and integrity monitoring are enabled for nodes
-// in the pool. Both settings are CIS GKE benchmark controls: Secure Boot
-// ensures only signed OS components run, and integrity monitoring detects
-// runtime changes to the boot sequence.
+// Whether Secure Boot and integrity monitoring are enabled for nodes in the
+// pool. Both settings are CIS GKE benchmark controls: Secure Boot ensures
+// only signed OS components run, and integrity monitoring detects runtime
+// changes to the boot sequence.
 private gcp.project.gkeService.cluster.nodepool.config.shieldedInstanceConfig @defaults("enableSecureBoot enableIntegrityMonitoring") {
   // Internal ID for this resource
   id string
@@ -4736,11 +4953,10 @@ private gcp.project.gkeService.cluster.nodepool.config.linuxNodeConfig @defaults
 
 // Google Kubernetes Engine (GKE) node pool parameters that can be configured on Windows nodes
 //
-// Examine the Windows-specific settings on a GKE node pool. Surfaces
-// the `osVersion` selecting which Windows Server LTSC image the pool
-// is pinned to (e.g., `LTSC2019`, `LTSC2022`). Auditors of mixed-OS
-// GKE clusters need this to verify that Windows nodes are running an
-// approved OS baseline.
+// Windows-specific settings on a GKE node pool. Surfaces the `osVersion`
+// selecting which Windows Server LTSC image the pool is pinned to (e.g.,
+// `LTSC2019`, `LTSC2022`). Auditors of mixed-OS GKE clusters need this to
+// verify that Windows nodes are running an approved OS baseline.
 private gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig @defaults("osVersion") {
   // Windows Server OS version pinned to this node pool
   //
@@ -4750,10 +4966,10 @@ private gcp.project.gkeService.cluster.nodepool.config.windowsNodeConfig @defaul
 
 // Google Kubernetes Engine (GKE) Node Pool kubelet configuration
 //
-// Examine kubelet settings applied to every node in the pool — the CPU
-// manager policy (e.g., `static` for guaranteed-QoS containers), the CPU
-// CFS quota period, and the per-pod PID limit. These settings affect
-// workload isolation and resource-exhaustion blast-radius.
+// Kubelet settings applied to every node in the pool: the CPU manager policy
+// (e.g., `static` for guaranteed-QoS containers), the CPU CFS quota period,
+// and the per-pod PID limit. These settings affect workload isolation and
+// resource-exhaustion blast-radius.
 private gcp.project.gkeService.cluster.nodepool.config.kubeletConfig @defaults("cpuManagerPolicy podPidsLimit") {
   // Internal ID for this resource
   id string
@@ -4799,10 +5015,12 @@ private gcp.project.gkeService.cluster.nodepool.config.confidentialNodes @defaul
 
 // Google Cloud (GCP) Pub/Sub
 //
-// Use this resource as the entry point for Pub/Sub in the project. It
-// hosts the messaging surface: `topics` and their `subscriptions`,
-// point-in-time `snapshots`, and the `schemas` that validate message
-// payloads — each exposing IAM policy, encryption, and retention settings.
+// Messaging surface for Pub/Sub in the project. It hosts `topics` and
+// their `subscriptions`, point-in-time `snapshots`, and the `schemas`
+// that validate message payloads. Each exposes IAM policy, encryption,
+// and retention settings, making this the starting point for auditing
+// who can publish or consume messages and how those messages are
+// protected.
 private gcp.project.pubsubService {
   // Project ID
   projectId string
@@ -4818,10 +5036,13 @@ private gcp.project.pubsubService {
 
 // Google Cloud (GCP) Pub/Sub topic
 //
-// Examine a Pub/Sub topic's encryption key, message storage policy,
-// retention duration, schema validation settings, and IAM policy. The
-// `public` field flags topics whose IAM policy grants access to
-// `allUsers` or `allAuthenticatedUsers`.
+// Named messaging channel that publishers send messages to and
+// subscriptions read from. The `config` sub-resource carries the
+// encryption key, message storage policy, retention duration, and
+// schema validation settings, and `iamPolicy` lists who may publish or
+// administer it. The `public` field flags topics whose IAM policy
+// grants any role to `allUsers` or `allAuthenticatedUsers`, a common
+// exposure finding.
 private gcp.project.pubsubService.topic @defaults("name") {
   // Project ID
   projectId string
@@ -4837,11 +5058,11 @@ private gcp.project.pubsubService.topic @defaults("name") {
 
 // Google Cloud (GCP) Pub/Sub topic configuration
 //
-// Examine the detailed settings for a Pub/Sub topic — the customer-managed
-// KMS key (`kmsKey`) used to encrypt messages at rest, the message storage
-// policy restricting which regions may persist messages, message retention
-// duration, topic lifecycle state, and the schema validation settings that
-// govern which message formats the topic accepts.
+// Detailed settings for a Pub/Sub topic: the customer-managed KMS key
+// (`kmsKey`) used to encrypt messages at rest, the message storage
+// policy restricting which regions may persist messages, message
+// retention duration, topic lifecycle state, and the schema validation
+// settings that govern which message formats the topic accepts.
 private gcp.project.pubsubService.topic.config @defaults("kmsKeyName messageStoragePolicy") {
   // Project ID
   projectId string
@@ -4917,11 +5138,12 @@ private gcp.project.pubsubService.topic.config.messagestoragepolicy @defaults("a
 
 // Google Cloud (GCP) Pub/Sub subscription
 //
-// Examine a Pub/Sub subscription's delivery configuration and IAM policy.
+// Named attachment to a topic that delivers its messages to consumers.
 // The `config` sub-resource exposes ack deadline, message ordering, push
 // endpoint, dead-letter policy, retry backoff, filter expression, and
-// retention settings. The `public` field flags subscriptions accessible
-// to `allUsers` or `allAuthenticatedUsers`.
+// retention settings. The `public` field flags subscriptions whose IAM
+// policy grants any role to `allUsers` or `allAuthenticatedUsers`, a
+// common exposure finding.
 private gcp.project.pubsubService.subscription @defaults("name") {
   // Project ID
   projectId string
@@ -4937,11 +5159,14 @@ private gcp.project.pubsubService.subscription @defaults("name") {
 
 // Google Cloud (GCP) Pub/Sub subscription configuration
 //
-// Examine the detailed delivery settings for a Pub/Sub subscription —
-// the parent topic, acknowledgement deadline, message retention duration,
-// push endpoint configuration, expiration policy, dead-letter queue,
-// retry backoff, message ordering and exactly-once delivery flags, filter
+// Detailed delivery settings for a Pub/Sub subscription: the parent
+// topic, acknowledgement deadline, message retention duration, push
+// endpoint configuration, expiration policy, dead-letter queue, retry
+// backoff, message ordering and exactly-once delivery flags, filter
 // expression, detachment state, and the topic's own retention window.
+// The `bigqueryConfig`, `cloudStorageConfig`, and `bigtableConfig`
+// fields describe egress paths that move topic data into a queryable or
+// persistent store.
 private gcp.project.pubsubService.subscription.config @defaults("topic.name ackDeadline expirationPolicy") {
   // Project ID
   projectId string
@@ -5045,10 +5270,10 @@ private gcp.project.pubsubService.subscription.config.pushconfig @defaults("attr
 
 // Google Cloud (GCP) Pub/Sub snapshot
 //
-// Examine a point-in-time Pub/Sub snapshot — the topic it was taken from
-// and the time at which it expires and is automatically deleted. Snapshots
-// allow subscriptions to seek back to a specific point in the message
-// backlog.
+// Point-in-time snapshot of a subscription's message backlog. It records
+// the topic it was taken from and the time at which it expires and is
+// automatically deleted. Snapshots allow subscriptions to seek back to a
+// specific point in the message backlog.
 private gcp.project.pubsubService.snapshot @defaults("name") {
   // Project ID
   projectId string
@@ -5070,10 +5295,10 @@ private gcp.project.pubsubService.snapshot @defaults("name") {
 
 // Google Cloud (GCP) Pub/Sub schema
 //
-// Examine a Pub/Sub schema that validates message payloads published to
-// associated topics. Exposes the schema type (`PROTOCOL_BUFFER` or `AVRO`),
-// the full schema definition text, the current revision ID, and the time
-// the revision was created.
+// Schema that validates message payloads published to associated topics.
+// It exposes the schema type (`PROTOCOL_BUFFER` or `AVRO`), the full
+// schema definition text, the current revision ID, and the time the
+// revision was created.
 private gcp.project.pubsubService.schema @defaults("name type") {
   // Project ID
   projectId string
@@ -5091,11 +5316,12 @@ private gcp.project.pubsubService.schema @defaults("name type") {
 
 // Google Cloud (GCP) Cloud Key Management Service (KMS)
 //
-// Use this resource as the entry point for Cloud KMS in the project. It
-// hosts the `keyrings` and, through them, the crypto keys and key versions
-// used for encryption — exposing rotation schedule, protection level, and
-// IAM policy. `locations` lists the regions where key material can be
-// created, and `retiredResources` surfaces deleted KMS resources.
+// Cloud KMS entry point for the project, hosting the `keyrings` and,
+// through them, the crypto keys and key versions used for encryption,
+// with their rotation schedule, protection level, and IAM policy.
+// `locations` lists the regions where key material can be created,
+// `ekmConnections` covers external key manager connections, and
+// `retiredResources` surfaces deleted KMS resources.
 private gcp.project.kmsService {
   // Project ID
   projectId string
@@ -5111,10 +5337,12 @@ private gcp.project.kmsService {
 
 // Google Cloud (GCP) KMS keyring
 //
-// Examine a Cloud KMS keyring — its location, creation time, and the
-// collection of `cryptokeys` it contains. A keyring is the regional
-// container that groups cryptographic keys; individual key rotation,
-// protection level, and IAM policy are on the `cryptokey` sub-resource.
+// Cloud KMS keyring: the regional container that groups cryptographic
+// keys, exposing its location, creation time, and the collection of
+// `cryptokeys` it contains. Individual key rotation, protection level,
+// and IAM policy are on the `cryptokey` sub-resource. The `public` field
+// flags a ring whose IAM policy grants a role to allUsers or
+// allAuthenticatedUsers, which cascades to every key in the ring.
 private gcp.project.kmsService.keyring @defaults("name") {
   // Project ID
   projectId string
@@ -5142,7 +5370,7 @@ private gcp.project.kmsService.keyring @defaults("name") {
 
 // Google Cloud (GCP) KMS crypto key
 //
-// Examine a Cloud KMS cryptographic key — its purpose
+// Cloud KMS cryptographic key, exposing its purpose
 // (`ENCRYPT_DECRYPT`, `ASYMMETRIC_SIGN`, `ASYMMETRIC_DECRYPT`, `MAC`),
 // rotation schedule (`nextRotation`, `rotationPeriod`), import-only flag,
 // destroy-scheduled duration, backend environment, key access
@@ -5168,7 +5396,11 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   rotationPeriod time
   // Whether automatic rotation is configured for this key (rotationPeriod is set)
   rotationEnabled() bool
-  // Template describing the settings for new crypto key versions
+  // Default settings for new crypto key versions
+  //
+  // Keys: `protectionLevel` (SOFTWARE, HSM, EXTERNAL, or EXTERNAL_VPC) and
+  // `algorithm` (the crypto key version algorithm applied to versions
+  // created for this key).
   versionTemplate dict
   // User-defined labels
   labels map[string]string
@@ -5178,7 +5410,12 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
   destroyScheduledDuration time
   // Resource name of the backend environment where the key material for all crypto key versions reside
   cryptoKeyBackend string
-  // Key access justifications policy (allowedAccessReasons)
+  // Key access justifications policy
+  //
+  // Single key `allowedAccessReasons`: the list of Key Access
+  // Justifications reason codes for which Cloud KMS permits access to the
+  // key material (for example CUSTOMER_INITIATED_ACCESS or
+  // GOOGLE_INITIATED_SYSTEM_OPERATION).
   keyAccessJustificationsPolicy dict
   // List of cryptokey versions
   versions() []gcp.project.kmsService.keyring.cryptokey.version
@@ -5196,7 +5433,7 @@ private gcp.project.kmsService.keyring.cryptokey @defaults("name purpose") {
 
 // Google Cloud (GCP) KMS crypto key version
 //
-// Examine an individual version of a Cloud KMS cryptographic key — its
+// Individual version of a Cloud KMS cryptographic key, exposing its
 // lifecycle state (`ENABLED`, `DISABLED`, `DESTROY_SCHEDULED`,
 // `DESTROYED`), protection level (`SOFTWARE`, `HSM`, `EXTERNAL`),
 // algorithm, HSM attestation, creation and destruction timestamps, import
@@ -5269,7 +5506,7 @@ private gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevel
 
 // Google Cloud (GCP) KMS EKM connection
 //
-// Examine a Cloud KMS connection to an External Key Manager (EKM)
+// Cloud KMS connection to an External Key Manager (EKM)
 // service. EKM connections let Cloud KMS create and use keys that are
 // stored and managed outside Google, with cryptographic operations
 // performed by the external KMS over Service Directory. Query the
@@ -5307,7 +5544,7 @@ private gcp.project.kmsService.ekmConnection @defaults("name keyManagementMode l
 
 // Google Cloud (GCP) KMS import job
 //
-// Examine a Cloud KMS import job — the short-lived wrapping key used to
+// Cloud KMS import job: the short-lived wrapping key used to
 // bring external key material into a Cloud KMS keyring. Query its
 // `importMethod` (the wrapping scheme, e.g.
 // `RSA_OAEP_3072_SHA256_AES_256`), `protectionLevel` (`SOFTWARE`, `HSM`,
@@ -5347,7 +5584,12 @@ private gcp.project.kmsService.keyring.importJob @defaults("name state importMet
   expireTime time
   // Time the import job actually expired (set when `state` is EXPIRED)
   expireEventTime time
-  // HSM attestation produced at key creation, when the import method has an HSM protection level
+  // HSM attestation produced at key creation
+  //
+  // Present when the import method has an HSM protection level. Keys:
+  // `format` (the attestation format), `content` (the signed attestation
+  // data), and `certChains` (the Cavium, Google card, and Google partition
+  // certificate chains needed to validate it).
   attestation dict
   // Backend environment binding for the wrapping key (e.g., a single-tenant HSM instance), when applicable
   cryptoKeyBackend string
@@ -5355,7 +5597,7 @@ private gcp.project.kmsService.keyring.importJob @defaults("name state importMet
 
 // Google Cloud (GCP) KMS retired resource (deleted key tracking)
 //
-// Examine a Cloud KMS resource that has been deleted — capturing its
+// Cloud KMS resource that has been deleted, capturing its
 // original resource name, type (`CryptoKey` or `CryptoKeyVersion`), and
 // the time it was deleted. Useful for auditing key-deletion events and
 // confirming that scheduled key destruction completed.
@@ -5372,12 +5614,13 @@ private gcp.project.kmsService.retiredResource @defaults("name resourceType") {
 
 // Google Cloud (GCP) Essential Contacts entry
 //
-// Examine a contact registered to receive security, legal, billing,
+// Contact registered to receive security, legal, billing,
 // technical, or product-update notifications for a GCP organization,
-// folder, or project. Exposes the contact's email address, preferred
-// language, the notification categories they are subscribed to, and
-// their validation state — allowing audits to confirm that critical
-// security contacts are present and validated.
+// folder, or project. Contacts subscribe to notification categories
+// and carry a validation state, so audits can confirm that critical
+// security contacts are present and validated. The email address,
+// preferred language, subscribed notificationCategories, and
+// validationState are all queryable.
 private gcp.essentialContact @defaults("email notificationCategories") {
   // Full resource path
   resourcePath string
@@ -5385,17 +5628,23 @@ private gcp.essentialContact @defaults("email notificationCategories") {
   email string
   // Preferred language for notifications, as a ISO 639-1 language code
   languageTag string
-  // Categories of notifications that the contact will receive communication for
+  // Notification categories the contact is subscribed to
+  //
+  // Any of ALL, SUSPENSION, SECURITY, TECHNICAL, BILLING, LEGAL,
+  // PRODUCT_UPDATES, or TECHNICAL_INCIDENTS.
   notificationCategories []string
   // Last time the validation state was updated
   validated time
-  // Validity of the contact
+  // Validation state of the contact's email address
+  //
+  // One of VALID, INVALID, or UNVALIDATED. Notifications are only
+  // delivered to contacts whose email address is VALID.
   validationState string
 }
 
 // Google Cloud (GCP) project API key
 //
-// Examine an API key scoped to the project — its display name, annotations,
+// API key scoped to the project, including its display name, annotations,
 // creation and deletion timestamps, the encrypted key string, and the
 // restrictions that limit which applications, IP addresses, or API targets
 // may use it. The `restrictions` sub-resource exposes the `unrestricted`
@@ -5444,23 +5693,39 @@ private gcp.project.apiKey @defaults("name") {
 
 // Google Cloud (GCP) project API key restrictions
 //
-// Examine the access restrictions applied to a GCP API key — Android app
-// restrictions, iOS app restrictions, HTTP referrer restrictions, server IP
-// restrictions, and specific API target restrictions. The `unrestricted`
-// derived field is `true` when none of these restriction types are
-// configured, which CIS benchmarks flag as a finding.
+// Access restrictions applied to a GCP API key: Android app restrictions,
+// iOS app restrictions, HTTP referrer restrictions, server IP restrictions,
+// and specific API target restrictions. The `unrestricted` derived field is
+// `true` when none of these restriction types are configured, which CIS
+// benchmarks flag as a finding.
 private gcp.project.apiKey.restrictions {
   // Parent resource path
   parentResourcePath string
-  // The Android apps that are allowed to use the key
+  // Android apps allowed to use the key
+  //
+  // Dict with `allowedApplications`, a list of `{packageName,
+  // sha1Fingerprint}` entries identifying each permitted Android app.
   androidKeyRestrictions dict
-  // A restriction for a specific service and optionally one or more specific methods
+  // API targets the key is restricted to
+  //
+  // Each entry is a `{service, methods}` dict: `service` is the target
+  // service name and `methods` is the list of allowed methods (an empty
+  // list means all methods of that service).
   apiTargets []dict
-  // The HTTP referrers that are allowed to use the key
+  // HTTP referrers allowed to use the key
+  //
+  // Dict with `allowedReferrers`, a list of referrer patterns permitted to
+  // use the key.
   browserKeyRestrictions dict
-  // The iOS apps that are allowed to use the key
+  // iOS apps allowed to use the key
+  //
+  // Dict with `allowedBundleIds`, a list of iOS bundle IDs permitted to use
+  // the key.
   iosKeyRestrictions dict
-  // The IP addresses that are allowed to use the key
+  // IP addresses allowed to use the key
+  //
+  // Dict with `allowedIps`, a list of IPv4 or IPv6 addresses or CIDR ranges
+  // permitted to use the key.
   serverKeyRestrictions dict
   // Whether the API key has no restrictions configured (no app/IP/referrer/API target restriction). CIS flags unrestricted keys.
   unrestricted() bool
@@ -5476,11 +5741,11 @@ private gcp.project.apiKey.restrictions {
 
 // Google Cloud (GCP) Cloud Logging
 //
-// Use this resource as the entry point for Cloud Logging in the project.
-// It hosts `buckets` (log storage with retention and CMEK settings),
-// `metrics` (log-based metrics for alerting on security events),
-// `sinks` (export configurations to Cloud Storage, BigQuery, or Pub/Sub),
-// and `exclusions` (filters that drop matching log entries before
+// Cloud Logging configuration for the project. Hosts `buckets` (log
+// storage with retention and CMEK settings), `metrics` (log-based
+// metrics for alerting on security events), `sinks` (export
+// configurations to Cloud Storage, BigQuery, or Pub/Sub), and
+// `exclusions` (filters that drop matching log entries before
 // ingestion). Together these are the primary surface for CIS logging
 // benchmark controls.
 private gcp.project.loggingservice {
@@ -5500,11 +5765,13 @@ private gcp.project.loggingservice {
 
 // Google Cloud (GCP) Cloud Logging bucket
 //
-// Examine a Cloud Logging log bucket — its location, retention period,
-// lock status, customer-managed KMS encryption key, lifecycle state,
-// Log Analytics enablement, restricted fields, index configurations,
-// and the views that control which log entries are visible to different
-// principals.
+// Cloud Logging log bucket storing ingested log entries. Its retention
+// period, lock status, and customer-managed KMS encryption key
+// determine how long logs are kept and how they are protected, and
+// Log Analytics enablement governs whether the bucket is queryable.
+// The views control which log entries are visible to different
+// principals, restricted fields deny access to specific field paths,
+// and index configurations tune query performance.
 private gcp.project.loggingservice.bucket @defaults("name") {
   // Project ID
   projectId string
@@ -5512,7 +5779,7 @@ private gcp.project.loggingservice.bucket @defaults("name") {
   location string
   // Raw CMEK settings dict
   //
-  // Deprecated in favor of `kmsKey()`.
+  // Deprecated in favor of `kmsKey`.
   cmekSettings @maturity("deprecated") dict
   // Customer-managed KMS key used to encrypt log entries in this bucket (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
@@ -5553,6 +5820,12 @@ private gcp.project.loggingservice.bucket @defaults("name") {
 }
 
 // Google Cloud (GCP) Logging bucket view
+//
+// View over a log bucket that restricts which log entries are visible
+// through it. The `filter` field is the advanced log filter applied to
+// the view; granting a principal access to a view rather than the whole
+// bucket narrows what logs they can read, so auditing view filters
+// confirms least-privilege access to sensitive log data.
 private gcp.project.loggingservice.bucket.view @defaults("name") {
   // Internal ID for this resource
   id string
@@ -5582,12 +5855,13 @@ private gcp.project.loggingservice.bucket.indexConfig @defaults("id") {
 
 // Google Cloud (GCP) Cloud Logging log-based metric
 //
-// Examine a log-based metric defined in the project — its advanced log
-// filter, description, and the alert policies that monitor it. The derived
-// fields `filtersIamChanges`, `filtersAuditConfigChanges`,
-// `filtersRouteChanges`, and `filtersFirewallChanges` indicate whether the
-// metric covers the specific mutation categories required by CIS GCP
-// benchmark logging controls.
+// Log-based metric defined in the project, counting log entries that
+// match an advanced log filter and feeding the alert policies that
+// monitor it. The derived fields `filtersIamChanges`,
+// `filtersAuditConfigChanges`, `filtersRouteChanges`, and
+// `filtersFirewallChanges` indicate whether the metric covers the
+// specific mutation categories required by CIS GCP benchmark logging
+// controls.
 private gcp.project.loggingservice.metric @defaults("description filter") {
   // Metric ID
   id string
@@ -5621,11 +5895,13 @@ private gcp.project.loggingservice.metric @defaults("description filter") {
 
 // Google Cloud (GCP) Cloud Logging sink
 //
-// Examine a Cloud Logging export sink — its destination (Cloud Storage
-// bucket, BigQuery dataset, or Pub/Sub topic), optional log filter,
-// writer identity used for authorization, and whether the sink exports
-// logs from child resources. The `storageBucket` field resolves the
-// destination to a typed storage bucket resource when applicable.
+// Cloud Logging export sink routing matching log entries to a
+// destination (Cloud Storage bucket, BigQuery dataset, or Pub/Sub
+// topic). An optional log filter selects which entries are exported,
+// the writer identity is the principal Logging adopts for
+// authorization, and `includeChildren` controls whether logs from
+// child resources are exported. The `storageBucket` field resolves the
+// destination to a storage bucket resource when applicable.
 private gcp.project.loggingservice.sink @defaults("destination") {
   // Sink ID
   id string
@@ -5649,11 +5925,13 @@ private gcp.project.loggingservice.sink @defaults("destination") {
 
 // Google Cloud (GCP) Cloud Logging exclusion filter
 //
-// Examine a log exclusion configured in the project — the advanced log
-// filter that selects entries to drop, whether the exclusion is currently
-// disabled, its description, and creation and update timestamps. Exclusions
-// can suppress security-relevant log entries if misconfigured; auditing
-// them confirms that critical event categories are not silently discarded.
+// Log exclusion configured in the project, dropping matching entries
+// before they are ingested. The advanced log filter selects entries to
+// drop, `disabled` indicates whether the exclusion is currently
+// inactive, and the description and timestamps record its intent and
+// history. Exclusions can suppress security-relevant log entries if
+// misconfigured; auditing them confirms that critical event categories
+// are not silently discarded.
 private gcp.project.loggingservice.exclusion @defaults("name disabled") {
   // Exclusion name
   name string
@@ -5671,13 +5949,13 @@ private gcp.project.loggingservice.exclusion @defaults("name disabled") {
 
 // Google Cloud (GCP) Identity and Access Management (IAM)
 //
-// Use this resource to enumerate the project's IAM building blocks: the
-// `serviceAccounts` and their service-account keys, custom `roles` defined in
-// the project, and the Workload Identity Federation pools (and their external
-// providers) reachable through `workloadIdentityPools`. This is the entry
-// point for IAM audits — service-account-key sprawl, key rotation, custom
-// role permission scope, and external federation trust anchors all hang off
-// of here.
+// Project-level IAM building blocks: the `serviceAccounts` and their
+// service-account keys, custom `roles` defined in the project, the IAM
+// `denyPolicies` attached to it, and the Workload Identity Federation pools
+// (and their external providers) reachable through `workloadIdentityPools`.
+// This is the entry point for IAM audits: service-account-key sprawl, key
+// rotation, custom role permission scope, and external federation trust
+// anchors all hang off of here.
 private gcp.project.iamService {
   // Project ID
   projectId string
@@ -5693,11 +5971,11 @@ private gcp.project.iamService {
 
 // Google Cloud (GCP) IAM custom role
 //
-// Examine a custom IAM role defined in the project — its title,
-// description, launch stage (`ALPHA`, `BETA`, `GA`, `DEPRECATED`,
-// `DISABLED`), the full list of permissions it grants, and whether it
-// has been soft-deleted. Custom roles with overly broad permission sets
-// are a common privilege-escalation finding.
+// Custom IAM role defined in the project, covering its title, description,
+// launch stage (`ALPHA`, `BETA`, `GA`, `DEPRECATED`, `DISABLED`), the full
+// list of permissions it grants, and whether it has been soft-deleted.
+// Custom roles with overly broad permission sets are a common
+// privilege-escalation finding.
 private gcp.project.iamService.role @defaults("title name") {
   // Project ID
   projectId string
@@ -5705,7 +5983,7 @@ private gcp.project.iamService.role @defaults("title name") {
   name string
   // Title of the role
   title string
-  // Human-readable description of the resource
+  // Human-readable description of the role
   description string
   // Launch stage of the role (ALPHA, BETA, GA, DEPRECATED, DISABLED)
   stage string
@@ -5719,14 +5997,14 @@ private gcp.project.iamService.role @defaults("title name") {
   //
   // True when any included permission is iam.serviceAccounts.actAs,
   // getAccessToken, signBlob, signJwt, getOpenIdToken, or
-  // implicitDelegation — the permissions that enable acting as a service
+  // implicitDelegation, the permissions that enable acting as a service
   // account and escalating privilege.
   grantsServiceAccountImpersonation() bool
 }
 
 // Google Cloud (GCP) IAM service account
 //
-// Examine a GCP service account — its email address, display name,
+// GCP service account, covering its email address, display name,
 // description, disabled status, OAuth 2.0 client ID, and all associated
 // keys. The `activeUserManagedKeys` field surfaces non-disabled,
 // user-managed keys (the audit hot spot for key sprawl), and
@@ -5778,7 +6056,7 @@ private gcp.project.iamService.serviceAccount @defaults("displayName name") {
 
 // Google Cloud (GCP) IAM service account key
 //
-// Examine an individual key associated with a service account — its
+// Individual key associated with a service account, covering its
 // algorithm, origin (`GOOGLE_PROVIDED` or `USER_PROVIDED`), type
 // (`SYSTEM_MANAGED` or `USER_MANAGED`), validity window
 // (`validAfterTime`, `validBeforeTime`), and disabled status. The
@@ -5810,12 +6088,12 @@ private gcp.project.iamService.serviceAccount.key @defaults("name") {
 
 // Google Cloud (GCP) IAM deny policy
 //
-// Examine the deny rules that block principals from using specific
-// permissions on the project, which take precedence over any allow policy.
-// Each entry in `rules` carries the denied permissions, the principals the
-// denial applies to, any exception principals or permissions excluded from
-// the denial, and an optional CEL condition that gates when the rule fires.
-// Deny policies are selected by their full resource `name`.
+// Deny rules that block principals from using specific permissions on the
+// project, which take precedence over any allow policy. Each entry in
+// `rules` carries the denied permissions, the principals the denial applies
+// to, any exception principals or permissions excluded from the denial, and
+// an optional CEL condition that gates when the rule fires. Deny policies
+// are selected by their full resource `name`.
 private gcp.project.iamService.denyPolicy @defaults("displayName name") {
   // Full resource name of the deny policy
   name string
@@ -5825,7 +6103,13 @@ private gcp.project.iamService.denyPolicy @defaults("displayName name") {
   displayName string
   // Arbitrary user-supplied metadata attached to the policy
   annotations map[string]string
-  // Deny rules that make up the policy, each with denied permissions, principals, exceptions, and an optional condition
+  // Deny rules that make up the policy
+  //
+  // Each rule is a dict with `description`, `deniedPrincipals`,
+  // `deniedPermissions`, `exceptionPrincipals`, and `exceptionPermissions`
+  // (lists of strings), plus an optional `denialCondition` dict carrying the
+  // CEL `expression`, `title`, `description`, and `location` that gates when
+  // the denial fires.
   rules []dict
   // Etag for optimistic concurrency control
   etag string
@@ -5837,13 +6121,13 @@ private gcp.project.iamService.denyPolicy @defaults("displayName name") {
 
 // Google Cloud (GCP) Workload Identity Federation pool
 //
-// Examine pool lifecycle (`state`, `disabled`, `expireTime`) and the external
-// identity providers attached to it via `providers`. A pool is the namespace
-// that external workloads (AWS roles, OIDC issuers, SAML IdPs, X.509 trust
-// stores) federate into before they can impersonate Google service accounts.
-// Pools are the top-level audit unit for federation: a `disabled=false`,
-// non-expired pool with a permissive provider is the path that lets external
-// callers obtain GCP credentials.
+// Namespace that external workloads (AWS roles, OIDC issuers, SAML IdPs,
+// X.509 trust stores) federate into before they can impersonate Google
+// service accounts, covering pool lifecycle (`state`, `disabled`,
+// `expireTime`) and the external identity providers attached to it via
+// `providers`. Pools are the top-level audit unit for federation: a
+// `disabled=false`, non-expired pool with a permissive provider is the path
+// that lets external callers obtain GCP credentials.
 private gcp.project.iamService.workloadIdentityPool @defaults("displayName name state") {
   // Project ID
   projectId string
@@ -5871,11 +6155,11 @@ private gcp.project.iamService.workloadIdentityPool @defaults("displayName name 
 
 // Google Cloud (GCP) Workload Identity Federation pool provider
 //
-// Examine which external identity provider (AWS account, OIDC issuer, SAML
-// IdP, or X.509 trust store) is allowed to mint tokens that federate into the
-// parent pool, plus the `attributeMapping` and `attributeCondition` that gate
-// which Google identities those external tokens may impersonate. Providers
-// are the trust-anchor audit unit: a permissive `attributeMapping` (mapping
+// External identity provider (AWS account, OIDC issuer, SAML IdP, or X.509
+// trust store) allowed to mint tokens that federate into a pool, plus the
+// `attributeMapping` and `attributeCondition` that gate which Google
+// identities those external tokens may impersonate. Providers are the
+// trust-anchor audit unit: a permissive `attributeMapping` (mapping
 // `google.subject` to an unfiltered external claim) or a missing
 // `attributeCondition` is the typical misconfiguration that turns federation
 // into anyone-can-impersonate-anyone. The `providerType` field is the
@@ -5929,8 +6213,8 @@ private gcp.project.iamService.workloadIdentityPool.provider @defaults("displayN
 
 // Google Cloud (GCP) Cloud Function (1st gen)
 //
-// Examine a first-generation Cloud Function deployed to a project. Covers
-// the trigger configuration (HTTP or event), runtime, service account,
+// First-generation Cloud Function deployed to a project, covering the
+// trigger configuration (HTTP or event), runtime, service account,
 // networking (VPC connector, ingress and egress settings), memory and
 // timeout limits, environment variables, secret bindings, KMS encryption
 // key, and build settings including the Artifact Registry repository and
@@ -5947,12 +6231,28 @@ private gcp.project.cloudFunction @defaults("name") {
   // Location of the archive with the function's source code
   sourceArchiveUrl string
   // Repository reference for the function's source code
+  //
+  // Present when the source is hosted in a repository. Keys: `url` (the
+  // repository URL pointing to the source), `deployedUrl` (the URL that was
+  // resolved and deployed at the last build).
   sourceRepository dict
   // Location of the upload with the function's source code
   sourceUploadUrl string
-  // HTTPS endpoint of source that can be triggered via URL
+  // HTTPS endpoint that can be triggered via URL
+  //
+  // Present for HTTP-triggered functions. Keys: `url` (the endpoint that
+  // invokes the function) and `securityLevel` (whether HTTPS is required,
+  // one of SECURITY_LEVEL_UNSPECIFIED, SECURE_ALWAYS, or SECURE_OPTIONAL).
   httpsTrigger dict
   // Source that fires events in response to a condition in another service
+  //
+  // Present for event-triggered functions. Keys: `eventType` (the event that
+  // fires the function, for example google.pubsub.topic.publish), `resource`
+  // (the resource the trigger monitors, such as a Pub/Sub topic or Storage
+  // bucket), `service` (the hostname of the emitting service), and
+  // `failurePolicy` (a nested object whose `retry` field indicates whether
+  // failed executions are retried). The `eventTriggerTopic` field resolves
+  // the Pub/Sub topic when the monitored resource is a topic.
   eventTrigger dict
   // Pub/Sub topic that fires this function's event trigger
   //
@@ -5998,8 +6298,18 @@ private gcp.project.cloudFunction @defaults("name") {
   // VPC network connector that this cloud function can connect to
   vpcConnector string
   // Egress settings for the connector controlling what traffic is diverted
+  //
+  // One of VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED, PRIVATE_RANGES_ONLY
+  // (only private IP ranges route through the connector), or ALL_TRAFFIC
+  // (all outbound traffic routes through the connector).
   egressSettings string
   // Ingress settings for the function controlling what traffic can reach
+  //
+  // Controls which callers can reach the function. One of
+  // INGRESS_SETTINGS_UNSPECIFIED, ALLOW_ALL (reachable from the public
+  // internet), ALLOW_INTERNAL_ONLY (only VPC and same-project traffic), or
+  // ALLOW_INTERNAL_AND_GCLB (internal traffic plus the external HTTP(S) load
+  // balancer).
   ingressSettings string
   // Resource name of a KMS crypto key used to encrypt/decrypt function resources
   kmsKeyName string
@@ -6012,8 +6322,19 @@ private gcp.project.cloudFunction @defaults("name") {
   // Cloud Build name of the function deployment
   buildName string
   // Secret environment variables
+  //
+  // Secret Manager secrets exposed to the function as environment variables,
+  // keyed by the environment variable name. Each value has keys: `projectId`
+  // (project holding the secret), `secret` (the secret name), and `version`
+  // (the bound secret version).
   secretEnvVars map[string]dict
   // Secret volumes
+  //
+  // Secret Manager secrets mounted into the function's filesystem. Each entry
+  // has keys: `mountPath` (directory the secret is mounted at), `projectId`
+  // (project holding the secret), `secret` (the secret name), and `versions`
+  // (a list of `{version, path}` objects mapping each mounted secret version
+  // to its relative file path under the mount).
   secretVolumes []dict
   // User-managed repository created in Artifact Registry
   //
@@ -6038,12 +6359,14 @@ private gcp.project.cloudFunction @defaults("name") {
 
 // Google Cloud (GCP) Cloud Function (v2 / 2nd gen)
 //
-// Examine a second-generation Cloud Function backed by Cloud Run. Covers
-// function state and environment generation (GEN_1, GEN_2), the deployed
-// HTTPS URL, KMS encryption key, build configuration (runtime, entry
-// point, Artifact Registry repository, worker pool), service configuration
-// (scaling limits, VPC connector, ingress settings, service account, secret
-// bindings), and the Eventarc event trigger.
+// Second-generation Cloud Function backed by Cloud Run. Covers function
+// state and environment generation (GEN_1, GEN_2), the deployed HTTPS URL,
+// KMS encryption key, build configuration (runtime, entry point, Artifact
+// Registry repository, worker pool), service configuration (scaling limits,
+// VPC connector, ingress settings, service account, secret bindings), and
+// the Eventarc event trigger. `allowsUnauthenticated` reports whether the
+// IAM policy lets allUsers or allAuthenticatedUsers invoke the function
+// without credentials.
 private gcp.project.cloudFunctionV2 @defaults("name state environment") {
   // Project ID
   projectId string
@@ -6093,7 +6416,11 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   runtime string
   // Name of the function (as defined in source code) that is executed
   entryPoint string
-  // Source location (storage or repository)
+  // Deployed source location
+  //
+  // Holds exactly one of `storageSource` (a Cloud Storage object), `repoSource`
+  // (a Cloud Source Repositories location), or `gitUri` (a Git repository URL),
+  // depending on where the function's source was fetched from for the build.
   source dict
   // Name of the Cloud Build custom worker pool to use
   buildWorkerPool string
@@ -6114,10 +6441,12 @@ private gcp.project.cloudFunctionV2.buildConfig @defaults("runtime entryPoint") 
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Cloud Build name of the latest successful deployment of this function
   build string
-  // Permanent fixed identifier for the resolved source
+  // Resolved source captured at build time
   //
-  // Carries the resolved storage source, resolved repo source, and the
-  // git_uri (with commits resolved) captured at build time.
+  // Records the exact source used for the build with dynamic references
+  // pinned. Contains `resolvedStorageSource` (Cloud Storage object with a
+  // resolved generation), `resolvedRepoSource` (repository source with the
+  // commit resolved), and `gitUri` (Git URI with commits resolved).
   sourceProvenance dict
   // Resolved Git URI of the source, if the function was built from a Git repository
   gitUri string
@@ -6156,8 +6485,18 @@ private gcp.project.cloudFunctionV2.serviceConfig @defaults("service timeoutSeco
   // Whether all traffic is routed to the latest revision
   allTrafficOnLatestRevision bool
   // Secret environment variables
+  //
+  // Each entry exposes a Secret Manager secret as an environment variable,
+  // with keys `key` (the environment variable name), `projectId` (project
+  // holding the secret), `secret` (secret name), and `version` (secret
+  // version, or "latest").
   secretEnvironmentVariables []dict
   // Secret volume mounts
+  //
+  // Each entry mounts a Secret Manager secret as files, with keys `mountPath`
+  // (directory the secret is mounted at), `projectId` (project holding the
+  // secret), `secret` (secret name), and `versions` (a list of `version` /
+  // `path` pairs mapping each secret version to a file under the mount path).
   secretVolumes []dict
 }
 
@@ -6172,6 +6511,11 @@ private gcp.project.cloudFunctionV2.eventTrigger @defaults("eventType") {
   // Event type (e.g. google.cloud.pubsub.topic.v1.messagePublished)
   eventType string
   // Event filter criteria
+  //
+  // Attribute filters that narrow which events fire the trigger. Each entry
+  // has keys `attribute` (the CloudEvent attribute to match), `value` (the
+  // required value), and `operator` (matching operator, e.g. "match-path-pattern"
+  // for path-pattern matching; empty for exact match).
   eventFilters []dict
   // Pub/Sub topic name for Pub/Sub triggers
   pubsubTopic string
@@ -6189,11 +6533,11 @@ private gcp.project.cloudFunctionV2.eventTrigger @defaults("eventType") {
 
 // Google Cloud Dataplex
 //
-// Use this resource as the entry point for Dataplex in the project. It
-// hosts the data-management hierarchy: `lakes` group data across storage
-// systems into zones, and from each lake you can drill into its zones and
-// the Cloud Storage buckets and BigQuery datasets they govern. `enabled`
-// reports whether the Dataplex API is turned on for the project.
+// Data-management hierarchy for Dataplex in the project. `lakes` group
+// data across storage systems into zones, and from each lake you can
+// reach its zones and the Cloud Storage buckets and BigQuery datasets
+// they govern. `enabled` reports whether the Dataplex API is turned on
+// for the project.
 private gcp.project.dataplexService @defaults("projectId") {
   // Project ID
   projectId string
@@ -6205,15 +6549,14 @@ private gcp.project.dataplexService @defaults("projectId") {
 
 // Google Cloud Dataplex lake
 //
-// Examine a Dataplex lake — the top-level container that organizes data
-// across storage systems into zones. Surfaces the lake's `location`,
-// lifecycle `state`, `serviceAccount` used to access managed resources,
-// the attached Dataproc Metastore service (`metastoreService`), and
-// aggregated asset counts (`activeAssets`,
-// `securityPolicyApplyingAssets`). Drill into `zones()` for the RAW and
-// CURATED zones, and from there into the buckets and datasets the lake
-// governs. Selected by its full resource name, for example
-// `projects/my-project/locations/us-central1/lakes/my-lake`.
+// Top-level container that organizes data across storage systems into
+// zones. Surfaces the lake's `location`, lifecycle `state`,
+// `serviceAccount` used to access managed resources, the attached
+// Dataproc Metastore service (`metastoreService`), and aggregated asset
+// counts (`activeAssets`, `securityPolicyApplyingAssets`). The `zones`
+// field holds the RAW and CURATED zones, and from there the buckets and
+// datasets the lake governs. Selected by its full resource name, for
+// example `projects/my-project/locations/us-central1/lakes/my-lake`.
 private gcp.project.dataplexService.lake @defaults("name state location") {
   // Full resource name of the lake
   id string
@@ -6257,13 +6600,13 @@ private gcp.project.dataplexService.lake @defaults("name state location") {
 
 // Google Cloud Dataplex zone
 //
-// Examine a zone within a Dataplex lake. A zone groups assets of a common
-// kind and exposes its `type` (RAW or CURATED), the `resourceLocationType`
-// governing where attached resources may live, the metadata-discovery
-// configuration (`discoveryEnabled`, `discoverySchedule`, and the include
-// and exclude path patterns), and lifecycle `state`. Drill into `assets()`
-// for the Cloud Storage buckets and BigQuery datasets attached to the
-// zone. Selected by its full resource name.
+// Zone within a Dataplex lake that groups assets of a common kind. Exposes
+// its `type` (RAW or CURATED), the `resourceLocationType` governing where
+// attached resources may live, the metadata-discovery configuration
+// (`discoveryEnabled`, `discoverySchedule`, and the include and exclude
+// path patterns), and lifecycle `state`. The `assets` field holds the
+// Cloud Storage buckets and BigQuery datasets attached to the zone.
+// Selected by its full resource name.
 private gcp.project.dataplexService.lake.zone @defaults("name type state") {
   // Full resource name of the zone
   id string
@@ -6312,13 +6655,12 @@ private gcp.project.dataplexService.lake.zone @defaults("name type state") {
 
 // Google Cloud Dataplex asset
 //
-// Examine an asset attached to a Dataplex zone. An asset binds an external
-// resource — a Cloud Storage bucket (`resourceType` STORAGE_BUCKET) or a
-// BigQuery dataset (BIGQUERY_DATASET) — into the zone. Surfaces the backing
-// `resourceName`, the `readAccessMode` (DIRECT or MANAGED), the state of
-// security-policy application to the resource (`securityStatusState`), the
-// metadata-discovery configuration, and lifecycle `state`. Selected by its
-// full resource name.
+// Binding of an external resource, a Cloud Storage bucket (`resourceType`
+// STORAGE_BUCKET) or a BigQuery dataset (BIGQUERY_DATASET), into a Dataplex
+// zone. Surfaces the backing `resourceName`, the `readAccessMode` (DIRECT
+// or MANAGED), the state of security-policy application to the resource
+// (`securityStatusState`), the metadata-discovery configuration, and
+// lifecycle `state`. Selected by its full resource name.
 private gcp.project.dataplexService.lake.zone.asset @defaults("name resourceType state") {
   // Full resource name of the asset
   id string
@@ -6371,10 +6713,10 @@ private gcp.project.dataplexService.lake.zone.asset @defaults("name resourceType
 
 // Google Cloud Workflows
 //
-// Use this resource as the entry point for Workflows in the project. It
-// hosts the `workflows` — serverless orchestrations that chain together
-// services and APIs — and `enabled` reports whether the Workflows API is
-// turned on for the project.
+// Serverless orchestration service for the project, chaining together
+// Google Cloud services and APIs into managed workflows. The `workflows`
+// field lists the workflow definitions across all locations, and `enabled`
+// reports whether the Workflows API is turned on for the project.
 private gcp.project.workflowsService @defaults("projectId") {
   // Project ID
   projectId string
@@ -6386,13 +6728,12 @@ private gcp.project.workflowsService @defaults("projectId") {
 
 // Google Cloud Workflows workflow
 //
-// Examine a workflow definition and its execution settings. Surfaces the
-// `state`, the `serviceAccount` identity executions run as, the
-// `sourceContents` (the workflow definition), the active `revisionId`,
-// `callLogLevel` and `executionHistoryLevel` logging settings, the
-// customer-managed encryption key (`cryptoKeyName`) and `allKmsKeys` in
-// effect, and user-defined environment variables. Selected by its full
-// resource name, for example
+// Single serverless workflow, covering its definition and execution
+// settings. Reports the lifecycle `state`, the `serviceAccount` identity
+// that executions run as, the workflow definition in `sourceContents`, the
+// call and execution-history logging levels, and the customer-managed
+// encryption keys protecting it. Selected by its full resource name, for
+// example
 // `projects/my-project/locations/us-central1/workflows/my-workflow`.
 private gcp.project.workflowsService.workflow @defaults("name state") {
   // Full resource name of the workflow
@@ -6450,11 +6791,11 @@ private gcp.project.workflowsService.workflow @defaults("name state") {
 
 // Google Cloud (GCP) Dataproc
 //
-// Use this resource as the entry point for Dataproc in the project. It
-// hosts the managed Spark and Hadoop surface: `clusters`, submitted
-// `jobs`, and the `autoscalingPolicies` that govern cluster scaling.
-// `regions` lists where Dataproc resources can be created and `enabled`
-// reports whether the service is turned on.
+// Managed Spark and Hadoop service for the project. Exposes the
+// `clusters` currently provisioned, the submitted `jobs`, and the
+// `autoscalingPolicies` that govern cluster scaling. `regions` lists
+// where Dataproc resources can be created and `enabled` reports whether
+// the service is turned on.
 private gcp.project.dataprocService {
   // Project ID
   projectId string
@@ -6472,13 +6813,15 @@ private gcp.project.dataprocService {
 
 // Google Cloud (GCP) Dataproc cluster
 //
-// Examine a Dataproc cluster's configuration and operational state. Covers
-// the cluster UUID, labels, GCE and GKE compute configurations (machine
-// types, disk settings, shielded-instance settings, service account,
-// network and subnet), lifecycle policy (idle and auto-delete TTLs),
-// software configuration, security settings, initialization actions,
-// current and historical status, and virtual-cluster configuration for
-// clusters that delegate to Kubernetes.
+// Managed Spark and Hadoop cluster's configuration and operational state
+//
+// Covers the cluster UUID, labels, GCE and GKE compute configurations
+// (machine types, disk settings, shielded-instance settings, service
+// account, network and subnet), lifecycle policy (idle and auto-delete
+// TTLs), software configuration, security settings, initialization
+// actions, current and historical status, and virtual-cluster
+// configuration for clusters that delegate to Kubernetes. This is the
+// primary surface for auditing how a cluster is exposed and hardened.
 private gcp.project.dataprocService.cluster @defaults("name") {
   // Project ID
   projectId string
@@ -6492,7 +6835,10 @@ private gcp.project.dataprocService.cluster @defaults("name") {
   config gcp.project.dataprocService.cluster.config
   // Labels associated with the cluster
   labels map[string]string
-  // Contains cluster daemon metrics such as HDF and YARN stats
+  // Cluster daemon metrics
+  //
+  // Keyed by `hdfsMetrics` and `yarnMetrics`, each a map of metric name to
+  // value reported by the cluster's HDFS and YARN daemons.
   metrics dict
   // Cluster status
   status gcp.project.dataprocService.cluster.status
@@ -6514,7 +6860,10 @@ private gcp.project.dataprocService.cluster @defaults("name") {
 private gcp.project.dataprocService.cluster.config {
   // Parent resource path
   parentResourcePath string
-  // Autoscaling configuration for the policy associated with the cluster
+  // Autoscaling configuration for the cluster
+  //
+  // Holds `policyUri`, the resource URI of the autoscaling policy bound to
+  // the cluster. See `autoscalingPolicyRef` for the resolved policy.
   autoscaling dict
   // Autoscaling policy governing cluster scaling
   autoscalingPolicyRef() gcp.project.dataprocService.autoscalingPolicy
@@ -6522,35 +6871,73 @@ private gcp.project.dataprocService.cluster.config {
   configBucket string
   // Cloud Storage staging bucket for job dependencies, config files, and job driver console output
   configBucketRef() gcp.project.storageService.bucket
-  // Dataproc metrics configuration
+  // Dataproc metrics collection configuration
+  //
+  // Holds a `metrics` array; each entry has a `metricSource` (the metrics
+  // source to enable, such as MONITORING_AGENT_DEFAULTS, HDFS, SPARK, YARN,
+  // SPARK_HISTORY_SERVER, HIVESERVER2, HIVEMETASTORE, or FLINK) and
+  // `metricOverrides`, the specific metrics collected from that source.
   metrics dict
-  // Encryption configuration
+  // Cluster encryption configuration
+  //
+  // Holds `gcePdKmsKeyName` (the Cloud KMS key encrypting cluster node
+  // persistent disks) and `kmsKey` (the key encrypting cluster resources).
+  // See `kmsKey` for the resolved Cloud KMS key resource.
   encryption dict
   // Customer-managed Cloud KMS key used to encrypt cluster node disks (and, for newer clusters, job arguments) at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
-  // Port/endpoint configuration
+  // HTTP endpoint configuration for cluster web interfaces
+  //
+  // Holds `enableHttpPortAccess` (whether the Component Gateway exposes
+  // cluster web UIs) and `httpPorts`, a map of web UI name to its URL. See
+  // `componentGatewayEnabled` for the hoisted enable flag.
   endpoint dict
-  // Whether the HTTP component gateway is enabled, exposing cluster web UIs — flat hoist of endpoint.enableHttpPortAccess
+  // Whether the HTTP Component Gateway is enabled
+  //
+  // True when the cluster exposes its web UIs (YARN, Spark, Jupyter, and
+  // others) through the Component Gateway. Hoisted from the `endpoint` dict's
+  // enableHttpPortAccess key for auditing publicly reachable cluster UIs.
   componentGatewayEnabled bool
-  // Whether Kerberos secure-mode authentication is enabled on the cluster — flat hoist of security.kerberosConfig.enableKerberos
+  // Whether Kerberos secure-mode authentication is enabled on the cluster
+  //
+  // True when the cluster runs in Hadoop Secure Mode with Kerberos
+  // authentication between daemons. Hoisted from the `security` dict's
+  // kerberosConfig.enableKerberos key.
   kerberosEnabled bool
   // Shared Compute Engine configuration
   gceCluster gcp.project.dataprocService.cluster.config.gceCluster
   // Kubernetes Engine config for Dataproc clusters deployed to Kubernetes
   gkeCluster gcp.project.dataprocService.cluster.config.gkeCluster
-  // Commands to execute on each node after config is completed
+  // Executables run on each node during cluster setup
+  //
+  // Each entry holds `executableFile` (the Cloud Storage URI of the script
+  // run on every node) and `executionTimeout` (how long the executable may
+  // run before cluster provisioning fails).
   initializationActions []dict
   // Lifecycle configuration
   lifecycle gcp.project.dataprocService.cluster.config.lifecycle
   // Compute Engine config for the cluster's master instance
   master gcp.project.dataprocService.cluster.config.instance
-  // Metastore configuration
+  // Hive metastore configuration
+  //
+  // Holds `dataprocMetastoreService`, the resource name of the Dataproc
+  // Metastore service the cluster uses as its Hive metastore.
   metastore dict
   // Compute Engine configuration for the cluster's secondary worker instances
   secondaryWorker gcp.project.dataprocService.cluster.config.instance
-  // Security configuration
+  // Cluster security configuration
+  //
+  // Holds `kerberosConfig` (Kerberos secure-mode settings including
+  // `enableKerberos`, realm, KDC, cross-realm trust, and the KMS-encrypted
+  // key and keystore URIs) and `identityConfig` (the
+  // `userServiceAccountMapping` for workforce identity federation). See
+  // `kerberosEnabled` for the hoisted Kerberos enable flag.
   security dict
   // Cluster software configuration
+  //
+  // Holds `imageVersion` (the Dataproc image version installed on the
+  // cluster) and `optionalComponents`, the optional components activated on
+  // the cluster (such as ANACONDA, JUPYTER, ZEPPELIN, ZOOKEEPER, HBASE).
   software dict
   // Cloud Storage bucket used to store ephemeral cluster and jobs data
   tempBucket string
@@ -6566,7 +6953,10 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   id string
   // Project ID
   projectId string
-  // Confidential instance configuration
+  // Confidential computing configuration
+  //
+  // Holds `enableConfidentialCompute`, whether cluster VMs run as
+  // Confidential VM instances with in-use memory encryption.
   confidentialInstance dict
   // Whether the cluster has only internal IP addresses
   internalIpOnly bool
@@ -6579,8 +6969,14 @@ private gcp.project.dataprocService.cluster.config.gceCluster {
   // Compute Engine network used for machine communications (resolved from networkUri)
   network() gcp.project.computeService.network
   // Node group affinity for sole-tenant clusters
+  //
+  // Holds `uri`, the URI of the sole-tenant node group that cluster VMs are
+  // scheduled onto.
   nodeGroupAffinity dict
-  // Type of IPv6 access for the cluster
+  // Type of private IPv6 access for the cluster
+  //
+  // One of PRIVATE_IPV6_GOOGLE_ACCESS_UNSPECIFIED, INHERIT_FROM_SUBNETWORK,
+  // OUTBOUND, or BIDIRECTIONAL.
   privateIpv6GoogleAccess string
   // Reservation affinity for consuming zonal reservations
   reservationAffinity gcp.project.dataprocService.cluster.config.gceCluster.reservationAffinity
@@ -6634,7 +7030,14 @@ private gcp.project.dataprocService.cluster.config.gkeCluster {
   id string
   // Target GKE cluster
   gkeClusterTarget string
-  // GKE node pools where workloads are scheduled
+  // GKE node pools where cluster workloads run
+  //
+  // Each entry holds `nodePool` (the target node pool name), `roles` (the
+  // roles the node pool serves: DEFAULT, CONTROLLER, SPARK_DRIVER, or
+  // SPARK_EXECUTOR), and `nodePoolConfig` with the node pool's `locations`,
+  // `autoscaling` (min and max node counts), and `config` (machine type,
+  // accelerators, boot-disk KMS key, local SSD count, and preemptible/spot
+  // flags).
   nodePoolTarget []dict
 }
 
@@ -6656,7 +7059,11 @@ private gcp.project.dataprocService.cluster.config.lifecycle {
 private gcp.project.dataprocService.cluster.config.instance {
   // Internal ID for this resource
   id string
-  // Compute Engine accelerators
+  // Compute Engine accelerators (GPUs) attached to the instances
+  //
+  // Each entry holds `acceleratorCount` (number of accelerator cards
+  // exposed to each instance) and `acceleratorTypeUri` (the accelerator
+  // type resource URI, such as nvidia-tesla-t4).
   accelerators []dict
   // Disk options
   diskConfig gcp.project.dataprocService.cluster.config.instance.diskConfig
@@ -6664,19 +7071,28 @@ private gcp.project.dataprocService.cluster.config.instance {
   imageUri string
   // List of instance names
   instanceNames []string
-  // List of references to Compute Engine instances
+  // References to the Compute Engine instances in the group
+  //
+  // Each entry holds `instanceName`, `instanceId`, and the instance's
+  // `publicKey` and `publicEciesKey` used to encrypt data for that VM.
   instanceReferences []dict
   // Whether the instance group contains preemptible instances
   isPreemptible bool
   // Compute Engine machine type used for cluster instances
   machineTypeUri string
-  // Config for Compute Engine Instance Group Manager that manages this group
+  // Compute Engine managed instance group backing this instance group
+  //
+  // Holds `instanceGroupManagerName` and `instanceTemplateName`, the names
+  // of the managed instance group and instance template Dataproc created
+  // for the group.
   managedGroupConfig dict
   // Minimum CPU platform for the instance group
   minCpuPlatform string
   // Number of VM instances in the instance group
   numInstances int
-  // The preemptibility of the instance group
+  // Preemptibility of the instance group
+  //
+  // One of PREEMPTIBILITY_UNSPECIFIED, NON_PREEMPTIBLE, PREEMPTIBLE, or SPOT.
   preemptibility string
 }
 
@@ -6712,9 +7128,17 @@ private gcp.project.dataprocService.cluster.status @defaults("state") {
 private gcp.project.dataprocService.cluster.virtualClusterConfig {
   // Parent resource path
   parentResourcePath string
-  // Auxiliary services configuration
+  // Auxiliary services attached to the virtual cluster
+  //
+  // Holds `metastoreConfig` (with `dataprocMetastoreService`, the Dataproc
+  // Metastore the cluster uses) and `sparkHistoryServerConfig` (with
+  // `dataprocCluster`, the cluster hosting the Spark History Server).
   auxiliaryServices dict
-  // Kubernetes cluster configuration
+  // Kubernetes cluster the virtual cluster runs on
+  //
+  // Holds `kubernetesNamespace` and `gkeClusterConfig`, which names the
+  // `targetCluster`, its `namespacedGkeDeploymentTarget`, and the
+  // `nodePoolTarget` node pools that back the workloads.
   kubernetesCluster dict
   // Cloud Storage bucket used to stage job dependencies, config files, and job driver console output
   stagingBucket string
@@ -6722,10 +7146,12 @@ private gcp.project.dataprocService.cluster.virtualClusterConfig {
 
 // Google Cloud (GCP) Dataproc job
 //
-// Examine a Dataproc job submitted to a cluster. Covers the job UUID,
-// status (PENDING, RUNNING, DONE, ERROR, CANCELLED), job type (hadoop,
-// spark, pyspark, hive, pig, presto, sparkR, sparkSql, flink), the
-// target cluster, user-defined labels, and the driver output resource URI.
+// Dataproc job submitted to a cluster
+//
+// Covers the job UUID, status (PENDING, RUNNING, DONE, ERROR, CANCELLED),
+// job type (hadoop, spark, pyspark, hive, pig, presto, sparkR, sparkSql,
+// flink), the target cluster, user-defined labels, and the driver output
+// resource URI.
 private gcp.project.dataprocService.job @defaults("name status") {
   // Project ID
   projectId string
@@ -6768,30 +7194,46 @@ private gcp.project.dataprocService.job @defaults("name status") {
 
 // Google Cloud (GCP) Dataproc autoscaling policy
 //
-// Examine a Dataproc autoscaling policy that governs cluster scaling.
-// Covers the worker and secondary-worker scale-up/scale-down configurations
-// and the basic autoscaling algorithm settings (cooldown period, scale-up
-// and scale-down factors, minimum and maximum worker counts).
+// Dataproc autoscaling policy that governs cluster scaling
+//
+// Covers the worker and secondary-worker scale-up/scale-down
+// configurations and the basic autoscaling algorithm settings (cooldown
+// period, scale-up and scale-down factors, minimum and maximum worker
+// counts).
 private gcp.project.dataprocService.autoscalingPolicy @defaults("name") {
   // Project ID
   projectId string
   // Full resource name
   name string
-  // Worker configuration
+  // Primary worker autoscaling bounds
+  //
+  // Holds `minInstances` and `maxInstances` (the worker count bounds the
+  // autoscaler stays within) and `weight` (this group's share of total
+  // workers relative to other groups).
   workerConfig dict
-  // Secondary worker configuration
+  // Secondary (preemptible) worker autoscaling bounds
+  //
+  // Holds `minInstances` and `maxInstances` (the secondary-worker count
+  // bounds the autoscaler stays within) and `weight` (this group's share of
+  // total workers relative to other groups).
   secondaryWorkerConfig dict
   // Basic autoscaling algorithm configuration
+  //
+  // Holds `cooldownPeriod` (minimum duration between scaling events) and
+  // `yarnConfig`, whose `scaleUpFactor`, `scaleDownFactor`,
+  // `scaleUpMinWorkerFraction`, `scaleDownMinWorkerFraction`, and
+  // `gracefulDecommissionTimeout` control how aggressively YARN-based
+  // clusters add and remove workers. `sparkStandaloneConfig` carries the
+  // equivalent settings for Spark Standalone clusters.
   basicAlgorithm dict
 }
 
 // Google Cloud (GCP) Cloud Run
 //
-// Use this resource as the entry point for Cloud Run in the project. It
-// hosts the deployed `services` and `jobs` — each exposing its container
-// image, revision configuration, ingress and IAM settings, and execution
-// environment — along with the `operations` history and the `regions`
-// where Cloud Run resources can run.
+// Cloud Run entry point for the project, hosting the deployed `services`
+// and `jobs`. Each exposes its container image, revision configuration,
+// ingress and IAM settings, and execution environment, alongside the
+// `operations` history and the `regions` where Cloud Run resources can run.
 private gcp.project.cloudRunService {
   // Project ID
   projectId string
@@ -6807,9 +7249,9 @@ private gcp.project.cloudRunService {
 
 // Google Cloud (GCP) Cloud Run long-running operation
 //
-// Examine the status of a Cloud Run long-running operation. Covers the
-// operation name and its completion state. Useful for auditing in-progress
-// or recently completed deployments and configuration changes.
+// Status of a Cloud Run long-running operation, covering the operation
+// name and its completion state. Useful for auditing in-progress or
+// recently completed deployments and configuration changes.
 private gcp.project.cloudRunService.operation @defaults("name") {
   // Project ID
   projectId string
@@ -6821,8 +7263,8 @@ private gcp.project.cloudRunService.operation @defaults("name") {
 
 // Google Cloud (GCP) Cloud Run service
 //
-// Examine a Cloud Run service's configuration and security posture.
-// Covers ingress settings, IAM policy, binary authorization configuration,
+// Configuration and security posture of a Cloud Run service, covering
+// ingress settings, IAM policy, binary authorization configuration,
 // the revision template (container images, scaling limits, VPC access,
 // service account, secret bindings, encryption key), traffic distribution
 // across revisions, terminal and sub-resource conditions, and whether the
@@ -6863,7 +7305,13 @@ private gcp.project.cloudRunService.service @defaults("name") {
   launchStage string
   // Template used to create revisions for the service
   template gcp.project.cloudRunService.service.revisionTemplate
-  // Specifies how to distribute traffic over a collection of revisions belonging to the service
+  // Traffic distribution across revisions
+  //
+  // Each entry exposes `type` (the traffic target type, e.g.
+  // TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST or
+  // TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION), `revision` (the target
+  // revision name), `percent` (the share of traffic sent to it), and `tag`
+  // (the traffic-split tag, if any).
   traffic []dict
   // Generation of this service currently serving traffic
   observedGeneration int
@@ -6875,7 +7323,10 @@ private gcp.project.cloudRunService.service @defaults("name") {
   latestReadyRevision string
   // Name of the last created revision
   latestCreatedRevision string
-  // Detailed status information for corresponding traffic targets
+  // Observed traffic distribution across revisions
+  //
+  // Each entry exposes `type`, `revision`, `percent`, and `tag` (matching
+  // the `traffic` targets) plus `uri`, the URL serving that traffic split.
   trafficStatuses []dict
   // Main URI in which this service is serving traffic
   uri string
@@ -6934,7 +7385,11 @@ private gcp.project.cloudRunService.service.revisionTemplate @defaults("name") {
   labels map[string]string
   // Unstructured key-value map that may be set by external tools to store an arbitrary metadata
   annotations map[string]string
-  // Scaling settings
+  // Instance scaling settings
+  //
+  // Exposes `minInstanceCount` and `maxInstanceCount`, the lower and upper
+  // bounds on the number of container instances Cloud Run runs for this
+  // revision.
   scaling dict
   // Raw VPC access dict
   //
@@ -6980,12 +7435,29 @@ private gcp.project.cloudRunService.container @defaults("name image") {
   // Arguments to the entrypoint
   args []string
   // Environment variables
+  //
+  // Each entry exposes `name`, `value` (the literal value, empty when the
+  // variable is sourced from a secret), and `valueSource`, which for a
+  // secret-backed variable carries `secretKeyRef` with the secret `secret`
+  // name and `version`. Inspect `valueSource` to audit which variables pull
+  // from Secret Manager.
   env []dict
-  // Compute resource requirements by the container
+  // Compute resource requirements
+  //
+  // Exposes `limits`, a map of resource names to quantities (for example
+  // `cpu` and `memory`), and `cpuIdle`, whether CPU is throttled to near
+  // zero outside of request processing.
   resources dict
-  // List of ports to expose from the container
+  // Ports exposed from the container
+  //
+  // Each entry exposes `name` (the port name, e.g. http1 or h2c) and
+  // `containerPort` (the port number the container listens on).
   ports []dict
-  // Volumes to mount into the container's file system
+  // Volumes mounted into the container's file system
+  //
+  // Each entry exposes `name` (the volume name, matching a volume declared
+  // on the revision) and `mountPath` (the path within the container where
+  // the volume is mounted).
   volumeMounts []dict
   // Container's working directory
   workingDir string
@@ -7008,22 +7480,28 @@ private gcp.project.cloudRunService.container.probe {
   // Minimum consecutive successes for the probe to be considered failed
   failureThreshold int
   // HTTP GET probe configuration
+  //
+  // Exposes `path` (the request path to probe) and `httpHeaders`, a list of
+  // `{name, value}` headers sent with each probe request. Empty when the
+  // probe is not an HTTP GET.
   httpGet dict
   // TCP socket probe configuration
+  //
+  // Exposes `port`, the TCP port the probe connects to. Empty when the
+  // probe is not a TCP socket check.
   tcpSocket dict
 }
 
 // Google Cloud (GCP) Cloud Run VPC access configuration
 //
-// Examine how a Cloud Run revision or job task reaches private
-// networks. Surfaces the Serverless VPC `connector` (when traffic
-// flows through a connector), the direct-VPC `networkInterfaces`
-// (when the task is attached to a VPC subnet), and the `egress`
-// policy that decides which outbound traffic is sent through the
-// VPC: `PRIVATE_RANGES_ONLY` keeps RFC1918 traffic on the VPC and
-// sends public-IP traffic over the default internet path, while
-// `ALL_TRAFFIC` forces every egress packet through the VPC — the
-// stronger control for data-exfiltration audits.
+// How a Cloud Run revision or job task reaches private networks.
+// Surfaces the Serverless VPC `connector` (when traffic flows through
+// a connector), the direct-VPC `networkInterfaces` (when the task is
+// attached to a VPC subnet), and the `egress` policy that decides which
+// outbound traffic is sent through the VPC: `PRIVATE_RANGES_ONLY` keeps
+// RFC1918 traffic on the VPC and sends public-IP traffic over the default
+// internet path, while `ALL_TRAFFIC` forces every egress packet through
+// the VPC (the stronger control for data-exfiltration audits).
 private gcp.project.cloudRunService.vpcAccessConfig @defaults("connector egress") {
   // Serverless VPC Access connector (full resource name `projects/{p}/locations/{l}/connectors/{c}`); empty when direct-VPC `networkInterfaces` is used
   connector string
@@ -7055,7 +7533,7 @@ private gcp.project.cloudRunService.condition @defaults("type state message") {
 
 // Google Cloud (GCP) Cloud Run job
 //
-// Examine a Cloud Run job and its execution configuration. Covers labels,
+// Cloud Run job and its execution configuration, covering labels,
 // annotations, launch stage, the execution template (container images,
 // parallelism, task count, VPC access, service account, secret bindings,
 // encryption key, retry limit), terminal and sub-resource conditions,
@@ -7173,18 +7651,22 @@ private gcp.project.cloudRunService.job.executionTemplate.taskTemplate {
 
 // Google Cloud (GCP) Access Approval settings
 //
-// Examine the Access Approval configuration for a project, folder, or
-// organization. Covers enrolled Google Cloud services, notification email
-// addresses for approval requests, the active asymmetric KMS key version
-// used to sign approvals, and whether an ancestor resource has enrolled
-// or configured a key — enabling audits of which services require explicit
-// human approval before Google personnel can access customer resources.
+// Access Approval configuration for a project, folder, or organization,
+// covering enrolled Google Cloud services, notification email addresses
+// for approval requests, the active asymmetric KMS key version used to
+// sign approvals, and whether an ancestor resource has enrolled or
+// configured a key. Audit which services require explicit human approval
+// before Google personnel can access customer resources.
 private gcp.accessApprovalSettings {
   // Resource path
   resourcePath string
   // List of email addresses to which notifications relating to approval requests should be sent
   notificationEmails []string
-  // List of Google Cloud services for which the given resource has access approval enrolled
+  // Google Cloud services enrolled for Access Approval
+  //
+  // Each entry has `cloudProduct` (the enrolled service, either "all" or a
+  // specific API name such as "compute.googleapis.com") and `enrollmentLevel`
+  // (one of ENROLLMENT_LEVEL_UNSPECIFIED or BLOCK_ALL).
   enrolledServices []dict
   // Whether at least one service is enrolled for access approval in an ancestor
   //
@@ -7200,10 +7682,11 @@ private gcp.accessApprovalSettings {
 
 // Google Cloud (GCP) Cloud Monitoring
 //
-// Use this resource as the entry point for Cloud Monitoring in the
-// project. It hosts the observability surface: `alertPolicies`,
-// `uptimeCheckConfigs`, `notificationChannels`, resource `groups`,
-// `dashboards`, and the monitored `services` used for SLO tracking.
+// Cloud Monitoring observability surface for the project, covering alert
+// policies, uptime check configurations, notification channels, resource
+// groups, dashboards, and the monitored services used for SLO tracking.
+// Query it to audit alerting coverage, uptime probes, and how operators
+// are notified when incidents open.
 private gcp.project.monitoringService {
   // Project ID
   projectId string
@@ -7223,13 +7706,12 @@ private gcp.project.monitoringService {
 
 // Google Cloud (GCP) Cloud Monitoring alert policy
 //
-// Examine a Cloud Monitoring alert policy that defines when incidents are
-// opened. Covers the condition set (metric thresholds, log-based metrics,
-// uptime failures) and how they are combined (AND / OR), notification
-// channels that receive alerts, documentation attached to notifications,
-// the alerting strategy (auto-close duration, notification rate limiting),
-// whether the policy is enabled, and validity errors that prevent
-// evaluation.
+// Alert policy that defines when incidents are opened. Covers the
+// condition set (metric thresholds, log-based metrics, uptime failures)
+// and how they are combined (AND / OR), notification channels that receive
+// alerts, documentation attached to notifications, the alerting strategy
+// (auto-close duration, notification rate limiting), whether the policy is
+// enabled, and validity errors that prevent evaluation.
 private gcp.project.monitoringService.alertPolicy {
   // Project ID
   projectId string
@@ -7237,17 +7719,34 @@ private gcp.project.monitoringService.alertPolicy {
   name string
   // Display name
   displayName string
-  // Documentation included with notifications and incidents related to this policy
+  // Documentation included with notifications and incidents
+  //
+  // Keys: `content` (the documentation text) and `mimeType` (its format,
+  // typically `text/markdown`).
   documentation dict
   // User-defined labels
   labels map[string]string
   // List of conditions for the policy
+  //
+  // Each condition has `name`, `displayName`, and one populated
+  // condition-type key (the others null): `threshold` (metric threshold:
+  // `filter`, `denominatorFilter`, `comparison`, `thresholdValue`,
+  // `duration`, `evaluationMissingData`), `absent` (`filter`, `duration`),
+  // `matchedLog` (`filter`, `labelExtractors`), or
+  // `monitoringQueryLanguage` (`query`, `duration`,
+  // `evaluationMissingData`).
   conditions []dict
-  // How to combine the results of multiple conditions to determine if an incident should be opened
+  // Condition combiner
+  //
+  // How the results of multiple conditions combine to open an incident. One
+  // of AND, OR, or AND_WITH_MATCHING_RESOURCE.
   combiner string
   // Whether the policy is enabled
   enabled bool
   // Description of how the alert policy is invalid
+  //
+  // Keys: `code` (a numeric status code) and `message` (a human-readable
+  // explanation of the validity problem).
   validity dict
   // Notification channel URLs to which notifications should be sent when incidents are opened or closed
   notificationChannelUrls []string
@@ -7261,18 +7760,21 @@ private gcp.project.monitoringService.alertPolicy {
   updated time
   // Email address of the user who last updated the alert policy
   updatedBy string
-  // Configuration for notification channels notifications
+  // Notification strategy configuration
+  //
+  // Keys: `notificationRateLimit` (an object with `period`, the minimum
+  // seconds between repeat notifications) and `autoClose` (seconds without
+  // data after which an incident is automatically closed).
   alertStrategy dict
 }
 
 // Google Cloud (GCP) Cloud Monitoring uptime check configuration
 //
-// Examine a Cloud Monitoring uptime check that probes an endpoint for
-// availability. Covers the check type (HTTP or TCP), target (monitored
-// resource or resource group), check period and timeout, checker type
-// (STATIC_IP_CHECKERS or VPC_CHECKERS), selected geographic regions,
-// content matchers for response validation, and whether the check is
-// currently disabled.
+// Uptime check that probes an endpoint for availability. Covers the check
+// type (HTTP or TCP), target (monitored resource or resource group), check
+// period and timeout, checker type (STATIC_IP_CHECKERS or VPC_CHECKERS),
+// selected geographic regions, content matchers for response validation,
+// and whether the check is currently disabled.
 private gcp.project.monitoringService.uptimeCheckConfig @defaults("displayName disabled checkerType") {
   // Full resource name
   name string
@@ -7289,14 +7791,33 @@ private gcp.project.monitoringService.uptimeCheckConfig @defaults("displayName d
   // Regions from which the check is run
   selectedRegions []string
   // HTTP check configuration
+  //
+  // Present for HTTP/HTTPS checks. Keys include `requestMethod`, `path`,
+  // `port`, `useSsl`, `validateSsl`, `contentType`, `headers`, `body`, and
+  // `acceptedResponseStatusCodes`.
   httpCheck dict
   // TCP check configuration
+  //
+  // Present for TCP checks. Key: `port`, the target port probed.
   tcpCheck dict
   // Content matchers for response validation
+  //
+  // Each matcher has `content` (the string or pattern to look for) and
+  // `matcher` (how it is applied: CONTAINS_STRING, NOT_CONTAINS_STRING,
+  // MATCHES_REGEX, NOT_MATCHES_REGEX, MATCHES_JSON_PATH, or
+  // NOT_MATCHES_JSON_PATH).
   contentMatchers []dict
   // Monitored resource
+  //
+  // The single resource being checked. Keys: `type` (the monitored
+  // resource type, e.g. `uptime_url` or `gce_instance`) and `labels`
+  // (type-specific label values such as `host` or `project_id`).
   monitoredResource dict
   // Resource group
+  //
+  // The group of resources checked, as an alternative to a single monitored
+  // resource. Keys: `groupId` (the group identifier) and `resourceType`
+  // (RESOURCE_TYPE_UNSPECIFIED, INSTANCE, or AWS_ELB_LOAD_BALANCER).
   resourceGroup dict
   // User-defined labels
   userLabels map[string]string
@@ -7304,11 +7825,11 @@ private gcp.project.monitoringService.uptimeCheckConfig @defaults("displayName d
 
 // Google Cloud (GCP) Cloud Monitoring notification channel
 //
-// Examine a Cloud Monitoring notification channel that receives alert
-// notifications. Covers the channel type (email, sms, slack, pagerduty,
-// webhook_tokenauth, and others), configuration labels (such as
-// email_address or channel_name), verification status (UNVERIFIED or
-// VERIFIED), and whether the channel is currently enabled.
+// Notification channel that receives alert notifications. Covers the
+// channel type (email, sms, slack, pagerduty, webhook_tokenauth, and
+// others), configuration labels (such as email_address or channel_name),
+// verification status (UNVERIFIED or VERIFIED), and whether the channel is
+// currently enabled.
 private gcp.project.monitoringService.notificationChannel @defaults("displayName type") {
   // Full resource name
   name string
@@ -7332,10 +7853,10 @@ private gcp.project.monitoringService.notificationChannel @defaults("displayName
 
 // Google Cloud (GCP) Cloud Monitoring resource group
 //
-// Examine a Cloud Monitoring resource group that organizes monitored
-// resources by a filter expression. Covers the group's display name,
-// parent group (for nested hierarchies), the filter that determines
-// membership, and whether the group is a cluster group.
+// Resource group that organizes monitored resources by a filter
+// expression. Covers the group's display name, parent group (for nested
+// hierarchies), the filter that determines membership, and whether the
+// group is a cluster group.
 private gcp.project.monitoringService.group @defaults("displayName") {
   // Full resource name
   name string
@@ -7351,10 +7872,10 @@ private gcp.project.monitoringService.group @defaults("displayName") {
 
 // Google Cloud (GCP) Cloud Monitoring dashboard
 //
-// Examine a Cloud Monitoring dashboard that visualizes metrics and data.
-// Covers the dashboard display name, ETag for concurrency control, and
-// the layout configuration (grid, mosaic, row, or column layout) that
-// defines how charts and widgets are arranged.
+// Dashboard that visualizes metrics and data. Covers the dashboard display
+// name, ETag for concurrency control, and the layout configuration (grid,
+// mosaic, row, or column layout) that defines how charts and widgets are
+// arranged.
 private gcp.project.monitoringService.dashboard @defaults("name displayName") {
   // Project ID
   projectId string
@@ -7364,17 +7885,21 @@ private gcp.project.monitoringService.dashboard @defaults("name displayName") {
   displayName string
   // Etag for concurrency control
   etag string
-  // Dashboard layout configuration (grid, mosaic, row, or column layout)
+  // Dashboard layout configuration
+  //
+  // Holds exactly one layout key (`gridLayout`, `mosaicLayout`,
+  // `rowLayout`, or `columnLayout`) describing how charts and widgets are
+  // arranged.
   layout dict
 }
 
 // Google Cloud (GCP) Cloud Monitoring service (for SLO tracking)
 //
-// Examine a Cloud Monitoring service used to define and track service
-// level objectives. Covers the service display name, telemetry
-// configuration, user-defined labels, and the service's SLOs — each
-// expressing a target (goal), measurement window (rolling period or
-// calendar period), and the service level indicator definition.
+// Service used to define and track service level objectives. Covers the
+// service display name, telemetry configuration, user-defined labels, and
+// the service's SLOs, each expressing a target (goal), measurement window
+// (rolling period or calendar period), and the service level indicator
+// definition.
 private gcp.project.monitoringService.service @defaults("name displayName") {
   // Project ID
   projectId string
@@ -7383,6 +7908,9 @@ private gcp.project.monitoringService.service @defaults("name displayName") {
   // Display name
   displayName string
   // Telemetry configuration
+  //
+  // Key: `resourceName`, the full name of the underlying monitored resource
+  // that provides telemetry for this service.
   telemetry dict
   // User-defined labels
   userLabels map[string]string
@@ -7392,11 +7920,11 @@ private gcp.project.monitoringService.service @defaults("name displayName") {
 
 // Google Cloud (GCP) Cloud Monitoring service level objective (SLO)
 //
-// Examine a service level objective defined for a Cloud Monitoring service.
-// Covers the SLO target (goal between 0 and 0.9999), the service level
-// indicator definition, the measurement window (rolling period in seconds
-// or a calendar period such as DAY, WEEK, or MONTH), and user-defined
-// labels for organizing SLOs.
+// Service level objective defined for a Cloud Monitoring service. Covers
+// the SLO target (goal between 0 and 0.9999), the service level indicator
+// definition, the measurement window (rolling period in seconds or a
+// calendar period such as DAY, WEEK, or MONTH), and user-defined labels
+// for organizing SLOs.
 private gcp.project.monitoringService.service.slo @defaults("name displayName goal") {
   // Project ID
   projectId string
@@ -7407,6 +7935,10 @@ private gcp.project.monitoringService.service.slo @defaults("name displayName go
   // SLO target (0 < goal <= 0.9999)
   goal float
   // Service level indicator definition
+  //
+  // Holds one indicator type: `basicSli` (availability or latency of a
+  // Google-defined service), `requestBased` (good/total request ratio or
+  // distribution cut), or `windowsBased` (good/bad time windows).
   serviceLevelIndicator dict
   // Rolling time period (e.g. "86400s" for 1 day)
   rollingPeriod string
@@ -7418,11 +7950,10 @@ private gcp.project.monitoringService.service.slo @defaults("name displayName go
 
 // Google Cloud (GCP) Binary Authorization
 //
-// Use this resource as the entry point for Binary Authorization in the
-// project. It hosts the project's deployment `policy` — covering default
-// and per-cluster admission rules, allowlist patterns, and global policy
-// evaluation mode — and the list of trusted `attestors` whose signatures
-// validate container images before deployment.
+// Binary Authorization deployment controls for the project. The `policy`
+// covers default and per-cluster admission rules, allowlist patterns, and
+// the global policy evaluation mode, while `attestors` lists the trusted
+// signers whose signatures validate container images before deployment.
 private gcp.project.binaryAuthorizationControl {
   // The policy for container image binary authorization
   policy gcp.project.binaryAuthorizationControl.policy
@@ -7432,16 +7963,18 @@ private gcp.project.binaryAuthorizationControl {
 
 // Google Cloud (GCP) Binary Authorization policy
 //
-// Examine the Binary Authorization policy that controls which container
-// images may be deployed in the project. Covers the default admission
-// rule (evaluation mode and enforcement mode), per-cluster admission
-// rules, per-Kubernetes-namespace and per-service-account rules,
+// Binary Authorization policy controlling which container images may be
+// deployed in the project. Covers the default admission rule (evaluation
+// mode and enforcement mode), per-cluster admission rules,
+// per-Kubernetes-namespace and per-service-account rules,
 // per-Istio-service-identity rules, admission allowlist patterns, and
 // whether a Google-maintained global policy is also evaluated.
 private gcp.project.binaryAuthorizationControl.policy {
   // The resource name
   name string
-  // Controls the evaluation of a Google-maintained global admission policy for common system-level images
+  // Whether a Google-maintained global admission policy for common system-level images is also evaluated
+  //
+  // One of ENABLE, DISABLE, or GLOBAL_POLICY_EVALUATION_MODE_UNSPECIFIED.
   globalPolicyEvaluationMode string
   // Admission policy allowlisting
   admissionWhitelistPatterns []string
@@ -7460,10 +7993,21 @@ private gcp.project.binaryAuthorizationControl.policy {
 }
 
 // Google Cloud (GCP) Binary Authorization admission rule
+//
+// Admission rule deciding whether a container image may be deployed.
+// The `evaluationMode` selects the check to apply (always allow, always
+// deny, or require attestation) and `enforcementMode` selects what
+// happens on a violation (block the deployment or only log it in
+// dry-run). When attestation is required, `requireAttestationsBy` names
+// the attestors whose signatures must be present.
 private gcp.project.binaryAuthorizationControl.admissionRule {
   // How this admission rule will be evaluated
+  //
+  // One of ALWAYS_ALLOW, REQUIRE_ATTESTATION, ALWAYS_DENY, or EVALUATION_MODE_UNSPECIFIED.
   evaluationMode string
-  // The action when a pod creation is denied by the admission rule
+  // Action taken when the admission rule denies a pod creation
+  //
+  // One of ENFORCED_BLOCK_AND_AUDIT_LOG, DRYRUN_AUDIT_LOG_ONLY, or ENFORCEMENT_MODE_UNSPECIFIED.
   enforcementMode string
   // The resource names of the attestors that must attest to a container image
   requireAttestationsBy []string
@@ -7471,8 +8015,8 @@ private gcp.project.binaryAuthorizationControl.admissionRule {
 
 // Google Cloud (GCP) Binary Authorization attestor
 //
-// Examine a Binary Authorization attestor trusted to verify container
-// image signatures. Covers the backing Grafeas Attestation Authority note,
+// Binary Authorization attestor trusted to verify container image
+// signatures. Covers the backing Grafeas Attestation Authority note,
 // the set of trusted public keys (PGP or PKIX) whose signatures satisfy
 // attestation requirements, the delegation service account email used to
 // query Container Analysis, and the last-updated timestamp. Audits look
@@ -7502,11 +8046,11 @@ private gcp.project.binaryAuthorizationControl.attestor @defaults("name") {
 
 // Google Cloud (GCP) Binary Authorization attestor public key
 //
-// Examine a public key trusted to verify signed attestations for the parent
-// attestor. The discriminator is `type`: `pgp` indicates an ASCII-armored
-// OpenPGP public key (`asciiArmoredPgpPublicKey`); `pkix` indicates a
-// PEM-encoded PKIX `SubjectPublicKeyInfo` (`pkixPublicKeyPem`) with a
-// `pkixSignatureAlgorithm` constraining the signature scheme. Audits look
+// Public key trusted to verify signed attestations for a Binary
+// Authorization attestor. The discriminator is `type`: `pgp` indicates an
+// ASCII-armored OpenPGP public key (`asciiArmoredPgpPublicKey`); `pkix`
+// indicates a PEM-encoded PKIX `SubjectPublicKeyInfo` (`pkixPublicKeyPem`)
+// with a `pkixSignatureAlgorithm` constraining the signature scheme. Audits look
 // for keys with weak algorithms (`RSA_SIGN_PKCS1_2048_SHA256` and friends),
 // missing signature algorithms (`SIGNATURE_ALGORITHM_UNSPECIFIED`), or PGP
 // keys where PKIX would be stronger.
@@ -7529,10 +8073,9 @@ private gcp.project.binaryAuthorizationControl.attestor.publicKey @defaults("id 
 
 // Google Cloud (GCP) Secret Manager
 //
-// Use this resource as the entry point for Secret Manager in the project.
-// It hosts the project's `secrets` — each exposing its replication policy,
-// rotation schedule, expiration, version state, and IAM policy for
-// secret-management audits.
+// Secret Manager service for the project, the entry point to the project's
+// `secrets`. Each secret exposes its replication policy, rotation schedule,
+// expiration, version state, and IAM policy for secret-management audits.
 private gcp.project.secretmanagerService {
   // Project ID
   projectId string
@@ -7542,12 +8085,11 @@ private gcp.project.secretmanagerService {
 
 // Google Cloud (GCP) Secret Manager secret
 //
-// Examine a Secret Manager secret and its security configuration. Covers
-// the replication policy (automatic or user-managed with specific regions),
-// customer-managed KMS encryption keys, rotation policy and whether
-// rotation is configured, expiration time, Pub/Sub notification topics,
-// version destroy TTL, IAM policy, and whether the secret's IAM policy
-// grants access to allUsers or allAuthenticatedUsers.
+// Secret Manager secret and its security configuration, including the
+// replication policy (automatic or user-managed with specific regions),
+// customer-managed KMS encryption keys, rotation policy, expiration, and
+// version state. The IAM policy and the derived `public` predicate report
+// whether the secret grants access to allUsers or allAuthenticatedUsers.
 private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   // Project ID
   projectId string
@@ -7560,6 +8102,12 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   // User-assigned labels
   labels map[string]string
   // Replication policy configuration
+  //
+  // Keys: `type` (AUTOMATIC or USER_MANAGED); `customerManagedEncryption`,
+  // the KMS key name protecting an automatically replicated secret; and
+  // `replicas`, a list of `{location, customerManagedEncryption}` entries
+  // for user-managed replication. The `replicationType` field exposes the
+  // `type` value directly.
   replication dict
   // Replication policy kind (AUTOMATIC for Google-selected locations, USER_MANAGED for explicitly chosen replica locations)
   replicationType string
@@ -7577,6 +8125,12 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
   // Etag of the secret
   etag string
   // Rotation policy configuration
+  //
+  // Keys: `rotationPeriod`, the interval between rotations as a duration;
+  // and `nextRotationTime`, the timestamp of the next scheduled rotation
+  // notification. Both are also exposed directly as the `rotationPeriod`
+  // and `nextRotationTime` fields, and `rotationEnabled` reports whether
+  // either is set.
   rotation dict
   // Frequency at which Secret Manager rotates the secret, as a duration (empty when no rotation policy is configured)
   rotationPeriod string
@@ -7616,11 +8170,11 @@ private gcp.project.secretmanagerService.secret @defaults("name createTime") {
 
 // Google Cloud (GCP) Secret Manager secret version
 //
-// Examine an individual version of a Secret Manager secret. Covers the
-// version state (ENABLED, DISABLED, or DESTROYED), creation and
-// destruction timestamps, customer-managed encryption status, scheduled
-// destroy time for versions pending deletion, and whether the client
-// provided a payload checksum when the version was created.
+// Individual version of a Secret Manager secret, including its state
+// (ENABLED, DISABLED, or DESTROYED), creation and destruction timestamps,
+// customer-managed encryption status, the scheduled destroy time for
+// versions pending deletion, and whether the client provided a payload
+// checksum when the version was created.
 private gcp.project.secretmanagerService.secret.version @defaults("name state") {
   // Full resource path (projects/*/secrets/*/versions/*)
   resourcePath string
@@ -7639,15 +8193,20 @@ private gcp.project.secretmanagerService.secret.version @defaults("name state") 
   // Scheduled destroy time (for delayed destruction)
   scheduledDestroyTime time
   // Customer-managed encryption status
+  //
+  // Single key `kmsKeyVersionName`: the resource name of the Cloud KMS key
+  // version used to encrypt this secret version. Empty when the version is
+  // Google-managed.
   customerManagedEncryption dict
 }
 
 // Google Cloud (GCP) Firestore
 //
-// Use this resource as the entry point for Firestore in the project. It
-// hosts the project's `databases` — each exposing its database type
+// Firestore document database service for the project. The `databases`
+// field lists every Firestore database, each exposing its database type
 // (Native or Datastore mode), location, concurrency mode, point-in-time
-// recovery setting, and delete-protection state.
+// recovery setting, and delete-protection state, so you can audit how the
+// project's document data is stored and protected.
 private gcp.project.firestoreService {
   // Project ID
   projectId string
@@ -7657,12 +8216,12 @@ private gcp.project.firestoreService {
 
 // Google Cloud (GCP) Firestore database
 //
-// Examine a Firestore database's configuration and protection settings.
-// Covers the database type (FIRESTORE_NATIVE or DATASTORE_MODE), location,
-// concurrency mode, App Engine integration mode, point-in-time recovery
-// enablement, delete-protection state, customer-managed KMS encryption
-// configuration, version retention period, the earliest recoverable
-// timestamp, resource manager tags, indexes, and backup schedules.
+// Single Firestore database and its protection settings, covering the
+// database type (FIRESTORE_NATIVE or DATASTORE_MODE), concurrency mode,
+// point-in-time recovery enablement, delete-protection state, and
+// customer-managed KMS encryption. Also exposes the database's indexes and
+// backup schedules, so you can confirm recovery, encryption, and deletion
+// safeguards are in place.
 private gcp.project.firestoreService.database @defaults("name") {
   // Project ID
   projectId string
@@ -7678,13 +8237,21 @@ private gcp.project.firestoreService.database @defaults("name") {
   concurrencyMode string
   // App Engine integration mode
   appEngineIntegrationMode string
-  // Whether point-in-time recovery is enabled
+  // Point-in-time recovery enablement state
+  //
+  // One of POINT_IN_TIME_RECOVERY_ENABLED or
+  // POINT_IN_TIME_RECOVERY_DISABLED.
   pointInTimeRecoveryEnablement string
   // Delete protection state
   deleteProtectionState string
   // Resource Manager tag keys/values bound to this database
   tags map[string]string
   // Customer-managed encryption key configuration
+  //
+  // Keys: `kmsKeyName` (resource name of the Cloud KMS key protecting the
+  // database) and `activeKeyVersion` (the KMS key versions currently in
+  // use). Empty when the database uses Google-managed encryption. The
+  // `kmsKey` field resolves the referenced Cloud KMS key.
   cmekConfig dict
   // Customer-managed KMS key used for encryption (null when Google-managed)
   //
@@ -7716,6 +8283,11 @@ private gcp.project.firestoreService.database.index @defaults("name queryScope")
   // API scope (DATASTORE_MODE_API, ANY_API)
   apiScope string
   // Index fields
+  //
+  // Each entry has `fieldPath` (the indexed document field) plus one of
+  // `order` (ASCENDING or DESCENDING for ordered indexes), `arrayConfig`
+  // (CONTAINS for array-contains indexes), or `vectorConfig` (nearest-neighbor
+  // vector index settings).
   fields []dict
   // Index state (CREATING, READY, NEEDS_REPAIR)
   state string
@@ -7728,8 +8300,15 @@ private gcp.project.firestoreService.database.backupSchedule @defaults("name") {
   // Backup retention period
   retention string
   // Daily recurrence config
+  //
+  // Present (as an empty object) when the backup runs once every day. Null
+  // when the schedule uses weekly recurrence instead.
   dailyRecurrence dict
   // Weekly recurrence config
+  //
+  // Present when the backup runs once a week, with key `day` naming the day
+  // of the week (MONDAY through SUNDAY). Null when the schedule uses daily
+  // recurrence instead.
   weeklyRecurrence dict
   // Creation time
   created time
@@ -7739,10 +8318,9 @@ private gcp.project.firestoreService.database.backupSchedule @defaults("name") {
 
 // Google Cloud (GCP) Spanner
 //
-// Use this resource as the entry point for Spanner in the project. It
-// hosts the project's `instances` (with their databases and backups) and
-// the available `instanceConfigs` that determine regional and
-// multi-region placement.
+// Spanner in the project, the entry point for the project's `instances`
+// (with their databases and backups) and the available `instanceConfigs`
+// that determine regional and multi-region placement.
 private gcp.project.spannerService {
   // Project ID
   projectId string
@@ -7754,8 +8332,8 @@ private gcp.project.spannerService {
 
 // Google Cloud (GCP) Spanner instance
 //
-// Examine a Cloud Spanner instance — the top-level billable unit that
-// holds databases and backups. Query its compute allocation (`nodeCount`,
+// Cloud Spanner instance, the top-level billable unit that holds
+// databases and backups. Reports compute allocation (`nodeCount`,
 // `processingUnits`, `autoscalingConfig`), edition, state, and endpoint
 // URIs. Drill into `databases` for schema and IAM audits, `backups` and
 // `backupSchedules` for retention policy audits, and `instancePartitions`
@@ -7784,6 +8362,12 @@ private gcp.project.spannerService.instance @defaults("name") {
   // Cloud Spanner edition
   edition string
   // Autoscaling configuration
+  //
+  // Present when the instance scales automatically. Keys:
+  // `autoscalingLimits` (`minNodes`/`maxNodes` or
+  // `minProcessingUnits`/`maxProcessingUnits`), `autoscalingTargets`
+  // (`highPriorityCpuUtilizationPercent`, `storageUtilizationPercent`),
+  // and `asymmetricAutoscalingOptions` for per-replica overrides.
   autoscalingConfig dict
   // Default backup schedule type
   defaultBackupScheduleType string
@@ -7796,6 +8380,10 @@ private gcp.project.spannerService.instance @defaults("name") {
   // Free-tier instance metadata (expireTime, upgradeTime, expireBehavior)
   freeInstanceMetadata dict
   // Per-replica compute capacity for multi-region instances
+  //
+  // One entry per replica. Keys: `replicaSelection` (with a `location`
+  // region name) and either `nodeCount` or `processingUnits` giving the
+  // capacity allocated to that replica.
   replicaComputeCapacity []dict
   // IAM policy bindings for the instance
   iamPolicy() []gcp.resourcemanager.binding
@@ -7817,12 +8405,12 @@ private gcp.project.spannerService.instance @defaults("name") {
 
 // Google Cloud (GCP) Spanner database
 //
-// Examine a Cloud Spanner database within an instance. Query its SQL
-// dialect (`GOOGLE_STANDARD_SQL` or `POSTGRESQL`), state, encryption
+// Cloud Spanner database within an instance. Reports its SQL dialect
+// (`GOOGLE_STANDARD_SQL` or `POSTGRESQL`), state, encryption
 // configuration and KMS keys (for CMEK multi-region databases), version
-// retention period, and earliest restore timestamp. Access the full DDL
-// schema via `ddl`, IAM bindings via `iamPolicy`, and fine-grained access
-// control roles via `databaseRoles`.
+// retention period, and earliest restore timestamp. The full DDL schema
+// is available via `ddl`, IAM bindings via `iamPolicy`, and fine-grained
+// access control roles via `databaseRoles`.
 private gcp.project.spannerService.instance.database @defaults("name") {
   // Project ID
   projectId string
@@ -7839,8 +8427,19 @@ private gcp.project.spannerService.instance.database @defaults("name") {
   // Earliest timestamp to which the database can be restored
   earliestVersionTime time
   // Encryption configuration
+  //
+  // Customer-managed encryption keys applied to the database. Keys:
+  // `kmsKeyName` for a single-region key, or `kmsKeyNames` listing the
+  // per-region keys of a multi-region database. Empty for Google-managed
+  // encryption. See `kmsKeys` for the resolved key resources.
   encryptionConfig dict
   // Encryption information
+  //
+  // One entry per encryption key protecting the database. Keys:
+  // `encryptionType` (`GOOGLE_DEFAULT_ENCRYPTION` or
+  // `CUSTOMER_MANAGED_ENCRYPTION`), `encryptionStatus` (a status object
+  // with `code` and `message`), and `kmsKeyVersion` for customer-managed
+  // keys.
   encryptionInfo []dict
   // Customer-managed KMS keys used for encryption; populated for multi-region databases that span multiple regions (empty when Google-managed)
   kmsKeys() []gcp.project.kmsService.keyring.cryptokey
@@ -7853,6 +8452,10 @@ private gcp.project.spannerService.instance.database @defaults("name") {
   // Creation time
   createdAt time
   // Restore source information if the database was restored from a backup
+  //
+  // Empty for databases created empty. Keys: `sourceType` (`BACKUP`) and
+  // `backupInfo` describing the origin (`backup` resource name,
+  // `versionTime`, `createTime`, `sourceDatabase`).
   restoreInfo dict
   // Backup this database was restored from
   //
@@ -7870,11 +8473,11 @@ private gcp.project.spannerService.instance.database @defaults("name") {
 
 // Google Cloud (GCP) Spanner backup
 //
-// Examine a Cloud Spanner backup created from a source database. Query its
-// state, expiration time, size in bytes, encryption information, and
-// database dialect. For incremental backups, `incrementalBackupChainId`
-// links backups in the same chain, and `oldestVersionTime` records how far
-// back the chain reaches. `freeableSizeBytes` and `exclusiveSizeBytes`
+// Cloud Spanner backup created from a source database. Reports its state,
+// expiration time, size in bytes, encryption information, and database
+// dialect. For incremental backups, `incrementalBackupChainId` links
+// backups in the same chain, and `oldestVersionTime` records how far back
+// the chain reaches. `freeableSizeBytes` and `exclusiveSizeBytes`
 // indicate the storage reclaimed or attributed to this backup within its
 // chain.
 private gcp.project.spannerService.instance.backup @defaults("name") {
@@ -7902,6 +8505,11 @@ private gcp.project.spannerService.instance.backup @defaults("name") {
   // Size of the backup in bytes
   sizeBytes int
   // Encryption information
+  //
+  // Keys: `encryptionType` (`GOOGLE_DEFAULT_ENCRYPTION` or
+  // `CUSTOMER_MANAGED_ENCRYPTION`), `encryptionStatus` (a status object
+  // with `code` and `message`), and `kmsKeyVersion` for customer-managed
+  // keys.
   encryptionInfo dict
   // Database dialect
   databaseDialect string
@@ -7925,13 +8533,13 @@ private gcp.project.spannerService.instance.backup @defaults("name") {
 
 // Google Cloud (GCP) Spanner instance configuration
 //
-// Examine a Cloud Spanner instance configuration — the regional or
-// multi-region placement template used when creating or comparing
-// instances. Query the list of replica regions (`replicas`), allowed
-// leader regions (`leaderOptions`), configuration type
-// (`GOOGLE_MANAGED` or `USER_MANAGED`), and free-instance availability.
-// For user-managed configurations, `baseConfig` names the Google-managed
-// config it derives from.
+// Cloud Spanner instance configuration, the regional or multi-region
+// placement template used when creating or comparing instances. Reports
+// the list of replica regions (`replicas`), allowed leader regions
+// (`leaderOptions`), configuration type (`GOOGLE_MANAGED` or
+// `USER_MANAGED`), and free-instance availability. For user-managed
+// configurations, `baseConfig` names the Google-managed config it
+// derives from.
 private gcp.project.spannerService.instanceConfig @defaults("name displayName") {
   // Project ID
   projectId string
@@ -7940,6 +8548,10 @@ private gcp.project.spannerService.instanceConfig @defaults("name displayName") 
   // Display name
   displayName string
   // Geographic placement of nodes (list of region configurations)
+  //
+  // One entry per replica. Keys: `location` (region name), `type`
+  // (`READ_WRITE`, `READ_ONLY`, or `WITNESS`), and `defaultLeaderLocation`
+  // (whether the region can host the leader).
   replicas []dict
   // Leader options (allowed leader regions)
   leaderOptions []string
@@ -7952,6 +8564,9 @@ private gcp.project.spannerService.instanceConfig @defaults("name displayName") 
   // User-defined key/value labels for organizing the resource
   labels map[string]string
   // Replicas available to be used but not currently in the base configuration
+  //
+  // Same shape as `replicas`. Keys: `location` (region name), `type`
+  // (`READ_WRITE`, `READ_ONLY`, or `WITNESS`), and `defaultLeaderLocation`.
   optionalReplicas []dict
   // Storage limit in bytes per processing unit
   storageLimitPerProcessingUnit int
@@ -7977,10 +8592,10 @@ private gcp.project.spannerService.instance.database.role @defaults("name") {
 
 // Google Cloud (GCP) Spanner backup schedule
 //
-// Examine an automated backup schedule attached to a Spanner database.
-// Query the cron-like `spec`, backup `retentionDuration`, backup type
-// (`FULL` or `INCREMENTAL`), and encryption configuration used for
-// scheduled backups.
+// Automated backup schedule attached to a Spanner database. Reports the
+// cron-like `spec`, backup `retentionDuration`, backup type (`FULL` or
+// `INCREMENTAL`), and encryption configuration used for scheduled
+// backups.
 private gcp.project.spannerService.instance.backupSchedule @defaults("name") {
   // Project ID
   projectId string
@@ -7991,10 +8606,19 @@ private gcp.project.spannerService.instance.backupSchedule @defaults("name") {
   // Resource name of the backup schedule
   name string
   // Schedule specification (cron-like configuration)
+  //
+  // Key `cronSpec` holds the schedule: `text` (the cron expression),
+  // `timeZone`, and `creationWindow` (the duration within which a
+  // scheduled backup must be created).
   spec dict
   // Retention duration for backups created by the schedule
   retentionDuration string
   // Encryption configuration used for scheduled backups
+  //
+  // Keys: `encryptionType` (`USE_DATABASE_ENCRYPTION`,
+  // `GOOGLE_DEFAULT_ENCRYPTION`, or `CUSTOMER_MANAGED_ENCRYPTION`),
+  // `kmsKeyName` for a single-region key, or `kmsKeyNames` for the
+  // per-region keys of a multi-region backup.
   encryptionConfig dict
   // Backup type spec (FULL or INCREMENTAL)
   backupType string
@@ -8004,9 +8628,9 @@ private gcp.project.spannerService.instance.backupSchedule @defaults("name") {
 
 // Google Cloud (GCP) Spanner instance partition
 //
-// Examine a Cloud Spanner instance partition — a sub-allocation of
-// compute capacity within an instance used to pin databases to specific
-// geographic regions. Query its `nodeCount` or `processingUnits`,
+// Cloud Spanner instance partition, a sub-allocation of compute capacity
+// within an instance used to pin databases to specific geographic
+// regions. Reports its `nodeCount` or `processingUnits`,
 // `autoscalingConfig`, configuration reference, state, and the list of
 // databases that reference the partition.
 private gcp.project.spannerService.instance.instancePartition @defaults("name") {
@@ -8025,6 +8649,12 @@ private gcp.project.spannerService.instance.instancePartition @defaults("name") 
   // Number of processing units allocated to the partition
   processingUnits int
   // Autoscaling configuration
+  //
+  // Present when the partition scales automatically. Keys:
+  // `autoscalingLimits` (`minNodes`/`maxNodes` or
+  // `minProcessingUnits`/`maxProcessingUnits`), `autoscalingTargets`
+  // (`highPriorityCpuUtilizationPercent`, `storageUtilizationPercent`),
+  // and `asymmetricAutoscalingOptions` for per-replica overrides.
   autoscalingConfig dict
   // Current state of the partition
   state string
@@ -8053,12 +8683,12 @@ private gcp.project.bigtableService {
 
 // Google Cloud (GCP) Bigtable instance
 //
-// Examine a Cloud Bigtable instance — the top-level container for
-// clusters, tables, and app profiles. Query its type (`PRODUCTION` or
-// `DEVELOPMENT`), state, and labels. Drill into `clusters` for storage
-// type and CMEK encryption configuration, `tables` for column-family and
-// deletion-protection settings, `appProfiles` for routing policy audits,
-// `backups` for retention review, and `iamPolicy` for access control.
+// Cloud Bigtable instance, the top-level container for clusters, tables,
+// and app profiles. Query its type (`PRODUCTION` or `DEVELOPMENT`), state,
+// and labels. Drill into `clusters` for storage type and CMEK encryption
+// configuration, `tables` for column-family and deletion-protection
+// settings, `appProfiles` for routing policy audits, `backups` for
+// retention review, and `iamPolicy` for access control.
 private gcp.project.bigtableService.instance @defaults("name") {
   // Project ID
   projectId string
@@ -8094,11 +8724,10 @@ private gcp.project.bigtableService.instance @defaults("name") {
 
 // Google Cloud (GCP) Bigtable cluster
 //
-// Examine a Cloud Bigtable cluster — the zonal compute and storage unit
-// within a Bigtable instance. Query its location (zone), state,
-// `serveNodes`, default storage type (`SSD` or `HDD`), encryption
-// configuration, and node scaling factor. The `kmsKey` field resolves to
-// the customer-managed KMS key when CMEK is enabled.
+// Zonal compute and storage unit within a Bigtable instance. Query its
+// location (zone), state, `serveNodes`, default storage type (`SSD` or
+// `HDD`), encryption configuration, and node scaling factor. The `kmsKey`
+// field resolves to the customer-managed KMS key when CMEK is enabled.
 private gcp.project.bigtableService.cluster @defaults("name") {
   // Project ID
   projectId string
@@ -8115,22 +8744,31 @@ private gcp.project.bigtableService.cluster @defaults("name") {
   // Default storage type (SSD or HDD)
   defaultStorageType string
   // Encryption configuration (CMEK)
+  //
+  // Present when customer-managed encryption is enabled, with the key
+  // `kmsKeyName` giving the KMS key that protects the cluster. Null for
+  // Google-managed encryption.
   encryptionConfig dict
   // Customer-managed KMS key used for cluster encryption (null when Google-managed)
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // Node scaling factor
   nodeScalingFactor string
   // Autoscaling configuration
+  //
+  // Keys `minNodes` and `maxNodes` bound the node count, `cpuTargetPercent`
+  // sets the CPU utilization target that drives scaling, and
+  // `storageUtilizationPerNode` sets the per-node storage target. Null when
+  // the cluster uses a fixed node count.
   autoscalingConfig dict
 }
 
 // Google Cloud (GCP) Bigtable table
 //
-// Examine a Cloud Bigtable table within an instance. Query its column
-// families and their garbage-collection configurations, timestamp
-// granularity, deletion protection status, automated backup policy, and
-// change stream configuration. `tieredStorageConfig` controls data
-// movement between SSD and HDD storage tiers.
+// Cloud Bigtable table within an instance. Query its column families and
+// their garbage-collection configurations, timestamp granularity, deletion
+// protection status, automated backup policy, and change stream
+// configuration. `tieredStorageConfig` controls data movement between SSD
+// and HDD storage tiers.
 private gcp.project.bigtableService.table @defaults("name") {
   // Project ID
   projectId string
@@ -8139,26 +8777,41 @@ private gcp.project.bigtableService.table @defaults("name") {
   // Resource name of the table
   name string
   // Column families and their configurations
+  //
+  // Keyed by column-family name. Each value carries `name`, `gcPolicy` (the
+  // garbage-collection policy), and `fullGCPolicy` (the full
+  // garbage-collection rule expression).
   columnFamilies dict
   // Timestamp granularity
   granularity string
   // Whether deletion protection is enabled
   deletionProtection bool
   // Automated backup policy
+  //
+  // Keys `retentionPeriod` and `frequency` (both durations) set how long
+  // automated backups are kept and how often they run, and `locations`
+  // lists the backup storage locations. Null when automated backups are
+  // disabled.
   automatedBackupPolicy dict
   // Change stream configuration
+  //
+  // The `retentionPeriod` key gives the duration for which change stream
+  // records are retained. Null when no change stream is enabled.
   changeStreamConfig dict
   // Tiered storage configuration controlling movement of data between SSD and HDD tiers
+  //
+  // The `infrequentAccess` key holds a nested `includeIfOlderThan` duration:
+  // data older than this moves to the infrequent-access (HDD) tier. Null
+  // when tiered storage is not configured.
   tieredStorageConfig dict
 }
 
 // Google Cloud (GCP) Bigtable app profile
 //
-// Examine a Cloud Bigtable app profile — the named configuration that
-// controls how client traffic is routed to clusters and how reads behave.
-// Query its `routingPolicy` (single-cluster vs. multi-cluster routing),
-// `description`, and `etag`. App profiles are selected by the `name`
-// field as it appears in the Bigtable instance.
+// Named configuration that controls how client traffic is routed to
+// clusters and how reads behave. Query its `routingPolicy` (single-cluster
+// vs. multi-cluster routing), `description`, and `etag`. App profiles are
+// selected by the `name` field as it appears in the Bigtable instance.
 private gcp.project.bigtableService.appProfile @defaults("name") {
   // Project ID
   projectId string
@@ -8169,6 +8822,10 @@ private gcp.project.bigtableService.appProfile @defaults("name") {
   // Description of the app profile
   description string
   // Routing policy configuration
+  //
+  // The `type` key selects the shape: "MULTI_CLUSTER_ROUTING_USE_ANY" adds
+  // `clusterIds` (the clusters eligible to serve requests);
+  // "SINGLE_CLUSTER_ROUTING" adds `clusterId` and `allowTransactionalWrites`.
   routingPolicy dict
   // ETag for optimistic concurrency control
   etag string
@@ -8176,10 +8833,10 @@ private gcp.project.bigtableService.appProfile @defaults("name") {
 
 // Google Cloud (GCP) Bigtable backup
 //
-// Examine a Cloud Bigtable backup created from a source table. Query its
-// state, source table, expiration time, start and end times, size in
-// bytes, and encryption information. Backups are stored in a specific
-// cluster and expire automatically at `expireTime`.
+// Cloud Bigtable backup created from a source table. Query its state,
+// source table, expiration time, start and end times, size in bytes, and
+// encryption information. Backups are stored in a specific cluster and
+// expire automatically at `expireTime`.
 private gcp.project.bigtableService.backup @defaults("name") {
   // Project ID
   projectId string
@@ -8210,15 +8867,19 @@ private gcp.project.bigtableService.backup @defaults("name") {
   // Current state of the backup
   state string
   // Encryption information
+  //
+  // Keys `encryptionType` (Google-managed vs. customer-managed),
+  // `encryptionStatus`, and `kmsKeyVersion` (the KMS key version protecting
+  // the backup when customer-managed).
   encryptionInfo dict
 }
 
 // Google Cloud (GCP) AlloyDB for PostgreSQL
 //
-// Use this resource as the entry point for AlloyDB in the project. It
-// hosts the project's `clusters` — each exposing its primary and
-// read-pool instances, automated backup policy, encryption configuration,
-// and network settings for PostgreSQL-compatible database audits.
+// AlloyDB for PostgreSQL in the project. The `clusters` collection
+// exposes each cluster's primary and read-pool instances, automated
+// backup policy, encryption configuration, and network settings for
+// PostgreSQL-compatible database audits.
 private gcp.project.alloydbService {
   // Project ID
   projectId string
@@ -8228,14 +8889,15 @@ private gcp.project.alloydbService {
 
 // Google Cloud (GCP) AlloyDB cluster
 //
-// Examine an AlloyDB for PostgreSQL cluster — the top-level container
-// for a highly available PostgreSQL-compatible database. Query its
-// `clusterType` (`PRIMARY` or `SECONDARY`), `databaseVersion`, `state`,
-// network configuration, encryption configuration (CMEK via `kmsKey`),
-// automated and continuous backup policies, SSL configuration, and
-// maintenance schedule. Drill into `instances` for primary and read-pool
-// instance details, `backups` for restore-point review, and `users` for
-// database user audits.
+// AlloyDB for PostgreSQL cluster, the top-level container for a highly
+// available PostgreSQL-compatible database. The `clusterType` field
+// distinguishes a `PRIMARY` cluster from a cross-region `SECONDARY`
+// replica and selects whether `primaryCluster` or `secondaryClusters`
+// resolves. Audit customer-managed encryption through `kmsKey`, the
+// automated and continuous backup policies, SSL enforcement, network
+// exposure, and maintenance windows. `instances` covers the primary and
+// read-pool members, `backups` the restore points, and `users` the
+// database roles.
 private gcp.project.alloydbService.cluster @defaults("name") {
   // Project ID
   projectId string
@@ -8246,38 +8908,87 @@ private gcp.project.alloydbService.cluster @defaults("name") {
   // UID of the cluster
   uid string
   // Current state of the cluster
+  //
+  // One of READY, STOPPED, EMPTY, CREATING, DELETING, FAILED,
+  // BOOTSTRAPPING, MAINTENANCE, or PROMOTING.
   state string
   // Cluster type (PRIMARY or SECONDARY)
   clusterType string
-  // Database version (PostgreSQL engine version)
+  // Database version
+  //
+  // The PostgreSQL engine version: one of POSTGRES_13, POSTGRES_14,
+  // POSTGRES_15, POSTGRES_16, POSTGRES_17, or POSTGRES_18.
   databaseVersion string
-  // Network configuration
+  // VPC network settings for private connectivity
+  //
+  // Keys: `network` (the VPC network resource path, also resolved by
+  // `network`) and `allocatedIpRange` (the named IP range allocated for
+  // private services access).
   networkConfig dict
   // Whether Private Service Connect is enabled on the cluster
   pscEnabled bool
-  // Encryption configuration (CMEK)
+  // Customer-managed encryption key configuration
+  //
+  // Contains the single key `kmsKeyName`, the Cloud KMS key protecting
+  // the cluster. Empty when the cluster uses Google-managed encryption.
+  // `kmsKey` resolves the same key.
   encryptionConfig dict
-  // Encryption information
+  // Applied encryption state
+  //
+  // Keys: `encryptionType` (`GOOGLE_DEFAULT_ENCRYPTION` or
+  // `CUSTOMER_MANAGED_ENCRYPTION`) and `kmsKeyVersions`, the Cloud KMS
+  // key versions in use.
   encryptionInfo dict
   // Automated backup policy
+  //
+  // Keys: `enabled`, `backupWindow` (the time allotted for a backup to
+  // complete), `location`, `labels`, and `encryptionConfig` (carrying
+  // `kmsKeyName` when backups use a customer-managed key).
   automatedBackupPolicy dict
-  // Continuous backup configuration
+  // Continuous backup and point-in-time recovery configuration
+  //
+  // Keys: `enabled`, `recoveryWindowDays` (days of logs retained for
+  // point-in-time recovery), and `encryptionConfig` (carrying
+  // `kmsKeyName`).
   continuousBackupConfig dict
-  // Continuous backup information
+  // Continuous backup state
+  //
+  // Keys: `enabledTime`, `earliestRestorableTime` (earliest point a
+  // restore can target), `schedule` (days of the week backups run), and
+  // `encryptionInfo`.
   continuousBackupInfo dict
-  // SSL configuration
+  // Client SSL/TLS enforcement configuration
+  //
+  // Keys: `sslMode` (`ALLOW_UNENCRYPTED_AND_ENCRYPTED`, `ENCRYPTED_ONLY`,
+  // or the legacy `SSL_MODE_ALLOW`, `SSL_MODE_REQUIRE`,
+  // `SSL_MODE_VERIFY_CA`) and `caSource` (`CA_SOURCE_MANAGED`).
   sslConfig dict
   // Labels for the cluster
   labels map[string]string
   // Annotations for the cluster
   annotations map[string]string
-  // Primary cluster configuration
+  // Cross-region replication settings on a primary cluster
+  //
+  // Present on a `PRIMARY` cluster. Contains `secondaryClusterNames`, the
+  // resource names of clusters replicating from this one, which
+  // `secondaryClusters` resolves.
   primaryConfig dict
-  // Secondary cluster configuration
+  // Cross-region replication settings on a secondary cluster
+  //
+  // Present on a `SECONDARY` cluster. Contains `primaryClusterName`, the
+  // resource name of the cluster it replicates from, which
+  // `primaryCluster` resolves.
   secondaryConfig dict
-  // Maintenance update policy
+  // Maintenance window and deny-period policy
+  //
+  // Keys: `maintenanceWindows` (the weekly day and time windows Google
+  // may apply updates in) and `denyMaintenancePeriods` (date ranges
+  // during which updates are blocked).
   maintenanceUpdatePolicy dict
-  // Maintenance schedule
+  // Next scheduled maintenance
+  //
+  // Contains `startTime`, the timestamp of the upcoming maintenance
+  // operation.
   maintenanceSchedule dict
   // Location of the cluster
   location string
@@ -8322,10 +9033,10 @@ private gcp.project.alloydbService.cluster @defaults("name") {
 
 // Google Cloud (GCP) AlloyDB cluster user
 //
-// Examine a database user defined on an AlloyDB cluster. Query the
-// `userType` (`ALLOYDB_BUILT_IN` for password-authenticated users or
-// `ALLOYDB_IAM_USER` for IAM-authenticated users) and the PostgreSQL
-// database role memberships granted to the user.
+// Database user defined on an AlloyDB cluster. The `userType` field is
+// `ALLOYDB_BUILT_IN` for password-authenticated users or
+// `ALLOYDB_IAM_USER` for IAM-authenticated users, and `databaseRoles`
+// lists the PostgreSQL role memberships granted to the user.
 private gcp.project.alloydbService.cluster.user @defaults("name userType") {
   // Project ID
   projectId string
@@ -8341,13 +9052,13 @@ private gcp.project.alloydbService.cluster.user @defaults("name userType") {
 
 // Google Cloud (GCP) AlloyDB instance
 //
-// Examine an AlloyDB instance within a cluster — either a primary
-// read-write instance, a read-pool instance, or a secondary instance.
-// Query its `instanceType`, `availabilityType` (`ZONAL` or `REGIONAL`),
-// `machineConfig`, IP addresses, database flags, query insights
-// configuration, client connection configuration, and Private Service
-// Connect settings. `activationPolicy` controls whether the instance is
-// always running or stopped.
+// AlloyDB instance within a cluster: either a primary read-write
+// instance, a read-pool instance, or a secondary instance, as reported
+// by `instanceType`. Audit its machine sizing, availability type
+// (`ZONAL` or `REGIONAL`), public-IP exposure, database flags, query
+// insights collection, and connection requirements. `activationPolicy`
+// reports whether the instance is running (`ALWAYS`) or stopped
+// (`NEVER`).
 private gcp.project.alloydbService.instance @defaults("name") {
   // Project ID
   projectId string
@@ -8363,7 +9074,10 @@ private gcp.project.alloydbService.instance @defaults("name") {
   state string
   // Instance type (PRIMARY, READ_POOL, or SECONDARY)
   instanceType string
-  // Machine configuration
+  // Compute sizing of the instance
+  //
+  // Keys: `cpuCount` (number of vCPUs) and `machineType` (the machine
+  // series and shape).
   machineConfig dict
   // Availability type (ZONAL or REGIONAL)
   availabilityType string
@@ -8373,7 +9087,13 @@ private gcp.project.alloydbService.instance @defaults("name") {
   ipAddress string
   // Public IP address of the instance
   publicIpAddress string
-  // Network configuration, including the public-IP setting and the list of authorized external networks permitted to reach the public endpoint
+  // Public-IP exposure and authorized-network settings
+  //
+  // Keys: `enablePublicIp` (whether the instance has a public endpoint,
+  // also exposed as the `enablePublicIp` scalar field),
+  // `enableOutboundPublicIp` (outbound internet egress), `network`,
+  // `allocatedIpRangeOverride`, and `authorizedExternalNetworks`, the
+  // CIDR blocks permitted to reach the public endpoint.
   networkConfig dict
   // Whether the instance has a public IP endpoint enabled
   enablePublicIp bool
@@ -8383,21 +9103,45 @@ private gcp.project.alloydbService.instance @defaults("name") {
   databaseFlags map[string]string
   // Labels for the instance
   labels map[string]string
-  // Query insights configuration
+  // Query Insights collection settings
+  //
+  // Keys: `recordApplicationTags`, `recordClientAddress` (whether client
+  // IP addresses are captured), `queryStringLength`, and
+  // `queryPlansPerMinute`.
   queryInsightsConfig dict
-  // Read pool configuration
+  // Read-pool sizing
+  //
+  // Contains `nodeCount`, the number of nodes in the read pool. Set only
+  // on `READ_POOL` instances.
   readPoolConfig dict
-  // Client connection configuration
+  // Client connection requirements
+  //
+  // Keys: `requireConnectors` (whether clients must connect through the
+  // AlloyDB Auth Proxy or a language connector) and `sslConfig` (with
+  // `sslMode` and `caSource`).
   clientConnectionConfig dict
-  // Private Service Connect instance configuration
+  // Private Service Connect settings
+  //
+  // Keys: `serviceAttachmentLink`, `pscDnsName`, `allowedConsumerProjects`
+  // (projects permitted to connect through Private Service Connect),
+  // `pscInterfaceConfigs`, and `pscAutoConnections`.
   pscInstanceConfig dict
   // Policy that controls whether the instance is up and running (ALWAYS, NEVER)
   activationPolicy string
-  // Managed connection pool configuration for the instance
+  // Managed connection pool settings
+  //
+  // Keys: `enabled`, `poolerCount` (number of connection poolers), and
+  // `flags`, a map of pooler configuration flags.
   connectionPoolConfig dict
-  // List of available nodes
+  // Nodes backing the instance
+  //
+  // Each entry has keys `id`, `zoneId`, `ip` (the node's private IP), and
+  // `state`.
   nodes []dict
-  // Writable node information
+  // Node accepting writes
+  //
+  // Keys `id`, `zoneId`, `ip`, and `state` for the current read-write
+  // node of the instance.
   writableNode dict
   // Whether the instance is in a reconciling state
   reconciling bool
@@ -8411,11 +9155,12 @@ private gcp.project.alloydbService.instance @defaults("name") {
 
 // Google Cloud (GCP) AlloyDB backup
 //
-// Examine an AlloyDB backup created from a source cluster. Query its
-// `type` (manual or automated), `state`, `databaseVersion`, size in
-// bytes, encryption configuration, and expiry time. `expiryQuantity`
-// describes count-based retention when the backup was created under a
-// quantitative retention policy.
+// AlloyDB backup created from a source cluster. The `type` field marks
+// whether the backup was taken on demand, automatically, or as a
+// continuous backup, and `expiryQuantity` describes count-based
+// retention when the backup was created under a quantitative retention
+// policy. Audit `state`, `databaseVersion`, size, encryption, and expiry
+// against backup and recovery requirements.
 private gcp.project.alloydbService.backup @defaults("name") {
   // Project ID
   projectId string
@@ -8426,8 +9171,12 @@ private gcp.project.alloydbService.backup @defaults("name") {
   // UID of the backup
   uid string
   // Current state of the backup
+  //
+  // One of READY, CREATING, FAILED, or DELETING.
   state string
   // Backup type
+  //
+  // One of ON_DEMAND, AUTOMATED, or CONTINUOUS.
   type string
   // Description of the backup
   description string
@@ -8440,15 +9189,26 @@ private gcp.project.alloydbService.backup @defaults("name") {
   sourceCluster() gcp.project.alloydbService.cluster
   // Database version
   databaseVersion string
-  // Encryption configuration
+  // Customer-managed encryption key configuration
+  //
+  // Contains the single key `kmsKeyName`, the Cloud KMS key protecting
+  // the backup. Empty when the backup uses Google-managed encryption.
+  // `kmsKey` resolves the same key.
   encryptionConfig dict
-  // Encryption information
+  // Applied encryption state
+  //
+  // Keys: `encryptionType` (`GOOGLE_DEFAULT_ENCRYPTION` or
+  // `CUSTOMER_MANAGED_ENCRYPTION`) and `kmsKeyVersions`.
   encryptionInfo dict
   // Size of the backup in bytes
   sizeBytes int
   // Expiry time
   expiryTime time
-  // Expiry quantity configuration
+  // Count-based retention state
+  //
+  // Set when the backup was created under a quantitative retention
+  // policy. Keys: `retentionCount` (backups remaining before this one is
+  // deleted) and `totalRetentionCount` (the configured retention count).
   expiryQuantity dict
   // Labels for the backup
   labels map[string]string
@@ -8538,7 +9298,7 @@ private gcp.project.computeService.securityPolicy.rule @defaults("priority actio
 
 // Google Cloud (GCP) Compute SSL policy
 //
-// Examine a Compute Engine SSL policy that governs the TLS protocol
+// Compute Engine SSL policy that governs the TLS protocol
 // version and cipher suites negotiated by HTTPS and SSL proxy load
 // balancers. Query its `profile` (`COMPATIBLE`, `MODERN`, `RESTRICTED`,
 // or `CUSTOM`), `minTlsVersion`, enabled features, and custom features
@@ -8581,7 +9341,7 @@ private gcp.project.computeService.sslPolicy @defaults("name profile minTlsVersi
 
 // Google Cloud (GCP) Compute SSL certificate
 //
-// Examine a Compute Engine SSL certificate attached to HTTPS or SSL proxy
+// Compute Engine SSL certificate attached to HTTPS or SSL proxy
 // load balancers. Query its `type` (`SELF_MANAGED` for user-uploaded
 // certificates or `MANAGED` for Google-managed certificates), subject
 // alternative names, managed certificate configuration and provisioning
@@ -8624,7 +9384,7 @@ private gcp.project.computeService.sslCertificate @defaults("name type") {
 
 // Google Cloud (GCP) Compute HA VPN gateway
 //
-// Examine a High Availability (HA) VPN gateway that provides redundant
+// High Availability (HA) VPN gateway that provides redundant
 // Site-to-Site VPN connectivity. Query its attached `network`, IP family
 // (`gatewayIpVersion`), stack type (`IPV4_ONLY`, `IPV4_IPV6`, or
 // `IPV6_ONLY`), `vpnInterfaces` (each with an IP address and optional
@@ -8661,7 +9421,7 @@ private gcp.project.computeService.vpnGateway @defaults("name") {
 
 // Google Cloud (GCP) Compute VPN tunnel
 //
-// Examine a Cloud VPN tunnel carrying encrypted traffic between a GCP
+// Cloud VPN tunnel carrying encrypted traffic between a GCP
 // network and a peer gateway. Query its `status`, `ikeVersion`,
 // `localTrafficSelector` and `remoteTrafficSelector` CIDRs, and the
 // `sharedSecretHash`. Resolve the peer via `peerExternalVpnGateway` or
@@ -8736,7 +9496,7 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
 
 // Google Cloud (GCP) Compute storage pool
 //
-// Examine a Compute Engine storage pool — a pre-provisioned block storage
+// Compute Engine storage pool, a pre-provisioned block storage
 // capacity container that disks are created from. Query its `state`,
 // capacity provisioning type (`ADVANCED` or `STANDARD`), performance
 // provisioning type, provisioned capacity in GiB, IOPS, and throughput.
@@ -8773,7 +9533,7 @@ private gcp.project.computeService.storagePool @defaults("name state") {
 
 // Google Cloud (GCP) Compute Cloud NAT configuration on a router
 //
-// Examine a Cloud NAT configuration attached to a Cloud Router. Query its
+// Cloud NAT configuration attached to a Cloud Router. Query its
 // NAT IP allocation option (`AUTO_ONLY` or `MANUAL_ONLY`), which subnet
 // IP ranges are NATed, port allocation settings (`minPortsPerVm`,
 // `maxPortsPerVm`, `enableDynamicPortAllocation`), endpoint-independent
@@ -8822,11 +9582,12 @@ private gcp.project.computeService.router.nat @defaults("name") {
 
 // Google Cloud (GCP) Certificate Authority Service
 //
-// Use this resource as the entry point for the Private CA Service in the
-// project. It hosts the `caPools` and, through them, the certificate
-// authorities and issued certificates — exposing tier, issuance policy,
-// and publishing options. This models private CA infrastructure, distinct
-// from the load-balancer-facing certs in `certificateManager`.
+// Private Certificate Authority (CA) service for the project, the entry
+// point for the private public-key infrastructure. Through `caPools` it
+// reaches the certificate authorities and the certificates they issue,
+// exposing tier, issuance policy, and publishing options. This models
+// private CA infrastructure, distinct from the load-balancer-facing
+// certificates in `certificateManager`.
 private gcp.project.certificateAuthorityService {
   // Project ID
   projectId string
@@ -8836,13 +9597,13 @@ private gcp.project.certificateAuthorityService {
 
 // Google Cloud (GCP) Certificate Authority Service CA pool
 //
-// Examine a CA pool within the Private CA Service — a logical grouping of
-// certificate authorities that share an issuance policy and publishing
-// options. Query the pool `tier` (`ENTERPRISE` for full-featured or
-// `DEVOPS` for high-volume issuance), `issuancePolicy` (constraints on
-// what the CAs may sign), `publishingOptions` (CRL/OCSP URLs), and
-// labels. Drill into `certificateAuthorities` and `certificates` to
-// review CA states and issued certificate details.
+// CA pool within the Private CA Service, a logical grouping of certificate
+// authorities that share an issuance policy and publishing options. The
+// `tier` is `ENTERPRISE` (full-featured) or `DEVOPS` (high-volume
+// issuance); `issuancePolicy` constrains what the CAs may sign, and
+// `publishingOptions` carries the CRL and CA-certificate publishing
+// settings. The `certificateAuthorities` and `certificates` fields reach
+// the CA states and issued certificate details in the pool.
 private gcp.project.certificateAuthorityService.caPool @defaults("name tier") {
   // Project ID
   projectId string
@@ -8855,8 +9616,19 @@ private gcp.project.certificateAuthorityService.caPool @defaults("name tier") {
   // Tier (ENTERPRISE, DEVOPS)
   tier string
   // Issuance policy
+  //
+  // Constraints applied to certificates the pool's CAs may sign. Keys:
+  // `allowedKeyTypes`, `maximumLifetime`, `allowedIssuanceModes`,
+  // `baselineValues`, `identityConstraints`, `passthroughExtensions`,
+  // `backdateDuration`, and `allowRequesterSpecifiedNotBeforeTime`.
   issuancePolicy dict
   // Publishing options
+  //
+  // CRL and CA-certificate publishing settings. Keys: `publishCaCert`
+  // (whether the CA certificate is published in the Authority Information
+  // Access extension of issued certificates), `publishCrl` (whether the
+  // CRL is published in the CRL Distribution Points extension), and
+  // `encodingFormat` (PEM or DER).
   publishingOptions dict
   // Whether each CA's certificate is published and referenced in the Authority Information Access X.509 extension of issued certificates
   publishCaCert bool
@@ -8874,14 +9646,14 @@ private gcp.project.certificateAuthorityService.caPool @defaults("name tier") {
 
 // Google Cloud (GCP) Certificate Authority
 //
-// Examine a certificate authority managed by the Private CA Service.
-// Query its `type` (`SELF_SIGNED` for root CAs or `SUBORDINATE` for
-// intermediate CAs), `state` (`ENABLED`, `DISABLED`, `STAGED`,
-// `AWAITING_USER_ACTIVATION`, `DELETION_REQUESTED`), key specification,
-// certificate configuration (subject, subject alternative names),
-// certificate lifetime, PEM-encoded CA certificate chains, GCS bucket
-// for published CRL and CA certs, and access URLs. `expireTime` is when
-// the CA certificate itself expires.
+// Certificate authority managed by the Private CA Service. Its `type` is
+// `SELF_SIGNED` (root CAs) or `SUBORDINATE` (intermediate CAs), and
+// `state` is one of `ENABLED`, `DISABLED`, `STAGED`,
+// `AWAITING_USER_ACTIVATION`, `DELETION_REQUESTED`, or `PURGED`. Alongside
+// the key specification, certificate configuration, lifetime, PEM-encoded
+// certificate chains, and the bucket serving the published CRL and CA
+// certificates, `expireTime` reports when the CA certificate itself
+// expires.
 private gcp.project.certificateAuthorityService.certificateAuthority @defaults("name state type") {
   // Project ID
   projectId string
@@ -8898,20 +9670,39 @@ private gcp.project.certificateAuthorityService.certificateAuthority @defaults("
   // Current state (ENABLED, DISABLED, STAGED, AWAITING_USER_ACTIVATION, DELETION_REQUESTED, PURGED)
   state string
   // Key specification
+  //
+  // Algorithm and key backing for the CA. Either `cloudKmsKeyVersion` (the
+  // Cloud KMS key version that signs certificates) or `algorithm` (one of
+  // RSA_PSS_2048_SHA256, RSA_PSS_3072_SHA256, RSA_PSS_4096_SHA256,
+  // RSA_PKCS1_2048_SHA256, RSA_PKCS1_3072_SHA256, RSA_PKCS1_4096_SHA256,
+  // EC_P256_SHA256, or EC_P384_SHA384).
   keySpec dict
-  // Certificate authority configuration (subject, subject alt name, etc.)
+  // Certificate authority configuration
+  //
+  // Description of the CA's own certificate. Keys: `subjectConfig`
+  // (subject and subject alternative names), `x509Config` (key usage,
+  // extended key usage, CA options, policy IDs), `publicKey`, and
+  // `subjectKeyId`.
   config dict
   // Lifetime of certificates issued by this CA
   lifetime string
   // PEM-encoded CA certificate chains
   pemCaCertificates []string
   // Subordinate configuration
+  //
+  // Issuer chain for a SUBORDINATE CA (empty for a SELF_SIGNED root).
+  // Either `certificateAuthority` (resource name of the issuing CA) or
+  // `pemIssuerChain` (the PEM-encoded issuer certificate chain).
   subordinateConfig dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
   // GCS bucket for published CRL and CA certificates
   gcsBucket string
   // Access URLs (CA certificate and CRL)
+  //
+  // Public URLs serving the CA's artifacts. Keys: `caCertificateAccessUrl`
+  // (the CA certificate) and `crlAccessUrls` (the certificate revocation
+  // lists).
   accessUrls dict
   // Time created
   createdAt time
@@ -8929,12 +9720,13 @@ private gcp.project.certificateAuthorityService.certificateAuthority @defaults("
 
 // Google Cloud (GCP) Certificate Authority Service certificate
 //
-// Examine a certificate issued by the Private CA Service within a CA
-// pool. Query the `subjectDescription` (common name, SAN, validity
-// period), `certDescription` (key usage, extended key usage, subject key
-// identifier), PEM-encoded certificate and chain, and revocation details.
-// `issuerCertificateAuthority` identifies which CA within the pool signed
-// this certificate.
+// Certificate issued by the Private CA Service within a CA pool. The
+// `subjectDescription` field carries the parsed description of the issued
+// certificate (subject, validity window, and X.509 extensions), while
+// `certDescription` carries the requested certificate configuration.
+// Together with the PEM-encoded certificate and chain and the
+// `revocationDetails`, the `issuerCertificateAuthority` field identifies
+// which CA in the pool signed this certificate.
 private gcp.project.certificateAuthorityService.certificate @defaults("name") {
   // Project ID
   projectId string
@@ -8952,15 +9744,34 @@ private gcp.project.certificateAuthorityService.certificate @defaults("name") {
   lifetime string
   // Requester-pinned start of the validity period, before which the issued certificate is not valid
   requestedNotBeforeTime time
-  // Subject description
+  // Parsed description of the issued certificate
+  //
+  // Description parsed from the issued X.509 certificate. Keys:
+  // `subjectDescription` (common name, subject alternative names,
+  // lifetime, not-before and not-after times), `x509Description` (key
+  // usage, extended key usage, CA options, policy IDs), `publicKey`,
+  // `subjectKeyId`, `authorityKeyId`, `crlDistributionPoints`,
+  // `aiaIssuingCertificateUrls`, `certFingerprint`, and
+  // `tbsCertificateDigest`.
   subjectDescription dict
-  // Certificate description (config)
+  // Requested certificate configuration
+  //
+  // Configuration the certificate was requested with. Keys:
+  // `subjectConfig` (subject and subject alternative names), `x509Config`
+  // (key usage, extended key usage, CA options), `publicKey`, and
+  // `subjectKeyId`.
   certDescription dict
   // PEM-encoded certificate
   pemCertificate string
   // PEM-encoded certificate chain
   pemCertificateChain []string
   // Revocation details
+  //
+  // Present once the certificate is revoked. Keys: `revocationState` (the
+  // reason, one of KEY_COMPROMISE, CERTIFICATE_AUTHORITY_COMPROMISE,
+  // AFFILIATION_CHANGED, SUPERSEDED, CESSATION_OF_OPERATION,
+  // CERTIFICATE_HOLD, PRIVILEGE_WITHDRAWN, or
+  // ATTRIBUTE_AUTHORITY_COMPROMISE) and `revocationTime`.
   revocationDetails dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -8972,16 +9783,15 @@ private gcp.project.certificateAuthorityService.certificate @defaults("name") {
 
 // Google Cloud (GCP) Certificate Manager
 //
-// Use this resource as the entry point for the Certificate Manager service in
-// the project. It hosts the load-balancer-facing TLS certificate surface:
-// `certificates` (Google-managed and self-managed leaf certs),
-// `certificateMaps` and their `certificateMapEntries` (the host→cert routing
-// attached to GCLB target proxies), `dnsAuthorizations` (the DNS challenge
-// records used to issue managed certs), `certificateIssuanceConfigs`
-// (private-CA-backed issuance settings), and `trustConfigs` (mTLS trust
-// anchors). Certificate Manager is distinct from `certificateAuthority` —
-// that resource models the Private CA Service, while this one models the
-// front-door certs Google's load balancers serve.
+// Certificate Manager service surface for the project, covering the
+// load-balancer-facing TLS certificate resources: `certificates`
+// (Google-managed and self-managed leaf certs), `certificateMaps` and their
+// `certificateMapEntries` (the host-to-cert routing attached to GCLB target
+// proxies), `dnsAuthorizations` (the DNS challenge records used to issue
+// managed certs), `certificateIssuanceConfigs` (private-CA-backed issuance
+// settings), and `trustConfigs` (mTLS trust anchors). Certificate Manager is
+// distinct from `certificateAuthority`, which models the Private CA Service,
+// while this one models the front-door certs Google's load balancers serve.
 private gcp.project.certificateManagerService {
   // Project ID
   projectId string
@@ -8999,7 +9809,7 @@ private gcp.project.certificateManagerService {
 
 // Google Cloud (GCP) Certificate Manager certificate
 //
-// Examine a single TLS certificate served by Google Cloud Load Balancing.
+// Single TLS certificate served by Google Cloud Load Balancing.
 // `type` is the discriminator: `managed` certificates are issued by Google
 // (or by the private CA referenced by `managedIssuanceConfig`) and surface
 // `managedDomains`, `managedDnsAuthorizations`, `managedState`,
@@ -9059,7 +9869,7 @@ private gcp.project.certificateManagerService.certificate @defaults("name type m
 
 // Google Cloud (GCP) Certificate Manager certificate map
 //
-// Examine a certificate map — the host-to-certificate routing table attached
+// Certificate map, the host-to-certificate routing table attached
 // to one or more Google Cloud Load Balancing target proxies. `gclbTargets`
 // lists the target proxies (and per-IP/port serving configs) the map is
 // bound to; an empty list means the map is provisioned but not yet routing
@@ -9084,7 +9894,7 @@ private gcp.project.certificateManagerService.certificateMap @defaults("name") {
   updateTime time
   // Output-only list of GCLB target proxies this map is attached to
   //
-  // Each entry is shaped {targetHttpsProxy|targetSslProxy, ipConfigs:[{ipv4Address|ipv6Address, ports:[]}]}.
+  // Each entry is shaped {targetHttpsProxy|targetSslProxy, ipConfigs:[{ipAddress, ports:[]}]}.
   gclbTargets []dict
   // Map entries (per-hostname certificate assignments)
   entries() []gcp.project.certificateManagerService.certificateMapEntry
@@ -9092,12 +9902,12 @@ private gcp.project.certificateManagerService.certificateMap @defaults("name") {
 
 // Google Cloud (GCP) Certificate Manager certificate map entry
 //
-// Examine a single host-to-certificate binding within a certificate map.
+// Single host-to-certificate binding within a certificate map.
 // Exactly one of `hostname` (a literal SNI hostname) or `matcher` (currently
 // only `PRIMARY`, used as the default fallback) is set. `certificates` lists
 // the resource names of up to four certificates assigned to this entry; load
 // balancers pick the best match by signature algorithm. `state` is the
-// serving state — `ACTIVE` once the entry is live, `PENDING` while
+// serving state: `ACTIVE` once the entry is live, `PENDING` while
 // propagating.
 private gcp.project.certificateManagerService.certificateMapEntry @defaults("name hostname matcher state") {
   // Project ID
@@ -9130,7 +9940,7 @@ private gcp.project.certificateManagerService.certificateMapEntry @defaults("nam
 
 // Google Cloud (GCP) Certificate Manager DNS authorization
 //
-// Examine a DNS authorization used to prove domain ownership when issuing
+// DNS authorization used to prove domain ownership when issuing
 // Google-managed certificates. Each authorization covers a single `domain`
 // and its wildcard. `dnsResourceRecord` is the CNAME the operator must
 // publish under the domain's DNS zone — once that record resolves, Google
@@ -9165,8 +9975,8 @@ private gcp.project.certificateManagerService.dnsAuthorization @defaults("name d
 
 // Google Cloud (GCP) Certificate Manager certificate issuance config
 //
-// Examine an issuance config — the binding between Certificate Manager and
-// a private CA pool that mints managed certificates. `certificateAuthorityConfig`
+// Issuance config binding Certificate Manager to a private CA pool that mints
+// managed certificates. `certificateAuthorityConfig`
 // names the CA pool and (if applicable) the workload service account used to
 // authenticate to it. `lifetime` is the requested workload-cert validity,
 // `rotationWindowPercentage` is the percentage of `lifetime` after which
@@ -9201,7 +10011,7 @@ private gcp.project.certificateManagerService.certificateIssuanceConfig @default
 
 // Google Cloud (GCP) Certificate Manager trust config
 //
-// Examine a trust config — the mTLS trust anchor set used by Google Cloud
+// Trust config, the mTLS trust anchor set used by Google Cloud
 // Load Balancing to authenticate client certificates. `trustStores` lists
 // the trust stores attached to the config; each store carries
 // `trustAnchors` (root CAs) and `intermediateCas` (intermediate CAs) as
@@ -9233,12 +10043,13 @@ private gcp.project.certificateManagerService.trustConfig @defaults("name") {
 
 // Google Cloud (GCP) audit logging configuration for a service
 //
-// Examine the Cloud Audit Logs configuration for a single GCP service
-// within a project, folder, or organization IAM policy. `service` is
-// either `allServices` (a catch-all) or a specific service hostname such
-// as `storage.googleapis.com`. Drill into `auditLogConfigs` to see which
+// Cloud Audit Logs configuration for a single GCP service within a
+// project, folder, or organization IAM policy. `service` is either
+// `allServices` (a catch-all) or a specific service hostname such as
+// `storage.googleapis.com`. The `auditLogConfigs` field reports which
 // log types (`ADMIN_READ`, `DATA_READ`, `DATA_WRITE`) are enabled and
-// which principals are exempted.
+// which principals are exempted, so you can audit whether data-access
+// logging is turned on for sensitive services.
 private gcp.resourcemanager.auditConfig @defaults("service") {
   // Internal ID for this resource
   id string
@@ -9260,12 +10071,14 @@ private gcp.resourcemanager.auditConfig.logConfig @defaults("logType") {
 
 // Google Cloud (GCP) Organization Policy
 //
-// Examine an Organization Policy applied to a project, folder, or
-// organization. Query the `constraintName` (e.g.,
-// `constraints/compute.disableSerialPortAccess`), the effective `spec`
-// (rules and inheritance behavior), the dry-run `dryRunSpec` for testing
-// policy changes before enforcement, and the `etag` for optimistic
-// concurrency control.
+// Organization Policy applied to a project, folder, or organization to
+// centrally restrict how Google Cloud resources may be configured. The
+// `constraintName` identifies which constraint the policy governs, for
+// example `constraints/compute.disableSerialPortAccess`. Derived fields
+// summarize the live spec for auditing: whether a boolean constraint is
+// `enforced`, the `allowedValues` and `deniedValues` of a list
+// constraint, `allowAll`/`denyAll`, and whether the policy inherits from
+// its parent.
 private gcp.orgPolicy @defaults("constraintName") {
   // Internal ID
   id string
@@ -9273,9 +10086,21 @@ private gcp.orgPolicy @defaults("constraintName") {
   name string
   // Constraint name (e.g., "constraints/compute.disableSerialPortAccess")
   constraintName string
-  // Policy specification
+  // Live policy specification
+  //
+  // Raw enforced policy spec. Keys: `rules` (each with `values` holding
+  // `allowedValues`/`deniedValues`, plus `allowAll`, `denyAll`, `enforce`,
+  // and an optional CEL `condition`), `inheritFromParent`, `reset`,
+  // `etag`, and `updateTime`. The `enforced`, `allowedValues`,
+  // `deniedValues`, `allowAll`, `denyAll`, and `inheritFromParent` fields
+  // expose the unconditional-rule values of this spec directly.
   spec dict
   // Dry-run policy specification (for testing)
+  //
+  // Proposed policy spec evaluated for testing without being enforced,
+  // with the same shape as `spec` (`rules`, `inheritFromParent`, `reset`,
+  // `etag`, `updateTime`). The `dryRunOnly` field reports whether a policy
+  // has only this dry-run spec and no enforced live spec.
   dryRunSpec dict
   // Etag for optimistic concurrency control
   etag string
@@ -9286,7 +10111,7 @@ private gcp.orgPolicy @defaults("constraintName") {
   // Whether a boolean constraint is enforced
   //
   // True when the live spec contains an unconditional rule with
-  // `enforce: true` — the form used by boolean constraints such as
+  // `enforce: true`, the form used by boolean constraints such as
   // `iam.disableServiceAccountKeyCreation`, `compute.requireOsLogin`, and
   // `storage.uniformBucketLevelAccess`. Reflects only the directly-set live
   // spec on this resource, not policy inherited from a parent.
@@ -9305,13 +10130,13 @@ private gcp.orgPolicy @defaults("constraintName") {
 
 // Google Cloud (GCP) Organization policy constraint
 //
-// Examine a predefined Organization Policy constraint — the policy
-// vocabulary item that an `orgPolicy` rule references. Query the
-// `constraintDefault` behavior when no policy is set
-// (`CONSTRAINT_DEFAULT_ALLOW` or `CONSTRAINT_DEFAULT_DENY`),
-// `listConstraint` details (allowed/denied values, supports wildcards),
-// and `booleanConstraint` details. The `name` field is the full
-// constraint identifier, e.g.,
+// Predefined Organization Policy constraint, the policy vocabulary item
+// that an `orgPolicy` rule references. The `constraintDefault` field
+// records the behavior when no policy is set (`CONSTRAINT_DEFAULT_ALLOW`
+// or `CONSTRAINT_DEFAULT_DENY`), while `listConstraint` and
+// `booleanConstraint` describe which of the two constraint kinds this is
+// and how its values are expressed. The `name` field is the full
+// constraint identifier, for example
 // `constraints/compute.disableSerialPortAccess`.
 private gcp.orgPolicy.constraint @defaults("name") {
   // Full resource name (e.g., constraints/compute.disableSerialPortAccess)
@@ -9323,15 +10148,26 @@ private gcp.orgPolicy.constraint @defaults("name") {
   // Default behavior when the constraint is not explicitly set (CONSTRAINT_DEFAULT_ALLOW, CONSTRAINT_DEFAULT_DENY)
   constraintDefault string
   // List constraint details (if this is a list constraint)
+  //
+  // Present when the constraint accepts a list of values. Keys:
+  // `supportsIn` (whether policy values may use the `in:` prefix to name a
+  // predefined group of values) and `supportsUnder` (whether values may
+  // use the `under:` prefix to match a resource-hierarchy subtree). Empty
+  // for boolean constraints.
   listConstraint dict
   // Boolean constraint details (if this is a boolean constraint)
+  //
+  // Present (as an empty object) when the constraint is boolean, meaning
+  // it is either enforced or not with no list of values. Empty for list
+  // constraints, so its presence versus `listConstraint` distinguishes the
+  // two constraint kinds.
   booleanConstraint dict
 }
 
 // Google Cloud (GCP) custom Organization Policy constraint
 //
-// Examine a customer-defined constraint that extends Organization Policy
-// beyond Google's predefined constraints. `resourceTypes` and `methodTypes`
+// Customer-defined constraint that extends Organization Policy beyond
+// Google's predefined constraints. `resourceTypes` and `methodTypes`
 // scope which resources and API operations the constraint governs,
 // `condition` holds the CEL expression evaluated against each resource, and
 // `actionType` decides whether a match is allowed or denied. Custom
@@ -9346,7 +10182,9 @@ private gcp.orgPolicy.customConstraint @defaults("displayName name") {
   description string
   // Resource types the constraint applies to (e.g., compute.googleapis.com/Instance)
   resourceTypes []string
-  // API operations the constraint is enforced on (CREATE, UPDATE)
+  // API operations the constraint is enforced on
+  //
+  // One or more of CREATE, UPDATE, DELETE, REMOVE_GRANT, or GOVERN_TAGS.
   methodTypes []string
   // CEL condition expression evaluated against the resource
   condition string
@@ -9358,7 +10196,7 @@ private gcp.orgPolicy.customConstraint @defaults("displayName name") {
 
 // Google Cloud (GCP) Compute instance group
 //
-// Examine a Compute Engine instance group — a collection of VM instances
+// Compute Engine instance group, a collection of VM instances
 // that can be managed together for load balancing and autoscaling.
 // Query its `size` (current instance count), `namedPorts` (protocol/port
 // pairs registered for load balancing), attached `network` and
@@ -9401,7 +10239,7 @@ private gcp.project.computeService.instanceGroup @defaults("name size") {
 
 // Google Cloud (GCP) Compute instance group manager (managed instance group)
 //
-// Examine a Compute Engine managed instance group (MIG) — a group manager
+// Compute Engine managed instance group (MIG), a group manager
 // that maintains a fleet of identical VM instances from a single instance
 // template. Query its `targetSize`, `currentActions` (creatingInstances,
 // deletingInstances, recreatingInstances), `autoHealingPolicies` (health
@@ -9455,7 +10293,7 @@ private gcp.project.computeService.instanceGroupManager @defaults("name targetSi
 
 // Google Cloud (GCP) Compute network firewall policy
 //
-// Examine a Compute Engine network firewall policy — a hierarchical or
+// Compute Engine network firewall policy, a hierarchical or
 // global/regional policy containing an ordered set of firewall rules that
 // can be associated with multiple VPC networks. Query its `ruleTupleCount`
 // (total rule tuples consumed toward the quota), `associations` (the
@@ -9551,9 +10389,10 @@ private gcp.retryConfig @defaults("maxAttempts maxDoublings") {
 
 // Google Cloud (GCP) Filestore
 //
-// Use this resource as the entry point for Filestore in the project. It
-// hosts the project's `instances` — each exposing its service tier, file
-// shares, network configuration, and capacity for managed NFS audits.
+// Managed NFS file storage in the project. The `instances` field lists each
+// Filestore file server with its service tier, file shares, network
+// configuration, and capacity, so managed NFS deployments can be audited
+// for encryption, deletion protection, and network exposure.
 private gcp.project.filestoreService {
   // Project ID
   projectId string
@@ -9563,11 +10402,11 @@ private gcp.project.filestoreService {
 
 // Google Cloud (GCP) Filestore instance
 //
-// Examine a managed NFS file server: its service tier (BASIC_HDD, BASIC_SSD,
-// HIGH_SCALE_SSD, ENTERPRISE, ZONAL, REGIONAL), current lifecycle state,
-// file share configurations, network interfaces with assigned IP addresses,
-// KMS encryption key, deletion-protection status, and zone-separation
-// compliance flags.
+// Managed NFS file server backing shared storage for workloads. Covers the
+// service tier, lifecycle state, file share and network configuration, the
+// customer-managed KMS encryption key (kmsKey), and deletion-protection and
+// zone-separation status, so you can verify how a file server is
+// provisioned, encrypted, and exposed on the network.
 private gcp.project.filestoreService.instance @defaults("name state tier") {
   // Project ID
   projectId string
@@ -9631,9 +10470,10 @@ private gcp.project.filestoreService.instance.network @defaults("network ipAddre
 
 // Google Cloud (GCP) Cloud Tasks
 //
-// Use this resource as the entry point for Cloud Tasks in the project. It
-// hosts the project's `queues` — each exposing its rate limits, retry
-// configuration, and processing state for task-queue audits.
+// Cloud Tasks in the project, the managed service for asynchronous task
+// execution. The `queues` field lists every task queue, each exposing its
+// dispatch rate limits, retry configuration, and processing state for
+// task-queue audits.
 private gcp.project.cloudTasksService {
   // Project ID
   projectId string
@@ -9643,10 +10483,11 @@ private gcp.project.cloudTasksService {
 
 // Google Cloud (GCP) Cloud Tasks queue
 //
-// Examine a Cloud Tasks queue: its current state (RUNNING, PAUSED, DISABLED),
-// dispatch rate limits, retry configuration (max attempts, backoff, max retry
-// duration), and any App Engine routing overrides that apply to tasks
-// dispatched from this queue.
+// Task queue that buffers and dispatches asynchronous work, with a current
+// state (RUNNING, PAUSED, DISABLED), dispatch rate limits, retry configuration
+// (max attempts, backoff, max retry duration), and any App Engine routing
+// overrides that apply to tasks dispatched from the queue. The `iamPolicy`
+// field reveals who can enqueue, lease, or manage tasks.
 private gcp.project.cloudTasksService.queue @defaults("name state") {
   // Project ID
   projectId string
@@ -9655,10 +10496,15 @@ private gcp.project.cloudTasksService.queue @defaults("name state") {
   // The current state of the queue (RUNNING, PAUSED, DISABLED)
   state string
   // Rate limits for task dispatches
+  //
+  // Keys: maxDispatchesPerSecond (float), maxBurstSize (int), and
+  // maxConcurrentDispatches (int).
   rateLimits dict
   // Retry configuration
   retryConfig gcp.retryConfig
   // Overrides for task-level app_engine_routing (App Engine queues only)
+  //
+  // Keys: service, version, instance, and host.
   appEngineRoutingOverride dict
   // IAM policy bindings on the queue (who can enqueue, lease, or manage tasks)
   iamPolicy() []gcp.resourcemanager.binding
@@ -9666,9 +10512,10 @@ private gcp.project.cloudTasksService.queue @defaults("name state") {
 
 // Google Cloud (GCP) Cloud Scheduler
 //
-// Use this resource as the entry point for Cloud Scheduler in the project.
-// It hosts the project's `jobs` — each exposing its cron schedule, target
-// (HTTP, Pub/Sub, or App Engine), retry configuration, and last-run state.
+// Cloud Scheduler for the project, the managed cron service that runs
+// scheduled jobs. The `jobs` field lists each job with its cron schedule,
+// target (HTTP, Pub/Sub, or App Engine), retry configuration, and last-run
+// state, so you can audit which automated tasks fire and how they run.
 private gcp.project.cloudSchedulerService {
   // Project ID
   projectId string
@@ -9678,10 +10525,12 @@ private gcp.project.cloudSchedulerService {
 
 // Google Cloud (GCP) Cloud Scheduler job
 //
-// Examine a Cloud Scheduler job: its cron schedule expression, time zone,
-// current state (ENABLED, PAUSED, DISABLED, UPDATE_FAILED), target type
-// (HTTP, Pub/Sub, or App Engine HTTP), retry configuration, and timestamps
-// for the last attempted run and the next scheduled run.
+// Single Cloud Scheduler job with its cron schedule expression and time
+// zone, current state (ENABLED, PAUSED, DISABLED, or UPDATE_FAILED), target
+// type (HTTP, Pub/Sub, or App Engine HTTP), retry configuration, and
+// timestamps for the last attempted and next scheduled run. Auditing jobs
+// surfaces which automated tasks run and, for HTTP targets, the service
+// account identity used to mint the authentication token.
 private gcp.project.cloudSchedulerService.job @defaults("name state schedule") {
   // Project ID
   projectId string
@@ -9721,9 +10570,10 @@ private gcp.project.cloudSchedulerService.job @defaults("name state schedule") {
 
 // Google Cloud (GCP) App Engine
 //
-// Use this resource as the entry point for App Engine in the project. It
-// hosts the `application` (with its location, serving status, and
-// identity settings) and the deployed `services` and their versions.
+// App Engine platform for a project. It hosts the singleton `application`
+// with its location, serving status, and identity settings, the deployed
+// `services` and their `versions`, and the `firewallRules` that form the
+// application's IP-level ingress perimeter.
 private gcp.project.appEngineService {
   // Project ID
   projectId string
@@ -9737,7 +10587,7 @@ private gcp.project.appEngineService {
 
 // Google Cloud (GCP) App Engine firewall ingress rule
 //
-// Examine an App Engine firewall ingress rule — the application's only
+// Single App Engine firewall ingress rule, the application's only
 // IP-level perimeter control. Each rule applies an `action` (ALLOW or DENY)
 // to a `sourceRange` CIDR, evaluated in `priority` order. A rule whose
 // `sourceRange` is "*" matches every address, so an ALLOW-all rule exposes
@@ -9757,7 +10607,7 @@ private gcp.project.appEngineService.firewallRule @defaults("priority action sou
 
 // Google Cloud (GCP) App Engine application
 //
-// Examine the App Engine application for a project: its serving
+// App Engine application for a project. It exposes the serving
 // location, serving status (SERVING, USER_DISABLED, SYSTEM_DISABLED), default
 // hostname, Cloud Storage buckets for code staging and Blobstore, GCR domain
 // for managed Docker images, database type (Firestore or Datastore), auth
@@ -9786,14 +10636,22 @@ private gcp.project.appEngineService.application @defaults("id locationId servin
   // Auth domain
   authDomain string
   // Feature settings
+  //
+  // Keys: `splitHealthChecks` (bool, whether split health checks are used)
+  // and `useContainerOptimizedOs` (bool, whether the flexible environment
+  // runs on Container-Optimized OS).
   featureSettings dict
-  // IAP configuration
+  // Identity-Aware Proxy configuration
+  //
+  // Keys: `enabled` (bool, whether IAP gates access to the application),
+  // `oauth2ClientId` (OAuth2 client ID used by IAP), and
+  // `oauth2ClientSecretSha256` (SHA-256 hash of the OAuth2 client secret).
   iap dict
 }
 
 // Google Cloud (GCP) App Engine service
 //
-// Examine an App Engine service (e.g., "default"): its traffic split
+// App Engine service (e.g., "default"), covering its traffic split
 // configuration across versions, resource labels, and the deployed versions
 // reachable through the `versions` field.
 private gcp.project.appEngineService.service @defaults("id") {
@@ -9806,6 +10664,10 @@ private gcp.project.appEngineService.service @defaults("id") {
   // Resource labels
   labels map[string]string
   // Traffic split configuration
+  //
+  // Keys: `shardBy` (how requests are routed across versions: UNSPECIFIED,
+  // COOKIE, IP, or RANDOM) and `allocations` (map of version ID to the
+  // fraction of traffic it receives).
   split dict
   // Versions of this service
   versions() []gcp.project.appEngineService.version
@@ -9813,7 +10675,7 @@ private gcp.project.appEngineService.service @defaults("id") {
 
 // Google Cloud (GCP) App Engine version
 //
-// Examine a deployed App Engine version: its serving status (SERVING,
+// Deployed App Engine version, covering its serving status (SERVING,
 // STOPPED), runtime (e.g., "python39", "go121", "nodejs20"), execution
 // environment (standard or flex), runtime API version, VPC access connector
 // configuration, URL handlers with their HTTPS enforcement and login
@@ -9838,19 +10700,30 @@ private gcp.project.appEngineService.version @defaults("id servingStatus") {
   // The version of the API in the given runtime environment
   runtimeApiVersion string
   // VPC access connector configuration
+  //
+  // Keys: `name` (full resource name of the Serverless VPC Access connector
+  // the version routes egress through) and `egressSetting` (which traffic
+  // uses the connector: ALL_TRAFFIC or PRIVATE_IP_RANGES).
   vpcAccessConnector dict
-  // URL handlers, each with its HTTPS enforcement (securityLevel) and login requirement
+  // URL handlers
+  //
+  // Ordered URL routing rules for the version. Keys per handler include
+  // `urlRegex` (the path pattern matched), `securityLevel` (HTTPS
+  // enforcement: SECURE_NEVER, SECURE_OPTIONAL, SECURE_ALWAYS), `login`
+  // (access requirement: LOGIN_OPTIONAL, LOGIN_ADMIN, LOGIN_REQUIRED), and
+  // `authFailAction` (response when the login requirement is not met).
   handlers []dict
-  // Inbound service channels the version accepts beyond HTTP (e.g. mail, XMPP, warmup) — additional ingress surface
+  // Inbound service channels the version accepts beyond HTTP (e.g. mail, XMPP, warmup); additional ingress surface
   inboundServices []string
 }
 
 // Google Cloud (GCP) API Gateway
 //
-// Use this resource as the entry point for API Gateway in the project. It
-// hosts the managed APIs (with their API configs) and the deployed
-// `gateways` — exposing managed-service names, deployment state, and the
-// hostnames clients use to reach backend services.
+// API Gateway configuration for the project, spanning the managed APIs
+// (with their deployed API configs) and the gateways that serve them.
+// Managed-service names, deployment state, and the hostnames clients use
+// to reach backend services are all queryable here, which matters when
+// auditing which APIs are exposed and how they authenticate to backends.
 private gcp.project.apiGatewayService {
   // Project ID
   projectId string
@@ -9862,10 +10735,11 @@ private gcp.project.apiGatewayService {
 
 // Google Cloud (GCP) API Gateway API
 //
-// Examine a managed API Gateway API: its lifecycle state (CREATING, ACTIVE,
-// FAILED, DELETING, UPDATING), the name of the Google-managed service backing
-// it, resource labels, creation and update timestamps, and the API
-// configurations deployed under this API.
+// Managed API Gateway API and its lifecycle. The state field reports one
+// of CREATING, ACTIVE, FAILED, DELETING, or UPDATING, and managedService
+// names the Google-managed service backing the API. Auditing an API
+// surfaces whether it is live and the API configurations deployed under
+// it through configs.
 private gcp.project.apiGatewayService.api @defaults("name state") {
   // Project ID
   projectId string
@@ -9889,11 +10763,12 @@ private gcp.project.apiGatewayService.api @defaults("name state") {
 
 // Google Cloud (GCP) API Gateway API config
 //
-// Examine an API Gateway API configuration: its lifecycle state (CREATING,
-// ACTIVE, FAILED, DELETING, UPDATING, ACTIVATING), the associated service
-// config ID, the IAM service account used by gateways to authenticate to
-// backend services, OpenAPI specification documents, resource labels, and
-// creation and update timestamps.
+// Deployed API Gateway configuration for an API. The state field reports
+// one of CREATING, ACTIVE, FAILED, DELETING, UPDATING, or ACTIVATING,
+// serviceConfigId ties the config to a managed-service revision, and
+// serviceAccount is the identity gateways serving this config use to
+// authenticate to backend services. The openapiDocuments field carries
+// the OpenAPI specification that defines the exposed routes.
 private gcp.project.apiGatewayService.apiConfig @defaults("name state") {
   // Project ID
   projectId string
@@ -9918,15 +10793,19 @@ private gcp.project.apiGatewayService.apiConfig @defaults("name state") {
   // Resource labels
   labels map[string]string
   // OpenAPI specification documents describing the API
+  //
+  // Each entry has `path` (the document filename) and `contents` (the
+  // base64-encoded OpenAPI specification text).
   openapiDocuments []dict
 }
 
 // Google Cloud (GCP) API Gateway gateway
 //
-// Examine an API Gateway deployment: its lifecycle state (CREATING, ACTIVE,
-// FAILED, DELETING, UPDATING), the API config it serves, the default hostname
-// clients use to reach backend services, resource labels, and creation and
-// update timestamps.
+// Deployed API Gateway that clients reach over the network. The
+// defaultHostname field is the host clients call, apiConfig names the
+// configuration it serves, and state reports one of CREATING, ACTIVE,
+// FAILED, DELETING, or UPDATING. Auditing gateways shows which APIs are
+// reachable and where their traffic is routed.
 private gcp.project.apiGatewayService.gateway @defaults("name state") {
   // Project ID
   projectId string
@@ -9950,10 +10829,10 @@ private gcp.project.apiGatewayService.gateway @defaults("name state") {
 
 // Google Cloud (GCP) Cloud Workstations
 //
-// Use this resource as the entry point for Cloud Workstations in the
-// project. It hosts the workstation `clusters` — each exposing its network
-// configuration, private-cluster settings, and degraded state for
-// managed-development-environment audits.
+// Cloud Workstations in the project, organized as workstation `clusters`.
+// Each cluster exposes its network configuration, private-cluster settings,
+// and degraded state, so you can audit the managed development environments
+// teams use to write and run code in the cloud.
 private gcp.project.workstationsService {
   // Project ID
   projectId string
@@ -9963,12 +10842,13 @@ private gcp.project.workstationsService {
 
 // Google Cloud (GCP) Cloud Workstations cluster
 //
-// Examine a Cloud Workstations cluster: its VPC network and subnetwork, the
-// private control-plane IP address, whether the cluster is in degraded mode,
-// whether it is currently reconciling toward its intended state, private
-// cluster configuration (endpoint enablement, cluster hostname, service
-// attachment URI, allowed projects), resource labels, client annotations, and
-// creation and update timestamps.
+// Cluster that provisions the VPC network, subnetwork, and control plane
+// backing a group of Cloud Workstations. Reports the private control-plane
+// IP address, whether the cluster is in degraded mode, whether it is
+// reconciling toward its intended state, its private-cluster configuration
+// (endpoint enablement, hostname, service attachment, and allowed projects),
+// resource labels, and client annotations. The `name` field is the full
+// resource name that selects the cluster.
 private gcp.project.workstationsService.cluster @defaults("name displayName degraded") {
   // Project ID
   projectId string
@@ -9996,16 +10876,25 @@ private gcp.project.workstationsService.cluster @defaults("name displayName degr
   labels map[string]string
   // Client-specified annotations
   annotations map[string]string
-  // Configuration for a private workstation cluster (enablePrivateEndpoint, clusterHostname, serviceAttachmentUri, allowedProjects)
+  // Private workstation cluster configuration
+  //
+  // Present when the cluster restricts control-plane access to a private
+  // endpoint. Keys: `enablePrivateEndpoint` (bool, whether the control plane
+  // is reachable only through the private endpoint), `clusterHostname`
+  // (string, hostname clients use to reach the private control plane),
+  // `serviceAttachmentUri` (string, Private Service Connect service
+  // attachment for the cluster), and `allowedProjects` (list of project IDs
+  // permitted to connect through the private endpoint).
   privateClusterConfig dict
 }
 
 // Google Cloud (GCP) Vertex AI Workbench
 //
-// Use this resource as the entry point for Vertex AI Workbench in the
-// project. It hosts the managed notebook `instances` — each exposing its
-// machine configuration, network and access settings, health state, and
-// public-IP exposure for data-science environment audits.
+// Vertex AI Workbench in the project, the managed JupyterLab environment
+// data scientists use for notebook development. The `instances` field lists
+// each managed notebook instance so you can audit machine configuration,
+// network and access settings, health state, and public-IP exposure of the
+// data-science environments running in the project.
 private gcp.project.workbenchService {
   // Project ID
   projectId string
@@ -10015,12 +10904,13 @@ private gcp.project.workbenchService {
 
 // Google Cloud (GCP) Vertex AI Workbench instance
 //
-// Examine a Vertex AI Workbench managed notebook instance: its lifecycle
-// state, health state (HEALTHY, UNHEALTHY, AGENT_NOT_INSTALLED), proxy
-// endpoint for Jupyter access, instance owners, whether proxy access and
-// public IP are disabled, whether deletion protection is enabled, Compute
-// Engine setup details (including network interfaces and disk configuration),
-// and creation and update timestamps.
+// Managed JupyterLab notebook instance backed by a Compute Engine VM. Query
+// it to audit whether the notebook is reachable from the internet
+// (disablePublicIp), whether proxy access to the Jupyter UI is turned off,
+// whether deletion protection is enabled, who owns the instance, and the
+// health state of the notebook agent (HEALTHY, UNHEALTHY, or
+// AGENT_NOT_INSTALLED). The Compute Engine configuration, including network
+// interfaces and disks, is exposed through gceSetup.
 private gcp.project.workbenchService.instance @defaults("name state healthState") {
   // Project ID
   projectId string
@@ -10044,7 +10934,14 @@ private gcp.project.workbenchService.instance @defaults("name state healthState"
   enableThirdPartyIdentity bool
   // Resource labels
   labels map[string]string
-  // Compute Engine setup for the notebook, including disablePublicIp and network interfaces
+  // Compute Engine backing configuration
+  //
+  // Compute Engine settings for the notebook VM. Keys include machineType,
+  // minCpuPlatform, acceleratorConfigs, gpuDriverConfig, bootDisk, dataDisks,
+  // networkInterfaces, serviceAccounts, shieldedInstanceConfig, vmImage,
+  // containerImage, metadata, tags, enableIpForwarding, and disablePublicIp.
+  // The top-level disablePublicIp field surfaces the same public-IP setting
+  // directly.
   gceSetup dict
   // Whether the instance has no external IP address assigned
   disablePublicIp bool
@@ -10056,10 +10953,11 @@ private gcp.project.workbenchService.instance @defaults("name state healthState"
 
 // Google Cloud (GCP) Notebooks
 //
-// Use this resource as the entry point for the legacy Notebooks service in
-// the project. It hosts the user-managed notebook `instances` — each
-// exposing its machine configuration, network settings, and public-IP
-// exposure. New deployments should use `workbench` instead.
+// Legacy Notebooks service for the project, hosting the user-managed
+// notebook `instances`. Each instance exposes its machine configuration,
+// network settings, and public-IP exposure, so you can audit notebook VMs
+// left over from before the move to Vertex AI Workbench. New deployments
+// should use `workbench` instead.
 private gcp.project.notebooksService {
   // Project ID
   projectId string
@@ -10069,17 +10967,21 @@ private gcp.project.notebooksService {
 
 // Google Cloud (GCP) legacy Notebooks instance
 //
-// Examine a User-Managed Notebooks instance: its lifecycle state, Compute
-// Engine machine type, whether a public IP is assigned (`noPublicIp`),
-// whether the notebook proxy is registered (`noProxyAccess`), VPC network and
-// subnet, service account, proxy URI for Jupyter access, creator email, and
-// creation and update timestamps.
+// User-managed Notebooks instance backed by a Compute Engine VM running
+// JupyterLab. Audit its network exposure through `noPublicIp` (whether an
+// external IP is assigned) and `noProxyAccess` (whether the notebook proxy is
+// registered), review the VPC network and subnet it runs in, and check the
+// service account it runs as and the creator who provisioned it.
 private gcp.project.notebooksService.instance @defaults("name state noPublicIp") {
   // Project ID
   projectId string
   // Full resource name (projects/{project}/locations/{location}/instances/{instance})
   name string
-  // State of the instance (ACTIVE, STOPPED, PROVISIONING, etc.)
+  // State of the instance
+  //
+  // One of STATE_UNSPECIFIED, STARTING, PROVISIONING, ACTIVE, STOPPING,
+  // STOPPED, DELETED, UPGRADING, INITIALIZING, REGISTERING, SUSPENDING, or
+  // SUSPENDED.
   state string
   // Compute Engine machine type of this instance
   machineType string
@@ -10107,11 +11009,10 @@ private gcp.project.notebooksService.instance @defaults("name state noPublicIp")
 
 // Google Cloud (GCP) Cloud Composer
 //
-// Use this resource as the entry point for Cloud Composer in the project.
-// It hosts the managed Apache Airflow `environments` — each exposing its
-// lifecycle state, image version, labels, and environment configuration
-// covering node config, software config, encryption, and web server
-// access control.
+// Cloud Composer in the project, hosting the managed Apache Airflow
+// `environments`. Each environment exposes its lifecycle state, image
+// version, labels, and environment configuration covering node config,
+// software config, encryption, and web server access control.
 private gcp.project.composerService {
   // Project ID
   projectId string
@@ -10121,7 +11022,7 @@ private gcp.project.composerService {
 
 // Google Cloud (GCP) Cloud Composer environment
 //
-// Examine a managed Apache Airflow environment running on Cloud Composer:
+// Managed Apache Airflow environment running on Cloud Composer, covering
 // its lifecycle state, the Composer image version it runs, user-defined
 // labels, creation and update timestamps, and the full environment
 // configuration covering node config, software config, encryption config,
@@ -10143,7 +11044,16 @@ private gcp.project.composerService.environment @defaults("name state imageVersi
   labels map[string]string
   // Composer image version running in the environment
   imageVersion string
-  // Environment configuration (node config, software config, encryption config, web server access control)
+  // Environment configuration
+  //
+  // Cloud Composer environment configuration. Keys include `nodeConfig`
+  // (network, subnetwork, service account, machine type), `softwareConfig`
+  // (Airflow image version, config overrides, PyPI packages, environment
+  // variables), `privateEnvironmentConfig`, `webServerNetworkAccessControl`,
+  // `encryptionConfig`, `databaseConfig`, `webServerConfig`, `workloadsConfig`,
+  // `maintenanceWindow`, `recoveryConfig`, `masterAuthorizedNetworksConfig`,
+  // `dataRetentionConfig`, `environmentSize`, `resilienceMode`, `nodeCount`,
+  // `dagGcsPrefix`, `airflowUri`, and `gkeCluster`.
   config dict
   // Customer-managed Cloud KMS key used to encrypt the environment at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
@@ -10155,10 +11065,10 @@ private gcp.project.composerService.environment @defaults("name state imageVersi
 
 // Google Cloud (GCP) Cloud Healthcare API
 //
-// Use this resource as the entry point for the Cloud Healthcare API in the
-// project. It hosts the `datasets` and, through them, the DICOM, FHIR, and
-// HL7v2 stores — exposing encryption configuration, time zone, and
-// notification settings for healthcare-data audits.
+// Cloud Healthcare API entry point for the project. Its `datasets`, and the
+// DICOM, FHIR, and HL7v2 stores they contain, expose encryption configuration,
+// time zone, and notification settings for auditing how protected health
+// information is stored and shared.
 private gcp.project.healthcareService {
   // Project ID
   projectId string
@@ -10168,9 +11078,9 @@ private gcp.project.healthcareService {
 
 // Google Cloud (GCP) Cloud Healthcare dataset
 //
-// Examine a Cloud Healthcare dataset: its default IANA time zone, customer-
-// managed encryption key configuration, and the DICOM, FHIR, and HL7v2
-// stores it contains.
+// Container for a group of related Cloud Healthcare stores. Holds the default
+// IANA time zone, the customer-managed encryption key that protects data at
+// rest, and the DICOM, FHIR, and HL7v2 stores in the dataset.
 private gcp.project.healthcareService.dataset @defaults("name timeZone") {
   // Project ID
   projectId string
@@ -10192,8 +11102,9 @@ private gcp.project.healthcareService.dataset @defaults("name timeZone") {
 
 // Google Cloud (GCP) Cloud Healthcare DICOM store
 //
-// Examine a Cloud Healthcare DICOM store: its resource labels and the Pub/Sub
-// notification destination configured for new DICOM instance ingestion events.
+// Store for medical imaging data in DICOM format. Exposes the resource labels
+// and the Pub/Sub notification destination configured for new DICOM instance
+// ingestion events.
 private gcp.project.healthcareService.dicomStore @defaults("name") {
   // Project ID
   projectId string
@@ -10202,16 +11113,20 @@ private gcp.project.healthcareService.dicomStore @defaults("name") {
   // Resource labels
   labels map[string]string
   // Pub/Sub notification destination for new DICOM instances
+  //
+  // Keys: `pubsubTopic` (the Pub/Sub topic name that change notifications are
+  // published to) and `sendForBulkImport` (whether notifications are also sent
+  // on bulk DICOM imports).
   notificationConfig dict
 }
 
 // Google Cloud (GCP) Cloud Healthcare FHIR store
 //
-// Examine a Cloud Healthcare FHIR store: the FHIR specification version
-// (DSTU2, STU3, R4, R5), whether referential integrity is disabled, whether
-// the updateCreate capability is enabled, complex data type reference parsing
-// mode, whether strict search-parameter handling is the default, and resource
-// labels.
+// Store for structured clinical data in FHIR format. Exposes the FHIR
+// specification version (DSTU2, STU3, R4, R5), whether referential integrity
+// is disabled, whether the updateCreate capability is enabled, the complex
+// data type reference parsing mode, whether strict search-parameter handling
+// is the default, and resource labels.
 private gcp.project.healthcareService.fhirStore @defaults("name version") {
   // Project ID
   projectId string
@@ -10225,7 +11140,11 @@ private gcp.project.healthcareService.fhirStore @defaults("name version") {
   disableReferentialIntegrity bool
   // Whether the store has the updateCreate capability
   enableUpdateCreate bool
-  // Whether references in complex data types are parsed (ENABLED, DISABLED, COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED)
+  // Complex data type reference parsing mode
+  //
+  // Whether references within complex FHIR data types (such as Extensions) are
+  // parsed. One of ENABLED, DISABLED, or
+  // COMPLEX_DATA_TYPE_REFERENCE_PARSING_UNSPECIFIED (treated as DISABLED).
   complexDataTypeReferenceParsing string
   // Whether search uses strict handling for unrecognized parameters
   defaultSearchHandlingStrict bool
@@ -10233,8 +11152,9 @@ private gcp.project.healthcareService.fhirStore @defaults("name version") {
 
 // Google Cloud (GCP) Cloud Healthcare HL7v2 store
 //
-// Examine a Cloud Healthcare HL7v2 store: its message parser configuration,
-// whether duplicate messages are rejected, and resource labels.
+// Store for HL7 version 2 messages exchanged between healthcare systems.
+// Exposes the message parser configuration, whether duplicate messages are
+// rejected, and resource labels.
 private gcp.project.healthcareService.hl7v2Store @defaults("name") {
   // Project ID
   projectId string
@@ -10242,7 +11162,13 @@ private gcp.project.healthcareService.hl7v2Store @defaults("name") {
   name string
   // Resource labels
   labels map[string]string
-  // Configuration for how the server parses messages
+  // HL7v2 message parser configuration
+  //
+  // Keys: `allowNullHeader` (whether messages with no header are allowed),
+  // `segmentTerminator` (byte(s) used as the segment terminator, defaulting to
+  // a carriage return when unset), `version` (parser version, one of
+  // PARSER_VERSION_UNSPECIFIED, V1, V2, or V3), and `schema` (the schema
+  // package used for schematized parsing, when configured).
   parserConfig dict
   // Whether duplicate messages are rejected
   rejectDuplicateMessage bool
@@ -10303,7 +11229,7 @@ private gcp.project.computeService.healthCheck @defaults("name type") {
 
 // Google Cloud (GCP) Compute URL map
 //
-// Examine a Compute Engine URL map: its default backend service, host rules
+// Compute Engine URL map: its default backend service, host rules
 // that match incoming hostnames, path matchers that route requests to backend
 // services or buckets, URL map tests, and whether the map is regional or
 // global.
@@ -10342,7 +11268,7 @@ private gcp.project.computeService.urlMap @defaults("name") {
 
 // Google Cloud (GCP) Compute target HTTP proxy
 //
-// Examine a Compute Engine target HTTP proxy: the URL map it routes traffic
+// Compute Engine target HTTP proxy: the URL map it routes traffic
 // through, whether proxy bind is enabled for Cloud Armor, and whether the
 // proxy is regional or global.
 private gcp.project.computeService.targetHttpProxy @defaults("name") {
@@ -10376,7 +11302,7 @@ private gcp.project.computeService.targetHttpProxy @defaults("name") {
 
 // Google Cloud (GCP) Compute target HTTPS proxy
 //
-// Examine a Compute Engine target HTTPS proxy: the URL map it routes traffic
+// Compute Engine target HTTPS proxy: the URL map it routes traffic
 // through, the SSL certificates it presents, the SSL policy governing TLS
 // version and cipher requirements, the QUIC override setting (NONE, ENABLE,
 // DISABLE), whether proxy bind is enabled for Cloud Armor, and whether the
@@ -10424,7 +11350,7 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
 
 // Google Cloud (GCP) Compute network peering
 //
-// Examine a VPC network peering connection: its state (ACTIVE, INACTIVE),
+// VPC network peering connection: its state (ACTIVE, INACTIVE),
 // the peer network resource, whether full-mesh routes are auto-created,
 // whether subnet routes are exchanged, and the import/export settings for
 // custom routes and public-IP subnet routes.
@@ -10459,7 +11385,7 @@ private gcp.project.computeService.network.peering @defaults("name state") {
 
 // Google Cloud (GCP) Compute static route
 //
-// Examine a Compute Engine route: its destination IP range, priority
+// Compute Engine route: its destination IP range, priority
 // (0-65535), the network it belongs to, the next hop (gateway, instance, IP
 // address, VPN tunnel, ILB forwarding rule, or NCC hub), the instance tags
 // that scope the route, route type (STATIC, BGP, SUBNET, TRANSIT), route
@@ -10524,7 +11450,7 @@ private gcp.project.computeService.route @defaults("name destRange") {
 
 // Google Cloud (GCP) Compute Private Service Connect service attachment
 //
-// Examine a Private Service Connect service attachment: its connection
+// Private Service Connect service attachment: its connection
 // preference (ACCEPT_AUTOMATIC, ACCEPT_MANUAL), the connected consumer
 // endpoints, consumer accept and reject lists, whether proxy protocol is
 // enabled, DNS domain names for service discovery, NAT subnets, the producer
@@ -10572,7 +11498,7 @@ private gcp.project.computeService.serviceAttachment @defaults("name connectionP
 
 // Google Cloud (GCP) Compute network endpoint group
 //
-// Examine a Compute Engine Network Endpoint Group (NEG): its endpoint type
+// Compute Engine Network Endpoint Group (NEG): its endpoint type
 // (GCE_VM_IP, GCE_VM_IP_PORT, SERVERLESS, PRIVATE_SERVICE_CONNECT,
 // INTERNET_IP_PORT, INTERNET_FQDN_PORT), default port, number of endpoints,
 // the network and subnetwork it belongs to, serverless backend configuration
@@ -10635,7 +11561,7 @@ private gcp.project.computeService.networkEndpointGroup @defaults("name networkE
 
 // Google Cloud (GCP) Compute Interconnect connection
 //
-// Examine a Dedicated or Partner Interconnect connection: its type
+// Dedicated or Partner Interconnect connection: its type
 // (DEDICATED, PARTNER), link type (10G_LR, 100G_LR), requested and
 // provisioned link counts, administrative status, operational status,
 // connection state (ACTIVE, UNPROVISIONED), Google and peer IP addresses for
@@ -10700,7 +11626,7 @@ private gcp.project.computeService.interconnect @defaults("name interconnectType
 
 // Google Cloud (GCP) Compute Interconnect Attachment (VLAN)
 //
-// Examine a Dedicated or Partner Interconnect VLAN attachment: its type
+// Dedicated or Partner Interconnect VLAN attachment: its type
 // (DEDICATED, PARTNER, PARTNER_PROVIDER), state (ACTIVE, UNPROVISIONED,
 // PENDING_PARTNER, DEFUNCT, PENDING_CUSTOMER), edge availability domain,
 // bandwidth, VLAN tag (802.1Q), encryption mode (NONE, IPSEC), IPv4 and IPv6
@@ -10770,7 +11696,7 @@ private gcp.project.computeService.interconnectAttachment @defaults("name type s
 
 // Google Cloud (GCP) Compute external VPN gateway (peer/customer-side)
 //
-// Examine the peer-side VPN gateway used in a Cloud VPN configuration: its
+// Peer-side VPN gateway used in a Cloud VPN configuration: its
 // redundancy type (SINGLE_IP_INTERNALLY_REDUNDANT, TWO_IPS_REDUNDANCY,
 // FOUR_IPS_REDUNDANCY), the IP addresses of the peer gateway's interfaces,
 // and resource labels.
@@ -10795,7 +11721,7 @@ private gcp.project.computeService.externalVpnGateway @defaults("name redundancy
 
 // Google Cloud (GCP) Compute target TCP proxy
 //
-// Examine a Compute Engine target TCP proxy: the backend service it forwards
+// Compute Engine target TCP proxy: the backend service it forwards
 // traffic to, the proxy header mode (NONE, PROXY_V1), whether proxy bind is
 // enabled, and whether the proxy is regional or global.
 private gcp.project.computeService.targetTcpProxy @defaults("name") {
@@ -10829,7 +11755,7 @@ private gcp.project.computeService.targetTcpProxy @defaults("name") {
 
 // Google Cloud (GCP) Compute target SSL proxy
 //
-// Examine a Compute Engine target SSL proxy: the backend service it forwards
+// Compute Engine target SSL proxy: the backend service it forwards
 // traffic to, the proxy header mode (NONE, PROXY_V1), the SSL certificates it
 // presents, the SSL policy governing TLS version and cipher requirements, and
 // the certificate map URL.
@@ -10868,7 +11794,7 @@ private gcp.project.computeService.targetSslProxy @defaults("name") {
 
 // Google Cloud (GCP) Compute packet mirroring policy
 //
-// Examine a Compute Engine packet mirroring policy: whether mirroring is
+// Compute Engine packet mirroring policy: whether mirroring is
 // enabled, its priority, the collector internal load balancer, the mirrored
 // resources (specific instances, subnetworks, or tags), traffic filter
 // configuration, and the network it applies to.
@@ -10905,7 +11831,7 @@ private gcp.project.computeService.packetMirroring @defaults("name enable") {
 
 // Google Cloud (GCP) Compute backend bucket
 //
-// Examine a Compute Engine backend bucket: the backing Cloud Storage bucket
+// Compute Engine backend bucket: the backing Cloud Storage bucket
 // name, whether Cloud CDN is enabled, the CDN policy configuration,
 // compression mode (AUTOMATIC, DISABLED), custom response headers, and the
 // edge security policy URL.
@@ -10936,7 +11862,7 @@ private gcp.project.computeService.backendBucket @defaults("name enableCdn") {
 
 // Google Cloud (GCP) Compute target pool (legacy network load balancing)
 //
-// Examine a legacy network load balancing target pool: its session affinity
+// Legacy network load balancing target pool: its session affinity
 // mode (NONE, CLIENT_IP, CLIENT_IP_PROTO, CLIENT_IP_PORT_PROTO), failover
 // ratio, backup pool URL, associated health check URLs, the instance URLs of
 // members in the pool, and the security policy applied.
@@ -10985,7 +11911,7 @@ private gcp.project.computeService.targetPool @defaults("name") {
 
 // Google Cloud (GCP) Compute public advertised prefix (BYOIP)
 //
-// Examine a Bring Your Own IP (BYOIP) public advertised prefix: the IP CIDR
+// Bring Your Own IP (BYOIP) public advertised prefix: the IP CIDR
 // range being advertised, its validation status (INITIAL, PTR_CONFIGURED,
 // VALIDATED, PREFIX_CONFIGURATION_COMPLETE, PREFIX_CONFIGURATION_IN_PROGRESS,
 // PREFIX_REMOVAL_IN_PROGRESS, READY_TO_USE), the DNS verification IP, BYOIP
@@ -11020,7 +11946,7 @@ private gcp.project.computeService.publicAdvertisedPrefix @defaults("name ipCidr
 
 // Google Cloud (GCP) Compute instance template
 //
-// Examine a Compute Engine instance template: the instance properties it
+// Compute Engine instance template: the instance properties it
 // defines (machine type, boot and data disks, network interfaces, service
 // account, metadata, and scheduling options), whether it was derived from an
 // existing instance, and its creation timestamp.
@@ -11045,10 +11971,10 @@ private gcp.project.computeService.instanceTemplate @defaults("name description"
 
 // Google Cloud (GCP) Cloud Deploy
 //
-// Use this resource as the entry point for Cloud Deploy in the project. It
+// Cloud Deploy in the project, the root for continuous-delivery audits. It
 // hosts the `deliveryPipelines` (the promotion sequences for releases) and
-// the `targets` they deploy to — exposing execution configuration and
-// per-target settings for continuous-delivery audits.
+// the `targets` they deploy to, exposing execution configuration and
+// per-target settings.
 private gcp.project.cloudDeployService {
   // Project ID
   projectId string
@@ -11060,10 +11986,10 @@ private gcp.project.cloudDeployService {
 
 // Google Cloud (GCP) Cloud Deploy delivery pipeline
 //
-// Examine a Cloud Deploy delivery pipeline: its serial pipeline stage
-// configuration, whether the pipeline is suspended, pipeline conditions
-// (readiness and pipeline readiness state), resource labels, annotations, and
-// the releases created from this pipeline.
+// Delivery pipeline defining an ordered promotion sequence for releases. The
+// `serialPipeline` stages, whether the pipeline is `suspended`, the readiness
+// `condition`, resource labels, annotations, and the `releases` created from
+// this pipeline support continuous-delivery configuration audits.
 private gcp.project.cloudDeployService.deliveryPipeline @defaults("name") {
   // Project ID
   projectId string
@@ -11083,9 +12009,17 @@ private gcp.project.cloudDeployService.deliveryPipeline @defaults("name") {
   updateTime time
   // Whether the pipeline is suspended
   suspended bool
-  // Serial pipeline configuration (stages)
+  // Ordered pipeline stages
+  //
+  // Deployment stages under the `stages` key, each with `targetId`, the
+  // `profiles` (Skaffold profiles) applied, a promotion `strategy`, and
+  // `deployParameters`.
   serialPipeline dict
-  // Pipeline conditions
+  // Pipeline readiness conditions
+  //
+  // Keyed by `pipelineReadyCondition` ({status, updateTime}),
+  // `targetsPresentCondition` ({status, missingTargets, updateTime}), and
+  // `targetsTypeCondition` ({status, errorDetails}).
   condition dict
   // Releases created from this pipeline
   releases() []gcp.project.cloudDeployService.release
@@ -11093,10 +12027,11 @@ private gcp.project.cloudDeployService.deliveryPipeline @defaults("name") {
 
 // Google Cloud (GCP) Cloud Deploy target
 //
-// Examine a Cloud Deploy deployment target: whether approval is required
-// before a release is promoted to this target, the target type (GKE cluster,
-// Cloud Run service, or custom target), execution configuration, resource
-// labels, and annotations.
+// Deployment target that a delivery pipeline promotes releases to. Whether
+// approval is required before promotion (`requireApproval`), the runtime the
+// target represents (`gke` cluster, Cloud Run `run`, or `customTarget`), the
+// `executionConfigs`, resource labels, and annotations support
+// deployment-target audits.
 private gcp.project.cloudDeployService.target @defaults("name") {
   // Project ID
   projectId string
@@ -11117,21 +12052,34 @@ private gcp.project.cloudDeployService.target @defaults("name") {
   // Whether approval is required for this target
   requireApproval bool
   // GKE cluster target
+  //
+  // Keys: `cluster` (cluster resource name), `internalIp` (whether to reach
+  // the cluster over its internal IP), `proxyUrl`, and `dnsEndpoint`.
   gke dict
   // Cloud Run target
+  //
+  // Holds the `location` key: the Cloud Run region the target deploys to.
   run dict
   // Custom target type
+  //
+  // Holds the `customTargetType` key: the resource name of the custom target
+  // type that defines how this target is rendered and deployed.
   customTarget dict
-  // Execution configs
+  // Execution environment configs
+  //
+  // Each config carries `usages` (any of RENDER, DEPLOY, VERIFY, PREDEPLOY,
+  // POSTDEPLOY), the `workerPool`, `serviceAccount`, `artifactStorage` bucket,
+  // `executionTimeout`, and `verbose` logging.
   executionConfigs []dict
 }
 
 // Google Cloud (GCP) Cloud Deploy release
 //
-// Examine a Cloud Deploy release: its Skaffold configuration URI and version,
-// overall render state (SUCCEEDED, FAILED, IN_PROGRESS), whether the release
-// was abandoned, render start and end timestamps, pipeline and release
-// readiness conditions, resource labels, and annotations.
+// Release rendered from a delivery pipeline for promotion to targets. The
+// Skaffold configuration (`skaffoldConfigUri`, `skaffoldVersion`), the overall
+// `renderState`, whether the release was `abandoned`, render timestamps, the
+// readiness `condition`, resource labels, and annotations support release
+// audits.
 private gcp.project.cloudDeployService.release @defaults("name") {
   // Full resource name
   name string
@@ -11157,16 +12105,20 @@ private gcp.project.cloudDeployService.release @defaults("name") {
   renderStartTime time
   // Render end time
   renderEndTime time
-  // Condition (pipeline readiness, release readiness, Skaffold support state)
+  // Release readiness conditions
+  //
+  // Keyed by `releaseReadyCondition` ({status}) and
+  // `skaffoldSupportedCondition` ({status, skaffoldSupportState,
+  // maintenanceModeTime, supportExpirationTime}).
   condition dict
 }
 
 // Google Cloud (GCP) Dataflow
 //
-// Use this resource as the entry point for Dataflow in the project. It
-// hosts the project's `jobs` — each exposing its pipeline type, current
-// state, environment configuration, and worker settings for stream and
-// batch processing audits.
+// Dataflow service for the project, the access point to the project's
+// `jobs`. Each job exposes its pipeline type, current state, environment
+// configuration, and worker settings for stream and batch processing
+// audits.
 private gcp.project.dataflowService {
   // Project ID
   projectId string
@@ -11176,11 +12128,11 @@ private gcp.project.dataflowService {
 
 // Google Cloud (GCP) Dataflow job
 //
-// Examine a Dataflow job: its pipeline type (JOB_TYPE_BATCH,
+// Dataflow pipeline job, covering its pipeline type (JOB_TYPE_BATCH,
 // JOB_TYPE_STREAMING), current state (JOB_STATE_RUNNING, JOB_STATE_DONE,
-// etc.), the environment configuration covering worker settings and SDK
-// pipeline options, region or location of execution, resource labels, and
-// creation timestamp.
+// and the other JOB_STATE_* values), the environment configuration for
+// worker settings and SDK pipeline options, region or location of
+// execution, resource labels, and creation timestamp.
 private gcp.project.dataflowService.job @defaults("name currentState") {
   // Project ID
   projectId string
@@ -11190,7 +12142,13 @@ private gcp.project.dataflowService.job @defaults("name currentState") {
   name string
   // Type of job (JOB_TYPE_BATCH, JOB_TYPE_STREAMING)
   type string
-  // Current state of the job (JOB_STATE_RUNNING, JOB_STATE_DONE, etc.)
+  // Current state of the job
+  //
+  // One of JOB_STATE_UNKNOWN, JOB_STATE_STOPPED, JOB_STATE_RUNNING,
+  // JOB_STATE_DONE, JOB_STATE_FAILED, JOB_STATE_CANCELLED,
+  // JOB_STATE_UPDATED, JOB_STATE_DRAINING, JOB_STATE_DRAINED,
+  // JOB_STATE_PENDING, JOB_STATE_CANCELLING, JOB_STATE_QUEUED, or
+  // JOB_STATE_RESOURCE_CLEANING_UP.
   currentState string
   // Timestamp when the job was created
   createTime time
@@ -11198,13 +12156,27 @@ private gcp.project.dataflowService.job @defaults("name currentState") {
   location string
   // Resource labels
   labels map[string]string
-  // The environment the job runs in
+  // Execution environment the job runs in
+  //
+  // Raw environment configuration, with keys including
+  // `serviceAccountEmail`, `serviceKmsKeyName`, `workerPools`,
+  // `workerRegion`, `workerZone`, `tempStoragePrefix`, `experiments`,
+  // `serviceOptions`, `shuffleMode`, `streamingMode`, `usePublicIps`,
+  // `sdkPipelineOptions`, and `flexResourceSchedulingGoal`. See `kmsKey`
+  // for the resolved encryption key and `workerIpConfiguration` for the
+  // resolved worker IP setting.
   environment dict
   // Customer-managed Cloud KMS key protecting pipeline state and shuffle data at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
   // VM IP configuration of the job's worker pools (WORKER_IP_PUBLIC, WORKER_IP_PRIVATE, or WORKER_IP_UNSPECIFIED)
   workerIpConfiguration string
-  // The SDK pipeline options
+  // SDK pipeline description
+  //
+  // Description of the compiled pipeline, with keys `displayData`
+  // (pipeline-level display data), `executionPipelineStage` (per-stage
+  // execution descriptions), `originalPipelineTransform` (per-transform
+  // descriptions and the collections between them), and `stepNamesHash`
+  // (hash of the submitted pipeline step names).
   pipelineDescription dict
   // Timestamp of the current state
   currentStateTime time
@@ -11212,10 +12184,11 @@ private gcp.project.dataflowService.job @defaults("name currentState") {
 
 // Google Cloud (GCP) Artifact Registry
 //
-// Use this resource as the entry point for Artifact Registry in the
-// project. It hosts the project's `repositories` — each exposing its
-// format, mode, encryption configuration, cleanup policies, and IAM policy
-// for container-image and package-storage audits.
+// Artifact Registry in the project, exposing the project's `repositories`.
+// Each repository carries its package format, mode, encryption
+// configuration, cleanup policies, and IAM policy, so this resource is the
+// entry point for auditing container-image and package storage across the
+// project.
 private gcp.project.artifactRegistryService {
   // Project ID
   projectId string
@@ -11225,12 +12198,13 @@ private gcp.project.artifactRegistryService {
 
 // Google Cloud (GCP) Artifact Registry repository
 //
-// Examine a single Artifact Registry repository — its package format
-// (DOCKER, MAVEN, NPM, PYTHON, APT, YUM, GO, GENERIC), repository mode
-// (STANDARD, VIRTUAL, REMOTE), encryption key, cleanup policies, format-
-// and mode-specific configuration, and IAM policy bindings. Use
-// `vulnerabilityScanningConfig` to audit whether container-image scanning
-// is active or inherited.
+// Single Artifact Registry repository: its package format (DOCKER, MAVEN,
+// NPM, PYTHON, APT, YUM, GO, GENERIC), mode (STANDARD, VIRTUAL, REMOTE),
+// encryption key, cleanup policies, format- and mode-specific
+// configuration, and IAM policy bindings. The `vulnerabilityScanningConfig`
+// field reports whether container-image scanning is active or inherited,
+// and `public` flags a repository whose IAM policy makes its artifacts
+// anonymously pullable.
 private gcp.project.artifactRegistryService.repository @defaults("name format location") {
   // Project ID
   projectId string
@@ -11292,11 +12266,11 @@ private gcp.project.artifactRegistryService.repository @defaults("name format lo
 
 // Google Cloud (GCP) Artifact Registry package
 //
-// Examine a package stored in an Artifact Registry repository, identified by
-// `name` (for example a container image name or a Maven/npm/PyPI package
-// name). Inspect `createTime` for when the package first appeared and
-// `updateTime` for the most recent push; iterate `versions` for the
-// individual published versions, their tags, and their content digests — the
+// Package stored in an Artifact Registry repository, identified by `name`
+// (for example a container image name or a Maven/npm/PyPI package name).
+// The `createTime` field records when the package first appeared and
+// `updateTime` the most recent push, while `versions` lists the individual
+// published versions, their tags, and their content digests, the
 // per-artifact provenance of what was published and when.
 private gcp.project.artifactRegistryService.repository.package @defaults("name updateTime") {
   // Project ID
@@ -11317,12 +12291,12 @@ private gcp.project.artifactRegistryService.repository.package @defaults("name u
 
 // Google Cloud (GCP) Artifact Registry package version
 //
-// Examine a published version of an Artifact Registry package, identified by
-// `name` (the version's digest or version string). Inspect `createTime` for
-// when the version was pushed; `relatedTags` for the human-readable tags
-// (such as `latest`) that point at it; `fingerprints` for the content hashes
-// that uniquely pin the bytes; and `metadata` for format-specific details
-// like the image manifest media type and build time.
+// Published version of an Artifact Registry package, identified by `name`
+// (the version's digest or version string). The `createTime` field records
+// when the version was pushed, `relatedTags` the human-readable tags (such
+// as `latest`) that point at it, `fingerprints` the content hashes that
+// uniquely pin the bytes, and `metadata` the format-specific details like
+// the image manifest media type and build time.
 private gcp.project.artifactRegistryService.repository.package.version @defaults("name createTime") {
   // Project ID
   projectId string
@@ -11338,7 +12312,10 @@ private gcp.project.artifactRegistryService.repository.package.version @defaults
   updateTime time
   // Tags that point at this version (e.g. latest, v1.2.3)
   relatedTags []string
-  // Content hashes that uniquely identify the version's bytes, each with its type and value
+  // Content hashes that uniquely pin the version's bytes
+  //
+  // Each entry is a dict with `type` (the hash algorithm, for example
+  // SHA256) and `value` (the hex-encoded hash).
   fingerprints []dict
   // Format-specific metadata (e.g. image manifest media type, image size, build time)
   metadata dict
@@ -11360,10 +12337,10 @@ private gcp.project.artifactRegistryService.repository.vulnScanConfig {
 
 // Google Cloud (GCP) Artifact Registry repository cleanup policy
 //
-// Examine a cleanup policy attached to an Artifact Registry repository.
-// Each policy has an `action` (DELETE or KEEP) and a `policyType` that
-// selects between a condition-based filter (`condition`) or a most-recent-
-// versions retention rule (`mostRecentVersions`).
+// Cleanup policy attached to an Artifact Registry repository. Each policy
+// has an `action` (DELETE or KEEP) and a `policyType` that selects between
+// a condition-based filter (`condition`) or a most-recent-versions
+// retention rule (`mostRecentVersions`).
 private gcp.project.artifactRegistryService.repository.cleanupPolicy @defaults("id action policyType") {
   // Internal ID
   id string
@@ -11443,10 +12420,10 @@ private gcp.project.artifactRegistryService.repository.upstreamPolicy @defaults(
 
 // Google Cloud (GCP) Backup and DR Service
 //
-// Use this resource as the entry point for the Backup and DR Service in
-// the project. It hosts the `managementServers`, the `backupVaults` that
-// store immutable backups, and the `backupPlans` that schedule them —
-// exposing retention and enforcement settings for data-protection audits.
+// Backup and DR Service configuration for the project, the entry point to
+// the `managementServers`, the `backupVaults` that store immutable backups,
+// and the `backupPlans` that schedule them. Retention and enforcement
+// settings surface here for data-protection audits.
 private gcp.project.backupdrService {
   // Project ID
   projectId string
@@ -11460,22 +12437,27 @@ private gcp.project.backupdrService {
 
 // Google Cloud (GCP) Backup and DR management server
 //
-// Examine a Backup and DR management server — its current lifecycle state
-// (CREATING, READY, UPDATING, DELETING, REPAIRING, ERROR), network
-// configuration, management URI, OAuth2 client ID, and whether Physical
-// Zone Separation is satisfied.
+// Backup and DR management server, covering its current lifecycle state,
+// network configuration, management URI, OAuth2 client ID, and whether
+// Physical Zone Separation is satisfied.
 private gcp.project.backupdrService.managementServer @defaults("name state") {
   // Full resource name
   name string
   // Human-readable description of the resource
   description string
-  // Current state (CREATING, READY, UPDATING, DELETING, REPAIRING, ERROR)
+  // Current state (CREATING, READY, UPDATING, DELETING, REPAIRING, MAINTENANCE, ERROR)
   state string
   // Type of the management server (BACKUP_RESTORE)
   type string
-  // Networks for the management server
+  // Networks the management server is attached to
+  //
+  // Each entry has `network` (the VPC network resource name) and
+  // `peeringMode` (currently PRIVATE_SERVICE_ACCESS).
   networks []dict
-  // Management URI
+  // Management server AGM/RD web and API URLs
+  //
+  // Keys: `webUi` (the management server WebUI URL) and `api` (the
+  // management server API URL).
   managementUri dict
   // OAuth2 client ID
   oauth2ClientId string
@@ -11493,17 +12475,20 @@ private gcp.project.backupdrService.managementServer @defaults("name state") {
 
 // Google Cloud (GCP) Backup and DR backup vault
 //
-// Examine a Backup and DR backup vault — its minimum enforced retention
-// duration, access restriction setting, whether the vault is deletable,
-// service account, total stored bytes, backup count, and the `dataSources`
-// that are protected within it. Use these fields to verify immutability
-// and data-protection policy compliance.
+// Backup and DR backup vault, a storage location that holds immutable
+// backups. Fields cover the minimum enforced retention duration, the
+// access restriction setting, whether the vault is deletable, the service
+// account, total stored bytes, backup count, and the `dataSources`
+// protected within it, letting you verify immutability and data-protection
+// policy compliance.
 private gcp.project.backupdrService.backupVault @defaults("name state") {
   // Full resource name
   name string
   // Human-readable description of the resource
   description string
-  // Current state
+  // Current lifecycle state
+  //
+  // One of CREATING, ACTIVE, DELETING, ERROR, or UPDATING.
   state string
   // Minimum enforced retention duration
   backupMinimumEnforcedRetentionDuration string
@@ -11519,7 +12504,10 @@ private gcp.project.backupdrService.backupVault @defaults("name state") {
   serviceAccount string
   // Total stored bytes
   totalStoredBytes int
-  // Access restriction
+  // Scope from which backups in the vault can be accessed and restored
+  //
+  // One of WITHIN_PROJECT, WITHIN_ORGANIZATION, UNRESTRICTED, or
+  // WITHIN_ORG_BUT_UNRESTRICTED_FOR_BA.
   accessRestriction string
   // Cloud KMS key name encrypting backups at rest (empty when Google-managed encryption is used)
   kmsKeyName string
@@ -11537,20 +12525,27 @@ private gcp.project.backupdrService.backupVault @defaults("name state") {
 
 // Google Cloud (GCP) Backup and DR data source
 //
-// Examine a data source protected within a Backup and DR backup vault —
-// its current state, configuration state, total stored bytes, backup
-// count, and the GCP resource or Backup Appliance application it
-// represents.
+// Data source protected within a Backup and DR backup vault, covering its
+// current state, configuration state, total stored bytes, backup count,
+// and the GCP resource or Backup Appliance application it represents.
 private gcp.project.backupdrService.dataSource @defaults("name state") {
   // Full resource name
   name string
-  // Current state
+  // Current lifecycle state
+  //
+  // One of CREATING, ACTIVE, DELETING, or ERROR.
   state string
   // User-defined key/value labels for organizing the resource
   labels map[string]string
-  // Data source GCP resource
+  // GCP resource backed up by this data source
+  //
+  // Keys: `gcpResourcename` (the full resource name), `location`, and
+  // `type` (the resource type, for example compute.googleapis.com/Instance).
   dataSourceGcpResource dict
-  // Data source Backup Appliance application
+  // Backup Appliance application backed up by this data source
+  //
+  // Keys: `applicationName`, `backupAppliance`, `applianceId`, `type`,
+  // `applicationId`, `hostname`, and `hostId`.
   dataSourceBackupApplianceApplication dict
   // Total stored bytes
   totalStoredBytes int
@@ -11558,7 +12553,10 @@ private gcp.project.backupdrService.dataSource @defaults("name state") {
   backupCount int
   // ETag used for concurrency control on resource updates
   etag string
-  // Configuration state
+  // Backup configuration state
+  //
+  // One of ACTIVE (a backup configuration protects this resource) or
+  // PASSIVE (no active backup configuration).
   configState string
   // Creation time
   createdAt time
@@ -11568,7 +12566,7 @@ private gcp.project.backupdrService.dataSource @defaults("name state") {
 
 // Google Cloud (GCP) Backup and DR backup plan
 //
-// Examine a Backup and DR backup plan — its target resource type, lifecycle
+// Backup and DR backup plan, covering its target resource type, lifecycle
 // state, associated backup vault, vault service account, and the backup
 // rules that define schedules and retention windows for automated
 // protection.
@@ -11577,7 +12575,9 @@ private gcp.project.backupdrService.backupPlan @defaults("name state") {
   name string
   // Human-readable description of the resource
   description string
-  // Current state
+  // Current lifecycle state
+  //
+  // One of CREATING, ACTIVE, DELETING, INACTIVE, or UPDATING.
   state string
   // Resource type
   resourceType string
@@ -11587,7 +12587,11 @@ private gcp.project.backupdrService.backupPlan @defaults("name state") {
   backupVaultServiceAccount string
   // User-defined key/value labels for organizing the resource
   labels map[string]string
-  // Backup rules
+  // Rules defining backup schedules and retention
+  //
+  // Each entry has `ruleId`, `backupRetentionDays` (days backups are kept),
+  // and `standardSchedule` (the automated backup schedule, with recurrence,
+  // backup window, and time zone).
   backupRules []dict
   // ETag used for concurrency control on resource updates
   etag string
@@ -11603,6 +12607,16 @@ private gcp.project.backupdrService.backupPlan @defaults("name state") {
 // hosts the machine-learning surface: `models`, `endpoints`, `datasets`,
 // `customJobs`, `pipelineJobs`, `featureOnlineStores`, `tensorboards`,
 // `metadataStores`, and the vector-search `indexes` and `indexEndpoints`.
+// Google Cloud (GCP) Vertex AI service
+//
+// Vertex AI resources in a project: models, serving endpoints and their
+// deployments, datasets, pipeline and training jobs, tuning and
+// hyperparameter tuning jobs, batch prediction jobs, feature stores and
+// groups, vector search indexes and index endpoints, Colab Enterprise
+// notebook runtimes, Agent Engine agents, RAG corpora, and deployment
+// monitoring jobs. Query these collections to audit the machine-learning
+// footprint of a project, including run-as identity, network exposure, and
+// encryption posture.
 private gcp.project.vertexaiService {
   // Project ID
   projectId string
@@ -11660,10 +12674,10 @@ private gcp.project.vertexaiService {
 
 // Google Cloud (GCP) Vertex AI metadata store
 //
-// Examine a Vertex AI Metadata Store — its current state, encryption
-// specification, and Dataplex integration configuration. Metadata stores
-// track ML artifacts, executions, and lineage for reproducibility and
-// governance audits.
+// Metadata store that tracks ML artifacts, executions, and lineage for
+// reproducibility and governance audits. Reports the current state, the
+// encryption specification, the customer-managed encryption key, and the
+// Dataplex integration configuration.
 private gcp.project.vertexaiService.metadataStore @defaults("name state") {
   // Full resource name
   name string
@@ -11685,11 +12699,12 @@ private gcp.project.vertexaiService.metadataStore @defaults("name state") {
 
 // Google Cloud (GCP) Vertex AI model
 //
-// Examine a Vertex AI model — its version ID and aliases, container
-// serving spec, supported deployment resource types, input/output storage
-// formats, artifact URI, training pipeline reference, encryption
-// specification (CMEK), and labels. Use these fields to audit model
-// provenance, encryption posture, and deployment readiness.
+// Machine-learning model registered in the Model Registry, whether trained
+// on Vertex AI or imported. Reports the version ID and aliases, the
+// container serving spec, supported deployment resource types, input and
+// output storage formats, artifact URI, training pipeline reference, and
+// customer-managed encryption. Audit these to verify model provenance,
+// encryption posture, and deployment readiness.
 private gcp.project.vertexaiService.model @defaults("name displayName") {
   // Full resource name
   name string
@@ -11747,11 +12762,11 @@ private gcp.project.vertexaiService.model @defaults("name displayName") {
 
 // Google Cloud (GCP) Vertex AI endpoint
 //
-// Examine a Vertex AI endpoint — its deployed models, traffic split
-// percentages, network attachment for private endpoints, whether public
-// endpoint access is enabled, encryption specification (CMEK), and labels.
-// Use these fields to audit model serving configuration and network
-// exposure.
+// Serving endpoint that hosts one or more deployed models behind a stable
+// address. Reports the model deployments and their traffic split, the VPC
+// network attachment for private endpoints, whether Private Service Connect
+// is enabled, and customer-managed encryption. Audit these to review model
+// serving configuration and network exposure.
 private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
   // Full resource name
   name string
@@ -11813,13 +12828,12 @@ private gcp.project.vertexaiService.endpoint @defaults("name displayName") {
 
 // Google Cloud (GCP) Vertex AI model deployment
 //
-// Examine a single model deployment on a Vertex AI endpoint. `model()`
-// resolves to the deployed Vertex AI model, `serviceAccount()` resolves the
-// identity the deployment runs as, and `disableContainerLogging` /
-// `enableAccessLogging` report the prediction-logging posture. The `id`
-// selects the deployment within its endpoint. Use these fields to audit
-// which models serve traffic and the identity and logging configuration of
-// each deployment.
+// Single model deployment on a Vertex AI endpoint. `model` resolves to the
+// deployed model, `serviceAccount` resolves the identity the deployment
+// runs as, and `disableContainerLogging` and `enableAccessLogging` report
+// the prediction-logging posture. The `id` selects the deployment within
+// its endpoint. Audit these to review which models serve traffic and the
+// identity and logging configuration of each deployment.
 private gcp.project.vertexaiService.endpoint.deployment @defaults("id displayName") {
   // ID of the deployment within the endpoint
   id string
@@ -11851,10 +12865,11 @@ private gcp.project.vertexaiService.endpoint.deployment @defaults("id displayNam
 
 // Google Cloud (GCP) Vertex AI pipeline job
 //
-// Examine a Vertex AI pipeline job — its current state (QUEUED, RUNNING,
-// SUCCEEDED, FAILED, CANCELLING, CANCELLED, PAUSED), pipeline and runtime
-// configuration, service account, VPC network, encryption specification,
-// template URI, and execution timestamps. Use these fields to audit ML
+// Vertex AI Pipelines run that executes an ML pipeline as a directed graph
+// of containerized steps. Reports the current state (PIPELINE_STATE_QUEUED,
+// RUNNING, SUCCEEDED, FAILED, CANCELLING, CANCELLED, PAUSED), the pipeline
+// and runtime configuration, run-as service account, VPC network,
+// encryption, template URI, and execution timestamps. Audit these to review
 // pipeline security posture and job lifecycle.
 private gcp.project.vertexaiService.pipelineJob @defaults("name displayName state") {
   // Full resource name
@@ -11917,10 +12932,10 @@ private gcp.project.vertexaiService.pipelineJob @defaults("name displayName stat
 
 // Google Cloud (GCP) Vertex AI dataset
 //
-// Examine a Vertex AI dataset — its metadata schema URI, user-defined
-// metadata payload, encryption specification (CMEK), and labels. Datasets
-// hold training data for AutoML and custom model workflows; audit them to
-// verify encryption posture and metadata compliance.
+// Managed dataset that holds training data for AutoML and custom model
+// workflows. Reports the metadata schema URI, the user-defined metadata
+// payload conforming to that schema, and customer-managed encryption. Audit
+// these to verify encryption posture and metadata compliance.
 private gcp.project.vertexaiService.dataset @defaults("name displayName") {
   // Full resource name
   name string
@@ -11948,11 +12963,11 @@ private gcp.project.vertexaiService.dataset @defaults("name displayName") {
 
 // Google Cloud (GCP) Vertex AI Feature Online Store
 //
-// Examine a Vertex AI Feature Online Store — its backend type (Bigtable or
-// Optimized), dedicated serving endpoint, encryption specification, Physical
-// Zone Separation and Isolation compliance flags, and current lifecycle
-// state. Feature Online Stores serve low-latency feature values to models
-// at prediction time.
+// Feature Online Store that serves low-latency feature values to models at
+// prediction time. Reports the backend type (Bigtable or Optimized), the
+// dedicated serving endpoint, encryption, the Physical Zone Separation
+// (satisfiesPzs) and Physical Zone Isolation (satisfiesPzi) compliance
+// flags, and the current lifecycle state.
 private gcp.project.vertexaiService.featureOnlineStore @defaults("name state") {
   // Full resource name
   name string
@@ -11984,10 +12999,9 @@ private gcp.project.vertexaiService.featureOnlineStore @defaults("name state") {
 
 // Google Cloud (GCP) Vertex AI Tensorboard instance
 //
-// Examine a Vertex AI Tensorboard instance — its display name, whether it
-// is the default Tensorboard for the project, encryption specification, and
-// labels. Tensorboard instances store and visualize ML experiment metrics
-// and model training runs.
+// TensorBoard instance that stores and visualizes ML experiment metrics and
+// model training runs. Reports whether it is the project default TensorBoard
+// (isDefault) and its customer-managed encryption.
 private gcp.project.vertexaiService.tensorboard @defaults("displayName") {
   // Full resource name
   name string
@@ -12011,10 +13025,12 @@ private gcp.project.vertexaiService.tensorboard @defaults("displayName") {
 
 // Google Cloud (GCP) Vertex AI custom training job
 //
-// Examine a Vertex AI custom training job — its current state (QUEUED,
+// Custom training job that runs user-provided training code on Vertex AI
+// managed infrastructure. Reports the current state (JOB_STATE_QUEUED,
 // PENDING, RUNNING, SUCCEEDED, FAILED, CANCELLING, CANCELLED, PAUSED,
-// EXPIRED), worker pool job specification, encryption specification, error
-// details, and execution timestamps. Use these fields to audit training
+// EXPIRED, UPDATING, PARTIALLY_SUCCEEDED), the worker-pool job
+// specification, run-as service account, peering VPC network, encryption,
+// error details, and execution timestamps. Audit these to review training
 // infrastructure configuration and job lifecycle.
 private gcp.project.vertexaiService.customJob @defaults("displayName state") {
   // Full resource name
@@ -12067,11 +13083,11 @@ private gcp.project.vertexaiService.customJob @defaults("displayName state") {
 
 // Google Cloud (GCP) Vertex AI vector search index
 //
-// Examine a Vertex AI vector search index — its metadata schema URI, index
-// update method (BATCH_UPDATE or STREAM_UPDATE), deployed index references,
-// index statistics (vector count, shard count), and encryption
-// specification. Vector search indexes enable approximate nearest-neighbor
-// search over high-dimensional embeddings.
+// Vector Search index that enables approximate nearest-neighbor search over
+// high-dimensional embeddings. Reports the metadata schema URI, the index
+// update method (BATCH_UPDATE or STREAM_UPDATE), the deployed-index
+// references, index statistics (vector count, shard count), and
+// customer-managed encryption.
 private gcp.project.vertexaiService.index @defaults("displayName") {
   // Full resource name
   name string
@@ -12103,11 +13119,11 @@ private gcp.project.vertexaiService.index @defaults("displayName") {
 
 // Google Cloud (GCP) Vertex AI vector search index endpoint
 //
-// Examine a Vertex AI vector search index endpoint — its deployed indexes,
-// VPC network for private endpoints, whether public endpoint access is
-// enabled, the public endpoint domain name, and encryption specification.
-// Index endpoints serve online vector similarity queries against deployed
-// indexes.
+// Vector Search index endpoint that serves online vector similarity queries
+// against deployed indexes. Reports the deployed indexes, the VPC network
+// used for private endpoints, whether public endpoint access is enabled
+// (publicEndpointEnabled) and its domain name, and customer-managed
+// encryption.
 private gcp.project.vertexaiService.indexEndpoint @defaults("displayName") {
   // Full resource name
   name string
@@ -12141,16 +13157,16 @@ private gcp.project.vertexaiService.indexEndpoint @defaults("displayName") {
 
 // Google Cloud (GCP) Colab Enterprise notebook runtime
 //
-// Examine a Colab Enterprise notebook runtime — a running managed Jupyter
-// environment. `serviceAccount` and `runtimeUser` report the identities
-// involved, `eucConfig` reports the end-user-credential setup, `networkSpec`
-// holds the VPC attachment and internet-access setting, `shieldedVmConfig`
-// reports Shielded VM protections, `idleShutdownConfig` reports
-// auto-shutdown, and `proxyUri` is the access endpoint. `healthState` and
-// `runtimeState` report status, `notebookRuntimeType` distinguishes
-// user-defined from one-click runtimes, and encryption at rest is reported
-// through `encryptionSpec` and the resolved `kmsKey()`. Use these fields to
-// audit notebook identity, network exposure, and hardening posture.
+// Colab Enterprise notebook runtime, a running managed Jupyter environment.
+// `serviceAccount` and `runtimeUser` report the identities involved,
+// `eucConfig` reports the end-user-credential setup, `networkSpec` holds the
+// VPC attachment and internet-access setting, `shieldedVmConfig` reports
+// Shielded VM protections, `idleShutdownConfig` reports auto-shutdown, and
+// `proxyUri` is the access endpoint. `healthState` and `runtimeState` report
+// status, `notebookRuntimeType` distinguishes user-defined from one-click
+// runtimes, and encryption at rest is reported through `encryptionSpec` and
+// the resolved `kmsKey`. Audit these to review notebook identity, network
+// exposure, and hardening posture.
 private gcp.project.vertexaiService.notebookRuntime @defaults("displayName runtimeState healthState") {
   // Full resource name
   name string
@@ -12216,14 +13232,14 @@ private gcp.project.vertexaiService.notebookRuntime @defaults("displayName runti
 
 // Google Cloud (GCP) Colab Enterprise notebook runtime template
 //
-// Examine a Colab Enterprise notebook runtime template — the reusable blueprint
-// that new notebook runtimes are created from. `eucConfig` reports the
+// Colab Enterprise notebook runtime template, the reusable blueprint that
+// new notebook runtimes are created from. `eucConfig` reports the
 // end-user-credential setup, `networkSpec` holds the VPC attachment and
-// internet-access setting, `shieldedVmConfig` reports Shielded VM protections,
-// and `idleShutdownConfig` reports auto-shutdown. `isDefault` marks the project
-// default template, and encryption at rest is reported through `encryptionSpec`
-// and the resolved `kmsKey()`. Use these fields to audit the security baseline
-// applied to all runtimes created from the template.
+// internet-access setting, `shieldedVmConfig` reports Shielded VM
+// protections, and `idleShutdownConfig` reports auto-shutdown. `isDefault`
+// marks the project default template, and encryption at rest is reported
+// through `encryptionSpec` and the resolved `kmsKey`. Audit these to review
+// the security baseline applied to all runtimes created from the template.
 private gcp.project.vertexaiService.notebookRuntimeTemplate @defaults("displayName isDefault") {
   // Full resource name
   name string
@@ -12283,12 +13299,12 @@ private gcp.project.vertexaiService.notebookRuntimeTemplate @defaults("displayNa
 
 // Google Cloud (GCP) Colab Enterprise notebook execution job
 //
-// Examine a Colab Enterprise notebook execution job — a scheduled or
-// one-off headless run of a notebook. `jobState` reports lifecycle status,
-// `kernelName` is the kernel the notebook runs under, `scheduleResourceName`
-// links to the schedule that triggered it (when scheduled), and
-// `executionTimeoutSeconds` is the configured run timeout. Encryption at
-// rest is reported through `encryptionSpec` and the resolved `kmsKey()`.
+// Colab Enterprise notebook execution job, a scheduled or one-off headless
+// run of a notebook. `jobState` reports lifecycle status, `kernelName` is
+// the kernel the notebook runs under, `scheduleRef` links to the schedule
+// that triggered it (when scheduled), and `executionTimeoutSeconds` is the
+// configured run timeout. Encryption at rest is reported through
+// `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.notebookExecutionJob @defaults("displayName jobState") {
   // Full resource name
   name string
@@ -12333,16 +13349,16 @@ private gcp.project.vertexaiService.notebookExecutionJob @defaults("displayName 
 
 // Google Cloud (GCP) Vertex AI Agent Engine agent
 //
-// Examine a Vertex AI Agent Engine agent — a managed, deployed AI agent
-// (the API resource is named a reasoning engine). `serviceAccount()`
-// resolves the identity that runs the agent's tool calls and API access,
-// `agentFramework` reports the agent framework it was built with (for
-// example `google-adk` or `langchain`), and `spec` holds the full
-// deployment specification including the Python package, dependency URIs,
-// deployment scaling, and any environment variables. Encryption at rest is
-// reported through `encryptionSpec` and the resolved `kmsKey()`. Use these
-// fields to audit which agents are deployed, the identity they run as, and
-// their encryption posture.
+// Vertex AI Agent Engine agent, a managed and deployed AI agent (the API
+// resource is named a reasoning engine). `serviceAccount` resolves the
+// identity that runs the agent's tool calls and API access, `agentFramework`
+// reports the agent framework it was built with (for example `google-adk` or
+// `langchain`), and `spec` holds the full deployment specification including
+// the Python package, dependency URIs, deployment scaling, and any
+// environment variables. Encryption at rest is reported through
+// `encryptionSpec` and the resolved `kmsKey`. Audit these to review which
+// agents are deployed, the identity they run as, and their encryption
+// posture.
 private gcp.project.vertexaiService.reasoningEngine @defaults("displayName agentFramework") {
   // Full resource name
   name string
@@ -12374,11 +13390,11 @@ private gcp.project.vertexaiService.reasoningEngine @defaults("displayName agent
 
 // Google Cloud (GCP) Vertex AI RAG Engine corpus
 //
-// Examine a Vertex AI RAG Engine corpus — the managed collection of
-// documents that grounds retrieval-augmented generation. `corpusStatus`
-// reports indexing state and any errors, and encryption at rest is reported
-// through `encryptionSpec` and the resolved `kmsKey()`. Use these fields to
-// audit which knowledge corpora exist and their encryption posture.
+// Vertex AI RAG Engine corpus, the managed collection of documents that
+// grounds retrieval-augmented generation. `corpusStatus` reports indexing
+// state and any errors, and encryption at rest is reported through
+// `encryptionSpec` and the resolved `kmsKey`. Audit these to review which
+// knowledge corpora exist and their encryption posture.
 private gcp.project.vertexaiService.ragCorpus @defaults("displayName") {
   // Full resource name
   name string
@@ -12400,10 +13416,10 @@ private gcp.project.vertexaiService.ragCorpus @defaults("displayName") {
 
 // Google Cloud (GCP) Vertex AI feature group
 //
-// Examine a Vertex AI feature group — a logical grouping of features backed
-// by a BigQuery source for the Feature Store. `bigQuery` reports the backing
-// BigQuery table or view and the entity-ID columns. Use these fields to
-// audit which feature data is registered and where it is sourced from.
+// Vertex AI feature group, a logical grouping of features backed by a
+// BigQuery source for the Feature Store. `bigQuery` reports the backing
+// BigQuery table or view and the entity-ID columns. Audit these to review
+// which feature data is registered and where it is sourced from.
 private gcp.project.vertexaiService.featureGroup @defaults("name") {
   // Full resource name
   name string
@@ -12423,12 +13439,12 @@ private gcp.project.vertexaiService.featureGroup @defaults("name") {
 
 // Google Cloud (GCP) Vertex AI persistent resource
 //
-// Examine a Vertex AI persistent resource — a long-lived managed cluster
-// (for example a Ray cluster) reused across training and tuning jobs.
-// `resourcePools` describes the machine pools and their autoscaling,
-// `network()` resolves the VPC network attachment, `reservedIpRanges` lists
-// the reserved IP ranges, `state` reports lifecycle status, and encryption at
-// rest is reported through `encryptionSpec` and the resolved `kmsKey()`.
+// Vertex AI persistent resource, a long-lived managed cluster (for example
+// a Ray cluster) reused across training and tuning jobs. `resourcePools`
+// describes the machine pools and their autoscaling, `network` resolves the
+// VPC network attachment, `reservedIpRanges` lists the reserved IP ranges,
+// `state` reports lifecycle status, and encryption at rest is reported
+// through `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.persistentResource @defaults("displayName state") {
   // Full resource name
   name string
@@ -12460,12 +13476,12 @@ private gcp.project.vertexaiService.persistentResource @defaults("displayName st
 
 // Google Cloud (GCP) Vertex AI schedule
 //
-// Examine a Vertex AI schedule — a recurring trigger that creates pipeline
-// jobs or notebook execution jobs on a cron cadence. `cron` is the schedule
+// Vertex AI schedule, a recurring trigger that creates pipeline jobs or
+// notebook execution jobs on a cron cadence. `cron` is the schedule
 // expression, `state` reports whether it is active or paused, the run-count
 // and concurrency fields bound how often and how many runs may overlap, and
-// `nextRunTime` is when the next run is due. Use these fields to audit
-// recurring ML automation.
+// `nextRunTime` is when the next run is due. Audit these to review recurring
+// ML automation.
 private gcp.project.vertexaiService.schedule @defaults("displayName state") {
   // Full resource name
   name string
@@ -12499,12 +13515,12 @@ private gcp.project.vertexaiService.schedule @defaults("displayName state") {
 
 // Google Cloud (GCP) Vertex AI deployment resource pool
 //
-// Examine a Vertex AI deployment resource pool — shared serving
-// infrastructure that multiple deployed models run on. `dedicatedResources`
-// describes the machine type and autoscaling, `serviceAccount` is the
-// identity the pool runs as, `disableContainerLogging` indicates whether
-// prediction request/response logging is turned off, and encryption at rest
-// is reported through `encryptionSpec` and the resolved `kmsKey()`.
+// Vertex AI deployment resource pool, shared serving infrastructure that
+// multiple deployed models run on. `dedicatedResources` describes the
+// machine type and autoscaling, `serviceAccount` is the identity the pool
+// runs as, `disableContainerLogging` indicates whether prediction
+// request/response logging is turned off, and encryption at rest is reported
+// through `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.deploymentResourcePool @defaults("name") {
   // Full resource name
   name string
@@ -12524,12 +13540,11 @@ private gcp.project.vertexaiService.deploymentResourcePool @defaults("name") {
 
 // Google Cloud (GCP) Vertex AI cached content
 //
-// Examine a Vertex AI context cache — precomputed model context (system
-// instructions, contents, tools) stored to reduce repeated prompt cost.
-// `model` is the model the cache is bound to, `usageMetadata` reports the
-// cached token counts, `expireTime` is when the cache expires, and
-// encryption at rest is reported through `encryptionSpec` and the resolved
-// `kmsKey()`.
+// Vertex AI context cache, precomputed model context (system instructions,
+// contents, tools) stored to reduce repeated prompt cost. `model` is the
+// model the cache is bound to, `usageMetadata` reports the cached token
+// counts, `expireTime` is when the cache expires, and encryption at rest is
+// reported through `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.cachedContent @defaults("displayName model") {
   // Full resource name
   name string
@@ -12553,15 +13568,15 @@ private gcp.project.vertexaiService.cachedContent @defaults("displayName model")
 
 // Google Cloud (GCP) Vertex AI batch prediction job
 //
-// Examine a Vertex AI batch prediction job — an offline scoring run that
-// reads instances, scores them with a model, and writes predictions out.
+// Vertex AI batch prediction job, an offline scoring run that reads
+// instances, scores them with a model, and writes predictions out.
 // `inputConfig` and `outputConfig` describe where data is read from and
 // written to (Cloud Storage or BigQuery), making this the primary surface
-// for auditing batch data movement. `model()` and `modelVersionId` identify
+// for auditing batch data movement. `model` and `modelVersionId` identify
 // the model used, `serviceAccount` is the identity the job runs as, `state`
 // reports lifecycle status, and `disableContainerLogging` indicates whether
 // prediction request/response logging is turned off. Encryption at rest is
-// reported through `encryptionSpec` and the resolved `kmsKey()`.
+// reported through `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.batchPredictionJob @defaults("displayName state") {
   // Full resource name
   name string
@@ -12607,13 +13622,13 @@ private gcp.project.vertexaiService.batchPredictionJob @defaults("displayName st
 
 // Google Cloud (GCP) Vertex AI tuning job
 //
-// Examine a Vertex AI tuning job — a managed fine-tuning run that adapts a
-// base foundation model into a tuned model. `baseModel` identifies the
-// foundation model being tuned, `tunedModelDisplayName` names the result,
-// `tunedModel` reports the produced model and its serving endpoint,
-// `tuningDataStats` summarizes the tuning dataset, `serviceAccount` is the
-// identity the job runs as, and `state` reports lifecycle status. Encryption
-// at rest is reported through `encryptionSpec` and the resolved `kmsKey()`.
+// Vertex AI tuning job, a managed fine-tuning run that adapts a base
+// foundation model into a tuned model. `baseModel` identifies the foundation
+// model being tuned, `tunedModelDisplayName` names the result, `tunedModel`
+// reports the produced model and its serving endpoint, `tuningDataStats`
+// summarizes the tuning dataset, `serviceAccount` is the identity the job
+// runs as, and `state` reports lifecycle status. Encryption at rest is
+// reported through `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.tuningJob @defaults("tunedModelDisplayName state") {
   // Full resource name
   name string
@@ -12659,13 +13674,13 @@ private gcp.project.vertexaiService.tuningJob @defaults("tunedModelDisplayName s
 
 // Google Cloud (GCP) Vertex AI training pipeline
 //
-// Examine a Vertex AI training pipeline — a managed workflow that trains a
-// model and optionally uploads it to the Model Registry. `inputDataConfig`
-// describes the dataset and data split the pipeline trains on,
-// `trainingTaskDefinition` is the Cloud Storage URI of the task schema,
-// `model()` and `parentModel()` resolve the model produced and the parent
-// it versions, and `state` reports lifecycle status. Encryption at rest is
-// reported through `encryptionSpec` and the resolved `kmsKey()`.
+// Vertex AI training pipeline, a managed workflow that trains a model and
+// optionally uploads it to the Model Registry. `inputDataConfig` describes
+// the dataset and data split the pipeline trains on, `trainingTaskDefinition`
+// is the Cloud Storage URI of the task schema, `model` and `parentModel`
+// resolve the model produced and the parent it versions, and `state` reports
+// lifecycle status. Encryption at rest is reported through `encryptionSpec`
+// and the resolved `kmsKey`.
 private gcp.project.vertexaiService.trainingPipeline @defaults("displayName state") {
   // Full resource name
   name string
@@ -12699,13 +13714,13 @@ private gcp.project.vertexaiService.trainingPipeline @defaults("displayName stat
 
 // Google Cloud (GCP) Vertex AI hyperparameter tuning job
 //
-// Examine a Vertex AI hyperparameter tuning job — a job that runs many
-// trials to search for the best hyperparameters. `studySpec` defines the
-// search space and objective, `trialJobSpec` is the per-trial training job
-// specification (including its worker pools, service account, and network),
-// the trial-count fields bound parallelism and failures, and `state`
-// reports lifecycle status. Encryption at rest is reported through
-// `encryptionSpec` and the resolved `kmsKey()`.
+// Vertex AI hyperparameter tuning job, a job that runs many trials to search
+// for the best hyperparameters. `studySpec` defines the search space and
+// objective, `trialJobSpec` is the per-trial training job specification
+// (including its worker pools, service account, and network), the
+// trial-count fields bound parallelism and failures, and `state` reports
+// lifecycle status. Encryption at rest is reported through `encryptionSpec`
+// and the resolved `kmsKey`.
 private gcp.project.vertexaiService.hyperparameterTuningJob @defaults("displayName state") {
   // Full resource name
   name string
@@ -12751,14 +13766,13 @@ private gcp.project.vertexaiService.hyperparameterTuningJob @defaults("displayNa
 
 // Google Cloud (GCP) Vertex AI model deployment monitoring job
 //
-// Examine a Vertex AI model deployment monitoring job — a job that watches
-// a deployed endpoint for prediction drift and training/serving skew.
-// `endpoint()` resolves the monitored Vertex AI endpoint, `state` and
-// `scheduleState` report the job and analysis-schedule status,
-// `enableMonitoringPipelineLogs` indicates whether monitoring pipeline logs
-// are written, and `nextScheduleTime` is when the next analysis run is due.
-// Encryption at rest is reported through `encryptionSpec` and the resolved
-// `kmsKey()`.
+// Vertex AI model deployment monitoring job, a job that watches a deployed
+// endpoint for prediction drift and training/serving skew. `endpoint`
+// resolves the monitored endpoint, `state` and `scheduleState` report the
+// job and analysis-schedule status, `enableMonitoringPipelineLogs` indicates
+// whether monitoring pipeline logs are written, and `nextScheduleTime` is
+// when the next analysis run is due. Encryption at rest is reported through
+// `encryptionSpec` and the resolved `kmsKey`.
 private gcp.project.vertexaiService.modelDeploymentMonitoringJob @defaults("displayName state") {
   // Full resource name
   name string
@@ -12794,25 +13808,30 @@ private gcp.project.vertexaiService.modelDeploymentMonitoringJob @defaults("disp
 
 // Google Cloud Security Command Center organization settings
 //
-// Examine the Security Command Center organization-level settings — whether
-// Cloud asset discovery is enabled and the asset discovery configuration
-// that controls which project types and regions are included in the
-// inventory.
+// Organization-level settings for Security Command Center, including whether
+// Cloud asset discovery is enabled (enableAssetDiscovery) and the asset
+// discovery configuration that controls which project types and regions are
+// included in the inventory.
 private gcp.scc.organizationSettings @defaults("name") {
   // Full resource name
   name string
   // Whether Cloud SCC asset discovery is enabled
   enableAssetDiscovery bool
   // Asset discovery configuration
+  //
+  // Controls which resources Cloud asset discovery scans. Keys: `projectIds`
+  // and `folderIds` (the projects and folders included or excluded) and
+  // `inclusionMode` (INCLUSION_MODE_UNSPECIFIED, INCLUDE_ONLY, or EXCLUDE).
   assetDiscoveryConfig dict
 }
 
 // Google Cloud Security Command Center source
 //
-// Examine a Security Command Center finding source — its display name,
-// description, and canonical name. Sources represent the security tools or
-// services (built-in or third-party) that generate findings surfaced in
-// Security Command Center.
+// Finding source in Security Command Center
+//
+// Security tool or service (built-in or third-party) that generates findings
+// surfaced in the Security Command Center console. Each source carries a
+// display name, description, and canonical name.
 private gcp.scc.source @defaults("name displayName") {
   // Full resource name (organizations/{orgId}/sources/{sourceId})
   name string
@@ -12826,12 +13845,16 @@ private gcp.scc.source @defaults("name displayName") {
 
 // Google Cloud Security Command Center finding
 //
-// Examine a Security Command Center finding — its category (e.g.,
-// OPEN_FIREWALL, PUBLIC_BUCKET_ACL), severity (CRITICAL, HIGH, MEDIUM,
-// LOW), state (ACTIVE, INACTIVE), mute state, finding class (THREAT,
-// VULNERABILITY, MISCONFIGURATION), affected resource name, event and
-// create times, source-specific properties, security marks, and external
-// exposure details including toxic combination and chokepoint analysis.
+// Google Cloud Security Command Center finding
+//
+// Individual security issue reported by Security Command Center, spanning
+// misconfigurations, vulnerabilities, and active threats. A finding carries a
+// category (for example OPEN_FIREWALL, PUBLIC_BUCKET_ACL), severity (CRITICAL,
+// HIGH, MEDIUM, LOW), state (ACTIVE, INACTIVE), mute state, and finding class
+// (THREAT, VULNERABILITY, MISCONFIGURATION). It also exposes the affected
+// resource, event and create times, source-specific properties, security
+// marks, and external exposure details including toxic combination and
+// chokepoint analysis.
 private gcp.scc.finding @defaults("name category severity") {
   // Full resource name
   name string
@@ -12860,7 +13883,7 @@ private gcp.scc.finding @defaults("name category severity") {
   // Compliance standards the finding maps to
   //
   // Each entry has `standard` (for example "cis", "pci-dss"), `version`, and
-  // `ids` — the specific control identifiers the finding relates to. Use this
+  // `ids` (the specific control identifiers the finding relates to). Use this
   // to roll findings up to benchmark controls.
   compliances []dict
   // Vulnerability details, including the CVE and its CVSS scores, when the finding describes a known vulnerability
@@ -12868,13 +13891,21 @@ private gcp.scc.finding @defaults("name category severity") {
   // Access details for the finding
   //
   // The principal, caller IP, user agent, and method that performed the
-  // action that triggered the finding — the "who" behind a threat finding.
+  // action that triggered the finding. This is the identity behind a threat
+  // finding.
   access dict
-  // Network connections associated with the finding (source/destination IP and port, protocol) — the command-and-control or data-movement tuples
+  // Network connections associated with the finding
+  //
+  // The source and destination IP and port and the protocol for each
+  // connection, capturing the command-and-control or data-movement tuples
+  // behind a threat finding.
   connections []dict
   // Kubernetes details for the finding (affected pods, namespaces, roles, and bindings) when the finding concerns a GKE workload
   kubernetes dict
-  // IAM bindings associated with the finding — the role and members granted (the ADD/REMOVE action) that triggered or relates to the finding
+  // IAM bindings associated with the finding
+  //
+  // The role and members granted, along with the action (ADD or REMOVE), for
+  // the binding change that triggered or relates to the finding.
   iamBindings []dict
   // Finding class (THREAT, VULNERABILITY, MISCONFIGURATION, etc.)
   findingClass string
@@ -12883,19 +13914,36 @@ private gcp.scc.finding @defaults("name category severity") {
   // Full resource name of the affected resource
   resourceName string
   // Chokepoint analysis for the finding
+  //
+  // A chokepoint is a resource or resource group that many attack paths pass
+  // through. The `relatedFindings` key lists the resource names of other
+  // findings that share this chokepoint.
   chokepoint dict
   // External exposure details for the finding
+  //
+  // Describes how the affected resource is reachable from the internet. Keys:
+  // `privateIpAddress`, `privatePort`, `publicIpAddress`, `publicPort`,
+  // `exposedService`, `exposedEndpoint`, `loadBalancerFirewallPolicy`,
+  // `serviceFirewallPolicy`, `forwardingRule`, `backendService`,
+  // `instanceGroup`, and `networkEndpointGroup`.
   externalExposure dict
-  // Toxic combination details (attack exposure score and related findings)
+  // Toxic combination details for the finding
+  //
+  // A toxic combination is a set of otherwise-benign findings that together
+  // create a serious risk. Keys: `attackExposureScore` (severity of the
+  // combined exposure) and `relatedFindings` (resource names of the findings
+  // that make up the combination).
   toxicCombination dict
 }
 
 // Google Cloud Security Command Center notification config
 //
-// Examine a Security Command Center notification configuration — its
-// Pub/Sub topic target, the service account used to publish messages, and
-// the CEL filter expression that controls which findings trigger
-// notifications.
+// Google Cloud Security Command Center notification config
+//
+// Notification configuration that streams findings out of Security Command
+// Center. It names the Pub/Sub topic target (pubsubTopic), the service
+// account used to publish messages (serviceAccount), and the CEL filter
+// expression that controls which findings trigger notifications (filter).
 private gcp.scc.notificationConfig @defaults("name") {
   // Full resource name
   name string
@@ -12911,10 +13959,11 @@ private gcp.scc.notificationConfig @defaults("name") {
 
 // Google Cloud Security Command Center mute config
 //
-// Examine a Security Command Center mute configuration — its display name,
-// CEL filter expression that determines which findings are muted, and the
-// identity of the most recent editor. Mute configs suppress findings that
-// match the filter from appearing as active in the console.
+// Google Cloud Security Command Center mute config
+//
+// Mute configuration that suppresses findings matching its CEL filter
+// expression from appearing as active in the console. It carries a display
+// name, the filter, and the identity of the most recent editor.
 private gcp.scc.muteConfig @defaults("name") {
   // Full resource name
   name string
@@ -12934,11 +13983,12 @@ private gcp.scc.muteConfig @defaults("name") {
 
 // Google Cloud Security Command Center BigQuery export config
 //
-// Examine a Security Command Center BigQuery export configuration — the
-// target BigQuery dataset, the CEL filter expression that selects which
-// findings are exported, and the identity of the most recent editor. BigQuery
-// exports stream matching findings into a dataset for analysis and
-// long-term retention.
+// Google Cloud Security Command Center BigQuery export config
+//
+// BigQuery export configuration that streams matching findings into a dataset
+// for analysis and long-term retention. It names the target BigQuery dataset
+// (dataset), the CEL filter expression that selects which findings are
+// exported (filter), and the identity of the most recent editor.
 private gcp.scc.bigQueryExport @defaults("name") {
   // Full resource name
   name string
@@ -12958,10 +14008,11 @@ private gcp.scc.bigQueryExport @defaults("name") {
 
 // Google Cloud Access Context Manager access policy
 //
-// Examine a VPC Service Controls access policy — its human-readable title,
-// parent organization, ETag, and the `accessLevels` and `servicePerimeters`
-// it contains. An access policy is the top-level container for all Access
-// Context Manager rules in an organization.
+// VPC Service Controls access policy, the top-level container for all
+// Access Context Manager rules in an organization. Carries the
+// human-readable title, parent organization, and ETag, and holds the
+// accessLevels (trust tiers) and servicePerimeters (isolation boundaries)
+// defined at the organization root.
 private gcp.accesscontextmanager.accessPolicy @defaults("name title") {
   // Full resource name (accessPolicies/{policyId})
   name string
@@ -12981,10 +14032,11 @@ private gcp.accesscontextmanager.accessPolicy @defaults("name title") {
 
 // Google Cloud Access Context Manager access level
 //
-// Examine a VPC Service Controls access level — its title, description,
-// basic conditions (device policy, IP ranges, required access levels), and
-// custom CEL expression. Access levels define trust tiers used in service
-// perimeter ingress and egress rules.
+// VPC Service Controls access level, a named trust tier referenced by
+// service perimeter ingress and egress rules. A level is defined either by
+// basic conditions (device policy, IP ranges, required access levels) or by
+// a custom CEL expression, both of which are queryable so you can audit
+// what a request must satisfy to meet the level.
 private gcp.accesscontextmanager.accessLevel @defaults("name title") {
   // Full resource name (accessPolicies/{policyId}/accessLevels/{levelId})
   name string
@@ -12993,8 +14045,19 @@ private gcp.accesscontextmanager.accessLevel @defaults("name title") {
   // Human-readable description of the resource
   description string
   // Basic access level conditions
+  //
+  // Structured basic-level definition. Keys: `combiningFunction` (AND or
+  // OR, how the conditions combine) and `conditions`, a list where each
+  // entry carries `ipSubnetworks`, `requiredAccessLevels`, `members`,
+  // `regions`, `negate`, and a `devicePolicy`. Null when the level is
+  // defined by a custom CEL expression instead; see `custom`.
   basic dict
   // Custom access level CEL expression
+  //
+  // Custom-level definition with a single `expr` key holding a CEL
+  // expression (`expression`, plus optional `title`, `description`, and
+  // `location`). Null when the level is defined by basic conditions
+  // instead; see `basic`.
   custom dict
   // Create time
   createTime time
@@ -13004,11 +14067,14 @@ private gcp.accesscontextmanager.accessLevel @defaults("name title") {
 
 // Google Cloud Access Context Manager service perimeter
 //
-// Examine a VPC Service Controls service perimeter — its type (REGULAR or
-// BRIDGE), enforced configuration (`statusConfig`), dry-run proposed
-// configuration (`specConfig`), and whether an explicit dry-run spec is
-// set. Use these fields to audit which projects, Google Cloud services,
-// access levels, and ingress/egress policies are in effect.
+// VPC Service Controls service perimeter, the boundary that isolates a set
+// of projects and restricts which Google Cloud services can be reached
+// across it. The perimeterType field distinguishes a regular perimeter
+// (PERIMETER_TYPE_REGULAR) from a bridge (PERIMETER_TYPE_BRIDGE). The
+// enforced configuration is exposed through statusConfig and the dry-run
+// proposed configuration through specConfig, letting you audit which
+// projects, services, access levels, and ingress/egress policies are in
+// effect versus proposed.
 private gcp.accesscontextmanager.servicePerimeter @defaults("name title") {
   // Full resource name
   name string
@@ -13040,10 +14106,11 @@ private gcp.accesscontextmanager.servicePerimeter @defaults("name title") {
 
 // Google Cloud (GCP) VPC Service Controls perimeter configuration
 //
-// Examine the enforced or dry-run configuration of a service perimeter —
-// the projects inside the perimeter, restricted Google Cloud services,
-// access levels that grant entry, VPC-accessible services settings, and
-// the ingress and egress policies that control cross-perimeter data flows.
+// Enforced or dry-run configuration of a VPC Service Controls service
+// perimeter: the projects inside the perimeter, restricted Google Cloud
+// services, access levels that grant entry, VPC-accessible services
+// settings, and the ingress and egress policies that control
+// cross-perimeter data flows.
 private gcp.accesscontextmanager.servicePerimeter.config {
   // Internal ID
   id string
@@ -13054,18 +14121,36 @@ private gcp.accesscontextmanager.servicePerimeter.config {
   // Access levels granting access to the perimeter
   accessLevels []string
   // VPC accessible services configuration
+  //
+  // Restriction on which services are reachable from the network inside
+  // the perimeter. Keys: `enableRestriction` (bool, whether the allow-list
+  // is enforced) and `allowedServices` (list of service names permitted
+  // when the restriction is on).
   vpcAccessibleServices dict
   // Ingress policies (rules for inbound access)
+  //
+  // Rules that allow access into the perimeter from outside. Each entry
+  // has `ingressFrom` (`sources`, `identities`, `identityType`) describing
+  // who may enter, and `ingressTo` (`operations`, `resources`) describing
+  // what they may reach.
   ingressPolicies []dict
   // Egress policies (rules for outbound access)
+  //
+  // Rules that allow access from inside the perimeter to resources outside
+  // it. Each entry has `egressFrom` (`identities`, `identityType`)
+  // describing who may leave, and `egressTo` (`operations`, `resources`,
+  // `externalResources`) describing what they may reach.
   egressPolicies []dict
 }
 
 // Google Cloud (GCP) Model Armor
 //
-// Use this resource as the entry point for Model Armor in the project. It
-// hosts the safety-filter `templates` and the project `floorSetting` — the
-// minimum AI safety configuration enforced across prompts and responses.
+// AI safety and security screening for the project. Model Armor inspects
+// prompts sent to and responses returned by large language models, filtering
+// for prompt injection, jailbreak attempts, sensitive-data exposure,
+// malicious URIs, and responsible-AI violations. Hosts the safety-filter
+// `templates` and the project `floorSetting`, the minimum AI safety
+// configuration enforced across all prompts and responses.
 private gcp.project.modelArmorService {
   // Project ID
   projectId string
@@ -13077,11 +14162,12 @@ private gcp.project.modelArmorService {
 
 // Google Cloud (GCP) Model Armor template
 //
-// Examine a Model Armor safety-filter template — its filter configuration
-// (RAI settings, SDP settings, PI and jailbreak filter, malicious URI
-// filter) and template metadata (enforcement type, error handling, multi-
-// language detection). Templates are applied to AI prompts and responses
-// to enforce safety policies.
+// Safety-filter template applied to AI prompts and responses to enforce
+// safety policies. A template combines a filter configuration (responsible-AI
+// settings, Sensitive Data Protection settings, prompt-injection and jailbreak
+// filter, malicious-URI filter) with template metadata (enforcement type,
+// error handling, multi-language detection). The `name` field is the full
+// resource path of the template.
 private gcp.project.modelArmorService.template @defaults("name") {
   // Full resource name
   name string
@@ -13095,26 +14181,44 @@ private gcp.project.modelArmorService.template @defaults("name") {
   labels map[string]string
   // Filter configuration (raiSettings, sdpSettings, piAndJailbreakFilterSettings, maliciousUriFilterSettings)
   filterConfig dict
-  // Template metadata (enforcement type, error settings, multi-language detection)
+  // Template metadata
+  //
+  // Operational settings for the template. Keys: customPromptSafetyErrorCode,
+  // customPromptSafetyErrorMessage, customLlmResponseSafetyErrorCode,
+  // customLlmResponseSafetyErrorMessage, logTemplateOperations,
+  // logSanitizeOperations, enforcementType (one of ENFORCEMENT_TYPE_UNSPECIFIED,
+  // INSPECT_ONLY, or INSPECT_AND_BLOCK), multiLanguageDetection, and modalities.
   templateMetadata dict
 }
 
 // Google Cloud (GCP) Model Armor floor setting
 //
-// Examine the Model Armor floor setting — the minimum AI safety
-// configuration enforced across the project, whether floor setting
-// enforcement is enabled, the Google Cloud services to which it applies,
-// and the AI Platform-specific floor setting configuration.
+// Minimum AI safety configuration enforced across the project. The floor
+// setting establishes a filter baseline that individual templates cannot
+// weaken, records whether enforcement is active, lists the Google Cloud
+// services it applies to, and carries the AI Platform-specific configuration.
 private gcp.project.modelArmorService.floorSetting @defaults("name") {
   // Full resource name
   name string
-  // ModelArmor filter configuration
+  // Filter configuration
+  //
+  // Baseline safety filters enforced by the floor setting. Keys: raiSettings
+  // (responsible-AI), sdpSettings (Sensitive Data Protection),
+  // piAndJailbreakFilterSettings (prompt injection and jailbreak), and
+  // maliciousUriFilterSettings.
   filterConfig dict
   // Whether floor setting enforcement is enabled
   enableFloorSettingEnforcement bool
-  // Integrated services for which the floor setting applies
+  // Integrated services
+  //
+  // Google Cloud services to which the floor setting applies. Each value is
+  // one of INTEGRATED_SERVICE_UNSPECIFIED or AI_PLATFORM.
   integratedServices []string
-  // AI Platform floor setting configuration
+  // AI Platform floor setting
+  //
+  // Vertex AI-specific floor setting configuration. Keys: enforcementType
+  // (a oneof, either inspectOnly or inspectAndBlock) and enableCloudLogging
+  // (whether Model Armor filter results are written to Cloud Logging).
   aiPlatformFloorSetting dict
   // Creation time
   created time
@@ -13162,7 +14266,12 @@ private gcp.project.identityPlatformService.config @defaults("mfaState improvedE
   mfaState string
   // Second-factor providers usable for multi-factor authentication
   mfaEnabledProviders []string
-  // Additional configured second-factor providers (for example TOTP)
+  // Additional second-factor providers
+  //
+  // One entry per configured second factor. Each dict has `state`, one of
+  // DISABLED, ENABLED, or MANDATORY, and, for time-based one-time password
+  // factors, a `totpProviderConfig` holding `adjacentIntervals` (the number
+  // of adjacent code intervals accepted when a code is verified).
   mfaProviderConfigs []dict
   // Whether email sign-in is enabled
   signInEmailEnabled bool
@@ -13180,7 +14289,12 @@ private gcp.project.identityPlatformService.config @defaults("mfaState improvedE
   passwordPolicyEnforcementState string
   // Whether users must have a compliant password to sign in
   passwordPolicyForceUpgradeOnSignin bool
-  // Password strength constraints (length limits and character-class requirements)
+  // Password strength constraints
+  //
+  // Character-class and length requirements enforced on passwords, with keys
+  // `minPasswordLength` and `maxPasswordLength` (integers) and the booleans
+  // `containsLowercaseCharacter`, `containsUppercaseCharacter`,
+  // `containsNumericCharacter`, and `containsNonAlphanumericCharacter`.
   passwordPolicyConstraints dict
   // reCAPTCHA enforcement state for email/password flows, one of OFF, AUDIT, or ENFORCE
   recaptchaEmailPasswordEnforcementState string
@@ -13188,7 +14302,13 @@ private gcp.project.identityPlatformService.config @defaults("mfaState improvedE
   recaptchaPhoneEnforcementState string
   // Whether the reCAPTCHA account defender is used
   recaptchaUseAccountDefender bool
-  // Blocking-function triggers (beforeCreate, beforeSignIn) and forwarded credentials
+  // Blocking-function configuration
+  //
+  // Cloud Functions invoked during authentication. The `triggers` key maps an
+  // event name (beforeCreate, beforeSignIn) to an object with `functionUri`
+  // and `updateTime`. The `forwardInboundCredentials` key controls which
+  // sign-in credentials are passed to those functions, with the booleans
+  // `idToken`, `accessToken`, and `refreshToken`.
   blockingFunctions dict
   // Whether users are blocked from signing themselves up
   clientDisabledUserSignup bool
@@ -13200,7 +14320,12 @@ private gcp.project.identityPlatformService.config @defaults("mfaState improvedE
   multiTenantAllowed bool
   // Default parent organization or folder for new tenant projects
   multiTenantDefaultTenantLocation string
-  // Allowed and disallowed regions for SMS verification-code delivery
+  // Region policy for SMS verification-code delivery
+  //
+  // Exactly one of two mutually exclusive keys is present. `allowByDefault`
+  // permits every region except those in its `disallowedRegions` list;
+  // `allowlistOnly` blocks every region except those in its `allowedRegions`
+  // list. Regions are CLDR two-letter country codes.
   smsRegionConfig dict
 }
 
@@ -13246,11 +14371,11 @@ private gcp.project.identityPlatformService.tenant @defaults("displayName tenant
 
 // Google Cloud (GCP) Discovery Engine
 //
-// Use this resource as the entry point for Discovery Engine — the API
-// behind AI Applications, Agentspace, and Gemini Enterprise. It hosts the
-// `dataStores` that index content for grounding and the `engines` (search,
-// chat, and agent apps) built on top of them. Resources are scanned in the
-// global, us, and eu multi-region locations.
+// Discovery Engine is the API behind AI Applications, Agentspace, and
+// Gemini Enterprise. It hosts the `dataStores` that index content for
+// grounding and the `engines` (search, chat, and agent apps) built on
+// top of them. Resources are scanned in the global, us, and eu
+// multi-region locations.
 private gcp.project.discoveryEngineService {
   // Project ID
   projectId string
@@ -13262,13 +14387,13 @@ private gcp.project.discoveryEngineService {
 
 // Google Cloud (GCP) Discovery Engine data store
 //
-// Examine a Discovery Engine data store — the indexed content that grounds
-// search and generative answers. `industryVertical` and `solutionTypes`
-// report what the store is built for, `contentConfig` reports the kind of
-// content indexed, `aclEnabled` indicates document-level access control, and
-// encryption at rest is reported through `kmsKeyName` and the resolved
-// `kmsKey()`. Use these fields to audit which knowledge sources exist and
-// their access-control and encryption posture.
+// Indexed content that grounds search and generative answers.
+// `industryVertical` and `solutionTypes` report what the store is built
+// for, `contentConfig` reports the kind of content indexed, `aclEnabled`
+// indicates document-level access control, and encryption at rest is
+// reported through `kmsKeyName` and the resolved `kmsKey`. These fields
+// reveal which knowledge sources exist and their access-control and
+// encryption posture.
 private gcp.project.discoveryEngineService.dataStore @defaults("displayName industryVertical") {
   // Full resource name
   name string
@@ -13294,13 +14419,13 @@ private gcp.project.discoveryEngineService.dataStore @defaults("displayName indu
 
 // Google Cloud (GCP) Discovery Engine engine
 //
-// Examine a Discovery Engine engine — a deployed search, chat, or agent
-// application (the unit branded as an app in AI Applications, Agentspace,
-// and Gemini Enterprise). `solutionType` reports what kind of app it is,
-// `industryVertical` its domain, `dataStores()` resolves the data stores it
-// grounds on, and `disableAnalytics` reports whether analytics collection is
-// turned off. Use these fields to audit which AI apps are deployed and what
-// data they draw on.
+// Deployed search, chat, or agent application (the unit branded as an app
+// in AI Applications, Agentspace, and Gemini Enterprise). `solutionType`
+// reports what kind of app it is, `industryVertical` its domain,
+// `dataStores` resolves the data stores it grounds on, and
+// `disableAnalytics` reports whether analytics collection is turned off.
+// These fields reveal which AI apps are deployed and what data they draw
+// on.
 private gcp.project.discoveryEngineService.engine @defaults("displayName solutionType") {
   // Full resource name
   name string
@@ -13405,9 +14530,9 @@ private gcp.project.documentaiService.processor.version @defaults("displayName s
 
 // Google Cloud (GCP) Eventarc
 //
-// Use this resource as the entry point for Eventarc in the project. It
-// hosts the `triggers` that route events to destinations and the
-// `channels` that deliver events from third-party and custom sources.
+// Eventarc event routing in the project. The `triggers` route events to
+// destinations such as Cloud Run, Cloud Functions, and Workflows, while the
+// `channels` deliver events from third-party and custom sources.
 private gcp.project.eventarcService {
   // Project ID
   projectId string
@@ -13419,11 +14544,11 @@ private gcp.project.eventarcService {
 
 // Google Cloud (GCP) Eventarc trigger
 //
-// Examine an Eventarc trigger — its event filters (CloudEvents attribute
-// matchers), destination configuration, transport configuration, associated
-// channel, service account, event data content type, and trigger condition
-// status. Triggers define which events are routed to which destinations
-// such as Cloud Run, Cloud Functions, or Workflows.
+// Eventarc trigger that defines which events are routed to which
+// destination, such as Cloud Run, Cloud Functions, or Workflows. Covers the
+// event filters (CloudEvents attribute matchers), the destination and
+// transport configuration, the associated channel, the identity the trigger
+// runs as, the event data content type, and the trigger condition status.
 private gcp.project.eventarcService.trigger @defaults("name") {
   // Full resource name
   name string
@@ -13442,14 +14567,28 @@ private gcp.project.eventarcService.trigger @defaults("name") {
   // Service account identity the trigger runs as
   serviceAccountRef() gcp.project.iamService.serviceAccount
   // Destination configuration
+  //
+  // The routing target keyed by destination type: `cloudRun` (service, path,
+  // region), `cloudFunction` (function resource name), `gke` (cluster,
+  // location, namespace, service, path), `workflow` (workflow resource
+  // name), and `httpEndpoint` (uri). A `networkConfig` key holds the network
+  // attachment when the destination is reached over a private network.
   destination dict
   // Transport configuration
+  //
+  // The intermediary that buffers events before delivery. The `pubsub` key
+  // holds the underlying Pub/Sub `topic` and `subscription` names created for
+  // the trigger.
   transport dict
   // Channel name (if using a channel)
   channelName string
   // User-defined key/value labels for organizing the resource
   labels map[string]string
   // Trigger condition
+  //
+  // Status conditions keyed by condition type. Each value is the condition's
+  // state code, with the human-readable message appended after a colon when
+  // one is present.
   conditions map[string]string
   // Event data content type
   eventDataContentType string
@@ -13473,10 +14612,10 @@ private gcp.project.eventarcService.trigger.eventFilter @defaults("attribute val
 
 // Google Cloud (GCP) Eventarc channel
 //
-// Examine an Eventarc channel — its provider name, associated Pub/Sub
-// topic, current state (PENDING, ACTIVE, INACTIVE), and CMEK crypto key
-// name. Channels receive events from third-party or custom event sources
-// and make them available to Eventarc triggers.
+// Eventarc channel that receives events from a third-party or custom event
+// source and makes them available to triggers. Covers the provider name, the
+// associated Pub/Sub topic, the current state (PENDING, ACTIVE, INACTIVE),
+// and the customer-managed encryption key.
 private gcp.project.eventarcService.channel @defaults("name state") {
   // Full resource name
   name string
@@ -13490,7 +14629,7 @@ private gcp.project.eventarcService.channel @defaults("name state") {
   state string
   // Crypto key name for CMEK
   //
-  // Deprecated in favor of kmsKey().
+  // Deprecated in favor of `kmsKey`.
   cryptoKeyName @maturity("deprecated") string
   // Customer-managed Cloud KMS key used to encrypt events flowing through the channel at rest
   kmsKey() gcp.project.kmsService.keyring.cryptokey
@@ -13506,13 +14645,12 @@ private gcp.project.eventarcService.channel @defaults("name state") {
 
 // Google Cloud (GCP) Sensitive Data Protection (Cloud DLP)
 //
-// Use this resource as the entry point for Sensitive Data Protection in
-// the project. It hosts the configuration surface (`inspectTemplates`,
-// `deidentifyTemplates`, `storedInfoTypes`, `jobTriggers`,
-// `discoveryConfigs`, `connections`), the `dlpJobs` that run inspection
-// and risk-analysis scans, and the data sensitivity profiles produced by
-// discovery — `projectDataProfiles`, `tableDataProfiles`,
-// `columnDataProfiles`, and `fileStoreDataProfiles`.
+// Sensitive Data Protection for the project. Hosts the configuration
+// surface (`inspectTemplates`, `deidentifyTemplates`, `storedInfoTypes`,
+// `jobTriggers`, `discoveryConfigs`, `connections`), the `dlpJobs` that
+// run inspection and risk-analysis scans, and the data sensitivity
+// profiles produced by discovery: `projectDataProfiles`,
+// `tableDataProfiles`, `columnDataProfiles`, and `fileStoreDataProfiles`.
 private gcp.project.dlpService {
   // Project ID
   projectId string
@@ -13534,24 +14672,24 @@ private gcp.project.dlpService {
   discoveryConfigs() []gcp.project.dlpService.discoveryConfig
   // Connections to data sources used by discovery (Cloud SQL, AlloyDB)
   connections() []gcp.project.dlpService.connection
-  // Project-level data sensitivity profiles produced by discovery — one per profiled project, with sensitivity and risk scores
+  // Project-level data sensitivity profiles produced by discovery, one per profiled project, with sensitivity and risk scores
   projectDataProfiles() []gcp.project.dlpService.projectDataProfile
-  // Table-level data sensitivity profiles for BigQuery tables — sensitivity score, predicted infoTypes, encryption status, and resource visibility
+  // Table-level data sensitivity profiles for BigQuery tables: sensitivity score, predicted infoTypes, encryption status, and resource visibility
   tableDataProfiles() []gcp.project.dlpService.tableDataProfile
-  // Column-level data sensitivity profiles for BigQuery columns — detected infoType, free-text status, and column data type
+  // Column-level data sensitivity profiles for BigQuery columns: detected infoType, free-text status, and column data type
   columnDataProfiles() []gcp.project.dlpService.columnDataProfile
   // File-store sensitivity profiles for Cloud Storage buckets
   //
-  // Reports sensitivity score, risk level, infoType summaries, and visibility (the GCS analog of AWS Macie bucket coverage).
+  // Reports sensitivity score, risk level, infoType summaries, and visibility for each profiled bucket.
   fileStoreDataProfiles() []gcp.project.dlpService.fileStoreDataProfile
 }
 
 // Google Cloud (GCP) Cloud DLP job
 //
-// Examine a single Cloud DLP inspect or risk-analysis job. `type` distinguishes
+// Single Cloud DLP inspect or risk-analysis job. `type` distinguishes
 // INSPECT_JOB (a scan that detects sensitive data in BigQuery, Cloud Storage,
 // or Datastore) from RISK_ANALYSIS_JOB (re-identification analysis). `state`
-// reflects lifecycle (PENDING, RUNNING, DONE, CANCELED, FAILED, ACTIVE);
+// reflects lifecycle (PENDING, RUNNING, DONE, CANCELED, FAILED, ACTIVE).
 // `details` contains the scan configuration and result counts as a dict whose
 // shape varies by `type`.
 private gcp.project.dlpService.dlpJob @defaults("name type state") {
@@ -13583,10 +14721,10 @@ private gcp.project.dlpService.dlpJob @defaults("name type state") {
 
 // Google Cloud (GCP) Cloud DLP discovery configuration
 //
-// Examine a discovery configuration — a schedule that auto-discovers and
-// profiles BigQuery and Cloud Storage resources. Inspect `status` for the
-// run state (RUNNING, PAUSED), `targets` for the resource selection rules,
-// and `inspectTemplates` for the inspection templates the discovery applies
+// Discovery configuration: a schedule that auto-discovers and profiles
+// BigQuery and Cloud Storage resources. `status` reports the run state
+// (RUNNING, PAUSED), `targets` holds the resource selection rules, and
+// `inspectTemplates` names the inspection templates the discovery applies
 // to scanned data.
 private gcp.project.dlpService.discoveryConfig @defaults("name displayName status") {
   // Full resource name
@@ -13617,10 +14755,10 @@ private gcp.project.dlpService.discoveryConfig @defaults("name displayName statu
 
 // Google Cloud (GCP) Cloud DLP connection to a data source
 //
-// Examine a Cloud DLP connection to a data source used during discovery
-// (Cloud SQL or AlloyDB). `state` reports connectivity health; `properties`
-// holds the connection details whose shape varies by the configured data
-// source: `cloudSql` (instance + db name + credential), etc.
+// Cloud DLP connection to a data source used during discovery (Cloud SQL
+// or AlloyDB). `state` reports connectivity health. `properties` holds the
+// connection details whose shape varies by the configured data source:
+// `cloudSql` (instance + db name + credential), etc.
 private gcp.project.dlpService.connection @defaults("name state") {
   // Full resource name
   name string
@@ -13628,13 +14766,15 @@ private gcp.project.dlpService.connection @defaults("name state") {
   state string
   // Connection errors if state is ERROR
   errors []dict
-  // Connection properties
+  // Connection details
+  //
+  // Shape varies by the configured data source. For Cloud SQL the `cloudSql` key holds the instance, database name, and credential configuration.
   properties dict
 }
 
 // Google Cloud (GCP) Cloud DLP project data profile
 //
-// Examine the project-level sensitivity profile produced by Cloud DLP discovery.
+// Project-level sensitivity profile produced by Cloud DLP discovery.
 // `sensitivityScore` and `dataRiskLevel` summarize the project's data risk;
 // `tableDataProfileCount` and `fileStoreDataProfileCount` indicate how many
 // per-resource profiles back this aggregate.
@@ -13659,11 +14799,11 @@ private gcp.project.dlpService.projectDataProfile @defaults("projectId sensitivi
 
 // Google Cloud (GCP) Cloud DLP table data profile
 //
-// Examine the sensitivity profile of a single BigQuery table. Inspect
-// `sensitivityScore` and `dataRiskLevel` for the aggregate scores;
-// `predictedInfoTypes` and `otherInfoTypes` for the detected infoTypes;
-// `encryptionStatus` and `resourceVisibility` for posture; and `bigqueryTable`
-// to traverse to the BigQuery table resource.
+// Sensitivity profile of a single BigQuery table. `sensitivityScore` and
+// `dataRiskLevel` give the aggregate scores; `predictedInfoTypes` and
+// `otherInfoTypes` list the detected infoTypes; `encryptionStatus` and
+// `resourceVisibility` describe posture; and `bigqueryTable` traverses to
+// the BigQuery table resource.
 private gcp.project.dlpService.tableDataProfile @defaults("tableId datasetId sensitivityScore dataRiskLevel") {
   // Full resource name of the profile
   name string
@@ -13717,8 +14857,8 @@ private gcp.project.dlpService.tableDataProfile @defaults("tableId datasetId sen
 
 // Google Cloud (GCP) Cloud DLP column data profile
 //
-// Examine the sensitivity profile of a single BigQuery column. `columnInfoType`
-// names the detected infoType; `freeTextScore` indicates how likely the column
+// Sensitivity profile of a single BigQuery column. `columnInfoType` names
+// the detected infoType; `freeTextScore` indicates how likely the column
 // holds free-form text that could contain sensitive data; `columnType` and
 // `policyState` describe BigQuery column metadata captured at profile time.
 private gcp.project.dlpService.columnDataProfile @defaults("column tableId sensitivityScore") {
@@ -13754,12 +14894,12 @@ private gcp.project.dlpService.columnDataProfile @defaults("column tableId sensi
 
 // Google Cloud (GCP) Cloud DLP file-store data profile
 //
-// Examine the sensitivity profile of a single Cloud Storage bucket — the GCS
-// analog of AWS Macie bucket coverage. `sensitivityScore` and `dataRiskLevel`
-// aggregate the bucket's sensitivity; `fileStoreInfoTypeSummaries` lists the
-// infoTypes detected across the bucket's files; `resourceVisibility` reports
-// public/restricted access; `bucket` traverses to the underlying Cloud Storage
-// bucket resource for owner-side queries (IAM, lifecycle, encryption).
+// Sensitivity profile of a single Cloud Storage bucket. `sensitivityScore`
+// and `dataRiskLevel` aggregate the bucket's sensitivity;
+// `fileStoreInfoTypeSummaries` lists the infoTypes detected across the
+// bucket's files; `resourceVisibility` reports public/restricted access;
+// and `bucket` traverses to the underlying Cloud Storage bucket resource
+// for owner-side queries (IAM, lifecycle, encryption).
 private gcp.project.dlpService.fileStoreDataProfile @defaults("fileStorePath sensitivityScore dataRiskLevel") {
   // Full resource name of the profile
   name string
@@ -13809,11 +14949,11 @@ private gcp.project.dlpService.fileStoreDataProfile @defaults("fileStorePath sen
 
 // Google Cloud (GCP) Cloud DLP inspect template
 //
-// Examine the configuration of a Cloud DLP inspect template. Inspect
-// `inspectConfig` for the info types, likelihood thresholds, and content
-// inspection rules that govern sensitive-data detection. Templates are
-// referenced by discovery configurations and job triggers to standardize
-// scanning parameters across the project.
+// Configuration of a Cloud DLP inspect template. `inspectConfig` holds the
+// info types, likelihood thresholds, and content inspection rules that
+// govern sensitive-data detection. Templates are referenced by discovery
+// configurations and job triggers to standardize scanning parameters across
+// the project.
 private gcp.project.dlpService.inspectTemplate @defaults("name displayName") {
   // Full resource name
   name string
@@ -13831,11 +14971,11 @@ private gcp.project.dlpService.inspectTemplate @defaults("name displayName") {
 
 // Google Cloud (GCP) Cloud DLP deidentify template
 //
-// Examine the configuration of a Cloud DLP deidentify template. Inspect
-// `deidentifyConfig` for the transformation rules (masking, encryption,
-// replacement, bucketing) applied to sensitive data fields detected during
-// inspection. Templates are referenced by DLP jobs to ensure consistent
-// de-identification across the project.
+// Configuration of a Cloud DLP deidentify template. `deidentifyConfig` holds
+// the transformation rules (masking, encryption, replacement, bucketing)
+// applied to sensitive data fields detected during inspection. Templates are
+// referenced by DLP jobs to ensure consistent de-identification across the
+// project.
 private gcp.project.dlpService.deidentifyTemplate @defaults("name displayName") {
   // Full resource name
   name string
@@ -13853,11 +14993,11 @@ private gcp.project.dlpService.deidentifyTemplate @defaults("name displayName") 
 
 // Google Cloud (GCP) Cloud DLP job trigger
 //
-// Examine a Cloud DLP job trigger — a scheduled or event-driven rule that
-// automatically launches DLP inspect jobs. Inspect `status` for operational
-// health (HEALTHY, PAUSED, CANCELLED), `triggers` for the schedule or
-// event conditions that activate the job, `inspectJob` for the scan
-// configuration, and `errors` for failures from recent activations.
+// Cloud DLP job trigger: a scheduled or event-driven rule that automatically
+// launches DLP inspect jobs. `status` reports operational health (HEALTHY,
+// PAUSED, CANCELLED), `triggers` holds the schedule or event conditions that
+// activate the job, `inspectJob` holds the scan configuration, and `errors`
+// lists failures from recent activations.
 private gcp.project.dlpService.jobTrigger @defaults("name displayName status") {
   // Full resource name
   name string
@@ -13881,8 +15021,8 @@ private gcp.project.dlpService.jobTrigger @defaults("name displayName status") {
 
 // Google Cloud (GCP) Cloud DLP stored info type
 //
-// Examine a Cloud DLP stored info type — a reusable, pre-built dictionary
-// or regular-expression detector that can be referenced across inspect
+// Cloud DLP stored info type: a reusable, pre-built dictionary or
+// regular-expression detector that can be referenced across inspect
 // templates and job triggers. `currentVersion` holds the active config,
 // stats, and build state; `pendingVersions` lists versions being rebuilt
 // when the underlying data source changes.
@@ -13903,10 +15043,10 @@ private gcp.project.dlpService.storedInfoType @defaults("name") {
 
 // Google Cloud (GCP) Batch
 //
-// Use this resource as the entry point for Batch in the project. It hosts
-// the project's `jobs` — each exposing its task groups, compute and
-// network configuration, and execution state for managed batch-compute
-// audits.
+// Batch service in the project, exposing the batch-compute `jobs` that run
+// containerized or script workloads on managed compute resources. Each job
+// reports its task groups, allocation and network configuration, and
+// execution state for managed batch-compute audits.
 private gcp.project.batchService {
   // Project ID
   projectId string
@@ -13916,11 +15056,12 @@ private gcp.project.batchService {
 
 // Google Cloud (GCP) Batch job
 //
-// Examine a Cloud Batch job and its execution configuration. Inspect
-// `taskGroups` for the task specifications, parallelism, and scheduling
-// policies; `allocationPolicy` for the compute and network resources
-// provisioned to run the tasks; `status` for the current lifecycle state;
-// and `logsPolicy` for where task logs are sent.
+// Cloud Batch job and its execution configuration. The `taskGroups` carry
+// the task specifications, parallelism, and scheduling policies;
+// `allocationPolicy` describes the compute and network resources (including
+// the service account and VPC) provisioned to run the tasks; `status`
+// reports the current lifecycle state; and `logsPolicy` records where task
+// logs are sent.
 private gcp.project.batchService.job @defaults("name") {
   // Full resource name
   name string
@@ -13930,13 +15071,28 @@ private gcp.project.batchService.job @defaults("name") {
   priority int
   // Task groups
   taskGroups []gcp.project.batchService.job.taskGroup
-  // Resource allocation policy
+  // Compute and network resources provisioned to run the job
+  //
+  // Keys: `location` (allowed regions and zones), `instances` (per-instance
+  // policy with machine type, provisioning model, and boot/attached disks),
+  // `serviceAccount` (identity and scopes the VMs run as), `network` (VPC
+  // network interfaces and firewall tags), `placement` (VM collocation),
+  // `labels`, and `tags`.
   allocationPolicy dict
-  // Job status
+  // Current execution state of the job
+  //
+  // Keys: `state` (one of STATE_UNSPECIFIED, QUEUED, SCHEDULED, RUNNING,
+  // SUCCEEDED, FAILED, DELETION_IN_PROGRESS, CANCELLATION_IN_PROGRESS, or
+  // CANCELLED), `statusEvents` (timestamped lifecycle events), `taskGroups`
+  // (per-group task counts by state), and `runDuration`.
   status dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
-  // Logs policy
+  // Where task logs are sent
+  //
+  // Keys: `destination` (one of DESTINATION_UNSPECIFIED, CLOUD_LOGGING, or
+  // PATH), `logsPath` (Cloud Storage or filesystem path used when destination
+  // is PATH), and `cloudLoggingOption` (Cloud Logging settings).
   logsPolicy dict
   // Creation time
   created time
@@ -13946,15 +15102,22 @@ private gcp.project.batchService.job @defaults("name") {
 
 // Google Cloud (GCP) Batch job task group
 //
-// Examine a task group within a Cloud Batch job. Inspect `taskSpec` for
-// the container or script definition, environment variables, and volume
-// mounts; `taskCount` and `parallelism` for the execution scale;
-// `schedulingPolicy` (AS_SOON_AS_POSSIBLE or IN_ORDER) for the run order;
-// and `permissiveSsh` for the inter-task SSH access setting.
+// Task group within a Cloud Batch job, describing how a set of identical
+// tasks runs. `taskSpec` holds the container or script definition,
+// environment, and volume mounts; `taskCount` and `parallelism` set the
+// execution scale; `schedulingPolicy` (AS_SOON_AS_POSSIBLE or IN_ORDER)
+// controls the run order; and `permissiveSsh` reports whether passwordless
+// SSH is allowed between the group's tasks.
 private gcp.project.batchService.job.taskGroup @defaults("name taskCount") {
   // Full resource name
   name string
-  // Task specification
+  // Container or script definition run by each task
+  //
+  // Keys: `runnables` (the containers or scripts to execute),
+  // `computeResource` (cpuMilli, memoryMib, and bootDiskMib requested per
+  // task), `maxRunDuration`, `maxRetryCount`, `lifecyclePolicies` (retry or
+  // fail actions keyed on exit codes), `volumes` (mounted storage), and
+  // `environment` (variables and secrets).
   taskSpec dict
   // Number of tasks
   taskCount int
@@ -13964,7 +15127,11 @@ private gcp.project.batchService.job.taskGroup @defaults("name taskCount") {
   schedulingPolicy string
   // Max tasks per VM
   taskCountPerNode int
-  // Whether tasks require Docker (vs VM)
+  // Whether Batch writes a hosts file listing all VMs in the group
+  //
+  // When true, Batch populates a file with the list of all VMs assigned to
+  // the task group and sets the BATCH_HOSTS_FILE environment variable to its
+  // path.
   requireHostsFile bool
   // Permissive SSH access between tasks
   permissiveSsh bool
@@ -13976,10 +15143,10 @@ private gcp.project.batchService.job.taskGroup @defaults("name taskCount") {
 
 // Google Cloud (GCP) Cloud IDS
 //
-// Use this resource as the entry point for Cloud IDS in the project. It
-// hosts the IDS `endpoints` — each exposing its severity threshold,
-// inspected network, traffic-logging setting, and operational state for
-// intrusion-detection audits.
+// Cloud IDS in the project, hosting the intrusion-detection
+// `endpoints`. Each endpoint exposes its severity threshold, the VPC
+// network under inspection, its traffic-logging setting, and its
+// operational state for intrusion-detection audits.
 private gcp.project.idsService {
   // Project ID
   projectId string
@@ -13989,11 +15156,11 @@ private gcp.project.idsService {
 
 // Google Cloud (GCP) Cloud IDS endpoint
 //
-// Examine a Cloud IDS intrusion-detection endpoint. Inspect `severity`
-// for the minimum threat level that generates alerts (INFORMATIONAL, LOW,
-// MEDIUM, HIGH, CRITICAL); `network` for the VPC network under inspection;
-// `state` for the operational lifecycle (CREATING, READY, DELETING,
-// UPDATING); and `trafficLogs` to verify whether full traffic logging is
+// Cloud IDS intrusion-detection endpoint. The `severity` field sets the
+// minimum threat level that generates alerts (INFORMATIONAL, LOW,
+// MEDIUM, HIGH, CRITICAL); `network` is the VPC network under inspection;
+// `state` tracks the operational lifecycle (CREATING, READY, DELETING,
+// UPDATING); and `trafficLogs` verifies whether full traffic logging is
 // enabled for forensic audits.
 private gcp.project.idsService.endpoint @defaults("name severity state") {
   // Full resource name
@@ -14030,12 +15197,12 @@ private gcp.project.idsService.endpoint @defaults("name severity state") {
 
 // VM Manager (OS Config) service for a project
 //
-// Use this resource to reach Google Cloud VM Manager resources for a
-// project: `patchDeployments` lists scheduled OS patch rollouts and
-// `osPolicyAssignments` lists the OS policy assignments applied to
-// instances across every zone. Per-instance patch and vulnerability
-// state is exposed on `gcp.project.computeService.instance` through
-// its `inventory` and `vulnerabilityReport` fields.
+// Google Cloud VM Manager resources for a project: `patchDeployments`
+// lists scheduled OS patch rollouts and `osPolicyAssignments` lists the
+// OS policy assignments applied to instances across every zone.
+// Per-instance patch and vulnerability state is exposed on
+// `gcp.project.computeService.instance` through its `inventory` and
+// `vulnerabilityReport` fields.
 private gcp.project.osConfigService {
   // Project ID
   projectId string
@@ -14047,29 +15214,49 @@ private gcp.project.osConfigService {
 
 // VM Manager OS patch deployment
 //
-// Examine a scheduled patch rollout managed by VM Manager: the
-// `instanceFilter` selecting which VM instances are patched, the
-// per-package-manager behavior and reboot policy in `patchConfig`,
-// the `oneTimeSchedule` or `recurringSchedule` that triggers it, the
-// `rollout` strategy and disruption budget, and the `state` that
-// audits whether the deployment is ACTIVE or PAUSED. Selected by the
-// full resource name.
+// Scheduled patch rollout managed by VM Manager: the `instanceFilter`
+// selecting which VM instances are patched, the per-package-manager
+// behavior and reboot policy in `patchConfig`, the `oneTimeSchedule` or
+// `recurringSchedule` that triggers it, the `rollout` strategy and
+// disruption budget, and the `state` that audits whether the deployment
+// is ACTIVE or PAUSED. Selected by the full resource name, for example
+// `projects/PROJECT/patchDeployments/DEPLOYMENT`.
 private gcp.project.osConfigService.patchDeployment @defaults("name state lastExecuteTime") {
   // Full resource name of the patch deployment
   name string
   // Optional human-readable description
   description string
   // Filter selecting which VM instances receive the patch
+  //
+  // Keys: `all` (bool targeting every instance in the project),
+  // `groupLabels` (label sets, matched if any set applies), `zones`,
+  // `instances` (full instance resource names), and
+  // `instanceNamePrefixes`.
   instanceFilter dict
   // Per-package-manager patch behavior and reboot configuration
+  //
+  // Keys: `rebootConfig` (DEFAULT, ALWAYS, NEVER), the per-manager
+  // settings `apt`, `yum`, `zypper`, `goo`, and `windowsUpdate`,
+  // `preStep` and `postStep` scripts run before and after patching,
+  // `migInstancesAllowed`, and `skipUnpatchableVms`.
   patchConfig dict
   // Length of time the patch is allowed to run, in seconds
   duration int
   // One-time schedule that triggers this patch deployment
+  //
+  // Key: `executeTime`, the timestamp at which the patch runs once.
   oneTimeSchedule dict
   // Recurring schedule that triggers this patch deployment
+  //
+  // Keys: `frequency` (DAILY, WEEKLY, MONTHLY), `timeZone`, `timeOfDay`,
+  // `startTime`, `endTime`, a `weekly` or `monthly` day selector, and
+  // the computed `lastExecuteTime` and `nextExecuteTime`.
   recurringSchedule dict
   // Rollout strategy and disruption budget for the patch
+  //
+  // Keys: `mode` (ZONE_BY_ZONE, CONCURRENT_ZONES) and
+  // `disruptionBudget` (a `fixed` count or a `percent` of instances)
+  // capping how many VMs are patched at once.
   rollout dict
   // Deployment state (ACTIVE, PAUSED)
   state string
@@ -14083,22 +15270,35 @@ private gcp.project.osConfigService.patchDeployment @defaults("name state lastEx
 
 // VM Manager OS policy assignment
 //
-// Examine an OS policy assignment that applies a set of OS policies
-// (`osPolicies`) to the VM instances selected by `instanceFilter`.
-// Each assignment tracks its `rollout` strategy, its progress through
-// `rolloutState`, the immutable `revisionId` of the applied
-// configuration, and whether the revision is a `baseline` or has been
-// `deleted`. Selected by the full resource name.
+// OS policy assignment that applies a set of OS policies (`osPolicies`)
+// to the VM instances selected by `instanceFilter`. Each assignment
+// tracks its `rollout` strategy, its progress through `rolloutState`,
+// the immutable `revisionId` of the applied configuration, and whether
+// the revision is a `baseline` or has been `deleted`. Selected by the
+// full resource name, for example
+// `projects/PROJECT/locations/ZONE/osPolicyAssignments/ASSIGNMENT`.
 private gcp.project.osConfigService.osPolicyAssignment @defaults("name rolloutState") {
   // Full resource name of the OS policy assignment
   name string
   // Optional human-readable description
   description string
   // OS policies applied to the selected instances
+  //
+  // Each entry has keys: `id`, `description`, `mode` (VALIDATION,
+  // ENFORCEMENT), `resourceGroups` (the packages, repositories, files,
+  // and exec resources to enforce), and `allowNoResourceGroupMatch`.
   osPolicies []dict
   // Filter selecting which VM instances the policies apply to
+  //
+  // Keys: `all` (bool targeting every instance), `inclusionLabels` and
+  // `exclusionLabels` (label sets to include or exclude), and
+  // `inventories` (matched on `osShortName` and `osVersion`).
   instanceFilter dict
   // Rollout strategy and disruption budget for the assignment
+  //
+  // Keys: `disruptionBudget` (a `fixed` count or a `percent` of
+  // instances) and `minWaitDuration`, the minimum time to wait after
+  // updating each instance before moving on.
   rollout dict
   // Immutable identifier of this revision of the assignment
   revisionId string
@@ -14120,12 +15320,12 @@ private gcp.project.osConfigService.osPolicyAssignment @defaults("name rolloutSt
 
 // Network Security service for a project
 //
-// Use this resource to reach Google Cloud Network Security resources
-// for a project: service-mesh `authorizationPolicies`, the
-// `serverTlsPolicies` and `clientTlsPolicies` that govern TLS
-// behavior, the `tlsInspectionPolicies` used to decrypt and inspect
-// traffic, the `addressGroups` referenced by firewall policy rules,
-// and the `urlLists` used for URL-based filtering.
+// Google Cloud Network Security resources for a project: service-mesh
+// `authorizationPolicies`, the `serverTlsPolicies` and
+// `clientTlsPolicies` that govern TLS behavior, the
+// `tlsInspectionPolicies` used to decrypt and inspect traffic, the
+// `addressGroups` referenced by firewall policy rules, and the
+// `urlLists` used for URL-based filtering.
 private gcp.project.networkSecurityService {
   // Project ID
   projectId string
@@ -14145,11 +15345,11 @@ private gcp.project.networkSecurityService {
 
 // Network Security authorization policy
 //
-// Examine an authorization policy that allows or denies traffic
-// between workloads in a service mesh or load-balanced application:
-// `action` records the default ALLOW or DENY decision and `rules`
-// lists the source and destination matchers that select which
-// requests the policy applies to. Selected by the full resource name.
+// Authorization policy that allows or denies traffic between workloads
+// in a service mesh or load-balanced application. `action` records the
+// default ALLOW or DENY decision and `rules` lists the source and
+// destination matchers that select which requests the policy applies
+// to. Selected by the full resource name.
 private gcp.project.networkSecurityService.authorizationPolicy @defaults("name action") {
   // Full resource name of the authorization policy
   name string
@@ -14158,6 +15358,11 @@ private gcp.project.networkSecurityService.authorizationPolicy @defaults("name a
   // Default action applied to matching traffic (ALLOW, DENY)
   action string
   // Source and destination matchers selecting which requests the policy applies to
+  //
+  // Each entry has `sources` (each with `ipBlocks` and `principals`) and
+  // `destinations` (each with `hosts`, `methods`, `ports`, and an
+  // `httpHeaderMatch`). A request matches a rule when it matches all of
+  // that rule's sources and destinations.
   rules []dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -14169,11 +15374,11 @@ private gcp.project.networkSecurityService.authorizationPolicy @defaults("name a
 
 // Network Security server TLS policy
 //
-// Examine a server-side TLS policy attached to inbound traffic: the
-// `allowOpen` predicate audits whether plaintext connections are
-// permitted, `mtlsPolicy` configures mutual TLS client validation,
-// and `serverCertificate` configures the certificate the server
-// presents. Selected by the full resource name.
+// Server-side TLS policy attached to inbound traffic. The `allowOpen`
+// predicate audits whether plaintext connections are permitted,
+// `mtlsPolicy` configures mutual TLS client validation, and
+// `serverCertificate` configures the certificate the server presents.
+// Selected by the full resource name.
 private gcp.project.networkSecurityService.serverTlsPolicy @defaults("name allowOpen") {
   // Full resource name of the server TLS policy
   name string
@@ -14182,6 +15387,12 @@ private gcp.project.networkSecurityService.serverTlsPolicy @defaults("name allow
   // Whether plaintext (non-TLS) connections are permitted
   allowOpen bool
   // Mutual TLS configuration for validating client certificates
+  //
+  // Holds `clientValidationCa` (the certificate authorities used to
+  // validate presented client certificates), `clientValidationMode`
+  // (also surfaced as the clientValidationMode field), and
+  // `clientValidationTrustConfig` (a Certificate Manager trust config
+  // used when the mode is REJECT_INVALID).
   mtlsPolicy dict
   // How connections with invalid or missing client certificates are handled
   //
@@ -14189,6 +15400,11 @@ private gcp.project.networkSecurityService.serverTlsPolicy @defaults("name allow
   // or REJECT_INVALID. Empty when no mTLS policy is set.
   clientValidationMode string
   // Certificate provider configuration for the certificate the server presents
+  //
+  // Holds either a `certificateProviderInstance` (with `pluginInstance`,
+  // the named provider such as `google_cloud_private_spiffe`) or a
+  // `grpcEndpoint` giving the address of a gRPC server that supplies the
+  // certificate and private key.
   serverCertificate dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -14200,12 +15416,12 @@ private gcp.project.networkSecurityService.serverTlsPolicy @defaults("name allow
 
 // Network Security client TLS policy
 //
-// Examine a client-side TLS policy used for outbound connections:
-// `sni` records the server name indication sent during the
-// handshake, `clientCertificate` configures the certificate the
-// client presents for mutual TLS, and `serverValidationCa` lists the
-// certificate authorities trusted to validate the server. Selected by
-// the full resource name.
+// Client-side TLS policy used for outbound connections. `sni` records
+// the server name indication sent during the handshake,
+// `clientCertificate` configures the certificate the client presents
+// for mutual TLS, and `serverValidationCa` lists the certificate
+// authorities trusted to validate the server. Selected by the full
+// resource name.
 private gcp.project.networkSecurityService.clientTlsPolicy @defaults("name sni") {
   // Full resource name of the client TLS policy
   name string
@@ -14214,8 +15430,17 @@ private gcp.project.networkSecurityService.clientTlsPolicy @defaults("name sni")
   // Server name indication sent during the TLS handshake
   sni string
   // Certificate provider configuration for the certificate the client presents
+  //
+  // Holds either a `certificateProviderInstance` (with `pluginInstance`,
+  // the named provider such as `google_cloud_private_spiffe`) or a
+  // `grpcEndpoint` giving the address of a gRPC server that supplies the
+  // certificate and private key.
   clientCertificate dict
   // Certificate authorities trusted to validate the server certificate
+  //
+  // Each entry holds either a `certificateProviderInstance` (with
+  // `pluginInstance`, the named provider) or a `grpcEndpoint` giving the
+  // address of a gRPC server that supplies the CA certificate.
   serverValidationCa []dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -14227,12 +15452,12 @@ private gcp.project.networkSecurityService.clientTlsPolicy @defaults("name sni")
 
 // Network Security TLS inspection policy
 //
-// Examine a TLS inspection policy that lets firewall rules decrypt,
-// inspect, and re-encrypt TLS traffic: `caPool` references the
-// Certificate Authority Service pool used to mint intercept
-// certificates, `minTlsVersion` and `tlsFeatureProfile` constrain the
-// negotiated TLS parameters, and `trustConfig` supplies additional
-// trusted certificates. Selected by the full resource name.
+// TLS inspection policy that lets firewall rules decrypt, inspect, and
+// re-encrypt TLS traffic. `caPool` references the Certificate
+// Authority Service pool used to mint intercept certificates,
+// `minTlsVersion` and `tlsFeatureProfile` constrain the negotiated TLS
+// parameters, and `trustConfig` supplies additional trusted
+// certificates. Selected by the full resource name.
 private gcp.project.networkSecurityService.tlsInspectionPolicy @defaults("name minTlsVersion") {
   // Full resource name of the TLS inspection policy
   name string
@@ -14260,12 +15485,11 @@ private gcp.project.networkSecurityService.tlsInspectionPolicy @defaults("name m
 
 // Network Security address group
 //
-// Examine an address group: a named, reusable collection of IP
-// addresses or ranges in `items` that firewall policy rules reference
-// instead of inline address lists. `type` records whether the group
-// holds IPv4 or IPv6 addresses, `capacity` is the maximum number of
-// items, and `purpose` records where the group may be used. Selected
-// by the full resource name.
+// Named, reusable collection of IP addresses or ranges in `items` that
+// firewall policy rules reference instead of inline address lists.
+// `type` records whether the group holds IPv4 or IPv6 addresses,
+// `capacity` is the maximum number of items, and `purpose` records
+// where the group may be used. Selected by the full resource name.
 private gcp.project.networkSecurityService.addressGroup @defaults("name type") {
   // Full resource name of the address group
   name string
@@ -14289,10 +15513,9 @@ private gcp.project.networkSecurityService.addressGroup @defaults("name type") {
 
 // Network Security URL list
 //
-// Examine a URL list: a named collection of URL patterns in `values`
-// that secure web proxy and firewall rules reference to allow or
-// block web traffic by destination. Selected by the full resource
-// name.
+// Named collection of URL patterns in `values` that secure web proxy
+// and firewall rules reference to allow or block web traffic by
+// destination. Selected by the full resource name.
 private gcp.project.networkSecurityService.urlList @defaults("name") {
   // Full resource name of the URL list
   name string
@@ -14312,9 +15535,10 @@ private gcp.project.networkSecurityService.urlList @defaults("name") {
 
 // Google Cloud (GCP) Backup for GKE
 //
-// Use this resource as the entry point for Backup for GKE in the project.
-// It hosts the `backupPlans` that schedule cluster backups and the
-// `restorePlans` that govern how those backups are restored.
+// Backup for GKE in the project, the managed service that protects GKE
+// cluster workloads and their volume data. `backupPlans` schedule cluster
+// backups and set retention, while `restorePlans` govern how those backups
+// are restored into a target cluster.
 private gcp.project.gkeBackupService {
   // Project ID
   projectId string
@@ -14326,12 +15550,14 @@ private gcp.project.gkeBackupService {
 
 // Google Cloud (GCP) GKE Backup plan
 //
-// Examine a Backup for GKE backup plan. Inspect `cluster` for the source
-// GKE cluster being protected; `backupSchedule` for the cron-based
-// schedule; `retentionPolicy` for how long backups are retained and
-// whether deletion protection is active; `backupConfig` for the scope
-// (all namespaces, selected namespaces, or selected applications); and
-// `state` for the plan's operational lifecycle.
+// Backup for GKE backup plan, defining how and when a GKE cluster's
+// workloads are backed up. `cluster` is the source cluster being
+// protected; `backupSchedule` holds the cron-based schedule;
+// `retentionPolicy` sets how long backups are kept and whether deletion
+// protection is locked; `backupConfig` sets the scope (all namespaces,
+// selected namespaces, or selected applications) and whether volume data
+// and secrets are included; and `state` reports the plan's operational
+// lifecycle.
 private gcp.project.gkeBackupService.backupPlan @defaults("name") {
   // Full resource name
   name string
@@ -14342,10 +15568,28 @@ private gcp.project.gkeBackupService.backupPlan @defaults("name") {
   // Source GKE cluster name
   cluster string
   // Retention policy
+  //
+  // Keys: `backupDeleteLockDays` (minimum days a backup is protected from
+  // deletion), `backupRetainDays` (days after creation a backup is
+  // automatically deleted, 0 means never), and `locked` (whether these
+  // retention settings can no longer be changed).
   retentionPolicy dict
   // Backup schedule
+  //
+  // Keys: `cronSchedule` (cron expression for time-based backups), `paused`
+  // (whether automatic backup creation is suspended), `rpoConfig` (recovery
+  // point objective target configuration), and `nextScheduledBackupTime`
+  // (when the next backup is due).
   backupSchedule dict
   // Backup configuration scope
+  //
+  // Exactly one scope key is set: `allNamespaces` (back up the whole
+  // cluster), `selectedNamespaces`, or `selectedApplications`. Other keys:
+  // `includeVolumeData` (whether PVC volume data is backed up),
+  // `includeSecrets` (whether Kubernetes Secrets are included),
+  // `encryptionKey` (customer-managed key used to encrypt the config
+  // portion of backups), and `permissiveMode` (whether non-standard
+  // configuration is allowed instead of failing the backup).
   backupConfig dict
   // Whether the plan is deactivated
   deactivated bool
@@ -14367,12 +15611,13 @@ private gcp.project.gkeBackupService.backupPlan @defaults("name") {
 
 // Google Cloud (GCP) GKE Backup restore plan
 //
-// Examine a Backup for GKE restore plan. Inspect `backupPlan` to traverse
-// to the source backup plan; `cluster` for the target GKE cluster where
-// backups are restored; `restoreConfig` for the namespace mapping,
-// substitution rules, and volume data restore policies; and `state` for
-// the plan's operational lifecycle (CLUSTER_PENDING, READY, FAILED,
-// DELETING).
+// Backup for GKE restore plan, defining how backups are restored into a
+// target GKE cluster. `backupPlan` links to the source backup plan;
+// `cluster` is the target cluster where backups are restored;
+// `restoreConfig` holds the namespace scope, substitution and
+// transformation rules, conflict policy, and volume data restore policies;
+// and `state` reports the plan's operational lifecycle (CLUSTER_PENDING,
+// READY, FAILED, DELETING).
 private gcp.project.gkeBackupService.restorePlan @defaults("name") {
   // Full resource name
   name string
@@ -14387,6 +15632,16 @@ private gcp.project.gkeBackupService.restorePlan @defaults("name") {
   // Target GKE cluster name
   cluster string
   // Restore configuration
+  //
+  // Keys: `volumeDataRestorePolicy` and `volumeDataRestorePolicyBindings`
+  // (how persistent volume data is restored), `clusterResourceConflictPolicy`
+  // (how conflicts with existing cluster-scoped resources are handled),
+  // `namespacedResourceRestoreMode` plus the namespace scope (exactly one of
+  // `allNamespaces`, `selectedNamespaces`, `selectedApplications`,
+  // `noNamespaces`, or `excludedNamespaces`), `clusterResourceRestoreScope`
+  // (which cluster-scoped resources are restored), `substitutionRules` and
+  // `transformationRules` (edits applied to resources during restore), and
+  // `restoreOrder` (ordering constraints between resource groups).
   restoreConfig dict
   // User-defined key/value labels for organizing the resource
   labels map[string]string
@@ -14408,9 +15663,11 @@ private gcp.project.gkeBackupService.restorePlan @defaults("name") {
 
 // Google Cloud (GCP) Container Analysis
 //
-// Use this resource as the entry point for Container Analysis in the
-// project. It hosts the vulnerability `occurrences` — the scan findings
-// attached to container images for software-supply-chain audits.
+// Container Analysis metadata for the project, the software-supply-chain
+// scan surface for container images. `occurrences` holds the scan findings
+// (vulnerabilities, build provenance, attestations, and more) attached to
+// image artifacts, and `notes` holds the metadata definitions those
+// findings reference.
 private gcp.project.containerAnalysisService {
   // Project ID
   projectId string
@@ -14422,13 +15679,13 @@ private gcp.project.containerAnalysisService {
 
 // Google Cloud (GCP) Container Analysis occurrence
 //
-// Examine a Container Analysis occurrence — a scan finding attached to a
-// container image artifact. `kind` identifies the occurrence type
-// (VULNERABILITY, BUILD, IMAGE, PACKAGE, DEPLOYMENT, DISCOVERY,
-// ATTESTATION, UPGRADE, COMPLIANCE, SBOM_REFERENCE); `resourceUri`
-// identifies the artifact; and the corresponding detail field (e.g.
-// `vulnerability`, `attestation`, `build`) holds the type-specific data
-// for software-supply-chain audits.
+// Container Analysis occurrence, a scan finding attached to a container
+// image artifact. `kind` identifies the occurrence type (VULNERABILITY,
+// BUILD, IMAGE, PACKAGE, DEPLOYMENT, DISCOVERY, ATTESTATION, UPGRADE,
+// COMPLIANCE, SBOM_REFERENCE); `resourceUri` identifies the artifact; and
+// the corresponding detail field (for example `vulnerability`,
+// `attestation`, `build`) holds the type-specific data for
+// software-supply-chain audits.
 private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
   // Full resource name
   name string
@@ -14486,13 +15743,31 @@ private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
   buildArtifacts []dict
   // Commands executed during the build, each with its name, arguments, and environment (when kind is BUILD)
   buildCommands []dict
-  // Image details (if kind is IMAGE)
+  // Image layer details (when kind is IMAGE)
+  //
+  // Keys: `fingerprint` (the layer-based image fingerprint), `distance`
+  // (number of layers by which this image differs from its base image),
+  // `layerInfo` (the Dockerfile directive for each layer), and
+  // `baseResourceUrl` (resource URL of the base image).
   image dict
-  // Package details (if kind is PACKAGE)
+  // Installed-package details (when kind is PACKAGE)
+  //
+  // Keys: `name` (package name), `location` (the CPE URI, version, and
+  // filesystem path where the package is installed), `packageType`,
+  // `cpeUri`, `architecture`, `license`, and `version`.
   packageInfo dict
-  // Deployment details (if kind is DEPLOYMENT)
+  // Deployment details (when kind is DEPLOYMENT)
+  //
+  // Keys: `userEmail` (identity that triggered the deployment), `deployTime`,
+  // `undeployTime`, `config`, `address`, `resourceUri` (the resources
+  // deployed), and `platform` (one of PLATFORM_UNSPECIFIED, GKE, FLEX, or
+  // CUSTOM).
   deployment dict
-  // Discovery details (if kind is DISCOVERY)
+  // Discovery scan status (when kind is DISCOVERY)
+  //
+  // Keys: `continuousAnalysis` (whether continuous analysis is active),
+  // `analysisStatus` (current scan status), `analysisStatusError`, `cpe`,
+  // `lastScanTime`, `archiveTime`, and `sbomStatus`.
   discovery dict
   // Attestation details (if kind is ATTESTATION)
   //
@@ -14513,8 +15788,8 @@ private gcp.project.containerAnalysisService.occurrence @defaults("name kind") {
 
 // Google Cloud (GCP) Container Analysis note
 //
-// Examine a Container Analysis note — a metadata definition that
-// occurrences reference, identified by `name`. `kind` selects the note type
+// Container Analysis note, a metadata definition that occurrences
+// reference, identified by `name`. `kind` selects the note type
 // (VULNERABILITY, BUILD, IMAGE, PACKAGE, DEPLOYMENT, DISCOVERY, ATTESTATION,
 // UPGRADE, COMPLIANCE, SBOM_REFERENCE) and the matching detail field holds
 // the type-specific definition. For ATTESTATION notes `attestationAuthority`
@@ -14531,10 +15806,21 @@ private gcp.project.containerAnalysisService.note @defaults("name kind") {
   // Note kind (VULNERABILITY, BUILD, IMAGE, PACKAGE, DEPLOYMENT, DISCOVERY, ATTESTATION, UPGRADE, COMPLIANCE, SBOM_REFERENCE)
   kind string
   // Attestation authority definition (when kind is ATTESTATION)
+  //
+  // Contains a single key `hint`, whose `humanReadableName` labels the
+  // attestation authority that underpins Binary Authorization trust.
   attestationAuthority dict
-  // Vulnerability definition with severity and affected packages (when kind is VULNERABILITY)
+  // Vulnerability definition (when kind is VULNERABILITY)
+  //
+  // Keys: `cvssScore`, `severity` (one of SEVERITY_UNSPECIFIED, MINIMAL, LOW,
+  // MEDIUM, HIGH, or CRITICAL), `details` (per-distro affected package ranges
+  // and fixes), `cvssV3`, `windowsDetails`, `sourceUpdateTime`, and
+  // `cvssVersion`.
   vulnerability dict
   // Build provenance definition (when kind is BUILD)
+  //
+  // Contains a single key `builderVersion`, the version of the builder that
+  // produces builds tracked by this note.
   build dict
   // Names of other notes related to this note
   relatedNoteNames []string
@@ -14550,9 +15836,11 @@ private gcp.project.containerAnalysisService.note @defaults("name kind") {
 
 // Google Cloud (GCP) Cloud Build
 //
-// Use this resource as the entry point for Cloud Build in the project. It
-// hosts the build `triggers` (with their source repositories and build
-// configuration) and the private `workerPools` that builds run on.
+// Cloud Build service for the project, the managed CI/CD platform that runs
+// container image and artifact builds. Exposes the build `triggers` (with
+// their source repositories and build configuration), the private
+// `workerPools` that builds execute on, and the `builds` history of past
+// executions.
 private gcp.project.cloudBuildService {
   // Project ID
   projectId string
@@ -14566,12 +15854,11 @@ private gcp.project.cloudBuildService {
 
 // Google Cloud (GCP) Cloud Build trigger
 //
-// Examine a Cloud Build trigger and its event configuration. Inspect
-// `disabled` to verify whether the trigger is active; `serviceAccount`
-// (and `iamServiceAccount`) for the identity builds run under;
-// `substitutions` for variable overrides passed to the build; and the
-// event source — `github`, `pubsubConfig`, `webhookConfig`, or
-// `repositoryEventConfig` — that fires the trigger.
+// Cloud Build trigger that starts a build in response to a source event.
+// The `disabled` flag reports whether the trigger is active, while
+// `serviceAccount` and the resolved `iamServiceAccount` identify the
+// identity builds run under. Exactly one event source fires the trigger:
+// `github`, `pubsubConfig`, `webhookConfig`, or `repositoryEventConfig`.
 private gcp.project.cloudBuildService.trigger @defaults("name description disabled") {
   // Project ID
   projectId string
@@ -14612,10 +15899,11 @@ private gcp.project.cloudBuildService.trigger @defaults("name description disabl
 
 // Google Cloud (GCP) Cloud Build trigger GitHub events configuration
 //
-// Examine the GitHub event configuration for a Cloud Build trigger. Inspect
-// `owner` and `name` to identify the GitHub repository; `push` for the
-// branch or tag regex that fires on push events; and `pullRequest` for the
-// branch filter and comment-control setting that govern pull-request builds.
+// GitHub event configuration for a Cloud Build trigger, covering the
+// repository (`owner` and `name`) and the events that fire a build. `push`
+// carries the branch or tag regex matched on push events, and `pullRequest`
+// carries the branch filter and comment-control policy that govern
+// pull-request builds.
 private gcp.project.cloudBuildService.trigger.githubEventsConfig @defaults("owner name") {
   // Internal ID
   id string
@@ -14625,18 +15913,27 @@ private gcp.project.cloudBuildService.trigger.githubEventsConfig @defaults("owne
   name string
   // GitHub App installation ID
   installationId int
-  // Push event filter configuration (branch/tag regex)
+  // Push event filter
+  //
+  // Dict with `branch` or `tag` (a regex selecting which refs fire a build
+  // on push) and `invertRegex` (when true, fire on refs that do not match
+  // the regex).
   push dict
-  // Pull request event filter configuration (branch regex, comment control)
+  // Pull request event filter
+  //
+  // Dict with `branch` (a regex selecting target branches), `commentControl`
+  // (COMMENTS_DISABLED, COMMENTS_ENABLED, or
+  // COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY), and `invertRegex`
+  // (when true, match branches that do not match the regex).
   pullRequest dict
 }
 
 // Google Cloud (GCP) Cloud Build trigger Pub/Sub configuration
 //
-// Examine the Pub/Sub event configuration for a Cloud Build trigger. Inspect
-// `topic` (and `pubsubTopic`) for the Pub/Sub topic that fires the trigger;
-// `serviceAccountEmail` for the identity used to create the subscription;
-// and `state` for connectivity health (OK, TOPIC_DELETED,
+// Pub/Sub event configuration for a Cloud Build trigger. The `topic` (and
+// resolved `pubsubTopic`) is the Pub/Sub topic whose messages fire the
+// trigger, `serviceAccountEmail` is the identity used to create the
+// subscription, and `state` reports connectivity health (OK, TOPIC_DELETED,
 // SUBSCRIPTION_DELETED, SUBSCRIPTION_MISCONFIGURED).
 private gcp.project.cloudBuildService.trigger.pubsubConfig @defaults("topic state") {
   // Internal ID
@@ -14657,9 +15954,9 @@ private gcp.project.cloudBuildService.trigger.pubsubConfig @defaults("topic stat
 
 // Google Cloud (GCP) Cloud Build trigger webhook configuration
 //
-// Examine the webhook event configuration for a Cloud Build trigger. Inspect
-// `state` for the health of the webhook secret binding — OK indicates the
-// Secret Manager secret is accessible; SECRET_DELETED indicates the secret
+// Webhook event configuration for a Cloud Build trigger. The `state` field
+// reports the health of the webhook secret binding: OK indicates the Secret
+// Manager secret is accessible, while SECRET_DELETED indicates the secret
 // has been removed and the trigger can no longer authenticate incoming
 // webhook requests.
 private gcp.project.cloudBuildService.trigger.webhookConfig @defaults("state") {
@@ -14671,12 +15968,12 @@ private gcp.project.cloudBuildService.trigger.webhookConfig @defaults("state") {
 
 // Google Cloud (GCP) Cloud Build trigger repository event configuration
 //
-// Examine the repository event configuration for a Cloud Build trigger
-// connected to a 2nd-gen Cloud Build repository. Inspect `repository` for
-// the connected repository resource name; `repositoryType` for the hosting
-// platform (GITHUB, GITHUB_ENTERPRISE, GITLAB_ENTERPRISE); `push` for the
-// branch or tag filter; and `pullRequest` for the pull-request branch
-// filter and comment-control policy.
+// Repository event configuration for a Cloud Build trigger connected to a
+// 2nd-gen Cloud Build repository. The `repository` field is the connected
+// repository resource name, `repositoryType` is the hosting platform
+// (GITHUB, GITHUB_ENTERPRISE, GITLAB_ENTERPRISE), and `push` and
+// `pullRequest` carry the branch and tag filters that select which events
+// build.
 private gcp.project.cloudBuildService.trigger.repositoryEventConfig @defaults("repository repositoryType") {
   // Internal ID
   id string
@@ -14684,19 +15981,29 @@ private gcp.project.cloudBuildService.trigger.repositoryEventConfig @defaults("r
   repository string
   // Repository type (GITHUB, GITHUB_ENTERPRISE, GITLAB_ENTERPRISE)
   repositoryType string
-  // Push event filter configuration
+  // Push event filter
+  //
+  // Dict with `branch` or `tag` (a regex selecting which refs fire a build
+  // on push) and `invertRegex` (when true, fire on refs that do not match
+  // the regex).
   push dict
-  // Pull request event filter configuration
+  // Pull request event filter
+  //
+  // Dict with `branch` (a regex selecting target branches), `commentControl`
+  // (COMMENTS_DISABLED, COMMENTS_ENABLED, or
+  // COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY), and `invertRegex`
+  // (when true, match branches that do not match the regex).
   pullRequest dict
 }
 
 // Google Cloud (GCP) Cloud Build worker pool
 //
-// Examine a Cloud Build private worker pool. Inspect `workerConfig` for
-// the machine type and disk size of individual build workers; `networkConfig`
-// for the peered VPC network and egress option that isolate builds from
-// the public internet; and `state` for the pool's operational lifecycle
-// (CREATING, RUNNING, DELETING, UPDATING).
+// Cloud Build private worker pool, a set of dedicated build machines that
+// run builds in isolation from the shared public pool. `workerConfig` gives
+// the machine type and disk size of individual workers, `networkConfig`
+// gives the peered VPC network and egress option that isolate builds from
+// the public internet, and `state` reports the pool's lifecycle (CREATING,
+// RUNNING, DELETING, UPDATING).
 private gcp.project.cloudBuildService.workerPool @defaults("name displayName state") {
   // Project ID
   projectId string
@@ -14720,11 +16027,10 @@ private gcp.project.cloudBuildService.workerPool @defaults("name displayName sta
 
 // Google Cloud (GCP) Cloud Build worker pool worker configuration
 //
-// Examine the machine configuration for workers in a Cloud Build private
-// worker pool. Inspect `machineType` for the Compute Engine machine family
-// (e.g. e2-standard-2); `diskSizeGb` for the boot disk size; and
-// `enableNestedVirtualization` to verify whether nested VM support is
-// active for builds that require it.
+// Machine configuration for workers in a Cloud Build private worker pool.
+// `machineType` is the Compute Engine machine family (e.g. e2-standard-2),
+// `diskSizeGb` is the boot disk size, and `enableNestedVirtualization`
+// reports whether nested VM support is active for builds that require it.
 private gcp.project.cloudBuildService.workerPool.workerConfig @defaults("machineType diskSizeGb") {
   // Internal ID
   id string
@@ -14738,11 +16044,12 @@ private gcp.project.cloudBuildService.workerPool.workerConfig @defaults("machine
 
 // Google Cloud (GCP) Cloud Build worker pool network configuration
 //
-// Examine the network configuration for a Cloud Build private worker pool.
-// Inspect `peeredNetwork` for the VPC network that workers are peered into;
-// `peeredNetworkIpRange` for the secondary IP range used for workers; and
-// `egressOption` to verify whether outbound internet access is blocked
-// (NO_PUBLIC_EGRESS) or permitted (PUBLIC_EGRESS) for builds.
+// Network configuration for a Cloud Build private worker pool.
+// `peeredNetwork` (and the resolved `peeredNetworkRef`) is the VPC network
+// that workers are peered into, `peeredNetworkIpRange` is the secondary IP
+// range used for workers, and `egressOption` reports whether outbound
+// internet access is blocked (NO_PUBLIC_EGRESS) or permitted
+// (PUBLIC_EGRESS) for builds.
 private gcp.project.cloudBuildService.workerPool.networkConfig @defaults("egressOption") {
   // Internal ID
   id string
@@ -14760,15 +16067,14 @@ private gcp.project.cloudBuildService.workerPool.networkConfig @defaults("egress
 
 // Google Cloud (GCP) Cloud Build build execution
 //
-// Examine a Cloud Build build execution — the record of what was built, when,
-// from which source, and with what result. Inspect `status` for the outcome
-// (SUCCESS, FAILURE, TIMEOUT, CANCELLED); `createTime`, `startTime`, and
-// `finishTime` for the build timeline; `serviceAccount` (and
-// `iamServiceAccount`) for the identity the build ran as; `buildTriggerId`
-// (and `trigger`) for the trigger that started it; `source` for the requested
-// source and `sourceProvenance` for the resolved source with per-file hashes
-// that pin exactly what was built; and `images` and `results` for the
-// artifacts the build produced.
+// Cloud Build build execution, the record of what was built, when, from
+// which source, and with what result. `status` reports the outcome (SUCCESS,
+// FAILURE, TIMEOUT, CANCELLED), `serviceAccount` (with the resolved
+// `iamServiceAccount`) is the identity the build ran as, and `buildTriggerId`
+// (with the resolved `trigger`) is the trigger that started it. `source` is
+// the requested source while `sourceProvenance` pins the exact source bytes
+// that were built with per-file hashes, and `images` and `results` describe
+// the artifacts the build produced.
 private gcp.project.cloudBuildService.build @defaults("buildId status createTime") {
   // Project ID
   projectId string
@@ -14825,12 +16131,11 @@ private gcp.project.cloudBuildService.build @defaults("buildId status createTime
 
 // Google Cloud (GCP) Cloud Asset Inventory
 //
-// Use this resource as the entry point for Cloud Asset Inventory in the
-// project. It provides a unified, cross-service view of resource provenance:
-// `resources` enumerates every asset with its creation and last-update times,
-// location, labels, and parent; and `iamPolicies` enumerates the IAM policies
-// across the project, each linked to the resource it is attached to —
-// answering who was granted what, and where.
+// Cloud Asset Inventory for the project, a unified cross-service view of
+// resource provenance. `resources` enumerates every asset with its creation
+// and last-update times, location, labels, and parent; `iamPolicies`
+// enumerates the IAM policies across the project, each linked to the resource
+// it is attached to, answering who was granted what and where.
 private gcp.project.assetService {
   // Project ID
   projectId string
@@ -14842,12 +16147,11 @@ private gcp.project.assetService {
 
 // Google Cloud (GCP) Cloud Asset Inventory resource
 //
-// Examine a single asset as recorded by Cloud Asset Inventory, identified by
-// its full resource `name`. Inspect `createTime` for when the asset was
-// created and `updateTime` for its last change — the creation and
-// modification provenance that individual service APIs often omit — alongside
-// `assetType`, `location`, `state`, `labels`, and `parentFullResourceName` to
-// place the asset within its hierarchy.
+// Single asset as recorded by Cloud Asset Inventory, identified by its full
+// resource `name`. The `createTime` and `updateTime` fields carry the
+// creation and modification provenance that individual service APIs often
+// omit, while `assetType`, `location`, `state`, `labels`, and
+// `parentFullResourceName` place the asset within its hierarchy.
 private gcp.project.assetService.resource @defaults("assetType displayName createTime") {
   // Full resource name (e.g. //compute.googleapis.com/projects/p/zones/z/instances/i)
   name string
@@ -14877,19 +16181,23 @@ private gcp.project.assetService.resource @defaults("assetType displayName creat
   networkTags []string
   // Full resource name of the asset's parent
   parentFullResourceName string
-  // Additional service-specific searchable attributes
+  // Additional searchable attributes
+  //
+  // Free-form service-specific attributes exposed by Cloud Asset Inventory's
+  // search index. The keys vary by `assetType` (for example a compute
+  // instance surfaces different attributes than a storage bucket).
   additionalAttributes dict
 }
 
 // Google Cloud (GCP) Cloud Asset Inventory IAM policy
 //
-// Examine an IAM policy as recorded by Cloud Asset Inventory, attached to the
-// resource named by `resource`. Inspect `bindings` for the role-to-member
-// grants and `project`, `folders`, and `organization` for where in the
-// hierarchy the policy lives — together these reconstruct who can access which
-// resource across the whole project, the access provenance that per-resource
-// IAM lookups only reveal one resource at a time. Selected by `resource`, the
-// full resource name the policy is attached to.
+// IAM policy as recorded by Cloud Asset Inventory, attached to the resource
+// named by `resource` (the full resource name, used as the selection key).
+// The `bindings` field holds the role-to-member grants, and `project`,
+// `folders`, and `organization` give where in the hierarchy the policy lives.
+// Together these reconstruct who can access which resource across the whole
+// project, the access provenance that per-resource IAM lookups reveal only
+// one resource at a time.
 private gcp.project.assetService.iamPolicy @defaults("resource assetType") {
   // Full resource name the policy is attached to
   resource string
@@ -14911,9 +16219,10 @@ private gcp.project.assetService.iamPolicy @defaults("resource assetType") {
 
 // Google Cloud (GCP) Identity-Aware Proxy (IAP)
 //
-// Use this resource as the entry point for Identity-Aware Proxy in the
-// project. It hosts the OAuth `brands` (and their OAuth clients) and the
-// `tunnelDestGroups` that scope TCP forwarding for access-control audits.
+// Identity-Aware Proxy configuration for the project, the entry point for
+// auditing IAP access control. It hosts the OAuth `brands` (and their OAuth
+// clients) and the `tunnelDestGroups` that scope TCP forwarding for
+// access-control audits.
 private gcp.project.iapService {
   // Project ID
   projectId string
@@ -14938,11 +16247,11 @@ private gcp.project.iapService {
 
 // Google Cloud (GCP) IAP OAuth brand
 //
-// Examine an Identity-Aware Proxy OAuth brand — the OAuth consent screen
-// configuration for a project. Inspect `applicationTitle` and
-// `supportEmail` for the user-visible consent screen content; and
-// `orgInternalOnly` to verify whether access is restricted to internal
-// organization users or open to external identities.
+// Identity-Aware Proxy OAuth brand, the OAuth consent screen configuration
+// for a project. The `applicationTitle` and `supportEmail` carry the
+// user-visible consent screen content, and `orgInternalOnly` indicates
+// whether access is restricted to internal organization users or open to
+// external identities.
 private gcp.project.iapService.brand @defaults("name applicationTitle") {
   // Project ID
   projectId string
@@ -14960,12 +16269,11 @@ private gcp.project.iapService.brand @defaults("name applicationTitle") {
 
 // Google Cloud (GCP) IAP OAuth client
 //
-// Examine an Identity-Aware Proxy OAuth client registered under a brand,
-// identified by `name`. These clients authorize IAP-secured access to the
-// project's web resources. Surfaces `displayName` for the human-readable
-// client name; review the set of clients for stale or unused entries as part
-// of credential-hygiene audits. The client secret is intentionally not
-// exposed.
+// Identity-Aware Proxy OAuth client registered under a brand, identified by
+// `name`. These clients authorize IAP-secured access to the project's web
+// resources. The `displayName` gives the human-readable client name; review
+// the set of clients for stale or unused entries as part of credential-hygiene
+// audits. The client secret is intentionally not exposed.
 private gcp.project.iapService.identityAwareProxyClient @defaults("name displayName") {
   // Full resource name, including the OAuth client ID
   name string
@@ -14975,10 +16283,10 @@ private gcp.project.iapService.identityAwareProxyClient @defaults("name displayN
 
 // Google Cloud (GCP) IAP tunnel destination group
 //
-// Examine an Identity-Aware Proxy tunnel destination group — a named set
-// of hosts or IP ranges that IAP TCP forwarding can route to. Inspect
-// `cidrs` for the allowed IP CIDR ranges and `fqdns` for the allowed fully
-// qualified domain names that define the group's reachable destinations.
+// Identity-Aware Proxy tunnel destination group, a named set of hosts or IP
+// ranges that IAP TCP forwarding can route to. The `cidrs` field lists the
+// allowed IP CIDR ranges and `fqdns` lists the allowed fully qualified domain
+// names that define the group's reachable destinations.
 private gcp.project.iapService.tunnelDestGroup @defaults("name") {
   // Project ID
   projectId string
@@ -14996,9 +16304,10 @@ private gcp.project.iapService.tunnelDestGroup @defaults("name") {
 
 // Google Cloud (GCP) Cloud Source Repositories
 //
-// Use this resource as the entry point for Cloud Source Repositories in
-// the project. It hosts the project's `repos` — each exposing its size,
-// mirror configuration, and IAM policy for source-control audits.
+// Cloud Source Repositories in the project, exposed through the `repos`
+// collection. Each repository reports its clone URL, disk footprint, and
+// mirror configuration, so audits can inventory hosted Git repositories
+// and flag those that sync from external upstreams.
 private gcp.project.sourceRepositoriesService {
   // Project ID
   projectId string
@@ -15008,11 +16317,11 @@ private gcp.project.sourceRepositoriesService {
 
 // Google Cloud (GCP) Cloud Source repository
 //
-// Examine a Cloud Source Repositories repository. Inspect `url` for the
-// clone endpoint; `size` for the repository's disk footprint in bytes; and
-// `mirrorConfig` for the upstream repository URL and authentication details
-// when the repo is mirrored from an external source such as GitHub or
-// Bitbucket.
+// Cloud Source Repositories repository, a Git repository hosted in the
+// project. The `url` field gives the clone endpoint, `size` reports the
+// repository's disk footprint in bytes, and `mirrorConfig` carries the
+// upstream repository URL and authentication details when the repository
+// is mirrored from an external source such as GitHub or Bitbucket.
 private gcp.project.sourceRepositoriesService.repo @defaults("name url") {
   // Project ID
   projectId string
@@ -15028,11 +16337,11 @@ private gcp.project.sourceRepositoriesService.repo @defaults("name url") {
 
 // Google Cloud (GCP) Cloud Source repository mirror configuration
 //
-// Examine the mirror configuration for a Cloud Source repository that
-// syncs from an external upstream. Inspect `url` for the upstream
-// repository address; `deployKeyId` for the SSH deploy key used to
-// authenticate; and `webhookId` for the push-notification webhook that
-// triggers sync when the upstream changes.
+// Mirror configuration for a Cloud Source repository that syncs from an
+// external upstream. The `url` field holds the upstream repository
+// address, `deployKeyId` names the SSH deploy key used to authenticate,
+// and `webhookId` names the push-notification webhook that triggers sync
+// when the upstream changes.
 private gcp.project.sourceRepositoriesService.repo.mirrorConfig @defaults("url") {
   // Internal ID
   id string
@@ -15046,10 +16355,11 @@ private gcp.project.sourceRepositoriesService.repo.mirrorConfig @defaults("url")
 
 // Google Cloud (GCP) Memorystore for Memcached
 //
-// Use this resource as the entry point for Memorystore for Memcached in
-// the project. It hosts the project's `instances` — each exposing its node
-// configuration, authorized network, memcached parameters, and maintenance
-// settings for cache-tier audits.
+// Memorystore for Memcached in the project, exposing every Memcached
+// instance through `instances`. Each instance reports its node
+// configuration, authorized network, effective memcached parameters, and
+// maintenance settings, so cache-tier audits can confirm sizing, network
+// exposure, and patch cadence across the fleet.
 private gcp.project.memcacheService {
   // Project ID
   projectId string
@@ -15059,12 +16369,13 @@ private gcp.project.memcacheService {
 
 // Google Cloud (GCP) Memcached instance
 //
-// Examine a Memorystore for Memcache instance. Inspect `nodeCount`,
-// `nodeCpuCount`, and `nodeMemorySizeMb` for the cluster's compute
-// allocation; `network` for the authorized VPC network; `parameters` for
-// the effective Memcached tuning parameters; `maintenancePolicy` for the
-// maintenance window configuration; and `state` for the instance's
-// operational lifecycle. Individual nodes are accessible via `nodes`.
+// Managed Memorystore for Memcache instance backing a cache tier.
+// `nodeCount`, `nodeCpuCount`, and `nodeMemorySizeMb` give the cluster's
+// compute allocation; `network` is the authorized VPC network the cache is
+// reachable from; `parameters` holds the effective Memcached tuning
+// parameters; `maintenancePolicy` describes the maintenance window; and
+// `state` reports the operational lifecycle. Individual nodes are available
+// through `nodes`.
 private gcp.project.memcacheService.instance @defaults("name state") {
   // Project ID
   projectId string
@@ -15094,11 +16405,22 @@ private gcp.project.memcacheService.instance @defaults("name state") {
   state string
   // Endpoint for Memcached Auto Discovery
   discoveryEndpoint string
-  // Instance-level annotation messages (each: code, message)
+  // Instance-level advisory messages
+  //
+  // Each entry has code and message. code is one of CODE_UNSPECIFIED or
+  // ZONE_DISTRIBUTION_UNBALANCED, flagging when nodes are unevenly spread
+  // across the instance's zones; message carries the human-readable detail.
   instanceMessages []dict
   // Maintenance policy of the instance
+  //
+  // Keys: description, createTime, updateTime, and weeklyMaintenanceWindow
+  // (each window carries day, startTime, and duration). Absent when no
+  // maintenance policy is configured.
   maintenancePolicy dict
   // Upcoming or last maintenance schedule
+  //
+  // Keys: startTime, endTime, and scheduleDeadlineTime, reflecting the next
+  // planned or most recent maintenance window for the instance.
   maintenanceSchedule dict
   // Creation time
   createTime time
@@ -15116,11 +16438,10 @@ private gcp.project.memcacheService.instance @defaults("name state") {
 
 // Google Cloud (GCP) Memcached node
 //
-// Examine an individual node within a Memorystore for Memcache instance.
-// Inspect `nodeId` for the stable node identifier, `zone` for its
-// placement, `host` and `port` for the connection endpoint, `state` for
-// the node's operational health, and `parameters` for the Memcached
-// tuning parameters effective on this node.
+// Single node within a Memorystore for Memcache instance. `nodeId` is the
+// stable node identifier, `zone` its placement, `host` and `port` the
+// connection endpoint, `state` the node's operational health, and
+// `parameters` the Memcached tuning parameters effective on this node.
 private gcp.project.memcacheService.instance.node @defaults("nodeId zone state") {
   // Project ID
   projectId string
@@ -15168,10 +16489,10 @@ private gcp.project.memcacheService.instance.node.parameters @defaults("id") {
 
 // Google Cloud (GCP) Datastream
 //
-// Use this resource as the entry point for Datastream in the project. It
-// hosts the change-data-capture surface: `streams`, the source and
-// destination `connectionProfiles` they use, and the `privateConnections`
-// that provide private network connectivity.
+// Datastream change-data-capture service for the project and the entry
+// point to its replication surface: the `streams` that move data, the
+// source and destination `connectionProfiles` they connect through, and
+// the `privateConnections` that provide private network connectivity.
 private gcp.project.datastreamService {
   // Project ID
   projectId string
@@ -15185,13 +16506,14 @@ private gcp.project.datastreamService {
 
 // Google Cloud (GCP) Datastream stream
 //
-// Examine a Datastream change-data-capture stream. Inspect `state` for the
-// operational lifecycle; `source` and `destination` to traverse to the
-// connection profiles at each end; `sourceConfig` and `destinationConfig`
-// for the type-specific replication parameters; `kmsKey` for the
-// customer-managed encryption key; `backfillStrategy` to verify whether
-// historical data is automatically backfilled; and `errors` for failures
-// reported by the stream.
+// Change-data-capture stream that continuously replicates data from a
+// source database into a destination such as BigQuery or Cloud Storage.
+// The `state` field reports the operational lifecycle, `backfillStrategy`
+// reveals whether historical data is backfilled automatically ("all") or
+// left for manual triggering ("none"), and `kmsKey` identifies the
+// customer-managed encryption key protecting the stream. Traverse
+// `source` and `destination` to the connection profiles at each end, and
+// inspect `errors` for failures the service reports.
 private gcp.project.datastreamService.stream @defaults("name state") {
   // Project ID
   projectId string
@@ -15231,10 +16553,10 @@ private gcp.project.datastreamService.stream @defaults("name state") {
 
 // Google Cloud (GCP) Datastream stream error
 //
-// Examine an error reported by a Datastream stream. Inspect `reason` for
-// the error code, `message` for the human-readable description, `errorTime`
-// for when the error occurred, and `details` for additional key-value
-// context returned by the Datastream service.
+// Error reported by a Datastream stream. `reason` carries the error code,
+// `message` the human-readable description, `errorTime` when it occurred,
+// and `details` additional key-value context returned by the Datastream
+// service.
 private gcp.project.datastreamService.stream.error @defaults("errorUuid reason") {
   // Project ID
   projectId string
@@ -15254,13 +16576,13 @@ private gcp.project.datastreamService.stream.error @defaults("errorUuid reason")
 
 // Google Cloud (GCP) Datastream connection profile
 //
-// Examine a Datastream connection profile — the credentials and endpoint
-// configuration for a data source or destination. Inspect `profileType`
-// (mysql, postgresql, oracle, sqlserver, mongodb, bigquery, gcs,
-// salesforce) to determine the profile variant; `profile` for the
-// type-specific connection parameters; `connectivityType` for the network
-// path (forwardSsh, privateConnectivity, staticServiceIp); and
-// `privateConnection` when private VPC connectivity is used.
+// Reusable definition of the credentials and endpoint for a Datastream
+// data source or destination. The `profileType` field selects the variant
+// (mysql, postgresql, oracle, sqlserver, mongodb, bigquery, gcs, or
+// salesforce) and determines the shape of the `profile` dict.
+// `connectivityType` records the network path to the source (forwardSsh,
+// privateConnectivity, or staticServiceIp), with `privateConnection`
+// resolving the peering when private VPC connectivity is used.
 private gcp.project.datastreamService.connectionProfile @defaults("name profileType") {
   // Project ID
   projectId string
@@ -15294,13 +16616,12 @@ private gcp.project.datastreamService.connectionProfile @defaults("name profileT
 
 // Google Cloud (GCP) Datastream private connection
 //
-// Examine a Datastream private connection — a VPC peering arrangement that
-// provides private network access from Datastream to on-premises or
-// private cloud data sources. Inspect `network` for the peered VPC;
-// `subnet` for the CIDR range allocated to the peering; `state` for the
-// lifecycle (CREATING, CREATED, FAILED, DELETING, DELETED); `error` for
-// any failure details; and `routes` for the routing entries configured
-// inside the private connection.
+// VPC peering arrangement that gives Datastream private network access to
+// on-premises or private-cloud data sources without traversing the public
+// internet. `network` resolves the peered VPC, `subnet` is the CIDR range
+// allocated to the peering, and `state` reports the lifecycle (CREATING,
+// CREATED, FAILED, DELETING, DELETED). Inspect `error` for failure details
+// and `routes` for the routing entries configured inside the connection.
 private gcp.project.datastreamService.privateConnection @defaults("name state") {
   // Project ID
   projectId string
@@ -15328,11 +16649,10 @@ private gcp.project.datastreamService.privateConnection @defaults("name state") 
 
 // Google Cloud (GCP) Datastream route
 //
-// Examine a route inside a Datastream private connection. Inspect
-// `destinationAddress` for the destination host or IP and
-// `destinationPort` for the optional port override that steers traffic
-// from Datastream workers through the private connection to the target
-// data source.
+// Routing entry inside a Datastream private connection that steers traffic
+// from Datastream workers through the private connection to a target data
+// source. `destinationAddress` is the destination host or IP and
+// `destinationPort` is the optional port override.
 private gcp.project.datastreamService.route @defaults("name destinationAddress") {
   // Project ID
   projectId string
@@ -15372,14 +16692,15 @@ private gcp.project.memorystoreService {
 
 // Google Cloud (GCP) Memorystore instance
 //
-// Examine a Memorystore instance running Valkey or Redis. Inspect `mode`
-// (STANDALONE, CLUSTER, CLUSTER_DISABLED) and `shardCount` for the
-// topology; `authorizationMode` and `transitEncryptionMode` for security
-// posture; `kmsKey` for customer-managed encryption; `persistenceConfig`
-// for RDB or AOF durability settings; `maintenancePolicy` for the
-// maintenance window; `deletionProtectionEnabled` to check against
-// accidental removal; and `automatedBackupConfig` for the backup schedule
-// and retention settings.
+// Memorystore instance running Valkey or Redis. The `mode` field
+// (STANDALONE, CLUSTER, CLUSTER_DISABLED) and `shardCount` describe the
+// topology; `authorizationMode` and `transitEncryptionMode` capture the
+// security posture; `kmsKey` covers customer-managed encryption;
+// `persistenceConfig` holds RDB or AOF durability settings;
+// `maintenancePolicy` defines the maintenance window;
+// `deletionProtectionEnabled` guards against accidental removal; and
+// `automatedBackupConfig` carries the backup schedule and retention
+// settings.
 private gcp.project.memorystoreService.instance @defaults("name state mode") {
   // Project ID
   projectId string
@@ -15463,10 +16784,10 @@ private gcp.project.memorystoreService.instance @defaults("name state mode") {
 
 // Google Cloud (GCP) Memorystore instance PSC attachment detail
 //
-// Examine a Private Service Connect attachment associated with a
-// Memorystore instance. Inspect `serviceAttachment` for the service
-// attachment resource name and `connectionType` to distinguish
-// PRIVATE_SERVICE_CONNECT from PUBLIC_ENDPOINT access paths.
+// Private Service Connect attachment associated with a Memorystore
+// instance. The `serviceAttachment` field holds the service attachment
+// resource name and `connectionType` distinguishes PRIVATE_SERVICE_CONNECT
+// from PUBLIC_ENDPOINT access paths.
 private gcp.project.memorystoreService.instance.pscAttachmentDetail @defaults("serviceAttachment") {
   // Project ID
   projectId string
@@ -15480,12 +16801,12 @@ private gcp.project.memorystoreService.instance.pscAttachmentDetail @defaults("s
 
 // Google Cloud (GCP) Memorystore backup collection
 //
-// Examine a Memorystore backup collection — the container that retains all
-// backups for a single instance. Inspect `instance` to traverse to the
-// source instance; `totalBackupCount` and `totalBackupSizeBytes` for
-// storage consumption; `kmsKey` for the customer-managed encryption key
-// protecting the backups; `lastBackupTime` for the most recent backup
-// timestamp; and `backups` to iterate the individual backup records.
+// Container that retains all backups for a single Memorystore instance.
+// The `instance` field traverses to the source instance; `totalBackupCount`
+// and `totalBackupSizeBytes` report storage consumption; `kmsKey` names the
+// customer-managed encryption key protecting the backups; `lastBackupTime`
+// gives the most recent backup timestamp; and `backups` iterates the
+// individual backup records.
 private gcp.project.memorystoreService.backupCollection @defaults("name") {
   // Project ID
   projectId string
@@ -15513,12 +16834,13 @@ private gcp.project.memorystoreService.backupCollection @defaults("name") {
 
 // Google Cloud (GCP) Memorystore backup
 //
-// Examine a Memorystore backup snapshot. Inspect `backupType` (ON_DEMAND or
-// AUTOMATED) and `state` for lifecycle status; `engineVersion`,
-// `nodeType`, `shardCount`, and `replicaCount` for the cluster shape at
-// backup time; `totalSizeBytes` for storage consumption; `encryptionInfo`
-// for the encryption details; `expireTime` for the retention deadline; and
-// `backupFiles` for the individual component files that make up the backup.
+// Memorystore backup snapshot. The `backupType` field (ON_DEMAND or
+// AUTOMATED) and `state` report lifecycle status; `engineVersion`,
+// `nodeType`, `shardCount`, and `replicaCount` capture the cluster shape at
+// backup time; `totalSizeBytes` reports storage consumption; `encryptionInfo`
+// holds the encryption details; `expireTime` marks the retention deadline;
+// and `backupFiles` lists the individual component files that make up the
+// backup.
 private gcp.project.memorystoreService.backup @defaults("name state") {
   // Project ID
   projectId string
@@ -15570,14 +16892,14 @@ private gcp.project.memorystoreService.backup.backupFile @defaults("fileName siz
 
 // Google Cloud (GCP) organization-scope Cloud Logging
 //
-// Use this resource as the entry point for organization-level Cloud
-// Logging configuration. It hosts the organization's logging
-// `sinks` — the export rules that forward log entries from every
-// project under the organization to a central destination (Cloud
-// Storage, BigQuery, Pub/Sub, or another log bucket). Org-level sinks
-// are the primary control for forcing tamper-resistant log
-// aggregation across the entire org, which is a baseline requirement
-// for incident response and most compliance frameworks.
+// Organization-level Cloud Logging configuration. It hosts the
+// organization's logging `sinks`, the export rules that forward log
+// entries from every project under the organization to a central
+// destination (Cloud Storage, BigQuery, Pub/Sub, or another log
+// bucket). Org-level sinks are the primary control for forcing
+// tamper-resistant log aggregation across the entire org, which is a
+// baseline requirement for incident response and most compliance
+// frameworks.
 private gcp.organization.loggingService {
   // Full organization resource name (organizations/{id})
   organizationName string
@@ -15587,12 +16909,13 @@ private gcp.organization.loggingService {
 
 // Google Cloud (GCP) organization-level Cloud Logging sink
 //
-// Examine an organization-scoped Cloud Logging export sink. Surfaces
-// the `destination` (Cloud Storage bucket, BigQuery dataset, Pub/Sub
+// Organization-scoped Cloud Logging export sink. Surfaces the
+// `destination` (Cloud Storage bucket, BigQuery dataset, Pub/Sub
 // topic, or another log bucket), the advanced log `filter`, the
 // `writerIdentity` used for authorization, and the `includeChildren`
-// flag — when true, the sink also receives log entries (recursively)
-// from any contained folders, billing accounts, or projects.
+// flag. When `includeChildren` is true, the sink also receives log
+// entries (recursively) from any contained folders, billing accounts,
+// or projects.
 private gcp.organization.loggingService.sink @defaults("name destination") {
   // Full organization resource name (organizations/{id})
   organizationName string
@@ -15618,12 +16941,12 @@ private gcp.organization.loggingService.sink @defaults("name destination") {
 
 // Google Cloud (GCP) folder-scope Cloud Logging
 //
-// Use this resource as the entry point for folder-level Cloud Logging
-// configuration. It hosts the folder's logging `sinks` — the export
-// rules that forward log entries from every project under the folder
-// to a central destination. Folder-level sinks are how a business unit
-// or environment enforces consistent log aggregation across all of its
-// projects without requiring per-project configuration.
+// Folder-level Cloud Logging configuration, which hosts the folder's
+// logging sinks: the export rules that forward log entries from every
+// project under the folder to a central destination. Folder-level sinks
+// are how a business unit or environment enforces consistent log
+// aggregation across all of its projects without requiring per-project
+// configuration.
 private gcp.folder.loggingService {
   // Full folder resource name (folders/{id})
   folderName string
@@ -15633,12 +16956,13 @@ private gcp.folder.loggingService {
 
 // Google Cloud (GCP) folder-level Cloud Logging sink
 //
-// Examine a folder-scoped Cloud Logging export sink. Surfaces the
-// `destination` (Cloud Storage bucket, BigQuery dataset, Pub/Sub topic,
-// or another log bucket), the advanced log `filter`, the
-// `writerIdentity` used for authorization, and the `includeChildren`
-// flag — when true, the sink also receives log entries (recursively)
-// from any contained projects or sub-folders.
+// Folder-scoped Cloud Logging export sink, selected by name within the
+// folder. The destination is a Cloud Storage bucket, BigQuery dataset,
+// Pub/Sub topic, or another log bucket, and filter is the advanced logs
+// filter that selects which entries are exported. writerIdentity is the
+// principal the sink uses for authorization, and when includeChildren is
+// true the sink also receives log entries (recursively) from any
+// contained projects or sub-folders.
 private gcp.folder.loggingService.sink @defaults("name destination") {
   // Full folder resource name (folders/{id})
   folderName string


### PR DESCRIPTION
## What

A broad documentation pass over `gcp.lr`, extending the pattern from **S3** (#9146), **AWS** (#9151), and **Azure** (#9153) to the GCP provider. These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**~78 services, ~650 edits.**

## Changes

- **Resource descriptions** rewritten to lead with the noun and convey audit/security significance, instead of opening with `Examine`/`Use` and re-listing the field table the website already renders.
- **Documented dict/map key shapes** — verified against the proto/protojson camelCase field names and the Go accessors, across compute, AlloyDB, Bigtable, BigQuery, Certificate Authority Service, Backup and DR, access context manager, org policy, and many more.
- **Security-field derivations and enum values** — e.g. `osLoginEnabled`'s instance-metadata-then-project-metadata fallback; enum value lists on state/mode fields.
- **Style-rule cleanup** — verb-led descriptions, em dashes, call-form `foo()` in prose, and a couple of over-length titles (dict shapes and derivation notes moved into descriptions).

## The pattern (same as prior PRs)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation. A field is named in prose only when it adds semantics the table can't.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, no title over the 150-char cap (two over-length titles caught by regeneration and split into title + description), no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and the proto field names), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.

Part of a provider-wide sweep; OCI, STACKIT, and Hetzner follow in their own PRs.
