### PR TITLE
📄 hetzner: enrich resource and field documentation

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -6,19 +6,16 @@ option go_package = "go.mondoo.com/mql/v13/providers/hetzner/resources"
 
 // Hetzner Cloud project
 //
-// Use the Hetzner Cloud namespace as the project-scoped entry point
-// for the Hetzner provider. Iterate `servers()` for cloud VMs (with
-// the matching `serverTypes()` and `images()`), `volumes()` for block
-// storage, `networks()` for project networks (Hetzner's VPC),
-// `floatingIps()` and `primaryIps()` for routable IPv4/IPv6,
-// `loadBalancers()` plus `loadBalancerTypes()` for the managed L4/L7
-// load balancers, `firewalls()` for stateful firewall rule sets,
-// `sshKeys()` for project SSH keys, `certificates()` for managed TLS
-// certs, `placementGroups()` for spread/anti-affinity placement,
-// `isos()` for boot ISOs, `locations()`/`datacenters()` for the
-// regional and AZ-style topology, `storageBoxes()` plus
-// `storageBoxTypes()` for managed backup/file storage, and `zones()`
-// for managed DNS zones and their records.
+// Project-scoped root of the Hetzner Cloud provider, exposing the
+// compute, networking, storage, and DNS resources reachable with the
+// project's API token. Cloud servers and their server types and
+// images, block storage volumes, project networks (Hetzner's VPC),
+// routable floating and primary IPv4/IPv6 addresses, managed load
+// balancers, stateful firewall rule sets, managed TLS certificates,
+// SSH keys, spread/anti-affinity placement groups, boot ISOs, the
+// regional and datacenter topology, managed Storage Boxes, and
+// managed DNS zones with their records are all queryable here,
+// providing a full inventory of a single Hetzner Cloud project.
 hetzner {
   // Cloud servers (virtual machines)
   servers() []hetzner.server
@@ -61,6 +58,15 @@ hetzner {
 }
 
 // Hetzner Cloud server (virtual machine)
+//
+// Cloud virtual machine along with its full runtime and networking posture:
+// public IPv4 and IPv6 addresses and their abuse-block state, attached
+// firewalls and their application status, private network attachments,
+// floating IPs, load balancers, backup window, and delete/rebuild
+// protection. The `exposure` field summarizes internet reachability by
+// combining the public IP with firewall ingress, which makes this the
+// resource to audit for unintentionally exposed hosts. Select a single
+// server by its numeric id, for example `hetzner.server(id: 42)`.
 private hetzner.server @defaults("id name status") {
   init(id? int)
   // Server ID
@@ -131,7 +137,10 @@ private hetzner.server @defaults("id name status") {
   iso() hetzner.iso
   // User-defined labels for organizing the resource
   labels map[string]string
-  // Resource protection (delete, rebuild)
+  // Resource protection settings
+  //
+  // Dict with two boolean keys: `delete` (the server cannot be deleted
+  // while true) and `rebuild` (the server cannot be rebuilt while true).
   protection dict
 }
 
@@ -183,12 +192,21 @@ private hetzner.network.exposure @defaults("internetReachable hasPublicIp") {
   firewallAllowsIngress bool
   // Ingress rules or services that admit traffic from any address
   //
-  // For a server, firewall inbound rules whose source is 0.0.0.0/0 or ::/0; for
-  // a load balancer, the forwarding services reachable on the public network.
+  // For a server, the firewall inbound rules whose source is 0.0.0.0/0 or ::/0,
+  // each with keys direction, protocol, sourceIps, destinationIps, and optional
+  // port and description. For a load balancer, the public forwarding services,
+  // each with keys protocol, listenPort, and destinationPort.
   openIngressRules []dict
 }
 
 // Hetzner Cloud server type (VM size)
+//
+// Hardware profile behind a Hetzner Cloud server: core count, memory,
+// disk, storage type (local or network), CPU type (shared or dedicated),
+// and CPU architecture (x86 or arm). Select a server type by its numeric
+// id, for example `hetzner.serverType(id: 22)`. The `deprecated` flag and
+// `locations` report where the type can still be provisioned and whether
+// Hetzner has scheduled it for removal.
 private hetzner.serverType @defaults("id name cores memory") {
   init(id? int)
   // Server type ID
@@ -227,11 +245,23 @@ private hetzner.serverType.location @defaults("available recommended") {
   available bool
   // Whether Hetzner recommends this server type in this location
   recommended bool
-  // Deprecation info {announced, unavailableAfter}; empty if not deprecated
+  // Deprecation schedule
+  //
+  // Present only when the server type is deprecated in this location. Keys:
+  // `announced` (timestamp the deprecation was announced) and
+  // `unavailableAfter` (timestamp after which new servers of this type can
+  // no longer be created). Empty when the type is not deprecated here.
   deprecation dict
 }
 
 // Hetzner Cloud image (system image, snapshot, backup, or app)
+//
+// A bootable disk image usable when creating servers: a Hetzner-provided
+// system image, a user-created snapshot, an automated backup, or an app
+// image. The `type` field distinguishes these categories. Select an image
+// by its numeric id, for example `hetzner.image(id: 12345)`. Useful for
+// auditing which images exist, their OS and architecture, deletion
+// protection, and whether an image is deprecated or bound to a server.
 private hetzner.image @defaults("id name type") {
   init(id? int)
   // Image ID
@@ -258,7 +288,10 @@ private hetzner.image @defaults("id name type") {
   architecture string
   // Whether rapid deploy is supported
   rapidDeploy bool
-  // Resource protection (delete)
+  // Resource protection
+  //
+  // Deletion protection state as `delete` (bool). When true, the image
+  // cannot be deleted until protection is disabled.
   protection dict
   // Deprecation timestamp (nullable)
   deprecated time
@@ -273,6 +306,14 @@ private hetzner.image @defaults("id name type") {
 }
 
 // Hetzner Cloud SSH key
+//
+// SSH public key registered on a Hetzner Cloud project and available to
+// inject into new servers at creation time, granting whoever holds the
+// matching private key root-level access. Auditing these keys shows which
+// credentials can be provisioned onto infrastructure, and the algorithm
+// and bits fields let you flag weak or deprecated key types (for example
+// short RSA keys or ssh-dss). Select a single key by its numeric id, for
+// example hetzner.sshKey(id: 12345).
 private hetzner.sshKey @defaults("id name fingerprint") {
   init(id? int)
   // SSH key ID
@@ -302,6 +343,13 @@ private hetzner.sshKey @defaults("id name fingerprint") {
 }
 
 // Hetzner Cloud block storage volume
+//
+// A network-attached block storage volume in a Hetzner Cloud project,
+// selected by its numeric `id`, for example `hetzner.volume(id: 12345)`.
+// Reports capacity, attachment state, filesystem format, deletion
+// protection, and the server the volume is currently mounted on, so
+// audits can flag unattached volumes, oversized allocations, or volumes
+// left without deletion protection.
 private hetzner.volume @defaults("id name size") {
   init(id? int)
   // Volume ID
@@ -322,13 +370,24 @@ private hetzner.volume @defaults("id name size") {
   server() hetzner.server
   // Filesystem format (ext4, xfs, "")
   format string
-  // Resource protection (delete)
+  // Volume protection settings
+  //
+  // The `delete` key (bool) is true when the volume is protected from
+  // deletion.
   protection dict
   // User-defined labels for organizing the resource
   labels map[string]string
 }
 
 // Hetzner Cloud network (VPC)
+//
+// Private network spanning one or more subnets that Hetzner Cloud servers and
+// load balancers attach to for internal traffic. Select a network by its
+// numeric id, for example hetzner.network(id: 4711). The ipRange field holds the
+// overall CIDR, subnets carves it into per-zone ranges, and routes lists static
+// next-hop entries. Inspect servers and loadBalancers to see what is attached,
+// and exposeRoutesToVswitch to check whether the network's routes are advertised
+// to a connected vSwitch.
 private hetzner.network @defaults("id name ipRange") {
   init(id? int)
   // Network ID
@@ -356,6 +415,14 @@ private hetzner.network @defaults("id name ipRange") {
 }
 
 // Hetzner Cloud floating IP
+//
+// A floating IPv4 or IPv6 address that can be reassigned between servers,
+// making it the building block for failover and high-availability setups.
+// Select one by its numeric identifier, for example
+// `hetzner.floatingIp(id: 12345)`. The `server` reference resolves the
+// server the IP is currently routed to (null when unassigned), `blocked`
+// flags an address the provider has administratively suspended, and
+// `dnsPtr` exposes the reverse DNS records configured for it.
 private hetzner.floatingIp @defaults("id ip type") {
   init(id? int)
   // Floating IP ID
@@ -384,7 +451,15 @@ private hetzner.floatingIp @defaults("id ip type") {
   created time
 }
 
-// Hetzner Cloud primary IP (replaces non-floating server IPs)
+// Hetzner Cloud primary IP
+//
+// A standalone IPv4 or IPv6 address that a server holds independently
+// of its lifecycle, so the address survives when the server is deleted
+// or replaced. Reports the address and `type`, whether it is currently
+// `blocked`, the `autoDelete` behavior that removes it alongside its
+// assignee, the reverse DNS records, delete protection, and the server
+// it is assigned to. Select a primary IP by its numeric id, for example
+// `hetzner.primaryIp(id: 12345)`.
 private hetzner.primaryIp @defaults("id ip type") {
   init(id? int)
   // Primary IP ID
@@ -421,20 +496,25 @@ private hetzner.primaryIp @defaults("id ip type") {
 
 // Hetzner Cloud load balancer
 //
-// A managed L4/L7 load balancer. Surfaces the routing `algorithm`, the
-// public network configuration, the `services()` it exposes (listen and
-// destination ports, health checks, the HTTP redirect flag, and attached
-// `certificates`), the backend `targets()`, the `privateNet`
-// attachments, the traffic counters, resource protection, applied
-// `labels`, and the creation timestamp. Select a load balancer by id
-// with `hetzner.loadBalancer(id: 123)`.
+// Managed L4/L7 load balancer that distributes incoming traffic across
+// backend servers and IP targets. The public network configuration and
+// the forwarding services it exposes govern its internet reachability
+// and TLS termination, making it a central resource for auditing
+// exposure, health checking, and PROXY protocol use. The routing
+// algorithm is one of round_robin or least_connections. Select a load
+// balancer by id with `hetzner.loadBalancer(id: 123)`.
 hetzner.loadBalancer @defaults("id name") {
   init(id? int)
   // Load balancer ID
   id int
   // Name
   name string
-  // Public network configuration {enabled, ipv4, ipv6}
+  // Public network configuration
+  //
+  // Dict with keys enabled (whether the load balancer has a public
+  // interface), and ipv4 and ipv6 (the assigned public addresses). When
+  // enabled is false the load balancer is reachable only over attached
+  // private networks.
   publicNet dict
   // Private network attachments
   privateNet() []hetzner.loadBalancer.privateNet
@@ -496,8 +576,16 @@ private hetzner.loadBalancer.service @defaults("protocol listenPort") {
   // Whether PROXY protocol is enabled
   proxyProtocol bool
   // Health check configuration
+  //
+  // Dict with keys protocol (tcp or http), port, interval and timeout in
+  // seconds, and retries. For http checks it also carries an http key
+  // holding {domain, path, response, statusCodes, tls}.
   healthCheck dict
-  // HTTP-specific options (sticky sessions, redirect_http, certificates)
+  // Session persistence and HTTP redirect options
+  //
+  // Dict with keys cookieName, cookieLifetime (seconds), redirectHttp
+  // (whether plain HTTP is redirected to HTTPS), and stickySessions. TLS
+  // certificates are exposed separately through certificates.
   http dict
   // TLS certificates attached to this service
   certificates() []hetzner.certificate
@@ -528,6 +616,14 @@ private hetzner.loadBalancer.target @defaults("type") {
 }
 
 // Hetzner Cloud load balancer type
+//
+// A load balancer size class such as lb11, lb21, or lb31, defining the
+// capacity limits a load balancer of that class is subject to: the
+// maximum concurrent connections, services, targets, and assigned TLS
+// certificates. Use it to confirm a load balancer is provisioned on a
+// class that fits its expected traffic, or to spot classes that are
+// scheduled for retirement through the `deprecated` timestamp. Select a
+// type by id with `hetzner.loadBalancerType(id: 1)`.
 private hetzner.loadBalancerType @defaults("id name") {
   init(id? int)
   // Load balancer type ID
@@ -564,7 +660,13 @@ hetzner.firewall @defaults("id name") {
   name string
   // Creation timestamp
   created time
-  // Firewall rules [{direction, protocol, port, sourceIps, destinationIps, description}]
+  // Firewall rules
+  //
+  // Each rule is a dict with `direction` (in or out), `protocol` (tcp,
+  // udp, icmp, esp, or gre), `sourceIps` and `destinationIps` (lists of
+  // CIDR blocks the rule matches), and optional `port` and `description`.
+  // An inbound rule whose `sourceIps` contains 0.0.0.0/0 or ::/0 opens the
+  // port to the entire internet.
   rules []dict
   // Servers the firewall is directly applied to (type=server entries)
   servers() []hetzner.server
@@ -582,6 +684,15 @@ hetzner.firewall @defaults("id name") {
 }
 
 // Hetzner Cloud TLS certificate
+//
+// A TLS certificate stored in a Hetzner Cloud project, either uploaded by
+// you or issued and renewed automatically by Hetzner as a managed
+// certificate. Select one by its numeric id, for example
+// `hetzner.certificate(id: 12345)`. Fields parsed from the certificate
+// body (keyAlgorithm, keyBits, signatureAlgorithm, notValidAfter,
+// selfSigned, isCa) support auditing key strength, expiry, and trust,
+// while servers and loadBalancers reveal which resources terminate TLS
+// with it.
 private hetzner.certificate @defaults("id name type") {
   init(id? int)
   // Certificate ID
@@ -630,7 +741,12 @@ private hetzner.certificate @defaults("id name type") {
   notValidAfter time
   // DNS names covered by the certificate
   domainNames []string
-  // Status of managed certificates {issuance, renewal, error}
+  // Issuance and renewal status of a managed certificate
+  //
+  // Populated for managed certificates only (empty for uploaded ones).
+  // Keys: `issuance` and `renewal`, each one of pending, completed,
+  // failed, scheduled, or unavailable, plus `error` (a human-readable
+  // message) present only when issuance or renewal has failed.
   status dict
   // Creation timestamp
   created time
@@ -643,6 +759,13 @@ private hetzner.certificate @defaults("id name type") {
 }
 
 // Hetzner Cloud placement group
+//
+// Group of Cloud Servers scheduled onto distinct physical hosts so that a
+// single hardware failure cannot take down every member at once. Query by
+// numeric id, for example `hetzner.placementGroup(id: 12345)`, to review
+// which servers share a group and confirm that fault-tolerant workloads
+// are spread across hardware. The `type` field reports the placement
+// strategy (currently only spread) and `servers` lists the group members.
 private hetzner.placementGroup @defaults("id name type") {
   init(id? int)
   // Placement group ID
@@ -660,6 +783,13 @@ private hetzner.placementGroup @defaults("id name type") {
 }
 
 // Hetzner Cloud ISO image
+//
+// Bootable ISO image that can be attached to a server for installation
+// or recovery, covering both Hetzner-provided public images and images
+// uploaded to the project. The `type` field distinguishes public from
+// private ISOs, and `deprecation` flags images scheduled for removal so
+// audits can catch servers relying on soon-to-be-unavailable media.
+// Select a single image by its ID, for example `hetzner.iso(id: 12345)`.
 private hetzner.iso @defaults("id name type") {
   init(id? int)
   // ISO ID
@@ -670,13 +800,27 @@ private hetzner.iso @defaults("id name type") {
   description string
   // Type (public, private)
   type string
-  // Deprecation info {announced, unavailableAfter}
+  // Deprecation schedule
+  //
+  // Empty when the image is not deprecated. When present it carries
+  // `announced` (timestamp the deprecation was announced) and
+  // `unavailableAfter` (timestamp after which the image can no longer
+  // be attached).
   deprecation dict
   // Architecture (x86, arm)
   architecture string
 }
 
-// Hetzner Cloud location (region)
+// Hetzner Cloud location
+//
+// A geographic location (region) where Hetzner Cloud resources can run,
+// such as `fsn1` (Falkenstein), `nbg1` (Nuremberg), `hel1` (Helsinki),
+// `ash` (Ashburn), or `hil` (Hillsboro). Select a location by its numeric
+// `id`, for example `hetzner.location(id: 1)`. Beyond the human-readable
+// `city`, `country`, and geographic coordinates, the `networkZone` groups
+// locations that can share private networks (eu-central, us-east, us-west),
+// which matters when planning cross-region connectivity and data residency.
+// The `servers` field lists the server instances running in this location.
 private hetzner.location @defaults("id name city") {
   init(id? int)
   // Location ID
@@ -700,6 +844,14 @@ private hetzner.location @defaults("id name city") {
 }
 
 // Hetzner Cloud datacenter
+//
+// A single datacenter within a Hetzner location, identified by a slug
+// such as fsn1-dc14. Select one by its numeric id, for example
+// hetzner.datacenter(id: 4). Reports the location it belongs to, the
+// server types it supports, which of those are currently available for
+// new servers, and which are open for migration, so you can plan
+// placement and capacity. The servers field lists the servers running
+// in this datacenter.
 private hetzner.datacenter @defaults("id name") {
   init(id? int)
   // Datacenter ID
@@ -721,6 +873,15 @@ private hetzner.datacenter @defaults("id name") {
 }
 
 // Hetzner Cloud Storage Box (managed backup/file storage)
+//
+// Managed backup and file-storage volume with its own login credentials
+// and network access controls. The enabled access protocols
+// (sambaEnabled, sshEnabled, webdavEnabled, zfsEnabled), whether the box is
+// reachableExternally beyond the Hetzner network, the automated snapshotPlan,
+// and delete protection together describe its exposure and data-retention
+// posture. Subaccounts carry independent credentials and access scopes, and
+// snapshots capture point-in-time copies. Select a Storage Box by id, for
+// example `hetzner.storageBox(id: 42)`.
 private hetzner.storageBox @defaults("id name status") {
   init(id? int)
   // Storage Box ID
@@ -770,6 +931,15 @@ private hetzner.storageBox @defaults("id name status") {
 }
 
 // Hetzner Cloud Storage Box type (storage tier)
+//
+// Storage tier available for Hetzner Cloud Storage Boxes, defining the
+// included capacity and the limits that apply to boxes of this tier: how
+// many manual snapshots, automatic snapshots, and subaccounts are
+// permitted. Select a type by `id` (for example
+// hetzner.storageBoxType(id: 42)) to inspect its `size`, its snapshot and
+// subaccount limits, and whether the tier has been deprecated. Useful for
+// confirming which tier a Storage Box runs on and what capacity and
+// snapshot headroom that tier provides.
 private hetzner.storageBoxType @defaults("id name size") {
   init(id? int)
   // Storage Box type ID
@@ -791,6 +961,13 @@ private hetzner.storageBoxType @defaults("id name size") {
 }
 
 // Hetzner Cloud Storage Box subaccount
+//
+// Independent set of credentials scoped to a subdirectory of a Storage Box,
+// with its own access controls. The homeDirectory limits which files the
+// subaccount can reach, readonly blocks writes, and the per-protocol toggles
+// (sambaEnabled, sshEnabled, webdavEnabled) together with reachableExternally
+// govern how and from where the credentials can be used. Audit these to catch
+// over-broad or externally reachable access grants.
 private hetzner.storageBox.subaccount @defaults("id username") {
   // Subaccount ID
   id int
@@ -823,6 +1000,12 @@ private hetzner.storageBox.subaccount @defaults("id username") {
 }
 
 // Hetzner Cloud Storage Box snapshot
+//
+// Point-in-time copy of a Storage Box used for backup and recovery. The
+// isAutomatic flag distinguishes snapshots created by the automated snapshot
+// plan from manual ones, while size and sizeFilesystem report the space the
+// snapshot occupies and the filesystem size captured at that moment. Review
+// these to verify backup coverage and retention.
 private hetzner.storageBox.snapshot @defaults("id name created") {
   // Snapshot ID
   id int
@@ -845,6 +1028,16 @@ private hetzner.storageBox.snapshot @defaults("id name created") {
 }
 
 // Hetzner Cloud DNS zone
+//
+// DNS zone hosted on Hetzner's authoritative nameservers, covering a single
+// domain and all of its resource records. Auditing a zone reveals whether
+// the domain is correctly delegated to Hetzner, who registers it, how many
+// records it holds, and whether delete protection is in place. Zones are
+// listed through `hetzner.zones` or selected by numeric `id`. Comparing
+// `assignedNameservers` (what Hetzner expects) against `delegatedNameservers`
+// (what the domain currently points at), together with `delegationStatus`,
+// surfaces broken or lame delegations, and `rrsets` exposes the individual
+// record sets published in the zone.
 private hetzner.zone @defaults("id name mode status") {
   init(id? int)
   // Zone ID
@@ -882,6 +1075,12 @@ private hetzner.zone @defaults("id name mode status") {
 }
 
 // Hetzner Cloud DNS resource record set
+//
+// Group of DNS records sharing one name and type within a zone, such as every
+// A record for `www` or the MX records at the domain apex. The `id` combines
+// the record name and type, and `records` holds the individual values with
+// their optional comments. Use it to inventory the DNS data published for a
+// domain and to confirm change protection on sensitive record sets.
 private hetzner.zone.rrset @defaults("name type") {
   // Record set ID (name/type)
   id string


### PR DESCRIPTION
## What

A documentation pass over `hetzner.lr`, the final provider in the sweep that began with **S3** (#9146) and covered **AWS** (#9151), **Azure** (#9153), **DigitalOcean** (#9156), **GCP** (#9158), **OCI** (#9159), and **STACKIT** (#9160). These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**20 services, 33 edits.**

## Changes

- **Two-part descriptions added** to the many user-queryable resources that were title-only — server, volume, network, floatingIp, primaryIp, image, iso, certificate, datacenter, location, placementGroup, sshKey, storageBox (+ subaccount/snapshot), the `*Type` records, and zone/rrset — each with an `id` selection-key example and audit/security significance.
- **Documented dict key shapes** — `protection`, `status`, `deprecation`, `publicNet`, `healthCheck`, firewall `rules` — verified against the `hcloud` SDK; fixed a load-balancer `http` dict comment that claimed a key it doesn't have.
- **Namespace-root cleanup** — dropped call-form `foo()` references and field enumeration.

## The pattern (same as prior PRs)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation. A field is named in prose only when it adds semantics the table can't.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, no title over the 150-char cap, no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and the hcloud SDK), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.

Final PR of the provider-wide documentation sweep.
