### PR TITLE
📄 gitlab: enrich resource and field documentation across services

### DIFF
--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -6,14 +6,16 @@ option go_package = "go.mondoo.com/mql/v13/providers/gitlab/resources"
 
 // GitLab Instance Application Settings
 //
-// Examine instance-wide security and configuration settings. Requires admin
-// access. Covers authentication controls (`requireTwoFactorAuthentication`,
-// `twoFactorGracePeriod`, `requireAdminTwoFactorAuthentication`,
-// `gitTwoFactorSessionExpiry`), password authentication toggles for web and
-// Git (`passwordAuthenticationEnabledForWeb`,
-// `passwordAuthenticationEnabledForGit`), new-user registration
-// (`signupEnabled`), and default visibility levels for projects and groups
-// (`defaultProjectVisibility`, `defaultGroupVisibility`).
+// Instance-wide security and configuration settings for a self-managed
+// GitLab deployment, readable only with an admin token. These settings
+// govern the whole instance rather than any single project or group,
+// which makes them the primary control surface for hardening audits:
+// two-factor enforcement and grace periods, web and Git password
+// authentication, new-user registration and admin approval, sign-up
+// domain allow/deny lists, password-complexity minimums, token and SSH
+// key expiration enforcement, default project and group visibility, and
+// SSRF-relevant toggles that let hooks and integrations reach the local
+// network.
 gitlab.settings @defaults("requireTwoFactorAuthentication") {
   // Settings ID
   id int
@@ -90,16 +92,15 @@ gitlab.settings @defaults("requireTwoFactorAuthentication") {
 
 // GitLab user
 //
-// Examine a single GitLab user account by id. Surfaces basic identity
-// (username, name, email, avatar), account state (locked, bot,
-// twoFactorEnabled), profile metadata (jobTitle, organization, location),
-// linked SSO identities and SSH keys, and admin-scoped fields (isAdmin,
-// isAuditor, external, lastSignInAt, currentSignInAt, lastActivityOn,
-// confirmedAt, note, usingLicenseSeat, canCreateGroup, canCreateProject,
-// privateProfile). The admin-scoped fields require the calling token to
-// be able to read `/users/:id` — with a non-admin token they return zero
-// values rather than failing the resource graph; a one-time warning is
-// emitted at runtime when this fallback is hit.
+// User account on a GitLab instance, keyed by numeric id (for example
+// `gitlab.user(id: 42)`). Covers basic identity (username, name, email,
+// avatar), account state (locked, bot, twoFactorEnabled), profile metadata
+// (jobTitle, organization, location), linked SSO identities and SSH keys, and
+// admin-scoped fields such as isAdmin, isAuditor, external, the sign-in and
+// activity timestamps, and note. The admin-scoped fields require the calling
+// token to be able to read `/users/:id`. With a non-admin token they return
+// zero values rather than failing the resource graph, and a one-time warning
+// is emitted at runtime when this fallback is hit.
 gitlab.user @defaults("username name state") {
   // User ID
   id int
@@ -185,10 +186,10 @@ gitlab.user @defaults("username name state") {
 
 // GitLab personal access token
 //
-// Examine a personal access token and its security posture: the `scopes` it
-// grants, whether it is `active` or `revoked`, and its `expiresAt` and
-// `lastUsedAt` timestamps. Use these to audit over-scoped, stale, or
-// non-expiring tokens.
+// Personal access token belonging to a user, with the fields needed to audit
+// over-scoped, stale, or non-expiring credentials: the `scopes` it grants,
+// whether it is `active` or `revoked`, and its `expiresAt` and `lastUsedAt`
+// timestamps.
 private gitlab.user.personalAccessToken @defaults("name active expiresAt") {
   // Token ID
   id int
@@ -242,10 +243,10 @@ private gitlab.user.sshKey @defaults("id title createdAt") {
 
 // Email address registered to a GitLab user account
 //
-// Examine an email address linked to a user account and whether it has been
-// confirmed. Unconfirmed addresses (`confirmedAt` is null) can indicate a
-// pending account takeover or an unverified secondary identity. Requires the
-// calling token to be able to read the user's emails (admin or self-access).
+// Email address linked to a user account and whether it has been confirmed.
+// Unconfirmed addresses (`confirmedAt` is null) can indicate a pending account
+// takeover or an unverified secondary identity. Requires the calling token to
+// be able to read the user's emails (admin or self-access).
 private gitlab.user.email @defaults("email confirmedAt") {
   // Email ID
   id int
@@ -255,7 +256,16 @@ private gitlab.user.email @defaults("email confirmedAt") {
   confirmedAt time
 }
 
-// GitLab member (used in both groups and projects)
+// GitLab group or project membership
+//
+// Membership record pairing a user account with the access level that
+// governs what they can do in a group or project (Guest, Reporter,
+// Developer, Maintainer, or Owner). Review memberships to find
+// over-privileged accounts, stale grants past their expiration, or
+// custom roles that elevate a member beyond their base access level.
+// The `role` and `accessLevel` fields report the effective permission
+// tier, `memberRole` resolves any custom role in effect, and
+// `isUsingSeat` indicates whether the member consumes a billable seat.
 private gitlab.member @defaults("user role") {
   // Member ID
   id int
@@ -339,13 +349,12 @@ private gitlab.memberRole @defaults("name baseAccessLevel") {
 
 // GitLab Namespace
 //
-// Examine a GitLab namespace — the container that scopes groups and user
-// projects. The `kind` field distinguishes group namespaces from user
-// namespaces. Subscription fields (`plan`, `trial`, `trialEndsOn`,
-// `maxSeatsUsed`, `seatsInUse`, `billableMembersCount`) reflect the
-// GitLab.com plan attached to the namespace. `membersCountWithDescendants`
-// counts members across the namespace hierarchy. Navigate to the parent
-// namespace via `parentId`.
+// Container that scopes groups and user projects in GitLab. The `kind`
+// field distinguishes group namespaces from user namespaces. Subscription
+// fields (`plan`, `trial`, `trialEndsOn`, `maxSeatsUsed`, `seatsInUse`,
+// `billableMembersCount`) reflect the GitLab.com plan attached to the
+// namespace, and `membersCountWithDescendants` counts members across the
+// namespace hierarchy.
 gitlab.namespace @defaults("name kind plan") {
   // Namespace ID
   id int
@@ -379,15 +388,16 @@ gitlab.namespace @defaults("name kind plan") {
 
 // GitLab Group
 //
-// Examine a GitLab group and its security posture. Core identity fields
-// include `name`, `fullName`, `fullPath`, `visibility`, `webURL`, and
-// `createdAt`. Security controls cover two-factor authentication enforcement
-// (`requireTwoFactorAuthentication`, `twoFactorGracePeriod`),
-// `membershipLock`, `preventForkingOutsideGroup`, and `emailsDisabled`.
-// Computed collections expose `members`, `subgroups`, `projects`, `labels`,
-// `pushRules`, `accessTokens`, `deployTokens`, `protectedBranches`,
-// `samlGroupLinks` (Premium/Ultimate), and `auditEvents` (Premium/Ultimate).
-// The associated `namespace` is available as a typed reference.
+// Namespace that owns projects, members, and subgroups, together with the
+// security controls applied across them. Group-level settings include
+// two-factor authentication enforcement, membership locking, restrictions on
+// forking projects outside the group, allowed IP address ranges, and the
+// default branch-protection policy inherited by new projects. Also queryable
+// are the group's members and their roles, CI/CD variables inherited by every
+// project, access and deploy tokens, webhooks, push rules, SAML group links,
+// and audit events (the last two on Premium and Ultimate). Vulnerabilities,
+// packages, and container registry repositories aggregate across the group
+// and all of its subgroups.
 gitlab.group @defaults("name visibility webURL") {
   // Group ID
   id int
@@ -551,7 +561,7 @@ private gitlab.group.auditEvent @defaults("id eventName createdAt") {
   ipAddress string
   // Path of the entity within the group hierarchy
   entityPath string
-  // Whether this was a failed login event
+  // Login method reported on a failed sign-in event (for example STANDARD), empty for other event types
   failedLogin string
   // User who performed the action (null if the author cannot be resolved)
   author() gitlab.user
@@ -565,8 +575,12 @@ private gitlab.group.auditEvent @defaults("id eventName createdAt") {
 
 // GitLab project audit event
 //
-// Records a security-relevant action against the project.
-// Available on Premium and Ultimate tiers via /projects/:id/audit_events.
+// Security-relevant action recorded against the project, such as a
+// member being added or removed, a deploy token created, or a
+// protected-branch setting changed. Available on Premium and Ultimate
+// tiers through the project audit events API. Useful for change
+// tracking and forensic investigation of who did what, when, and from
+// which IP address.
 private gitlab.project.auditEvent @defaults("id eventName createdAt") {
   // Audit event ID
   id int
@@ -598,7 +612,7 @@ private gitlab.project.auditEvent @defaults("id eventName createdAt") {
   ipAddress string
   // Path of the entity the event applies to
   entityPath string
-  // Whether this was a failed login event
+  // Login method reported on a failed sign-in event (for example STANDARD), empty for other event types
   failedLogin string
   // User who performed the action (null if the author cannot be resolved)
   author() gitlab.user
@@ -612,19 +626,17 @@ private gitlab.project.auditEvent @defaults("id eventName createdAt") {
 
 // GitLab Project
 //
-// Examine a GitLab project and its security configuration. Core identity
-// fields include `name`, `fullName`, `fullPath`, `visibility`, `webURL`,
-// `defaultBranch`, `archived`, and `mirror`. Feature toggles cover issues,
-// merge requests, wiki, snippets, container registry, Service Desk, packages,
-// Auto DevOps, and requirements. Merge-request governance fields include
-// `onlyAllowMergeIfPipelineSucceeds`,
-// `onlyAllowMergeIfAllDiscussionsAreResolved`,
-// `allowMergeOnSkippedPipeline`, and `mergeMethod`. Computed collections
-// expose `approvalRules`, `approvalSettings`, `protectedBranches`,
-// `projectMembers`, `projectFiles`, `webhooks`, `mergeRequests`, `issues`,
-// `releases`, `variables`, `milestones`, `labels`, `pipelines`, `runners`,
-// `pushRules`, `accessTokens`, `deployKeys`, `deployTokens`, and
-// `securitySettings`.
+// A GitLab project: the repository together with its CI/CD configuration,
+// feature toggles, and access controls. Projects hold source code, issues,
+// merge requests, pipelines, and packages, so a project is the primary unit
+// for auditing GitLab's security posture: who the code is visible to,
+// whether merges require passing pipelines and resolved discussions, how
+// branches and tags are protected, how approvals and push rules are
+// enforced, and which members, access tokens, deploy keys, and integrations
+// can reach the code. Computed collections also surface confirmed
+// vulnerabilities, audit events, and container-registry and package
+// protection rules. Select a project by its full path with namespace, for
+// example `gitlab.project(fullPath: "mondoohq/test-project")`.
 gitlab.project @defaults("fullName visibility webURL") {
   // Project ID
   id int
@@ -634,7 +646,10 @@ gitlab.project @defaults("fullName visibility webURL") {
   fullName string
   // Project path
   path string
-  // Path with namespace (e.g., `mondoohq/test-project`) — used as the project's stable identifier across GitLab APIs
+  // Path with namespace
+  //
+  // Full path including the namespace (e.g., `mondoohq/test-project`), used as
+  // the project's stable identifier across GitLab APIs.
   fullPath string
   // Create date of the project
   createdAt time
@@ -838,10 +853,12 @@ gitlab.project @defaults("fullName visibility webURL") {
 
 // GitLab project integration
 //
-// Examine an active integration (external service) wired into the project,
-// such as Slack, Jira, or a generic webhook-style service. `slug` identifies
-// the integration type and the event flags show which project events are
-// forwarded to it. Integrations are a data-egress and inbound-trigger surface.
+// External service wired into a project, such as Slack, Jira, or a generic
+// webhook-style service. The `slug` field identifies the integration type
+// and the per-event boolean flags show which project events are forwarded to
+// the service. Because integrations push project activity outward and can
+// accept inbound triggers, they are a data-egress and inbound-trigger surface
+// worth auditing.
 private gitlab.project.integration @defaults("title slug active") {
   // Integration ID
   id int
@@ -893,10 +910,12 @@ private gitlab.project.integration @defaults("title slug active") {
 
 // GitLab protected environment
 //
-// Examine a protected deployment environment and the gates guarding it. The
-// `name` field is the environment (or wildcard). `deployAccessLevels` lists
-// who may deploy, `requiredApprovalCount` is the number of approvals a
-// deployment needs, and `approvalRules` describes the approver groups/users.
+// Deployment gates guarding a protected environment (such as production).
+// The `name` field selects the environment or wildcard pattern it covers,
+// for example `production` or `review/*`. `deployAccessLevels` restricts who
+// may deploy, `requiredApprovalCount` sets how many approvals a deployment
+// needs, and `approvalRules` names the approver groups and users. Weak or
+// missing gates on a production environment let unreviewed changes reach it.
 private gitlab.project.protectedEnvironment @defaults("name requiredApprovalCount") {
   // Environment name or wildcard pattern
   name string
@@ -916,11 +935,11 @@ private gitlab.project.protectedEnvironment @defaults("name requiredApprovalCoun
 
 // CI/CD job-token access scope
 //
-// Examine how the project restricts inbound CI/CD job-token access. When
+// Inbound CI/CD job-token access controls for the project, governing which
+// other projects and groups may use their job tokens to reach it. When
 // `inboundEnabled` is true, only the projects in `inboundAllowlistProjects`
-// and groups in `allowlistGroups` may use their job tokens to access this
-// project; when false, any project's job token may reach it (a lateral-
-// movement risk).
+// and groups in `allowlistGroups` are permitted; when false, any project's
+// job token may reach this project, a lateral-movement risk worth auditing.
 private gitlab.project.jobTokenScope @defaults("inboundEnabled") {
   // Whether inbound job-token access is limited to the allowlist
   inboundEnabled bool
@@ -932,9 +951,10 @@ private gitlab.project.jobTokenScope @defaults("inboundEnabled") {
 
 // GitLab protected tag
 //
-// Examine a protected tag rule and the access levels permitted to create
-// tags matching it. The `name` is the tag name or wildcard pattern (for
-// example `v*`). `createAccessLevels` lists each role, user, group, or deploy
+// Protected tag rule and the access levels permitted to create tags
+// matching it, so you can audit who can cut release tags on the
+// project. The `name` is the tag name or wildcard pattern (for example
+// `v*`). `createAccessLevels` lists each role, user, group, or deploy
 // key allowed to create the tag.
 private gitlab.project.protectedTag @defaults("name") {
   // Tag name or wildcard pattern
@@ -945,14 +965,14 @@ private gitlab.project.protectedTag @defaults("name") {
 
 // GitLab project approval rule
 //
-// Examine a single approval rule that gates merging into the project.
+// A single approval rule that gates merging into the project.
 // The rule's `ruleType` distinguishes `any_approver` (any user with
 // write access can approve), `regular` (a defined list of users and/or
 // groups), `code_owner` (the relevant CODEOWNERS entries must approve),
 // and `report_approver` (a security or license-scanning report must
-// pass — `reportType` narrows this further to `license_scanning`,
+// pass, with `reportType` narrowing this further to `license_scanning`,
 // `code_coverage`, or `scan_finding`). `approvalsRequired` is the
-// number of approvals the rule demands. The typed `users`,
+// number of approvals the rule demands. The `users`,
 // `eligibleApprovers`, `groups`, and `protectedBranches` accessors
 // resolve the approvers and the branches the rule applies to.
 // `appliesToAllProtectedBranches` is true when the rule covers every
@@ -992,17 +1012,14 @@ private gitlab.project.approvalRule @defaults("name ruleType approvalsRequired")
 
 // GitLab project CODEOWNERS file
 //
-// Examine the CODEOWNERS file for a project. The file is resolved
-// from the default branch in this order: `CODEOWNERS`,
-// `.gitlab/CODEOWNERS`, `docs/CODEOWNERS`. Surfaces the `path` the
-// file was found at, the raw `content`, the parsed `rules` (each
-// with `section`, `pattern`, `owners`, `required`, and
-// `approvalsRequired`), and the convenience flag `present`
-// indicating whether any CODEOWNERS file exists at all. Use this to
-// audit code-review coverage gaps (paths with no required owners),
-// the presence of section overrides (`[Section][Approvals=N]`), and
-// any `^` optional sections that weaken default required-review
-// enforcement.
+// CODEOWNERS file for a project, resolved from the default branch in
+// this order: `CODEOWNERS`, `.gitlab/CODEOWNERS`, `docs/CODEOWNERS`.
+// The `present` flag reports whether any CODEOWNERS file exists at
+// all, `path` gives the location it was found at, `content` is the
+// raw text, and `rules` holds the parsed entries. Use this to audit
+// code-review coverage gaps (paths with no required owners), section
+// overrides (`[Section][Approvals=N]`), and any `^` optional sections
+// that weaken default required-review enforcement.
 private gitlab.project.codeowners @defaults("path present") {
   // Whether a CODEOWNERS file exists on the default branch
   present bool
@@ -1016,18 +1033,16 @@ private gitlab.project.codeowners @defaults("path present") {
 
 // GitLab CODEOWNERS rule
 //
-// Examine a single rule extracted from a CODEOWNERS file. The
-// `pattern` is the path glob the rule applies to; `owners` lists
-// the user/group identifiers (with the leading `@` preserved); the
-// `section` field carries the name of the `[Section]` header the
-// rule appears under (empty for rules outside any section);
-// `required` is true when the section was declared as
-// `[Section]` (without a leading `^`); `optional` is true when the
-// section was declared as `^[Section]`. The `approvalsRequired`
-// field captures the section-level override (e.g.
-// `[Section][2]`); it is 0 when no override is set. The
-// `lineNumber` is preserved so audit reports can cite the file
-// location.
+// Single rule extracted from a CODEOWNERS file. The `pattern` is the
+// path glob the rule applies to; `owners` lists the user/group
+// identifiers (with the leading `@` preserved); `section` carries the
+// name of the `[Section]` header the rule appears under (empty for
+// rules outside any section); `required` is true when the section was
+// declared as `[Section]` (without a leading `^`); `optional` is true
+// when the section was declared as `^[Section]`. The
+// `approvalsRequired` field captures the section-level override (e.g.
+// `[Section][2]`); it is 0 when no override is set. The `lineNumber`
+// is preserved so audit reports can cite the file location.
 private gitlab.project.codeowners.rule @defaults("pattern owners section") {
   // Line number of the rule within the file (1-indexed)
   lineNumber int
@@ -1035,7 +1050,7 @@ private gitlab.project.codeowners.rule @defaults("pattern owners section") {
   section string
   // Whether the parent section is `^[Section]` (optional review)
   optional bool
-  // Whether the parent section enforces required review (the default — `[Section]`)
+  // Whether the parent section enforces required review (the default, `[Section]`)
   required bool
   // Section-level override of the number of required approvals; 0 when no override is set
   approvalsRequired int
@@ -1045,7 +1060,18 @@ private gitlab.project.codeowners.rule @defaults("pattern owners section") {
   owners []string
 }
 
-// GitLab project approval settings
+// Merge-request approval settings for a GitLab project
+//
+// The project's approval-enforcement configuration: how many approvals a
+// merge request needs before it can merge, whether those approvals are reset
+// when new commits are pushed, and who is trusted to grant them. The boolean
+// controls surface common weakenings of code review, such as authors or
+// committers approving their own changes (mergeRequestsAuthorApproval,
+// mergeRequestsDisableCommittersApproval), reviewers overriding the configured
+// approvers per merge request (disableOverridingApproversPerMergeRequest), and
+// whether a password is required to approve (requirePasswordToApprove). The
+// approvers and approverGroups lists name the users and groups configured as
+// default approvers on the project.
 private gitlab.project.approvalSetting @defaults("approvalsBeforeMerge requirePasswordToApprove") {
   // Number of approvals before merge
   approvalsBeforeMerge int
@@ -1068,6 +1094,16 @@ private gitlab.project.approvalSetting @defaults("approvalsBeforeMerge requirePa
 }
 
 // GitLab protected branch
+//
+// Branch protection rules for a project, controlling who can push, merge,
+// and remove protection on a given branch. Auditing these settings verifies
+// that critical branches (such as the default branch) enforce review and
+// prevent unauthorized or force pushes. Each branch is identified by `name`,
+// and `pushAccessLevels`, `mergeAccessLevels`, and `unprotectAccessLevels`
+// spell out exactly which roles, users, groups, or deploy keys hold each
+// permission. The `allowForcePush` and `codeOwnerApproval` flags capture
+// whether history-rewriting pushes are permitted and whether Code Owner
+// sign-off is required before merging.
 private gitlab.project.protectedBranch @defaults("name allowForcePush") {
   // Branch name
   name string
@@ -1090,8 +1126,8 @@ private gitlab.project.protectedBranch @defaults("name allowForcePush") {
 // A single access grant on a protected branch, describing who may perform the
 // push, merge, or unprotect action. Each entry grants access either to a role
 // (via `accessLevel`), a specific `user`, a specific `group`, or a deploy key
-// (via `deployKeyId`). Read these from a protected branch's `pushAccessLevels`,
-// `mergeAccessLevels`, or `unprotectAccessLevels`.
+// (via `deployKeyId`). Exactly one of these targets is set per grant; the
+// others are null or zero.
 private gitlab.protectedBranch.accessLevel @defaults("accessLevel accessLevelDescription") {
   // Numeric access level (0 No access, 30 Developer, 40 Maintainer, 60 Admin)
   accessLevel int
@@ -1105,23 +1141,44 @@ private gitlab.protectedBranch.accessLevel @defaults("accessLevel accessLevelDes
   group() gitlab.group
 }
 
-// GitLab project file
+// GitLab project repository file
+//
+// File tracked in a GitLab project's repository, listed recursively from
+// the project's default branch. Reading `content` returns the decoded file
+// text, which lets you audit tracked files for committed secrets,
+// credentials, or insecure configuration. The `path` field is the file's
+// full path within the repository and serves as the selection key.
 private gitlab.project.file @defaults("path type") {
-  // File path
+  // Full path of the file within the repository
   path string
-  // File type
+  // Repository tree entry type
+  //
+  // Object type of the entry in the git tree. Only file blobs are listed,
+  // so this is always "blob" (directory "tree" entries are excluded).
   type string
-  // File name
+  // File name (final path segment)
   name string
-  // File content
+  // Decoded file content
+  //
+  // Raw text of the file at the project's default branch, fetched on
+  // access. Query it to scan tracked files for secrets, credentials, or
+  // insecure settings.
   content() string
 }
 
 // GitLab project webhook
 //
-// Note: GitLab's API never returns the configured secret token in list/get
-// responses (write-only field), so we cannot expose its presence directly.
-// Use the GitLab UI or audit logs to verify a token is configured.
+// HTTP callback registered against a project that GitLab invokes to
+// deliver event payloads to an external endpoint whenever selected
+// activity occurs, such as pushes, merge requests, or pipeline runs.
+// Audit webhooks to confirm payloads reach only trusted destinations
+// over a verified TLS connection: url is the delivery target and
+// sslVerification reports whether the receiver's certificate is
+// validated. The per-event boolean fields (pushEvents,
+// mergeRequestsEvents, pipelineEvents, and the rest) show which
+// activity is sent to that endpoint. The configured secret token is
+// never returned by the API, so its presence cannot be read here;
+// confirm token configuration through the GitLab UI or audit logs.
 private gitlab.project.webhook @defaults("url sslVerification") {
   // Webhook ID
   id int
@@ -1131,7 +1188,11 @@ private gitlab.project.webhook @defaults("url sslVerification") {
   name string
   // Webhook description
   description string
-  // Whether SSL verification is enabled - disabling permits man-in-the-middle interception of webhook payloads
+  // Whether TLS certificate verification is enabled for webhook delivery
+  //
+  // When false, GitLab does not validate the receiving endpoint's TLS
+  // certificate, which permits man-in-the-middle interception of the
+  // webhook payload and any secret token sent with it.
   sslVerification bool
   // Whether push events trigger the webhook
   pushEvents bool
@@ -1175,21 +1236,46 @@ private gitlab.project.webhook @defaults("url sslVerification") {
   branchFilterStrategy string
   // Custom webhook payload template configured for this hook (empty when default payload is used)
   customWebhookTemplate string
-  // Custom HTTP headers sent with the webhook request (values may be redacted by GitLab)
+  // Custom HTTP headers sent with the webhook request
+  //
+  // Keyed by header name (for example an `Authorization` or custom
+  // `X-*` header) with the configured header value. GitLab redacts the
+  // values of headers it treats as secret, so those entries may be
+  // empty or masked.
   customHeaders map[string]string
-  // URL variables interpolated into the webhook URL (values may be redacted by GitLab)
+  // URL variables interpolated into the webhook URL
+  //
+  // Keyed by variable name, with the value substituted into `{name}`
+  // placeholders in the webhook url. Values GitLab treats as secret
+  // are redacted, so they may be empty or masked.
   urlVariables map[string]string
   // Webhook creation time
   createdAt time
   // Time until which the webhook is disabled (set by GitLab when too many failures occur)
   disabledUntil time
-  // Alert status of the webhook
+  // Delivery health of the webhook
+  //
+  // One of executable (delivering normally), disabled (permanently
+  // turned off after repeated delivery failures), or
+  // temporarily_disabled (auto-paused after recent failures, with
+  // disabledUntil giving the resume time).
   alertStatus string
   // The project this webhook is registered against
   project() gitlab.project
 }
 
 // GitLab project merge request
+//
+// Proposed set of changes from a source branch into a target branch,
+// identified by internalId (the project-scoped merge request number).
+// Merge requests are where code review and merge gating happen, so they
+// are central to auditing change control: state and detailedMergeStatus
+// show whether a change merged and whether it satisfied gating rules,
+// blockingDiscussionsResolved and reviewers reveal review coverage, and
+// mergeWhenPipelineSucceeds, forceRemoveSourceBranch, and
+// allowMaintainerToPush expose the merge automation and source-branch
+// settings in effect. The author, mergeUser, and closedBy accessors
+// attribute who opened, merged, and closed each request.
 private gitlab.project.mergeRequest @defaults("internalId title state") {
   // Merge request ID
   id int
@@ -1260,6 +1346,12 @@ private gitlab.project.mergeRequest @defaults("internalId title state") {
 }
 
 // GitLab project issue
+//
+// Single issue tracked in a project, exposing its state, author, labels,
+// milestone, and due date. The confidential flag marks issues restricted
+// to project members, and state distinguishes opened from closed work.
+// Useful for auditing unresolved confidential reports or stale open items,
+// and for confirming that sensitive issues stay marked confidential.
 private gitlab.project.issue @defaults("internalId title state") {
   // Issue ID
   id int
@@ -1294,6 +1386,15 @@ private gitlab.project.issue @defaults("internalId title state") {
 }
 
 // GitLab project release
+//
+// A published or scheduled release of a project, keyed by its Git
+// tag. Releases mark shippable versions and carry the release notes,
+// the commit they point at, the downloadable assets (source archives
+// and attached links), and any collected evidence. Use it to audit
+// what was shipped, verify that releases reference the expected
+// commits, and check release evidence for supply-chain integrity. The
+// upcomingRelease field distinguishes scheduled-but-unpublished
+// releases from live ones.
 private gitlab.project.release @defaults("tagName name") {
   // Release tag name
   tagName string
@@ -1328,6 +1429,16 @@ private gitlab.project.release @defaults("tagName name") {
 }
 
 // GitLab project CI/CD variable
+//
+// A single CI/CD variable exposed to a project's pipelines, holding a
+// key/value pair that jobs read as an environment variable or file. These
+// variables frequently carry secrets (deploy tokens, cloud credentials, API
+// keys), so they are a common audit target: `masked` reports whether the
+// value is hidden in job logs, `protected` restricts it to jobs on protected
+// branches and tags, and `environmentScope` limits which deployment
+// environments can use it. A variable is identified by its `key` together
+// with its `environmentScope`, so the same key can exist with different
+// values per environment.
 private gitlab.project.variable @defaults("key masked protected") {
   // Variable key/name
   key string
@@ -1348,6 +1459,13 @@ private gitlab.project.variable @defaults("key masked protected") {
 }
 
 // GitLab project milestone
+//
+// Milestone defined on a GitLab project, used to group issues and merge
+// requests toward a shared goal or release. Tracks the milestone title,
+// description, and scheduling window (startDate and dueDate), along with
+// its state (active or closed) and whether it has passed its due date
+// (expired). The internalId is the project-scoped number shown in the
+// GitLab UI, while id is the globally unique identifier.
 private gitlab.project.milestone @defaults("internalId title state") {
   // Milestone ID
   id int
@@ -1376,6 +1494,15 @@ private gitlab.project.milestone @defaults("internalId title state") {
 }
 
 // GitLab project label
+//
+// Label defined on a GitLab project, used to categorize and triage
+// issues and merge requests. Fields cover the label's display
+// appearance (color, textColor), its description, and the counts of
+// open and closed issues and open merge requests carrying the label,
+// which help audit how labels are applied across a project. The
+// priority field orders labels within the project, and isProjectLabel
+// distinguishes a label scoped to this project from a group label
+// inherited across the group's projects.
 private gitlab.project.label @defaults("name color") {
   // Label ID
   id int
@@ -1433,7 +1560,7 @@ private gitlab.group.label @defaults("name color") {
 
 // GitLab group CI/CD variable
 //
-// Examine a CI/CD variable defined at the group level. Group variables are
+// CI/CD variable defined at the group level. Group variables are
 // inherited by every project in the group, so an unmasked or unprotected
 // secret here is exposed to all of that group's pipelines. Use `masked` to
 // find values printed in job logs and `protected` to find values available on
@@ -1459,7 +1586,7 @@ private gitlab.group.variable @defaults("key masked protected") {
 
 // GitLab group webhook
 //
-// Examine a webhook registered at the group level. Group webhooks fire for
+// Webhook registered at the group level. Group webhooks fire for
 // events across every project in the group, making a misconfigured endpoint a
 // broad data-egress and inbound-trigger surface. `sslVerification` reflects
 // whether TLS certificates are validated (disabling it permits man-in-the-
@@ -1538,6 +1665,16 @@ private gitlab.group.webhook @defaults("url sslVerification") {
 }
 
 // GitLab CI/CD pipeline
+//
+// A single CI/CD pipeline run for the project, covering how it was
+// triggered and how it finished. The `status` field reports the run's
+// outcome (success, failed, canceled, and so on) and `source` records
+// what kicked it off (a push, a schedule, an API call, a merge request
+// event). The `ref`, `sha`, and `user` fields tie the run to the branch
+// or tag, commit, and account behind it, while `yamlErrors` surfaces
+// invalid .gitlab-ci.yml configuration and `coverage` reports the
+// measured test coverage. Useful for auditing build provenance, failed
+// or skipped runs, and who is able to trigger pipelines.
 private gitlab.project.pipeline @defaults("id status ref") {
   // Pipeline ID
   id int
@@ -1592,19 +1729,18 @@ private gitlab.project.pipeline @defaults("id status ref") {
 
 // GitLab CI/CD runner
 //
-// Examine a runner registered for the project. Surfaces the basic
-// inventory fields (`id`, `name`, `description`, `runnerType`,
-// `paused`, `isShared`, `online`, `status`) and a set of
-// security-relevant fields fetched on demand via the runner-details
-// endpoint: `tagList` (job-scoping labels), `runUntagged` (whether
-// the runner accepts jobs without matching tags),
-// `lockedToProject`, `accessLevel` ("not_protected" /
-// "ref_protected" — whether the runner is allowed on non-protected
-// refs), `maximumTimeout`, `contactedAt` (last check-in),
-// `maintenanceNote`, and `projects` / `groups` listing the projects
-// and groups the runner is associated with. Use these to audit
-// untagged shared-runner exposure, runners pinned to protected
-// refs, and stale runners that have not contacted GitLab.
+// CI/CD runner registered for a GitLab project
+//
+// GitLab Runner that executes CI/CD jobs for the project, covering
+// project-specific runners as well as shared instance or group
+// runners visible to the project. Beyond inventory (type, paused,
+// shared, online, status), it exposes security-relevant settings
+// used to audit job exposure: whether the runner picks up untagged
+// jobs, whether it is locked to its associated projects, and the
+// access level governing whether it may run on non-protected refs.
+// Use it to find untagged shared-runner exposure, runners that are
+// not restricted to protected refs, and stale runners that have not
+// checked in.
 private gitlab.project.runner @defaults("id description status runnerType") {
   // Runner ID
   id int
@@ -1624,7 +1760,7 @@ private gitlab.project.runner @defaults("id description status runnerType") {
   status string
   // Registration token expiry; nil when the token does not expire
   tokenExpiresAt time
-  // Tags applied to the runner — jobs with matching `tags:` are routed here
+  // Tags applied to the runner; jobs whose `tags:` match are routed here
   tagList() []string
   // Whether the runner picks up jobs that don't carry a `tags:` directive
   runUntagged() bool
@@ -1640,11 +1776,19 @@ private gitlab.project.runner @defaults("id description status runnerType") {
   maintenanceNote() string
   // Path-with-namespace of projects the runner is associated with (e.g. "acme/api")
   projects() []string
-  // Web URLs of groups the runner is associated with (group-type runners) — the GitLab SDK exposes only the URL form for runner-detail groups
+  // Web URLs of the groups the runner is associated with (group-type runners)
   groups() []string
 }
 
 // GitLab project push rules
+//
+// Server-side constraints GitLab enforces on every push to a project's
+// repository. Push rules govern commit message formats, branch naming,
+// author and committer identity, file names and sizes, secret-leak
+// prevention, and commit-signature requirements. Query this to audit
+// whether a project blocks known secrets (preventSecrets), rejects
+// unsigned commits (rejectUnsignedCommits), and restricts commits to
+// verified GitLab users (commitCommitterCheck).
 private gitlab.project.pushRule @defaults("preventSecrets rejectUnsignedCommits commitCommitterCheck") {
   // Push rule ID
   id int
@@ -1713,6 +1857,15 @@ private gitlab.group.pushRule @defaults("preventSecrets rejectUnsignedCommits co
 }
 
 // GitLab project access token
+//
+// Project-scoped credential that authenticates automation and CI/CD
+// workloads as a dedicated bot user rather than a human account.
+// Review these tokens to catch over-privileged scopes, tokens that
+// never expire, revoked-but-lingering credentials, and tokens that
+// have not been used in a long time. The `scopes` and `accessLevel`
+// fields together define what a token can do, `expiresAt` and
+// `lastUsedAt` gauge exposure over time, and `revoked` and `active`
+// report whether it can still be used.
 private gitlab.project.accessToken @defaults("id name active expiresAt") {
   // Token ID
   id int
@@ -1731,6 +1884,10 @@ private gitlab.project.accessToken @defaults("id name active expiresAt") {
   // Last time the token was used
   lastUsedAt time
   // Access level granted by the token
+  //
+  // Numeric GitLab membership level the token acts with: 10 (Guest),
+  // 20 (Reporter), 30 (Developer), 40 (Maintainer), or 50 (Owner).
+  // Higher values grant broader project permissions.
   accessLevel int
   // Bot user the token authenticates as, or null when it cannot be resolved
   user() gitlab.user
@@ -1761,6 +1918,14 @@ private gitlab.group.accessToken @defaults("id name active expiresAt") {
 }
 
 // GitLab project deploy key
+//
+// SSH public key that grants a machine or automation access to a project's
+// repository without a user account. Deploy keys are a common supply-chain
+// exposure: `canPush` reports whether the key has write access (not just
+// read), `key` is the raw public key material, `fingerprint` and
+// `fingerprintSHA256` identify it, and `expiresAt` shows whether the key ever
+// stops being valid. Audit these to find long-lived or push-capable keys that
+// widen the project's attack surface.
 private gitlab.project.deployKey @defaults("id title canPush") {
   // Deploy key ID
   id int
@@ -1785,6 +1950,14 @@ private gitlab.project.deployKey @defaults("id title canPush") {
 }
 
 // GitLab project deploy token
+//
+// Long-lived credential scoped to a single project that grants clients
+// (CI runners, external systems) read or write access to the project's
+// Git repository and its container and package registries. Auditing
+// deploy tokens surfaces standing credentials that bypass user
+// authentication: check `expired` and `revoked` to find inactive
+// entries and `scopes` to confirm each token is limited to the access
+// it actually needs.
 private gitlab.project.deployToken @defaults("id name expired revoked") {
   // Deploy token ID
   id int
@@ -1798,7 +1971,10 @@ private gitlab.project.deployToken @defaults("id name expired revoked") {
   revoked bool
   // Whether the token has expired
   expired bool
-  // Token scopes (read_repository, read_registry, write_registry, etc.)
+  // Access the token grants
+  //
+  // One or more of read_repository, read_registry, write_registry,
+  // read_package_registry, and write_package_registry.
   scopes []string
 }
 
@@ -1839,6 +2015,19 @@ private gitlab.group.protectedBranch @defaults("name allowForcePush") {
 }
 
 // GitLab project security settings
+//
+// Project-level toggles that govern GitLab's built-in security scanning
+// and remediation features. `secretPushProtectionEnabled` blocks commits
+// that contain detected secrets before they reach the repository, and
+// `continuousVulnerabilityScansEnabled` re-scans existing dependencies as
+// new advisories are published. The `autoFix*` flags control whether
+// GitLab opens automatic merge requests to remediate findings from SAST,
+// DAST, dependency scanning, and container scanning, and
+// `containerScanningForRegistryEnabled` extends container scanning to
+// images already stored in the project's registry. Audit these to confirm
+// a project enforces the scanning coverage its compliance policy expects.
+// Most fields require a GitLab tier that includes the corresponding
+// scanner.
 private gitlab.project.securitySetting @defaults("secretPushProtectionEnabled continuousVulnerabilityScansEnabled") {
   // Whether auto-fix for container scanning is enabled
   autoFixContainerScanning bool
@@ -1858,9 +2047,9 @@ private gitlab.project.securitySetting @defaults("secretPushProtectionEnabled co
 
 // Security scanner finding from a GitLab project
 //
-// Examine confirmed vulnerabilities surfaced by GitLab's built-in
-// security scanners — SAST, DAST, dependency scanning, secret
-// detection, and container scanning. Filter by `severity`, `state`,
+// Confirmed vulnerabilities surfaced by GitLab's built-in security
+// scanners: SAST, DAST, dependency scanning, secret detection, and
+// container scanning. Filter by `severity`, `state`,
 // or `reportType` to drive audit queries: open CRITICAL findings,
 // undismissed secrets in commits, or unresolved CVEs in
 // dependencies. Use `scanner` to attribute a finding to the tool
@@ -1949,7 +2138,7 @@ private gitlab.project.vulnerability.scanner @defaults("name vendor") {
 
 // Container registry repository in a GitLab project
 //
-// Examine a Docker / OCI image repository published to the project's
+// Docker or OCI image repository published to the project's
 // container registry. Each repository carries `name`, `path` (the
 // pull path prefix), and `location` (the full pull URL).
 // `tagsCount` is a fast snapshot; iterate `tags` for the full list
@@ -1987,7 +2176,7 @@ private gitlab.project.containerRegistryRepository @defaults("path tagsCount sta
 
 // Container registry repository tag
 //
-// A single tag in a container repository — what `docker pull` would
+// A single tag in a container repository, what `docker pull` would
 // resolve. Use `digest` for tag-pinning audits (a moving tag like
 // `latest` can be re-pushed; the digest is immutable) and
 // `totalSize` to spot oversized images. `location` is the full
@@ -2013,10 +2202,10 @@ private gitlab.project.containerRegistryRepository.tag @defaults("name digest to
 
 // Container registry expiration (cleanup) policy
 //
-// Defines how the project's container registry trims old tags. The
-// policy runs on a `cadence` and deletes tags older than
-// `olderThan` whose names match `nameRegexDelete`, keeping at most
-// `keepN` per repository and always preserving names matching
+// Cleanup policy that trims old tags from the project's container
+// registry. The policy runs on a `cadence` and deletes tags older
+// than `olderThan` whose names match `nameRegexDelete`, keeping at
+// most `keepN` per repository and always preserving names matching
 // `nameRegexKeep`. `enabled` reflects whether the policy is active;
 // `nextRunAt` is the next scheduled run.
 private gitlab.project.containerExpirationPolicy @defaults("enabled cadence keepN olderThan") {
@@ -2042,9 +2231,9 @@ private gitlab.project.containerExpirationPolicy @defaults("enabled cadence keep
 
 // Container registry protection rule
 //
-// Gates pushes and deletes against container repositories whose path
+// Push and delete protection for container repositories whose path
 // matches `repositoryPathPattern`. The two minimum-access-level
-// fields enforce who in the project can perform each action — one of
+// fields enforce who in the project can perform each action: one of
 // `maintainer`, `owner`, or `admin`. An empty value means the action
 // is not protected.
 private gitlab.project.containerRegistryProtectionRule @defaults("repositoryPathPattern minimumAccessLevelForPush minimumAccessLevelForDelete") {
@@ -2064,16 +2253,14 @@ private gitlab.project.containerRegistryProtectionRule @defaults("repositoryPath
 
 // Package published to a GitLab project's package registry
 //
-// Examine a single package version in the project's package
-// registry. `packageType` distinguishes the package format
-// (`maven`, `npm`, `conan`, `nuget`, `pypi`, `composer`, `generic`,
-// `golang`, `debian`, `helm`, `terraform_module`, `rubygems`,
-// `ml_model`). `version` is the published version string; `tags`
-// lists distribution tags (e.g. npm `latest`). `status` is one of
-// `default`, `hidden`, `processing`, `error`, or `pending_destruction`.
-// `lastDownloadedAt` is null until the package is first pulled.
-// Iterate `files` for the package's contained artifacts with their
-// SHA-256/SHA-1/MD5 checksums.
+// Single package version in the project's package registry.
+// `packageType` distinguishes the package format (`maven`, `npm`,
+// `conan`, `nuget`, `pypi`, `composer`, `generic`, `golang`, `debian`,
+// `helm`, `terraform_module`, `rubygems`, `ml_model`) and `status` its
+// lifecycle state (`default`, `hidden`, `processing`, `error`,
+// `pending_destruction`). Auditing the registry reveals what artifacts
+// a project publishes; `files` holds the contained artifacts with their
+// SHA-256/SHA-1/MD5 checksums for tamper detection.
 private gitlab.project.package @defaults("name version packageType status") {
   // Package ID
   id int
@@ -2108,8 +2295,8 @@ private gitlab.project.package @defaults("name version packageType status") {
 
 // File within a GitLab package
 //
-// One artifact inside a package — a `.jar`, `.tgz`, `.whl`, etc.
-// Use the SHA-256 checksum for tamper detection and SBOM
+// One artifact inside a package, such as a `.jar`, `.tgz`, or `.whl`.
+// The SHA-256 checksum supports tamper detection and SBOM
 // correlation; SHA-1 and MD5 are provided for legacy formats that
 // publish them.
 private gitlab.project.package.file @defaults("fileName size fileSHA256") {
@@ -2133,12 +2320,11 @@ private gitlab.project.package.file @defaults("fileName size fileSHA256") {
 
 // Package protection rule
 //
-// Gates pushes and deletes against packages whose name matches
-// `packageNamePattern` (with the format restricted to
-// `packageType`). The two minimum-access-level fields enforce who
-// can perform each action — one of `developer`, `maintainer`,
-// `owner`, or `admin`. An empty value means the action is not
-// protected.
+// Access control that gates pushes and deletes against packages whose
+// name matches `packageNamePattern` (with the format restricted to
+// `packageType`). The two minimum-access-level fields enforce who can
+// perform each action: one of `developer`, `maintainer`, `owner`, or
+// `admin`. An empty value means the action is not protected.
 private gitlab.project.packageProtectionRule @defaults("packageNamePattern packageType minimumAccessLevelForPush minimumAccessLevelForDelete") {
   // Rule ID
   id int


### PR DESCRIPTION
## What

A documentation pass over `gitlab.lr`, applying the pattern established across the provider-wide sweep (starting with S3, #9146). These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**~38 services, ~52 edits.** (`gitlab.project` and its ~30 sub-resources were audited per-sub-resource so the large root got its own focused pass.)

## Changes

- **Two-part descriptions added** to user-queryable resources that were title-only — project `accessToken`, `approvalSetting`, `deployKey`, `deployToken`, `file`, `issue`, `label`, `mergeRequest`, `milestone`, `pipeline`, `protectedBranch`, `pushRule`, `release`, `securitySetting`, and `member` — conveying change-control and credential significance.
- **Verb-led descriptions** (`Examine`/`Defines`/`Records`) rewritten to lead with the noun and drop field enumeration; added selection-key examples.
- **Enum values** (`accessToken`/`deployToken` access levels and scopes) and a `failedLogin` title/type-mismatch fix applied to *both* audit-event resources (group and project).
- **Style-rule cleanup** — em dashes, `typed`/`fetched on demand` mechanism leaks, and parent-navigation hints.

## The pattern (same as prior PRs)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, no title over the 150-char cap, no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and the GitLab SDK), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.
