### PR TITLE
🧹 Harden provider-verification cleanup to prevent leaked cloud infra

### DIFF
--- a/.claude/skills/provider-verification/SKILL.md
+++ b/.claude/skills/provider-verification/SKILL.md
@@ -91,14 +91,21 @@ so leftovers are unambiguous. Two sources, cleanest first:
    then delete them:
 
    ```bash
-   # Azure — each run puts everything in one resource group
+   # Azure — each run puts everything in one resource group; this deletes them.
    az group list --query "[?tags.project=='mql-pr-verify'].name" -o tsv \
      | xargs -r -I{} az group delete -n {} --yes --no-wait
 
-   # AWS — per region you provision in
-   aws resourcegroupstaggingapi get-resources \
-     --tag-filters Key=Project,Values=mql-pr-verify \
-     --query 'ResourceTagMappingList[].ResourceARN' --output text
+   # AWS — sweep EVERY region, not just this run's; a prior run may have used
+   # another. get-resources only *lists* — the tagging API cannot delete, and it
+   # lags deletions by hours, so it also over-reports. To DELETE, prefer
+   # `terraform destroy` from the leftover scratch dir; otherwise use a
+   # tag-scoped nuke tool or per-service deletion (see cloud-notes teardown).
+   for R in $(aws ec2 describe-regions --query 'Regions[].RegionName' --output text); do
+     echo "== $R =="
+     aws resourcegroupstaggingapi get-resources --region "$R" \
+       --tag-filters Key=project,Values=mql-pr-verify \
+       --query 'ResourceTagMappingList[].ResourceARN' --output text
+   done
 
    # GCP — Terraform tags land as labels
    gcloud asset search-all-resources \
@@ -132,7 +139,43 @@ one cloud is involved, dispatch one subagent per cloud to write its stack in
 parallel — each agent writes the `.tf`, runs `terraform init/validate/plan`,
 and reports a per-resource hourly cost. Agents must not `apply`.
 
-Tag every resource with `project = mql-pr-verify` so leftovers are findable.
+**Tagging is mandatory and enforced — not applied per resource.** A single
+hand-applied tag is how leftovers escape: one resource created without it (or by
+a crashed run) bills unnoticed for months. Close that hole two ways.
+
+First, set the run's identity once, before writing any Terraform:
+
+- `RUN_ID` — reuse the scratch-dir id (e.g. `mql-verify-<timestamp>`). It lets
+  teardown and the reaper delete a whole run's resources as a unit, and lets
+  concurrent runs tell their resources apart (replaces the "created in the last
+  few minutes" guess).
+- `EXPIRY` — an RFC3339 timestamp of `now + TTL` (default **8h**; raise it for
+  known-slow stacks like Composer). This is the machine-readable contract the
+  out-of-band reaper enforces — it deletes anything whose `EXPIRY` is in the past.
+
+Second, apply the schema through each provider's **default tags**, so every
+resource is tagged automatically and none can be created bare:
+
+| Cloud | Mechanism |
+|---|---|
+| AWS | `default_tags { tags = {...} }` in the `aws` provider block |
+| Azure | `default_tags` on the `azurerm` provider **and** one resource group per run |
+| GCP | default `labels` on the provider / resources (lower-case keys) |
+
+Schema — identical keys on every cloud:
+
+```
+project        = "mql-pr-verify"   # canonical value; never a per-effort variant
+mondoo-run-id  = <RUN_ID>
+mondoo-expiry  = <EXPIRY>           # reaper deletes when this is in the past
+mondoo-created = <now, RFC3339>
+owner          = <whoami / git user.email>
+source         = "provider-verification"
+```
+
+Resources that genuinely cannot be tagged must live **inside** the per-run
+container (resource group / VPC / project) so they are still deletable by run.
+Note any that can't be tagged in the report.
 
 ### 6. Cost gate
 
@@ -175,6 +218,12 @@ best-effort via the cloud CLI (see cloud-notes) so the accessor still gets
 exercised. If even that is impossible, verify the accessor resolves cleanly
 (empty, no error) and say so.
 
+**CLI-created resources are not in Terraform state, so `terraform destroy` will
+not remove them.** Tag each with the same schema (step 5) and append its id and
+delete command to a `cli-resources.json` manifest in the run's scratch dir, so
+teardown (step 11) explicitly deletes them and nothing escapes. Anything you
+cannot tag must go in the per-run container.
+
 ### 9. Triage bugs
 
 A bug is any verification failure caused by **provider code**, including
@@ -211,10 +260,25 @@ cloud.
 Destroy is fragile — handle the known failure modes in cloud-notes (orphaned
 EFS mount targets blocking AWS subnets, OCI API circuit-breakers, resources
 Terraform dropped from state). Fall back to CLI deletion when `terraform
