### PR TITLE
✨ azure: add roleAssignments() to AI Services account for Entra RBAC access posture

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -13637,6 +13637,15 @@ azure.subscription.cognitiveServicesService.account @defaults("id name location 
   connections() []azure.subscription.cognitiveServicesService.account.connection
   // Private endpoint connections to the account
   privateEndpointConnections() []azure.subscription.privateEndpointConnection
+  // Microsoft Entra role assignments granting access to the account
+  //
+  // The effective role assignments at the account scope, including those
+  // inherited from the resource group, subscription, and management-group
+  // ancestors. Combined with disableLocalAuth (API-key authentication), this
+  // answers who can call and administer the account through Entra RBAC (for
+  // example who holds Cognitive Services User or Cognitive Services
+  // Contributor).
+  roleAssignments() []azure.subscription.authorizationService.roleAssignment
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
 }

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -17487,6 +17487,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.cognitiveServicesService.account.privateEndpointConnections": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetPrivateEndpointConnections()).ToDataRes(types.Array(types.Resource("azure.subscription.privateEndpointConnection")))
 	},
+	"azure.subscription.cognitiveServicesService.account.roleAssignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetRoleAssignments()).ToDataRes(types.Array(types.Resource("azure.subscription.authorizationService.roleAssignment")))
+	},
 	"azure.subscription.cognitiveServicesService.account.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
 	},
@@ -40287,6 +40290,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.cognitiveServicesService.account.privateEndpointConnections": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).PrivateEndpointConnections, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.cognitiveServicesService.account.roleAssignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionCognitiveServicesServiceAccount).RoleAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.cognitiveServicesService.account.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -94788,6 +94795,7 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccount struct {
 	Projects                        plugin.TValue[[]any]
 	Connections                     plugin.TValue[[]any]
 	PrivateEndpointConnections      plugin.TValue[[]any]
+	RoleAssignments                 plugin.TValue[[]any]
 	SystemMetadata                  plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -95071,6 +95079,22 @@ func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetPrivateEndpoint
 		}
 
 		return c.privateEndpointConnections()
+	})
+}
+
+func (c *mqlAzureSubscriptionCognitiveServicesServiceAccount) GetRoleAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoleAssignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.cognitiveServicesService.account", c.__id, "roleAssignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roleAssignments()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -975,6 +975,7 @@ azure.subscription.cognitiveServicesService.account.raiTopic.topicId 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopic.topicName 13.12.2
 azure.subscription.cognitiveServicesService.account.raiTopics 13.12.2
 azure.subscription.cognitiveServicesService.account.restrictOutboundNetworkAccess 13.11.3
+azure.subscription.cognitiveServicesService.account.roleAssignments 13.31.1
 azure.subscription.cognitiveServicesService.account.sku 13.11.3
 azure.subscription.cognitiveServicesService.account.storedCompletionsDisabled 13.12.2
 azure.subscription.cognitiveServicesService.account.systemMetadata 13.19.2

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.31.0",
-  "generated_at": "2026-07-18T09:08:41-07:00",
+  "generated_at": "2026-07-18T10:34:00-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -393,6 +393,12 @@
       "service": "Microsoft.Authorization",
       "action": "NewListForScopePager",
       "source_file": "iam_pim.go"
+    },
+    {
+      "permission": "Microsoft.Authorization/roleAssignments/read",
+      "service": "Microsoft.Authorization",
+      "action": "NewListForScopePager",
+      "source_file": "cognitiveservices.go"
     },
     {
       "permission": "Microsoft.Authorization/roleAssignments/read",

--- a/providers/azure/resources/cognitiveservices.go
+++ b/providers/azure/resources/cognitiveservices.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v3"
 	"github.com/rs/zerolog/log"
 
@@ -402,6 +403,56 @@ type mqlAzureSubscriptionCognitiveServicesServiceAccountInternal struct {
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) privateEndpointConnections() ([]any, error) {
 	return azurePrivateEndpointConnectionsToMql(a.MqlRuntime, a.cachePrivateEndpointConnections)
+}
+
+// roleAssignments returns the effective Microsoft Entra role assignments at the
+// account scope. NewListForScopePager with no filter returns assignments at the
+// scope and inherited from the resource group, subscription, and management-
+// group ancestors, so the result reflects effective RBAC access to the account
+// (not just assignments made directly on it).
+func (a *mqlAzureSubscriptionCognitiveServicesServiceAccount) roleAssignments() ([]any, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := authorization.NewRoleAssignmentsClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	pager := client.NewListForScopePager(a.Id.Data, &authorization.RoleAssignmentsClientListForScopeOptions{})
+	res := []any{}
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusForbidden {
+				log.Warn().Err(err).Msg("could not list cognitive services account role assignments due to access denied")
+				return res, nil
+			}
+			return nil, err
+		}
+		for _, roleAssignment := range page.Value {
+			if roleAssignment == nil {
+				continue
+			}
+			mqlRoleAssignment, err := newMqlRoleAssignment(a.MqlRuntime, roleAssignment)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlRoleAssignment)
+		}
+	}
+	return res, nil
 }
 
 func (a *mqlAzureSubscriptionCognitiveServicesServiceAccountVirtualNetworkRule) id() (string, error) {


### PR DESCRIPTION
## What

Answers "who can call and administer this AI Services (Cognitive Services) account" via Microsoft Entra RBAC — the access half of the account's posture, pairing with the existing `disableLocalAuth` (API-key) control.

## Changes

- Adds `roleAssignments() []azure.subscription.authorizationService.roleAssignment` to the account, backed by `RoleAssignmentsClient.NewListForScopePager` scoped to the account resource ID, reusing the existing `newMqlRoleAssignment` row builder (so each assignment already carries `scope`/`principalId`/`principalType`/`condition` and its typed `role()`).
- **No filter**, so the result is the *effective* assignments at the account scope — including those inherited from the resource group, subscription, and management-group ancestors. A Subscription Owner can call the account without a direct assignment, so effective access is the honest answer for "who can reach this." Documented in the field comment.
- Access-denied returns the partial list rather than erroring, matching the provider's other cognitive-services collections.

## Why this is the clean per-resource accessor

Azure governs data-plane access to an AI Services account two ways: API keys (`disableLocalAuth`, already modeled) and Entra RBAC role assignments at the resource scope. `ListForScope` returns exactly the RBAC side for *this* account, so — unlike AWS SageMaker endpoints, where invocation is identity-based IAM with no resource-side policy — a per-resource `roleAssignments()` is a true, complete answer here.

## Testing

- `go build ./...` in `providers/azure` passes; full `providers/azure/resources` test suite passes.
- `azure.permissions.json` regenerated — `Microsoft.Authorization/roleAssignments/read` was already required (via `iam.go`); this adds the source-file attribution for `cognitiveservices.go`, no net-new IAM permission.
- 1 new `.lr.versions` entry at `13.31.1`. Live verification deferred to the batched provider-verification run.
