### PR TITLE
📄 github: enrich resource and field documentation across services

### DIFF
--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -6,8 +6,9 @@ option go_package = "go.mondoo.com/mql/v13/providers/github/resources"
 
 // GitHub
 //
-// Use to access GitHub organizations, repositories, teams, users, packages,
-// deploy keys, and security and governance settings across the connected account.
+// Namespace root for GitHub queries, exposing organizations, repositories,
+// teams, users, packages, deploy keys, and security and governance settings
+// across the connected account.
 private github {}
 
 // Git commit
@@ -62,14 +63,13 @@ private git.gpgSignature @defaults("sha") {
 
 // GitHub Organization
 //
-// Examine a GitHub organization's profile, membership, and security configuration.
-// Provides identity fields (`login`, `name`, `email`, `company`), repository and
-// membership counts, governance flags such as `twoFactorRequirementEnabled`,
-// `membersCanCreateRepositories`, and Advanced Security settings, plus computed
-// collections including `members`, `owners`, `teams`, `repositories`,
-// `webhooks`, `packages`, `runners`, `auditLog`, `samlConfig`, `ipAllowList`,
-// `customRoles`, `oauthApps`, `personalAccessTokens`, `auditLogStreamConfig`,
-// `secrets`, and `variables`.
+// GitHub organization account, the top-level container for its repositories,
+// members, teams, and org-wide governance. Query it to audit an organization's
+// security posture: two-factor enforcement, the default repository permission and
+// member creation policies, GitHub Advanced Security, secret scanning and
+// Dependabot defaults for new repositories, SAML single sign-on, the IP allow
+// list, custom roles, approved OAuth apps and fine-grained personal access
+// tokens, audit log streaming, and GitHub Copilot Business configuration.
 github.organization @defaults("login name") {
   // Organization login
   login string
@@ -227,9 +227,11 @@ github.organization @defaults("login name") {
 
 // SAML SSO configuration for a GitHub organization
 //
-// Examine the SAML single sign-on configuration for a GitHub Enterprise Cloud
-// organization. Provides `enabled`, the `ssoUrl`, the IdP `issuer`, `digestMethod`,
-// `signatureMethod`, and the PEM-encoded `idpCertificate`.
+// SAML single sign-on configuration for a GitHub Enterprise Cloud organization,
+// governing whether members authenticate through an external identity provider.
+// Reports whether SSO is `enabled`, the identity-provider sign-in `ssoUrl` and
+// `issuer`, the negotiated `digestMethod` and `signatureMethod` algorithms, and
+// the PEM-encoded `idpCertificate` used to validate assertions.
 private github.organization.samlConfig @defaults("enabled ssoUrl") {
   // Whether SAML SSO is enabled for the organization
   enabled bool
@@ -247,9 +249,10 @@ private github.organization.samlConfig @defaults("enabled ssoUrl") {
 
 // IP allow list configuration for a GitHub organization
 //
-// Examine the IP allow list for a GitHub Enterprise Cloud organization. Provides
-// `enabled`, `enabledForInstalledApps`, and the list of `entries` (each a
-// `github.organization.ipAllowList.entry` with an IP/CIDR range and active status).
+// IP allow list for a GitHub Enterprise Cloud organization, restricting which
+// source addresses may reach the organization. Reports whether the list is
+// `enabled`, whether it also applies to installed GitHub Apps
+// (`enabledForInstalledApps`), and the individual allowed `entries`.
 private github.organization.ipAllowList @defaults("enabled") {
   // Whether the IP allow list is enabled
   enabled bool
@@ -261,9 +264,9 @@ private github.organization.ipAllowList @defaults("enabled") {
 
 // IP allow list entry
 //
-// Examine a single allowed IP address or CIDR range in an organization's IP allow
-// list. Provides `name`, `allowedValue` (the IP or CIDR), `isActive`, and the
-// `createdAt` and `updatedAt` timestamps.
+// Single allowed IP address or CIDR range in an organization's IP allow list. The
+// `allowedValue` field holds the address or range and `isActive` reports whether
+// the entry is currently enforced.
 private github.organization.ipAllowList.entry @defaults("name allowedValue") {
   // Entry ID
   id string
@@ -281,10 +284,11 @@ private github.organization.ipAllowList.entry @defaults("name allowedValue") {
 
 // GitHub organization custom role
 //
-// Examine a custom organization role in a GitHub Enterprise Cloud organization.
-// Provides `name`, `description`, the `baseRole` it extends (read, triage, write,
-// maintain, admin), the list of `permissions` identifiers granted, the `source`
-// origin (Organization or Enterprise), and `createdAt`/`updatedAt` timestamps.
+// Custom organization role in a GitHub Enterprise Cloud organization. A custom
+// role extends a `baseRole` (read, triage, write, maintain, admin) with an
+// explicit set of granted `permissions` identifiers, letting you audit exactly
+// what elevated access a non-standard role confers and where it was defined
+// (`source`: Organization or Enterprise).
 private github.organization.customRole @defaults("id name baseRole") {
   // Role ID
   id int
@@ -306,10 +310,11 @@ private github.organization.customRole @defaults("id name baseRole") {
 
 // OAuth application or SAML SSO-authorized credential
 //
-// Examine an OAuth application or other credential (personal access token, SSH key)
-// that has been authorized through SAML SSO for a GitHub Enterprise Cloud organization.
-// Provides the owning user `login`, `credentialType`, granted `scopes`,
-// `authorizedAt`, `lastAccessedAt`, and expiry details.
+// OAuth application or SAML SSO-authorized credential (personal access token or
+// SSH key) that has been granted standing access to a GitHub Enterprise Cloud
+// organization. Use it to review third-party and user credentials that can act
+// against the org: the owning user `login`, the `credentialType`, granted
+// `scopes`, and when the credential was authorized and last accessed.
 private github.organization.oauthApp @defaults("login credentialType") {
   // Login of the user that owns the underlying credential
   login string
@@ -341,10 +346,11 @@ private github.organization.oauthApp @defaults("login credentialType") {
 
 // Fine-grained personal access token approved for an organization
 //
-// Examine a fine-grained personal access token that has been approved to access
-// a GitHub Enterprise Cloud organization. Provides `tokenName`, `tokenId`, the
-// owning `owner` user, `repositorySelection`, granted `permissions` (categorized
-// by organization, repository, and other), `expired`, `expiresAt`, and `lastUsedAt`.
+// Fine-grained personal access token approved to access a GitHub Enterprise Cloud
+// organization. Reports the token `owner`, its `repositorySelection` (none, all,
+// or a subset), the categorized `permissions` it was granted, and its lifecycle
+// (`expired`, `expiresAt`, `lastUsedAt`) so you can audit standing programmatic
+// access to the organization.
 private github.organization.personalAccessToken @defaults("tokenName tokenId") {
   // Approval ID
   id int
@@ -358,7 +364,10 @@ private github.organization.personalAccessToken @defaults("tokenName tokenId") {
   owner() github.user
   // Repository selection (none, all, subset)
   repositorySelection string
-  // Permissions granted, categorized (organization, repository, other)
+  // Permissions granted by the token
+  //
+  // Keyed by category: `organization`, `repository`, and `other`. Each value maps
+  // a permission name to the granted access level (for example `read` or `write`).
   permissions dict
   // Time the token was granted access to the organization
   accessGrantedAt time
@@ -372,10 +381,11 @@ private github.organization.personalAccessToken @defaults("tokenName tokenId") {
 
 // Audit log streaming configuration for a GitHub organization
 //
-// Examine the audit log streaming destination configured for a GitHub Enterprise
-// Cloud organization. Provides `enabled`, `streamType` (Azure Blob Storage, Amazon
-// S3, Splunk, HTTPS Endpoint, Datadog, Google Cloud Storage, etc.), `streamId`,
-// and `createdAt`/`updatedAt` timestamps.
+// Audit log streaming destination configured for a GitHub Enterprise Cloud
+// organization. Reports whether streaming is `enabled` and the `streamType`
+// destination (Azure Blob Storage, Azure Event Hubs, Amazon S3, Splunk, HTTPS
+// Endpoint, Datadog, or Google Cloud Storage), so you can confirm audit events
+// are forwarded to an external system for retention.
 private github.organization.auditLogStreamConfig @defaults("enabled streamType") {
   // Whether audit log streaming is enabled
   enabled bool
@@ -393,8 +403,11 @@ private github.organization.auditLogStreamConfig @defaults("enabled streamType")
 
 // GitHub repository fine-grained permission
 //
-// Examine a single fine-grained permission available for organization repositories.
-// Provides the permission `name` and its human-readable `description`.
+// Fine-grained permission that can be granted on the repositories of an
+// organization, forming the building blocks of custom repository roles.
+// Enumerating these permissions lets you audit which capabilities an
+// organization can delegate through its roles. The permission is selected
+// by its name, with a human-readable description of what it grants.
 private github.repositoryFineGrainedPermission @defaults("name") {
   // Permission name
   name string
@@ -404,10 +417,11 @@ private github.repositoryFineGrainedPermission @defaults("name") {
 
 // GitHub organization custom property
 //
-// Examine a custom property defined at the organization level. Provides `name`,
-// `description`, `valueType`, whether the property is `required`, `defaultValue`,
-// `allowedValues`, `valuesEditableBy`, and `sourceType` (where the property
-// was defined).
+// Custom property defined at the organization level. Custom properties attach
+// governed metadata to repositories; this reports the property `name`, its
+// `valueType`, whether a value is `required`, the `defaultValue` and
+// `allowedValues` that constrain it, who may set it (`valuesEditableBy`), and
+// where it was defined (`sourceType`).
 private github.organization.customProperty @defaults("name required") {
   // The name of the property
   name string
@@ -429,12 +443,11 @@ private github.organization.customProperty @defaults("name required") {
 
 // GitHub Copilot Business configuration
 //
-// Examine the GitHub Copilot Business configuration for an organization. Provides
-// the `seatManagementSetting` (assign_all, assign_selected, disabled), the
-// `publicCodeSuggestions` policy (allow, block), the `copilotChat` setting, the
-// seat breakdown (`seatsTotal`, `seatsActiveThisCycle`, `seatsInactiveThisCycle`,
-// `seatsPendingCancellation`, `seatsPendingInvitation`, `seatsAddedThisCycle`),
-// the `contentExclusion` patterns keyed by repository, and the per-user `seats`.
+// GitHub Copilot Business configuration for an organization. Reports how seats are
+// assigned (`seatManagementSetting`: assign_all, assign_selected, or disabled),
+// the `publicCodeSuggestions` and `copilotChat` policies, the seat-usage
+// breakdown, the `contentExclusion` glob patterns that keep files out of
+// suggestions, and the per-user `seats`.
 private github.organization.copilot @defaults("seatManagementSetting seatsTotal") {
   // Seat management setting (assign_all, assign_selected, disabled, unconfigured)
   seatManagementSetting string
@@ -469,11 +482,11 @@ private github.organization.copilot @defaults("seatManagementSetting seatsTotal"
 
 // GitHub Copilot seat assignment
 //
-// Examine a single Copilot for Business seat assignment in an organization.
-// Provides the `user` the seat is assigned to, the `assigningTeamName` when the
-// seat is granted via team membership, the `planType`, the
-// `pendingCancellationDate` if the seat is scheduled for removal, and last-activity
-// tracking (`lastActivityAt`, `lastActivityEditor`).
+// Single Copilot Business seat assignment in an organization. Identifies the
+// `user` the seat is assigned to (or the `assigningTeamName` when granted through
+// team membership), the `planType`, any `pendingCancellationDate`, and
+// last-activity tracking (`lastActivityAt`, `lastActivityEditor`) for spotting
+// unused seats.
 private github.organization.copilot.seat @defaults("assigneeLogin planType lastActivityAt") {
   // Login of the user the seat is assigned to (empty when the assignee is a team)
   assigneeLogin string
@@ -505,11 +518,12 @@ private github.organization.copilot.seat @defaults("assigneeLogin planType lastA
 
 // GitHub user
 //
-// Examine a GitHub user account. Provides profile fields (`login`, `name`, `email`,
-// `bio`, `company`, `location`, `avatarUrl`, `twitterUsername`), account stats
-// (`followers`, `following`), status flags (`siteAdmin`, `hireable`), timestamps
-// (`createdAt`, `updatedAt`, `suspendedAt`), and computed collections
-// `repositories`, `gists`, and `publicKeys`.
+// GitHub user account, covering public profile details, follower and following
+// counts, and account status. The `siteAdmin` flag identifies instance
+// administrators on GitHub Enterprise, and `suspendedAt` records when an account
+// was suspended, both useful for auditing privileged or disabled accounts. Also
+// exposes the user's `repositories`, `gists`, and registered `publicKeys` for
+// reviewing what an account owns and which SSH keys can act on its behalf.
 private github.user @defaults("login name email company") {
   // User ID
   id int
@@ -555,10 +569,12 @@ private github.user @defaults("login name email company") {
 
 // GitHub team
 //
-// Examine a team within a GitHub organization. Provides `name`, `slug`,
-// `description`, `privacy`, `defaultPermission`, and `type`, plus computed
-// collections `members` (team members) and `repositories` (repositories the
-// team has access to), and the parent `organization`.
+// Team within a GitHub organization, grouping members and granting them
+// shared access to repositories. Teams are a primary unit of access
+// control: auditing a team's `privacy`, its `defaultPermission`, and the
+// `repositories` it can reach shows which members inherit access to which
+// code. The `members` collection lists the users on the team and
+// `organization` links back to the owning org.
 private github.team @defaults("id name") {
   // Team ID
   id int
@@ -568,11 +584,18 @@ private github.team @defaults("id name") {
   description string
   // Team slug
   slug string
-  // Team privacy configuration
+  // Team visibility
+  //
+  // One of `secret` (visible only to members and organization owners) or
+  // `closed` (visible to all organization members).
   privacy string
-  // Team default permission
+  // Default permission the team is granted on repositories it is added to
+  //
+  // One of `pull`, `triage`, `push`, `maintain`, or `admin`.
   defaultPermission string
-  // Team type (organization, enterprise)
+  // Team type
+  //
+  // One of `organization` or `enterprise`.
   type string
   // Team members
   members() []github.user
@@ -584,29 +607,40 @@ private github.team @defaults("id name") {
 
 // GitHub repository collaborator
 //
-// Examine an external collaborator on a GitHub repository. Provides the
-// collaborator's `user` identity and the list of `permissions` granted.
+// User granted access to a GitHub repository, along with the permission
+// levels they hold. Auditing collaborators reveals who can read, write, or
+// administer a repository and helps spot over-privileged access. The `user`
+// field carries the collaborator's GitHub identity and `permissions` lists
+// the granted access levels.
 private github.collaborator @defaults("user.login user.name") {
   // Collaborator ID
   id int
   // Collaborator's user information
   user github.user
-  // Collaborator's permissions
+  // Access levels granted to the collaborator
+  //
+  // Permission levels the collaborator holds on the repository. Any of
+  // admin, maintain, push, triage, or pull.
   permissions []string
 }
 
 // GitHub package
 //
-// Examine a package hosted on GitHub Packages. Provides `name`, `packageType`,
-// `visibility`, `versionCount`, `owner`, timestamps (`createdAt`, `updatedAt`),
-// the associated `repository`, and computed `versions` listing all
-// `github.packageVersion` entries.
+// Package hosted on GitHub Packages, such as a container image, npm
+// module, or Maven artifact published from a repository. Query it to
+// audit what a repository publishes, who owns it, and how each version
+// is exposed. The `packageType` field identifies the registry
+// ecosystem and `visibility` reports whether consumers outside the
+// organization can pull the package.
 private github.package @defaults("name packageType visibility repository.fullName") {
   // Package ID
   id int
   // Package name
   name string
   // Package type
+  //
+  // Registry ecosystem hosting the package. One of npm, maven,
+  // rubygems, docker, nuget, or container.
   packageType string
   // Package owner
   owner github.user
@@ -614,9 +648,11 @@ private github.package @defaults("name packageType visibility repository.fullNam
   createdAt time
   // Package update time
   updatedAt time
-  // Package version numbers
+  // Number of versions published for the package
   versionCount int
   // Package visibility
+  //
+  // Who can pull the package. One of public, private, or internal.
   visibility string
   // Package repository information
   repository() github.repository
@@ -626,9 +662,10 @@ private github.package @defaults("name packageType visibility repository.fullNam
 
 // GitHub package version
 //
-// Examine a specific version of a GitHub package. Provides `name`, `url`,
-// `packageHtmlUrl`, `license`, `description`, and `createdAt`/`updatedAt`
-// timestamps.
+// A single published version of a package hosted on GitHub Packages,
+// carrying the version's name, canonical url, packageHtmlUrl landing page,
+// license, description, and the createdAt and updatedAt timestamps that
+// let you audit how recently a version was published or refreshed.
 private github.packageVersion @defaults("id name") {
   // Version ID
   id int
@@ -650,9 +687,11 @@ private github.packageVersion @defaults("id name") {
 
 // GitHub Packages collection
 //
-// Iterate over packages hosted on GitHub Packages for the connected account.
-// Provides filtered views by `visibility`: `public`, `private`, and `internal`
-// packages, each returning a list of `github.package` resources.
+// Packages hosted on GitHub Packages for the connected account, covering
+// container images, npm/Maven/NuGet/RubyGems artifacts, and other supported
+// registries. The default list returns every `github.package`, while `public`,
+// `private`, and `internal` return the subsets filtered by package visibility,
+// so you can audit which artifacts are exposed beyond the organization.
 github.packages {
   []github.package
   // Public packages
@@ -665,19 +704,15 @@ github.packages {
 
 // GitHub repository
 //
-// Examine a GitHub repository. Provides identity fields (`fullName`, `name`,
-// `description`, `visibility`, `language`, `topics`), counts (`watchersCount`,
-// `forksCount`, `stargazersCount`, `openIssuesCount`), behavioral flags
-// (`archived`, `disabled`, `private`, `isFork`, `isTemplate`, `allowAutoMerge`,
-// `allowMergeCommit`, `allowRebaseMerge`, `allowSquashMerge`), security settings
-// (`advancedSecurityEnabled`, `secretScanningEnabled`,
-// `secretScanningPushProtectionEnabled`, `dependabotSecurityUpdatesEnabled`), and
-// computed collections including `branches`, `commits`, `contributors`,
-// `collaborators`, `files`, `releases`, `webhooks`, `workflows`, `forks`,
-// `openIssues`, `closedIssues`, `milestones`, `dependabotAlerts`,
-// `secretScanningAlerts`, `codeScanningAlerts`, `runners`, `environments`,
-// `deployments`, `rulesets`, `deployKeys`, `codeowners`, `actionsSettings`,
-// `license`, `spdxSbom`, `secrets`, and `variables`.
+// Single repository in an organization or user account, the core unit for
+// auditing source-code security and supply-chain posture. Covers visibility and
+// merge settings, the GitHub Advanced Security stack (secret scanning, push
+// protection, Dependabot, and code scanning), and access surfaces such as
+// collaborators, deploy keys, webhooks, and Actions secrets and variables. Also
+// exposes CI and release history through workflows, runners, deployments,
+// environments, and branch and tag rulesets. Selected by repository name within
+// the connected owner, for example `github.repository(name: "cnquery")`, when
+// authenticated as a user.
 github.repository @defaults("fullName") {
   // can only be used when logged in to github as a user
   init(name string)
@@ -753,7 +788,11 @@ github.repository @defaults("fullName") {
   //
   // One of "all" or "collaborators_only".
   pullRequestCreationPolicy string
-  // Repository custom properties
+  // Custom properties assigned to the repository
+  //
+  // Keyed by the organization-defined custom property name, with each value
+  // being the string or list of strings assigned to that property on this
+  // repository. Empty when the organization defines no custom properties.
   customProperties dict
   // List of open merge requests for the repository
   openMergeRequests() []github.mergeRequest
@@ -892,7 +931,7 @@ private github.repository.copilotCloudAgent @defaults("isFirewallEnabled require
 
 // GitHub Pages site
 //
-// Examine the GitHub Pages configuration for a repository. Provides the published
+// GitHub Pages configuration for a repository, covering the published
 // `url` and `htmlUrl`, the build `status` (built, building, errored, or empty
 // when no build has happened), the `buildType` (legacy publishing from a branch
 // vs. workflow-based), the source `sourceBranch` and `sourcePath` (for legacy
@@ -950,9 +989,12 @@ private github.repository.pages @defaults("status cname httpsEnforced") {
 
 // GitHub repository deploy key
 //
-// Examine an SSH deploy key configured on a repository. Provides `title`,
-// the `key` (public SSH key material), `readOnly` status, `verified`, `createdAt`,
-// `lastUsed`, `ageInDays`, the `addedBy` user, and the associated `repository`.
+// SSH deploy key granting a repository access for automated clients such as
+// CI systems and deployment tooling. Deploy keys are a common source of
+// long-lived, unrotated credentials, so audit them for keys that carry write
+// access (`readOnly` is false), have gone stale (`lastUsed`, `ageInDays`), or
+// are unverified. The `key` field holds the public SSH key material, and
+// `addedBy` attributes the key to the user who configured it.
 private github.deployKey @defaults("id title readOnly") {
   // Deploy key ID
   id int
@@ -978,9 +1020,11 @@ private github.deployKey @defaults("id title readOnly") {
 
 // GitHub user public SSH key
 //
-// Examine a public SSH key registered to a GitHub user account. Provides `title`,
-// the `key` (public SSH key material), `verified`, `createdAt`, `ageInDays`, and
-// the owning `user`.
+// Public SSH key registered to a GitHub user account and used to authenticate
+// Git operations over SSH. Auditing these keys surfaces stale or unverified
+// credentials: `verified` reports whether GitHub confirmed the key belongs to
+// the account, while `createdAt` and `ageInDays` reveal long-lived keys that
+// may warrant rotation.
 private github.publicKey @defaults("id title") {
   // Public key ID
   id int
@@ -1000,10 +1044,11 @@ private github.publicKey @defaults("id title") {
 
 // GitHub repository CODEOWNERS configuration
 //
-// Examine the parsed CODEOWNERS configuration for a repository. Provides `path`
-// (the location where the file was found: `.github/CODEOWNERS`, `CODEOWNERS`, or
-// `docs/CODEOWNERS`), `exists`, `content` (raw file text), and `rules` — each
-// a `github.codeowners.rule` with a `pattern` and list of `owners`.
+// Parsed CODEOWNERS configuration for a repository, mapping path patterns to the
+// users and teams required to review matching changes. Provides `path` (the
+// location where the file was found: `.github/CODEOWNERS`, `CODEOWNERS`, or
+// `docs/CODEOWNERS`), `exists`, `content` (raw file text), and `rules`, each a
+// `github.codeowners.rule` with a `pattern` and list of `owners`.
 private github.repository.codeowners @defaults("path exists") {
   // Path within the repository where CODEOWNERS was found (.github/CODEOWNERS, CODEOWNERS, or docs/CODEOWNERS); empty if not found
   path string
@@ -1017,9 +1062,10 @@ private github.repository.codeowners @defaults("path exists") {
 
 // CODEOWNERS rule
 //
-// Examine a single rule from a repository CODEOWNERS file. Provides the path
-// `pattern` (e.g., `*.go`, `docs/*`), the list of `owners` (GitHub usernames,
-// team slugs, or email addresses), and the `lineNumber` in the source file.
+// Single rule from a repository CODEOWNERS file, mapping a path `pattern`
+// (e.g., `*.go`, `docs/*`) to the `owners` responsible for those paths. The
+// `owners` list holds GitHub usernames, team slugs, or email addresses, and
+// `lineNumber` gives the rule's position in the source file.
 private github.codeowners.rule @defaults("pattern") {
   // The path pattern (e.g. *, *.go, docs/*)
   pattern string
@@ -1031,10 +1077,11 @@ private github.codeowners.rule @defaults("pattern") {
 
 // GitHub repository SPDX SBOM
 //
-// Examine the Software Bill of Materials (SPDX format) generated by GitHub for a
-// repository. Provides `spdxVersion`, `name`, `dataLicense`, `documentNamespace`,
-// `createdAt`, `creators`, a list of `packages` (`github.repository.sbom.package`),
-// and `relationships` between those packages.
+// Software Bill of Materials (SPDX format) generated by GitHub for a repository,
+// enumerating every dependency GitHub detected so you can audit supply-chain
+// components and their licenses. Provides `spdxVersion`, `name`, `dataLicense`,
+// `documentNamespace`, `createdAt`, `creators`, a list of `packages`
+// (`github.repository.sbom.package`), and `relationships` between those packages.
 private github.repository.sbom @defaults("name spdxVersion") {
   // SPDX identifier for the document
   spdxId string
@@ -1058,10 +1105,11 @@ private github.repository.sbom @defaults("name spdxVersion") {
 
 // SPDX SBOM package entry
 //
-// Examine a package listed in a GitHub repository's SPDX SBOM. Provides `spdxId`,
-// `name`, `versionInfo`, `downloadLocation`, `filesAnalyzed`,
-// `licenseConcluded`, `licenseDeclared`, and `externalRefs` (each a
-// `github.repository.sbom.package.externalRef` with a locator such as a purl).
+// Single package listed in a GitHub repository's SPDX SBOM, one detected
+// dependency of the repository. Provides `spdxId`, `name`, `versionInfo`,
+// `downloadLocation`, `filesAnalyzed`, `licenseConcluded`, `licenseDeclared`,
+// and `externalRefs` (each a `github.repository.sbom.package.externalRef` with
+// a locator such as a purl).
 private github.repository.sbom.package @defaults("name versionInfo") {
   // Unique SPDX identifier for this package
   spdxId string
@@ -1083,9 +1131,10 @@ private github.repository.sbom.package @defaults("name versionInfo") {
 
 // SPDX SBOM package external reference
 //
-// Examine an external reference for a package in a GitHub repository SBOM. Provides
-// `referenceCategory` (e.g., `PACKAGE-MANAGER`), `referenceType` (e.g., `purl`),
-// and `referenceLocator` (e.g., `pkg:gem/rails@6.0.1`).
+// External reference for a package in a GitHub repository SBOM, linking the
+// package to an outside identifier or resource. Provides `referenceCategory`
+// (e.g., `PACKAGE-MANAGER`), `referenceType` (e.g., `purl`), and
+// `referenceLocator` (e.g., `pkg:gem/rails@6.0.1`).
 private github.repository.sbom.package.externalRef {
   // The category of reference to an external resource this reference refers to. E.g. `PACKAGE-MANAGER`.
   referenceCategory string
@@ -1097,9 +1146,10 @@ private github.repository.sbom.package.externalRef {
 
 // SPDX SBOM dependency relationship
 //
-// Examine a dependency relationship between two elements in a GitHub repository's
-// SPDX SBOM. Provides `relationshipType` (e.g., `DEPENDS_ON`), `spdxElementId`
-// (the source), and `relatedSpdxElement` (the target).
+// Dependency relationship between two elements in a GitHub repository's SPDX
+// SBOM, connecting a source element to a related target. Provides
+// `relationshipType` (e.g., `DEPENDS_ON`), `spdxElementId` (the source), and
+// `relatedSpdxElement` (the target).
 private github.repository.sbom.relationship {
   // Type of relationship (e.g., "DEPENDS_ON")
   relationshipType string
@@ -1111,8 +1161,10 @@ private github.repository.sbom.relationship {
 
 // GitHub repository license
 //
-// Examine the license detected for a repository. Provides the license `key`,
-// `name`, `spdxId`, and `url` to the license text.
+// Open-source license that GitHub detected for a repository, used to audit
+// license compliance and confirm a repository carries an approved license.
+// The `spdxId` identifies the license under the SPDX standard (for example
+// MIT or Apache-2.0), and `url` links to the full license text.
 private github.license @defaults("spdxId") {
   // License key
   key string
@@ -1126,11 +1178,15 @@ private github.license @defaults("spdxId") {
 
 // GitHub repository ruleset
 //
-// Examine a repository or organization ruleset that controls branch and tag
-// protections. Provides `name`, `target` (branch or tag), `sourceType`,
-// `enforcement` level (active, evaluate, disabled), `bypassActors`, `conditions`
-// (ref and repository name patterns), and `rules` (the individual protection
-// constraints configured).
+// Rule-based branch and tag protection defined at the repository or
+// organization level. Rulesets replace classic branch protection, so
+// auditing them reveals which refs are guarded, how strictly the rules
+// are applied, and who can bypass them. The `sourceType` field
+// distinguishes rules defined directly on the repository from those
+// inherited from the organization. The `enforcement` level determines
+// whether a ruleset actively blocks non-conforming changes, only reports
+// them, or is turned off, and `bypassActors` exposes the escape hatches
+// that let specific users, teams, or apps sidestep the protections.
 private github.repositoryRuleset @defaults("id name enforcement") {
   // Ruleset ID
   id int
@@ -1144,11 +1200,29 @@ private github.repositoryRuleset @defaults("id name enforcement") {
   source string
   // Enforcement level (active, evaluate, disabled)
   enforcement string
-  // Users, teams, or apps allowed to bypass this ruleset (each dict has actor type, id, and bypass mode)
+  // Actors allowed to bypass this ruleset
+  //
+  // Each entry has `actor_id` (numeric id of the actor), `actor_type`
+  // (one of Integration, OrganizationAdmin, RepositoryRole, Team, or
+  // DeployKey), and `bypass_mode` (always, or pull_request to bypass
+  // only for pull requests).
   bypassActors []dict
-  // Conditions that select which refs the ruleset applies to (ref_name, repository_name patterns)
+  // Conditions that select which refs and repositories the ruleset targets
+  //
+  // Keyed by condition type, including `ref_name`, `repository_name`,
+  // `repository_id`, and `repository_property`. Name-based conditions
+  // (`ref_name`, `repository_name`) hold `include` and `exclude` arrays
+  // of fnmatch patterns; the special value `~ALL` matches everything and
+  // `~DEFAULT_BRANCH` matches the default branch.
   conditions dict
-  // Protection rules in this ruleset (each dict configures a constraint such as required reviews or status checks)
+  // Protection rules enforced by this ruleset
+  //
+  // Each entry has a `type` (the constraint kind, such as pull_request,
+  // required_status_checks, required_signatures, deletion,
+  // non_fast_forward, or required_linear_history) and a `parameters`
+  // object whose shape depends on the type (for example the required
+  // approving-review count for pull_request, or the list of required
+  // checks for required_status_checks).
   rules []dict
   // Ruleset creation time
   createdAt time
@@ -1158,10 +1232,15 @@ private github.repositoryRuleset @defaults("id name enforcement") {
 
 // GitHub Actions settings for a repository
 //
-// Examine the GitHub Actions security configuration for a repository. Provides
-// `enabled`, `allowedActions` (all, local_only, selected), `shaPinningRequired`,
-// `defaultWorkflowPermissions` (read or write), and
-// `canApprovePullRequestReviews`.
+// GitHub Actions security configuration for a single repository. Determines
+// whether workflows can run, which actions and reusable workflows are permitted
+// to run (`allowedActions` is one of all, local_only, or selected), whether
+// action references must be pinned to a full commit SHA, the default token
+// permissions granted to the GITHUB_TOKEN at the start of a workflow run
+// (`defaultWorkflowPermissions` is read or write), and whether Actions is
+// allowed to approve pull requests. Audit these to catch overly permissive
+// supply-chain settings, such as unrestricted actions, write-by-default tokens,
+// or self-approving workflows.
 private github.repositoryActionsSettings @defaults("allowedActions") {
   // Whether GitHub Actions is enabled
   enabled bool
@@ -1177,10 +1256,13 @@ private github.repositoryActionsSettings @defaults("allowedActions") {
 
 // GitHub Actions settings for an organization
 //
-// Examine the GitHub Actions security configuration for an organization. Provides
-// `enabledRepositories` (all, none, selected), `allowedActions` (all, local_only,
-// selected), `shaPinningRequired`, `defaultWorkflowPermissions` (read or write),
-// and `canApprovePullRequestReviews`.
+// Organization-wide GitHub Actions security configuration, useful for auditing
+// which repositories may run Actions, which actions and workflows are permitted,
+// and how much power the default `GITHUB_TOKEN` grants. The `enabledRepositories`
+// field controls scope (all, none, selected), `allowedActions` restricts sources
+// (all, local_only, selected), `defaultWorkflowPermissions` sets the token grant
+// (read or write), and `canApprovePullRequestReviews` reveals whether workflow
+// runs can approve their own pull request reviews.
 private github.organizationActionsSettings @defaults("allowedActions") {
   // Which repositories can use Actions (all, none, selected)
   enabledRepositories string
@@ -1196,20 +1278,27 @@ private github.organizationActionsSettings @defaults("allowedActions") {
 
 // GitHub repository file
 //
-// Examine a file or directory entry in a GitHub repository. Provides `path`,
-// `name`, `type`, `sha`, `isBinary`, `downloadUrl`, `exists`, and computed
-// `content` (file text). For directory entries, `files` lists child
-// `github.file` resources.
+// File or directory entry in a GitHub repository, used to audit the presence
+// and contents of tracked files such as workflow definitions, security
+// policies, or CODEOWNERS. The `type` field distinguishes a regular file from
+// a directory, `files` lists the child entries of a directory, and `content`
+// returns the decoded text of a file.
 private github.file @defaults("name type") {
   // File path
   path string
   // File name
   name string
   // File type
+  //
+  // Either "file" for a regular file or "dir" for a directory.
   type string
   // File shasum
   sha string
   // Whether the file is a binary
+  //
+  // Derived from the file extension against a known set of executable and
+  // package types (for example exe, dll, so, jar, class, rpm, deb, msi, whl).
+  // Directory entries and files without a matching extension are false.
   isBinary bool
   // List of files in the directory
   files() []github.file
@@ -1227,8 +1316,11 @@ private github.file @defaults("name type") {
 
 // GitHub release
 //
-// Examine a release published from a repository. Provides `name`, `tagName`,
-// `preRelease`, `createdAt`, `publishedAt`, `url`, and the release `author`.
+// Published release cut from a repository, tied to a git tag and often
+// carrying distributable artifacts. Auditing releases confirms that
+// shipped versions map to expected tags, distinguishes stable releases
+// from pre-releases via `preRelease`, and attributes each publish to an
+// `author` for change-provenance review.
 private github.release @defaults("name tagName") {
   // Release URL
   url string
@@ -1248,10 +1340,12 @@ private github.release @defaults("name tagName") {
 
 // GitHub webhook
 //
-// Examine a webhook configured on a repository or organization. Provides `name`,
-// `url`, subscribed `events`, `config` (content type, insecure_ssl flag, and
-// redacted secret reference), the `contentType` and `insecureSsl` fields,
-// `active` status, and `createdAt`/`updatedAt` timestamps.
+// HTTP callback that GitHub invokes when subscribed events occur on a repository
+// or organization, delivering event payloads to an external endpoint. Auditing
+// webhooks reveals where repository and organization activity is sent, which
+// events trigger delivery, whether the endpoint is still `active`, and whether
+// TLS certificate verification is disabled (`insecureSsl`), which would expose
+// payloads to interception.
 private github.webhook @defaults("id name") {
   // Webhook ID
   id int
@@ -1261,7 +1355,12 @@ private github.webhook @defaults("id name") {
   url string
   // List of events for the webhook
   events []string
-  // Webhook configuration: content_type (json/form), insecure_ssl (0/1), and a redacted secret reference
+  // Webhook delivery configuration
+  //
+  // Keys: `content_type` (`json` or `form`), `insecure_ssl` (`0` or `1`, where
+  // `1` skips TLS certificate verification), `url` (the delivery endpoint), and
+  // `secret` (returned obfuscated by GitHub). The `contentType` and `insecureSsl`
+  // fields surface the content-type and SSL-verification values directly.
   config dict
   // Payload media type: "json" or "form"
   contentType string
@@ -1277,10 +1376,12 @@ private github.webhook @defaults("id name") {
 
 // GitHub Actions workflow
 //
-// Examine a GitHub Actions workflow definition in a repository. Provides `name`,
-// `path`, `state`, `createdAt`, `updatedAt`, the associated `file`, and
-// `configuration` (the parsed workflow YAML including trigger events, jobs, and
-// environment variables).
+// GitHub Actions workflow defined in a repository under `.github/workflows`.
+// Workflows drive CI/CD and automation, so auditing them matters for supply
+// chain security: what events trigger a run, which jobs and permissions they
+// grant, and whether a workflow is active or disabled. The `configuration`
+// field exposes the parsed workflow YAML so trigger events, jobs, and
+// permissions can be inspected, and `file` links to the underlying source file.
 private github.workflow @defaults("id name") {
   // Workflow ID
   id int
@@ -1289,6 +1390,9 @@ private github.workflow @defaults("id name") {
   // Workflow path
   path string
   // Workflow state
+  //
+  // Whether the workflow is enabled or why it is disabled. One of active,
+  // deleted, disabled_fork, disabled_inactivity, or disabled_manually.
   state string
   // Workflow create time
   createdAt time
@@ -1296,15 +1400,22 @@ private github.workflow @defaults("id name") {
   updatedAt time
   // Workflow file
   file() github.file
-  // Parsed workflow YAML (name, on, jobs, env, etc.)
+  // Parsed workflow YAML
+  //
+  // The workflow definition parsed from its YAML source. Top-level keys mirror
+  // the GitHub Actions workflow syntax: name, on (trigger events), jobs,
+  // permissions, env, defaults, concurrency, and run-name.
   configuration() dict
 }
 
 // GitHub repository branch
 //
-// Examine a branch in a GitHub repository. Provides `name`, `isProtected`,
-// `isDefault`, `headCommitSha`, computed `headCommit` (the tip `github.commit`),
-// and `protectionRules` (the associated `github.branchprotection` configuration).
+// A single branch within a GitHub repository, selected by `name`. Central to
+// auditing whether critical branches are guarded: `isProtected` reports whether
+// branch protection applies, and `protectionRules` reaches the associated
+// `github.branchprotection` settings that govern required reviews, status checks,
+// and force-push or deletion limits. `isDefault` marks the repository's default
+// branch, while `headCommit` resolves the commit at the branch tip.
 private github.branch @defaults("name") {
   // Repository branch name
   name string
@@ -1326,35 +1437,75 @@ private github.branch @defaults("name") {
 
 // GitHub branch protection rule
 //
-// Examine the branch protection configuration for a repository branch. Provides
-// required check settings (`requiredStatusChecks`, `requiredPullRequestReviews`,
-// `requiredConversationResolution`, `requiredSignatures`, `requireLinearHistory`),
-// enforcement options (`enforceAdmins`, `restrictions`, `allowForcePushes`,
-// `allowDeletions`, `lockBranch`, `allowForkSyncing`, `blockCreations`),
-// and review requirements (`requiredApprovingReviewCount`, `requireCodeOwnerReviews`,
-// `dismissStaleReviews`, `requireLastPushApproval`, `dismissalRestrictions`).
+// Branch protection configuration for a repository branch, covering the controls
+// that gate merges and pushes: required status checks, required pull-request
+// reviews and approval counts, required conversation resolution, signed-commit
+// and linear-history requirements, administrator enforcement, push restrictions,
+// and whether force pushes, deletions, and branch locking are allowed. Auditing
+// these settings shows whether a branch enforces code review and blocks
+// unreviewed or destructive changes.
 private github.branchprotection @defaults("id") {
   // Repository branch protection ID
   id string
-  // Require status checks to pass before merging
+  // Required status checks
+  //
+  // Status-check requirements for merging into the branch. Keys: `strict`
+  // (branches must be up to date before merging), `contexts` (list of required
+  // check names, deprecated), `checks` (list of `{context, app_id}` entries
+  // naming each required check and the app that must provide it), `contexts_url`,
+  // and `url`. Whether this protection is configured at all is flattened onto
+  // this resource as requiredStatusChecksEnabled.
   requiredStatusChecks dict
-  // Require a pull request before merging
+  // Required pull request reviews
+  //
+  // Pull-request review requirements. Keys: `dismissStaleReviews`,
+  // `requireCodeOwnerReviews`, `requiredApprovingReviewCount`,
+  // `requireLastPushApproval`, `dismissalRestrictions` (a `{users, teams}` object
+  // listing who may dismiss reviews), and `bypassPullRequestAllowances` (a
+  // `{users, teams, apps}` object listing who may bypass the requirement). The
+  // most-asserted values are also flattened onto this resource as
+  // requiredApprovingReviewCount, requireCodeOwnerReviews, dismissStaleReviews,
+  // and requireLastPushApproval.
   requiredPullRequestReviews dict
-  // Require conversation resolution before merging
+  // Required conversation resolution
+  //
+  // Whether all pull-request comments must be resolved before merging. The
+  // single key `enabled` holds the state; the same value is flattened onto this
+  // resource as requiredConversationResolutionEnabled.
   requiredConversationResolution dict
   // Whether signed commits are required
   requiredSignatures bool
   // Whether signed commits are required (alias for requiredSignatures)
   requireSignedCommits bool
-  // Require linear history
+  // Linear history requirement
+  //
+  // Whether a linear commit history is enforced (no merge commits). The single
+  // key `enabled` holds the state; the same value is flattened onto this resource
+  // as requireLinearHistoryEnabled.
   requireLinearHistory dict
-  // Include administrators
+  // Administrator enforcement
+  //
+  // Whether the branch protections also apply to repository administrators. Keys:
+  // `enabled` and `url`. The state is also flattened onto this resource as
+  // enforceAdminsEnabled.
   enforceAdmins dict
-  // Restrict who can push to matching branches
+  // Push restrictions
+  //
+  // Restriction of who may push to matching branches. Keys: `users` (list of user
+  // logins), `teams` (list of team slugs), and `apps` (list of app slugs) with
+  // push access. Empty or absent when no push restriction is configured.
   restrictions dict
-  // Allow force pushes
+  // Force-push allowance
+  //
+  // Whether force pushes are permitted on matching branches. The single key
+  // `enabled` holds the state; the same value is flattened onto this resource as
+  // allowForcePushesEnabled.
   allowForcePushes dict
-  // Allow deletions
+  // Deletion allowance
+  //
+  // Whether matching branches may be deleted. The single key `enabled` holds the
+  // state; the same value is flattened onto this resource as
+  // allowDeletionsEnabled.
   allowDeletions dict
   // Whether creation of branches matching the pattern is blocked
   blockCreations bool
@@ -1384,16 +1535,23 @@ private github.branchprotection @defaults("id") {
   dismissStaleReviews bool
   // Whether the most recent pusher is required to approve a pull request
   requireLastPushApproval bool
-  // Users and teams allowed to dismiss reviews
+  // Review dismissal restrictions
+  //
+  // Users and teams permitted to dismiss pull-request reviews, flattened from the
+  // pull-request review settings. Keys: `users` (list of user logins) and `teams`
+  // (list of team names).
   dismissalRestrictions dict
 }
 
 // GitHub repository commit
 //
-// Examine a commit in a GitHub repository. Provides `sha`, `url`, `author`,
-// `committer`, `authoredDate`, `committedDate`, commit change `stats`
-// (additions, deletions, total), and the underlying `commit` object
-// (`git.commit`) with the full message and GPG signature.
+// A single commit in a GitHub repository, keyed by its `sha`. Ties the
+// version-control record to GitHub accounts: the `author` and `committer`
+// resolve to the GitHub users who wrote and applied the change, while the
+// underlying `commit` carries the raw Git commit including the full message
+// and GPG signature for verifying provenance and signed-commit policies.
+// The `stats` report the size of the change (lines added, deleted, and the
+// combined total).
 private github.commit @defaults("sha") {
   // Commit owner
   owner string
@@ -1409,7 +1567,10 @@ private github.commit @defaults("sha") {
   committer github.user
   // Commit resource object
   commit git.commit
-  // Commit statistics: additions, deletions, total
+  // Change size statistics
+  //
+  // Line-count summary for the commit. Keys: `additions` (lines added),
+  // `deletions` (lines removed), and `total` (additions plus deletions).
   stats dict
   // Authored date
   authoredDate time
@@ -1419,16 +1580,21 @@ private github.commit @defaults("sha") {
 
 // GitHub pull request
 //
-// Examine a pull request in a GitHub repository. Provides `number`, `title`,
-// `state`, `createdAt`, `updatedAt`, `closedAt`, `merged`, `mergedAt`, `mergedBy`,
-// `labels`, `assignees`, `requestedReviewers`, `milestone`, `owner`, and computed
-// collections `commits` and `reviews`.
+// Pull request in a GitHub repository, covering its lifecycle state,
+// authorship, review activity, and merge outcome. Useful for auditing who
+// authored and merged a change, whether reviewers were requested, and how
+// code reached the target branch. The commits collection exposes the
+// change set and the reviews collection the review decisions recorded
+// against it.
 private github.mergeRequest @defaults("id state") {
   // Pull request ID
   id int
   // Pull request number
   number int
   // Pull request state
+  //
+  // One of "open" or "closed". A merged pull request reports "closed"; use
+  // the merged field to distinguish a merge from a close-without-merge.
   state string
   // Pull request creation time (in UTC)
   createdAt time
@@ -1464,14 +1630,25 @@ private github.mergeRequest @defaults("id state") {
 
 // GitHub pull request review
 //
-// Examine a review submitted on a pull request. Provides `state`, `url`,
-// `authorAssociation`, and the reviewing `user`.
+// A review submitted against a pull request, recording whether a reviewer
+// approved, requested changes, or only commented. Useful for auditing that
+// merged changes received the approvals a branch protection or compliance
+// policy requires, and that reviewers have the expected relationship to the
+// repository. The `state` field carries the review verdict and
+// `authorAssociation` describes how the reviewer relates to the project.
 private github.review @defaults("url state") {
   // Review URL
   url string
   // Review state
+  //
+  // The verdict the reviewer submitted. One of APPROVED,
+  // CHANGES_REQUESTED, COMMENTED, DISMISSED, or PENDING.
   state string
   // Author association
+  //
+  // How the reviewer relates to the repository at the time of the review.
+  // One of COLLABORATOR, CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR,
+  // MANNEQUIN, MEMBER, NONE, or OWNER.
   authorAssociation string
   // Review user information
   user github.user
@@ -1479,11 +1656,12 @@ private github.review @defaults("url state") {
 
 // GitHub App installation
 //
-// Examine a GitHub App installation on an organization or user account. Provides
-// `appId`, `appSlug`, `targetType`, `repositorySelection`, subscribed `events`,
-// `permissions` (resource type to access level), `suspendedAt`, `suspendedBy`,
-// `createdAt`, `updatedAt`, and computed `repositories` accessible to this
-// installation when `repositorySelection` is "selected".
+// GitHub App installed on an organization or user account, granting the app a
+// scoped set of permissions and a repository selection. Audit installations to
+// see which apps hold access, the `permissions` they were granted, the `events`
+// they subscribe to, and whether the installation is currently suspended. When
+// `repositorySelection` is "selected", `repositories` lists the exact set of
+// repositories the app can reach.
 private github.installation @defaults("id appId") {
   // Application installation ID
   id int
@@ -1501,7 +1679,11 @@ private github.installation @defaults("id appId") {
   repositorySelection string
   // Subscribed events
   events []string
-  // Permissions granted to this installation (resource type → access level, e.g., contents: read, pull_requests: write)
+  // Permissions granted to this installation
+  //
+  // Map of resource type to access level, keyed by the resource name
+  // (contents, pull_requests, metadata, issues, actions, and so on).
+  // Each value is one of "read", "write", or "admin".
   permissions dict
   // Time the installation was suspended (null if not suspended)
   suspendedAt time
@@ -1513,9 +1695,11 @@ private github.installation @defaults("id appId") {
 
 // GitHub gist
 //
-// Examine a GitHub gist. Provides `description`, `public` status, `owner`,
-// `createdAt`, `updatedAt`, and the list of `files` (each a `github.gistfile`
-// with name, language, size, and content).
+// Shareable code snippet or set of files hosted on GitHub. Audit gists to
+// catch code, configuration, or secrets that a user has published outside of
+// managed repositories. The `public` field distinguishes a secret gist
+// (unlisted but reachable by URL) from one that is fully public, and `files`
+// exposes the contents of each file for inspection.
 private github.gist @defaults("description") {
   // Gist ID
   id string
@@ -1535,14 +1719,15 @@ private github.gist @defaults("description") {
 
 // GitHub gist file
 //
-// Examine a file within a GitHub gist. Provides `filename`, `type`, `language`,
-// `rawUrl`, `size`, and computed `content` (the file text).
+// Single file within a GitHub gist, including its detected `language`, MIME
+// `type`, `size` in bytes, and the raw `content`. Reading the content lets
+// audits scan published gist files for secrets or sensitive data.
 private github.gistfile @defaults("filename") {
   // Gist ID
   gistId string
   // Gist file name
   filename string
-  // Gist file type
+  // MIME content type of the gist file
   type string
   // Gist file language
   language string
@@ -1551,14 +1736,20 @@ private github.gistfile @defaults("filename") {
   // Gist file size
   size int
   // Gist file content
+  //
+  // Raw text of the file, retrieved from its `rawUrl`. Resolves only for
+  // text-based MIME `type` values (for example text/plain, text/markdown,
+  // application/json, application/javascript, and common script types);
+  // binary or unsupported content types return an error.
   content() string
 }
 
 // GitHub milestone
 //
-// Examine a milestone in a GitHub repository. Provides `title`, `description`,
-// `state` (open or closed), `openIssues`, `closedIssues`, `creator`, `dueOn`,
-// and `createdAt`/`updatedAt`/`closedAt` timestamps.
+// Milestone that groups issues and pull requests in a GitHub repository
+// toward a shared goal or release. Track progress with the `openIssues`
+// and `closedIssues` counts, the `state` (open or closed), and the `dueOn`
+// target date to audit whether planned work is on schedule.
 private github.milestone @defaults("title state") {
   // Milestone ID
   id int
@@ -1592,9 +1783,11 @@ private github.milestone @defaults("title state") {
 
 // GitHub issue
 //
-// Examine an issue in a GitHub repository. Provides `number`, `title`, `state`,
-// `body`, `url`, `user` (opener), `assignees`, `labels`, `milestone`, `locked`,
-// `draft`, `closedBy`, and `createdAt`/`updatedAt`/`closedAt` timestamps.
+// Issue tracked in a GitHub repository, covering its open or closed state,
+// the user who opened it, current assignees, applied labels, associated
+// milestone, lock status, and the user who closed it. Useful for auditing
+// issue triage ownership, backlog hygiene, and whether a conversation has
+// been locked to collaborators.
 private github.issue @defaults("title") {
   // Issue ID
   id int
@@ -1603,6 +1796,8 @@ private github.issue @defaults("title") {
   // Issue title
   title string
   // Issue state
+  //
+  // Either "open" or "closed".
   state string
   // Issue body
   body string
@@ -1616,7 +1811,10 @@ private github.issue @defaults("title") {
   closedAt time
   // User who opened the issue
   user github.user
-  // Labels applied to the issue (each dict: name, color, description)
+  // Labels applied to the issue
+  //
+  // Each entry carries the label `name`, hex `color`, `description`, and
+  // `default` flag (true for labels created with the repository).
   labels []dict
   // Users to whom the issue is assigned
   assignees []github.user
@@ -1632,11 +1830,13 @@ private github.issue @defaults("title") {
 
 // GitHub Dependabot alert
 //
-// Examine a Dependabot vulnerability alert for a repository. Provides `number`,
-// `state` (auto_dismissed, dismissed, fixed, open), `severity`, `dependency`,
-// `securityAdvisory`, `securityVulnerability`, `dismissedBy`, `dismissedReason`,
-// `dismissedComment`, and
-// `createdAt`/`updatedAt`/`dismissedAt`/`fixedAt`/`autoDismissedAt` timestamps.
+// Dependabot vulnerability alert raised against a repository's dependency graph,
+// flagging a dependency with a known security advisory. Each alert is keyed by
+// its per-repository `number` and carries the affected `dependency`, the
+// `securityAdvisory` and `securityVulnerability` that triggered it, its
+// remediation lifecycle (`state`, `fixedAt`, and dismissal details), and its
+// `severity`. Query these to audit which repositories carry unresolved
+// vulnerable dependencies and how each alert was triaged.
 private github.dependabotAlert @defaults("number state severity") {
   // Alert number
   number int
@@ -1644,11 +1844,24 @@ private github.dependabotAlert @defaults("number state severity") {
   state string
   // Severity of the alert: low, medium, high, or critical
   severity string
-  // Vulnerable dependency information
+  // Vulnerable dependency
+  //
+  // Keys: `package` (a nested object with `ecosystem` and `name`),
+  // `manifest_path` (the file that declares the dependency), and `scope`
+  // (development or runtime).
   dependency dict
-  // Security advisory details
+  // Security advisory
+  //
+  // The GitHub advisory behind the alert. Keys: `ghsa_id`, `cve_id`, `summary`,
+  // `description`, `severity`, `cvss`, `cwes`, `epss`, `identifiers`,
+  // `references`, `vulnerabilities`, `published_at`, `updated_at`, and
+  // `withdrawn_at`.
   securityAdvisory dict
-  // Specific vulnerability details
+  // Vulnerability matched against the dependency
+  //
+  // The specific advisory entry that applies to this dependency. Keys:
+  // `package` (with `ecosystem` and `name`), `severity`,
+  // `vulnerable_version_range`, and `first_patched_version`.
   securityVulnerability dict
   // API URL
   url string
@@ -1667,6 +1880,9 @@ private github.dependabotAlert @defaults("number state severity") {
   // User who dismissed the alert
   dismissedBy github.user
   // Reason for dismissal
+  //
+  // One of fix_started, inaccurate, no_bandwidth, not_used, or tolerable_risk.
+  // Empty for alerts that have not been dismissed.
   dismissedReason string
   // Comment on dismissal
   dismissedComment string
@@ -1674,12 +1890,14 @@ private github.dependabotAlert @defaults("number state severity") {
 
 // GitHub secret scanning alert
 //
-// Examine a secret scanning alert for a repository. Provides `number`, `state`
-// (open, resolved), `resolution`, `secretType`, `secretTypeDisplayName`, `secret`
-// (partially redacted), `validity` (active, inactive, unknown), `publiclyLeaked`,
-// `multiRepo`, push protection bypass details (`pushProtectionBypassed`,
-// `pushProtectionBypassedBy`, `pushProtectionBypassedAt`), `resolvedBy`,
-// `resolutionComment`, and timestamp fields.
+// Credential (API key, token, or password) that GitHub secret scanning detected
+// committed to a repository, exposing it for potential misuse. Auditing these
+// alerts surfaces leaked secrets that need rotation: `secretType` and
+// `secretTypeDisplayName` identify the kind of credential, `validity` reports
+// whether it is still live (active, inactive, unknown), and `publiclyLeaked`
+// and `multiRepo` flag broader exposure across public code or several
+// repositories. The `state` (open, resolved), `resolution`, and
+// push-protection bypass fields track whether the leak has been remediated.
 private github.secretScanningAlert @defaults("number state") {
   // Alert number
   number int
@@ -1723,19 +1941,28 @@ private github.secretScanningAlert @defaults("number state") {
 
 // GitHub code scanning alert
 //
-// Examine a code scanning alert for a repository. Provides `number`, `state`
-// (open, closed, dismissed, fixed), `rule` (id, severity, description, tags),
-// `tool` (name, version, GUID), `dismissedBy`, `dismissedReason`,
-// `dismissedComment`, `closedBy`, `mostRecentInstance`, and
-// `createdAt`/`updatedAt`/`fixedAt`/`closedAt`/`dismissedAt` timestamps.
+// Security finding raised by a code scanning tool (such as CodeQL) against a
+// repository. Each alert records an unresolved or resolved vulnerability along
+// with its `state` (open, closed, dismissed, fixed), the `rule` that fired,
+// the analysis `tool` that produced it, and, when suppressed, who dismissed it
+// and the reason. Use it to audit outstanding findings and verify that
+// dismissals are justified.
 private github.codeScanningAlert @defaults("number state") {
   // Alert number
   number int
   // Alert state (open, closed, dismissed, fixed)
   state string
-  // Rule metadata for the alert (id, severity, description, tags)
+  // Rule that triggered the alert
+  //
+  // Dictionary describing the code scanning rule, with keys `id`, `name`,
+  // `severity` (none, note, warning, error), `security_severity_level` (low,
+  // medium, high, critical), `description`, `full_description`, `help`, and
+  // `tags`.
   rule dict
-  // Analysis tool that produced the alert (name, version, GUID)
+  // Analysis tool that produced the alert
+  //
+  // Dictionary describing the scanning tool, with keys `name`, `version`, and
+  // `guid`.
   tool dict
   // API URL
   url string
@@ -1756,21 +1983,32 @@ private github.codeScanningAlert @defaults("number state") {
   // User who dismissed the alert
   dismissedBy github.user
   // Reason for dismissal
+  //
+  // One of `false positive`, `won't fix`, or `used in tests`, or empty when
+  // the alert has not been dismissed.
   dismissedReason string
   // Comment on dismissal
   dismissedComment string
   // Most recent instance of this alert
+  //
+  // Dictionary describing the latest occurrence, with keys `ref`,
+  // `analysis_key`, `category`, `environment`, `state`, `commit_sha`,
+  // `message` (with a `text` field), `location` (with `path`, `start_line`,
+  // `end_line`, `start_column`, `end_column`), `html_url`, and
+  // `classifications`.
   mostRecentInstance dict
 }
 
 // GitHub organization audit log entry
 //
-// Examine a single event in a GitHub organization's audit log. Provides `action`
-// (e.g., `user.login`, `repo.create`), `actor`, `actorLocation`, the affected
-// `user`, `org`, `business`, `timestamp`, SAML identity fields
-// (`externalIdentityNameId`, `externalIdentityUsername`), token metadata
-// (`hashedToken`, `tokenId`, `tokenScopes`), and additional `data` and
-// `additionalFields` dictionaries for event-specific attributes.
+// Single event from a GitHub organization's audit log, available for GitHub
+// Enterprise Cloud organizations. Records the `action` performed (for example
+// `user.login` or `repo.create`), the `actor` and their `actorLocation`, the
+// affected `user`, `org`, and `business`, the event `timestamp`, SAML identity
+// attributes (`externalIdentityNameId`, `externalIdentityUsername`), and token
+// metadata (`hashedToken`, `tokenId`, `tokenScopes`). The `data` and
+// `additionalFields` maps carry attributes specific to each action, useful for
+// auditing who did what, from where, and with which credentials.
 private github.auditLogEntry @defaults("action actor timestamp") {
   // Unique document ID
   documentId string
@@ -1808,17 +2046,31 @@ private github.auditLogEntry @defaults("action actor timestamp") {
   tokenId int
   // Token scopes (if applicable)
   tokenScopes string
-  // Additional event data
+  // Event-specific attributes
+  //
+  // Map of extra attributes GitHub attaches to certain actions, keyed by
+  // attribute name with action-dependent values. The set of keys present
+  // depends on the entry's `action` (for example a repository event may
+  // include `repo` and `visibility`, a permission change `permission`).
   data dict
-  // Additional fields not explicitly defined
+  // Attributes not mapped to a dedicated field
+  //
+  // Catch-all map of any audit-log attributes GitHub returns for the event
+  // that this resource does not expose as a named field, keyed by the raw
+  // attribute name. Contents vary by `action`.
   additionalFields dict
 }
 
 // GitHub Actions self-hosted runner
 //
-// Examine a self-hosted runner registered to a repository or organization. Provides
-// `name`, `os` (linux, macos, windows), `architecture`, `status` (online, offline),
-// `busy`, `ephemeral`, and `labels` (each a `github.runnerLabel`).
+// Self-hosted runner registered to a repository or organization to execute
+// GitHub Actions workflow jobs on infrastructure you control. Because a
+// self-hosted runner runs workflow code on your own hosts, its configuration
+// carries real risk: use it to audit which platform (`os` of linux, macos, or
+// windows) and `architecture` a runner reports, whether it is currently
+// `online` or `offline` via `status`, whether it is `ephemeral` (torn down
+// after a single job) versus persistent, and the `labels` that route jobs to
+// it. The `busy` flag reports whether a job is executing right now.
 private github.runner @defaults("id name os status") {
   // Runner ID
   id int
@@ -1840,8 +2092,11 @@ private github.runner @defaults("id name os status") {
 
 // GitHub Actions runner label
 //
-// Examine a label assigned to a self-hosted runner. Provides `name` and `type`
-// (read-only for system labels, custom for user-defined labels).
+// Label assigned to a self-hosted Actions runner, used to route workflow jobs
+// to runners with matching `runs-on` labels. The `type` field distinguishes
+// read-only labels applied by the system from custom labels defined by the
+// runner administrator, which is useful when auditing whether jobs can be
+// steered onto specific self-hosted machines.
 private github.runnerLabel @defaults("name type") {
   // Label ID
   id int
@@ -1853,10 +2108,14 @@ private github.runnerLabel @defaults("name type") {
 
 // GitHub deployment environment
 //
-// Examine a deployment environment configured in a repository. Provides `name`,
-// `waitTimer`, `canAdminsBypass`, `protectedBranches`, `customBranchPolicies`,
-// `protectionRules` (each a `github.environmentProtectionRule`), `createdAt`,
-// `updatedAt`, `secrets`, and `variables`.
+// Deployment environment configured in a repository, such as production or
+// staging. Environments gate deployments through protection rules: required
+// reviewers, a `waitTimer` delay before a deployment can proceed, and branch
+// restrictions governed by `protectedBranches` and `customBranchPolicies`.
+// `canAdminsBypass` reveals whether administrators can override those rules,
+// and each entry in `protectionRules` is a github.environmentProtectionRule.
+// Environment-scoped `secrets` and `variables` expose the configuration made
+// available to workflows deploying to this environment.
 private github.environment @defaults("name id") {
   // Environment ID
   id int
@@ -1888,9 +2147,13 @@ private github.environment @defaults("name id") {
 
 // GitHub environment protection rule
 //
-// Examine a protection rule on a deployment environment. Provides `type`
-// (required_reviewers, wait_timer, or branch_policy), `waitTimer` in minutes,
-// `preventSelfReview`, and `reviewers` (users or teams required to approve).
+// Protection rule guarding deployments to an environment, the control that
+// decides whether a deployment can proceed and who must sign off. The `type`
+// field selects which control applies: `required_reviewers` gates a deployment
+// behind approvals from the listed reviewers, `wait_timer` delays it by a fixed
+// number of minutes, and `branch_policy` restricts which branches or tags may
+// deploy. Audit these rules to confirm production environments require review
+// and cannot be deployed to directly.
 private github.environmentProtectionRule @defaults("type") {
   // Rule ID
   id int
@@ -1900,15 +2163,23 @@ private github.environmentProtectionRule @defaults("type") {
   waitTimer int
   // Whether to prevent self-review
   preventSelfReview bool
-  // Required reviewers (users or teams)
+  // Reviewers required to approve a deployment
+  //
+  // One entry per required reviewer, present for the `required_reviewers` rule
+  // type. Each entry carries `type` (`User` or `Team`) plus the reviewer's own
+  // fields flattened in: `login` and `id` for a user, `name`, `slug`, and `id`
+  // for a team.
   reviewers []dict
 }
 
 // GitHub deployment
 //
-// Examine a deployment record for a repository. Provides `sha`, `ref`, `task`,
-// `environment`, `description`, `creator`, `payload`, `createdAt`, `updatedAt`,
-// and the computed `latestStatus` (`github.deploymentStatus`).
+// Deployment record requesting that a specific commit be released to an
+// environment. The `sha` and `ref` identify the code being deployed, while
+// `environment` and `task` describe where and how. Query it to audit what
+// reached production and staging, who triggered each release, and the
+// `latestStatus` reporting whether the deployment succeeded, failed, or is
+// still in progress.
 private github.deployment @defaults("id environment sha") {
   // Deployment ID
   id int
@@ -1932,7 +2203,11 @@ private github.deployment @defaults("id environment sha") {
   createdAt time
   // Deployment update time
   updatedAt time
-  // Deployment payload (custom data)
+  // Deployment payload
+  //
+  // Free-form JSON data supplied by the client when the deployment was
+  // created. Keys are user-defined and vary by workflow (for example a
+  // release version or a feature-flag set); GitHub imposes no schema on it.
   payload dict
   // Statuses URL
   statusesUrl string
@@ -1942,10 +2217,13 @@ private github.deployment @defaults("id environment sha") {
 
 // GitHub deployment status
 //
-// Examine a status update on a deployment. Provides `state` (pending, success,
-// failure, error, inactive, in_progress, queued), `description`, `environment`,
-// `creator`, `targetUrl`, `logUrl`, `environmentUrl`, and
-// `createdAt`/`updatedAt` timestamps.
+// A single status update recorded against a deployment, tracking how a release
+// progressed through an environment over time. The `state` field carries the
+// outcome (pending, success, failure, error, inactive, in_progress, or queued),
+// `environment` names the target it applied to, and `creator` identifies who or
+// what posted it. Auditing the status history shows whether deployments to
+// sensitive environments succeeded, stalled, or errored, and links out to the
+// deployed target and its logs.
 private github.deploymentStatus @defaults("id state") {
   // Status ID
   id int
@@ -1971,12 +2249,14 @@ private github.deploymentStatus @defaults("id state") {
 
 // GitHub Actions secret
 //
-// Examine a GitHub Actions secret configured at the repository, organization, or
-// environment scope. Secret values are never exposed by the API; this resource
-// provides metadata only: `name`, `scope`, `visibility` (for organization secrets:
-// all, private, selected), `organizationName`, `repositoryName`,
-// `repositoryOwner`, `environmentName`, `createdAt`, `updatedAt`, and computed
-// `selectedRepositories` when visibility is "selected".
+// Encrypted secret available to GitHub Actions workflows, configured at the
+// repository, organization, or environment scope. Secret values are never
+// returned by the API, so this exposes metadata only, which is useful for
+// auditing where secrets live and how broadly they are shared. The scope
+// field selects which owner fields apply, and for an organization secret the
+// visibility field (all, private, or selected) determines which repositories
+// may read it; when visibility is "selected", selectedRepositories enumerates
+// exactly which repositories have access.
 private github.actionsSecret @defaults("name scope visibility") {
   // Secret name
   name string
@@ -2004,12 +2284,16 @@ private github.actionsSecret @defaults("name scope visibility") {
 
 // GitHub Actions variable
 //
-// Examine a GitHub Actions variable configured at the repository, organization, or
-// environment scope. Variable values are readable by anyone with read access to the
-// scope. Provides `name`, `value`, `scope`, `visibility` (for organization
-// variables: all, private, selected), `organizationName`, `repositoryName`,
-// `repositoryOwner`, `environmentName`, `createdAt`, `updatedAt`, and computed
-// `selectedRepositories` when visibility is "selected".
+// Plaintext configuration value available to GitHub Actions workflows, defined at
+// the repository, organization, or environment scope. Unlike secrets, variable
+// values are stored and returned in cleartext and are readable by anyone with read
+// access to the owning scope, so auditing them catches sensitive data that should
+// have been a secret. The `scope` field records where the variable lives
+// (organization, repository, or environment) and selects which of the
+// `organizationName`, `repositoryName`, `repositoryOwner`, and `environmentName`
+// owner fields are populated. For organization variables, `visibility` controls
+// which repositories can consume the variable, and `selectedRepositories` resolves
+// the allowed set when visibility is "selected".
 private github.actionsVariable @defaults("name scope visibility") {
   // Variable name
   name string


### PR DESCRIPTION
## What

A documentation pass over `github.lr`, applying the pattern established across the provider-wide sweep (starting with S3, #9146). These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**43 services, ~106 edits.**

## Changes

- **Resource descriptions** rewritten to lead with the noun and convey audit/security significance (branch protection, secret/code scanning, deploy keys, PAT permissions), instead of opening with `Examine`/`Iterate` and re-listing the field table.
- **Documented dict/`[]dict` key shapes** — `branchprotection` rules, code-scanning and Dependabot alert `rule`/`securityAdvisory`/`securityVulnerability`, installation and PAT `permissions`, issue/mergeRequest `labels`, commit `stats`, audit-log entry `data`/`additionalFields` — verified against the go-github structs.
- **Enum value lists** — alert `dismissedReason` (distinct sets for code-scanning vs Dependabot), package `type`/`visibility`, collaborator `permission`, issue/PR `state` — plus a `versionCount` title/type-mismatch fix.

## The pattern (same as prior PRs)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, no title over the 150-char cap, no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and go-github), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.