-destroy` cannot finish. Confirm nothing tagged `mql-pr-verify` remains.
+destroy` cannot finish. When state is lost entirely, delete the whole run by its
+`mondoo-run-id` tag rather than resource-by-resource.
+
+**Verify per service, not via the tagging API.** AWS Resource Groups Tagging
+(and GCP asset search) lag deletions by hours and keep listing resources that
+are already gone — trusting them produces false "still leaked" alarms *and* can
+mask a genuine miss. Confirm the delete against the owning service
+(`describe-*` / `get-*` returning NotFound), and remember non-deletable historical
+records (deregistered ECS/Batch definitions, terminated EMR clusters, canceled
+signer profiles) will linger in the tag API at $0 — those are expected, not leaks.
 
 Note anything that genuinely cannot be deleted (e.g. an App Engine app) in the
 report — do not leave the user guessing.
+
+**Teardown is not the only safety net.** It runs inside this agent process, so a
+crash between apply and here orphans everything. The `mondoo-expiry` tag exists so
+an out-of-band reaper (scheduled independently of any run) can delete expired
+resources regardless of whether this run finished. Tearing down cleanly here is
+still required — the reaper is the backstop, not the plan.
 
 ### 12. Report
 
@@ -249,6 +313,10 @@ After the report, if there are unfixable bugs, offer to open a tracking issue.
   approval. Always show the number.
 - **One combined fix PR** for all bugs, regardless of how many providers.
 - **Always tear down** — unconditionally, at the end.
+- **Every resource carries the full tag schema** (`project`, `mondoo-run-id`,
+  `mondoo-expiry`, `mondoo-created`, `owner`, `source`) via provider default
+  tags. Untagged infra is invisible to both cleanup and the reaper — it is
+  exactly how leaks happen.
 - **Cheapest infra that works.** This is a verification run, not a deployment.
 - **Honest reporting.** An empty result is a pass only when empty is correct;
   otherwise it is a bug. Never claim a field works without seeing real data.

--- a/.claude/skills/provider-verification/references/cloud-notes.md
+++ b/.claude/skills/provider-verification/references/cloud-notes.md
@@ -38,7 +38,12 @@ failed `apply`.
 - **SageMaker domain**: needs a VPC + subnet + execution IAM role.
 - **CloudFront viewer mTLS**: set `viewer_mtls_config` on the distribution
   referencing a `aws_cloudfront_trust_store` (CA bundle uploaded to S3).
-- Tag with `Project = mql-pr-verify`.
+- **Private CA (`aws_acmpca_certificate_authority`)**: a general-purpose CA bills
+  **~$400/month flat** whether or not it issues a cert, with no compute to signal
+  it is running — a silent cost bomb. Prefer avoiding it; if a check needs one,
+  make sure `mondoo-expiry` is short and confirm it is deleted in teardown.
+- **Apply tags via `default_tags` on the `aws` provider block** (schema in
+  SKILL.md step 5) — never per resource, or one untagged resource escapes cleanup.
 
 ## Azure
 
@@ -137,4 +142,21 @@ cleanly (empty list, no error) and record the limitation.
   service. `terraform state rm` the App Engine resources and delete the rest;
   report the App Engine app as a permanent leftover (it costs ~$0 idle).
 
-After teardown, confirm nothing tagged `mql-pr-verify` remains in any account.
+## Verifying teardown (do not trust the tag API)
+
+- **The Resource Groups Tagging API lags deletions by hours** and keeps listing
+  resources that are already gone — it *over*-reports leftovers. Confirm each
+  delete against the owning service (`describe-*` / `get-*` → NotFound), not the
+  tag sweep. In one cleanup, ~40% of what the tag API listed was already deleted.
+- **`get-resources` cannot delete** — it only lists. Deletion is `terraform
+  destroy`, a tag-scoped nuke tool, or per-service calls in dependency order.
+- **Non-deletable historical records are expected, not leaks** (and cost $0):
+  deregistered ECS task-definitions and Batch job-definitions linger as
+  `INACTIVE` forever, terminated EMR clusters and completed SageMaker jobs stay
+  listed, canceled signer profiles remain. Don't chase them.
+- **Scope teardown by `mondoo-run-id`**, and sweep **all regions** — a leftover
+  can sit in a region the current run never touched (as can a security group in
+  the account's *default* VPC, which a VPC-scoped teardown will miss).
+
+After teardown, confirm nothing tagged `mql-pr-verify` for this `mondoo-run-id`
+remains — verified per service, per the points above.


### PR DESCRIPTION
## Why

A `provider-verification` run leaked cloud resources that billed **~\$2,000** before anyone noticed. The skill already had a teardown step (11), a pre-flight sweep (4), and a "confirm nothing remains" check — yet it still leaked. Root cause: **all three safeguards run inside the same agent process that provisions**, so a crash between `apply` (step 7) and teardown (step 11) orphans everything — and the single biggest cost item (a ~\$1,280 Private CA) was created *without* the `mql-pr-verify` tag the sweep greps for, so the skill's own cleanup was blind to it.

Evidence from the account: the leaked EMR clusters died `TERMINATED_WITH_ERRORS` in seconds (runs that crashed before teardown), and resources carried **8 different `project`-tag conventions** while the sweep matched only one.

## What this PR changes (tagging + process)

- **Mandatory, enforced tag schema** applied via provider **default tags** (AWS `default_tags` / Azure per-run resource group / GCP labels) so *no resource can be created untagged*. Adds:
  - `mondoo-run-id` — delete a run's resources wholesale; isolate concurrent runs (replaces the "created in the last few minutes" guess).
  - `mondoo-expiry` — an RFC3339 TTL that an out-of-band reaper enforces.
- **Fix the AWS pre-flight** (step 4): it previously only *listed* ARNs and swept one region. Now it sweeps every region and documents that the tagging API can't delete and lags deletions — so deletion is `terraform destroy` / a tag-scoped nuke / per-service.
- **Teardown verification** (step 11): confirm deletes against the owning service (`describe`/`get` → NotFound), *not* the tagging API (which over-reports by hours); scope by `mondoo-run-id`; sweep all regions; note the reaper is the backstop for crashed runs, not a substitute.
- **CLI-created resources** (step 8) aren't in TF state — now must be tagged and recorded in a `cli-resources.json` manifest so teardown removes them.
- **cloud-notes**: flag AWS **Private CA** as a ~\$400/mo silent cost bomb; add a "verifying teardown" section (stale tag API, non-deletable \$0 historical records like deregistered ECS/Batch defs and terminated EMR clusters, and default-VPC security groups a VPC-scoped teardown misses).

## Follow-up (not in this PR)

The real durable fix is an **out-of-band reaper** — a scheduled workflow, independent of any agent run, that deletes anything past `mondoo-expiry`. The `mondoo-expiry`/`mondoo-run-id` tags added here are the contract it needs. That + an AWS Budget alert on the `project=mql-pr-verify` tag will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)