### PR TITLE
📄 openstack: enrich resource and field documentation across services

### DIFF
--- a/providers/openstack/resources/openstack.lr
+++ b/providers/openstack/resources/openstack.lr
@@ -6,29 +6,18 @@ option go_package = "go.mondoo.com/mql/v13/providers/openstack/resources"
 
 // OpenStack connection
 //
-// Use the OpenStack provider to query identity, compute, network, storage, and
-// other service resources within a scoped project. The root resource exposes
-// Keystone principals (`projects`, `users`, `roles`, `domains`, `groups`),
-// Keystone credentials and the service catalog (`credentials`, `trusts`,
-// `identityServices`, `identityEndpoints`, `regions`),
-// Nova compute assets (`servers`, `flavors`, `keypairs`, `serverGroups`,
-// `hypervisors`, `computeServices`, `aggregates`, `computeLimits`), Placement
-// resource inventory (`resourceProviders`), Neutron
-// networking (`networks`, `subnets`, `routers`, `ports`, `floatingIps`,
-// `securityGroups`, `subnetPools`, `qosPolicies`, `trunks`), FWaaS v2
-// (`firewallGroups`, `firewallPolicies`, `firewallRules`), VPNaaS v2
-// (`vpnServices`, `vpnIkePolicies`, `vpnIpsecPolicies`, `vpnEndpointGroups`,
-// `vpnSiteConnections`), Cinder block storage
-// (`volumes`, `snapshots`, `backups`, `volumeTypes`, `blockStorageQuotaSet`),
-// Glance images (`images`), Barbican key management (`secrets`,
-// `secretContainers`, `secretOrders`), Octavia load balancing
-// (`loadBalancers`, `listeners`, `pools`, `healthMonitors`, `l7Policies`),
-// Swift object storage (`objectStorageAccount`, `objectStorageContainers`),
-// Designate DNS (`dnsZones`), Manila shared file systems (`shares`,
-// `securityServices`, `shareNetworks`), Magnum container infrastructure
-// (`clusters`, `clusterTemplates`), Trove databases (`databaseInstances`),
-// Ironic bare metal (`baremetalNodes`), and Heat orchestration (`stacks`).
-// `authUrl`, `projectId`, and `region` identify the connection scope.
+// Root entry point to a single scoped OpenStack project, gathering its
+// identity, compute, networking, storage, load-balancing, key-management, DNS,
+// shared-file, container-infrastructure, database, bare-metal, and
+// orchestration resources under one connection. Keystone principals and the
+// service catalog support identity and access-control audits (who exists, what
+// roles they hold, and where credentials and trusts delegate authority); Nova,
+// Placement, and Cinder collections surface the compute, capacity, and
+// block-storage posture of the project; and the Neutron, FWaaS v2, VPNaaS v2,
+// Octavia, and Barbican collections cover the networking, perimeter
+// firewalling, site-to-site VPN, load-balancing, and secret-management surface
+// most relevant to security review. The `authUrl`, `projectId`, and `region`
+// fields identify the connection scope every other resource is read against.
 openstack {
   // Keystone auth URL the connection is bound to
   authUrl string
@@ -184,6 +173,15 @@ openstack {
 }
 
 // OpenStack Keystone project (formerly "tenant")
+//
+// Keystone project that owns and scopes cloud resources such as compute
+// instances, networks, and volumes. Projects are the primary unit of
+// ownership, quota, and access control in OpenStack, so auditing them
+// reveals which tenancies exist, whether they are still enabled, and how
+// they nest beneath domains and parent projects. Select a project by its
+// UUID, for example `openstack.project(id: "a1b2c3d4-...")`. The isDomain
+// field distinguishes an ordinary project from one that acts as a domain,
+// and parent is null for top-level projects.
 private openstack.project @defaults("id name enabled") {
   init(id? string)
   // Project ID (UUID)
@@ -205,6 +203,15 @@ private openstack.project @defaults("id name enabled") {
 }
 
 // OpenStack Keystone user
+//
+// Identity account in the Keystone identity service, selected by its
+// UUID with `openstack.user(id: "...")`. Exposes the account's enabled
+// state, password expiry, and per-user security options such as
+// multi-factor authentication enforcement and lockout exemption, along
+// with the domain it belongs to, its effective role assignments, group
+// memberships, and the application and EC2-compatible credentials it
+// owns. Audit these to find over-privileged, stale, or MFA-exempt
+// accounts.
 private openstack.user @defaults("id name enabled") {
   init(id? string)
   // User ID (UUID)
@@ -240,6 +247,15 @@ private openstack.user @defaults("id name enabled") {
 }
 
 // OpenStack Keystone role
+//
+// Named permission set that Keystone grants to users or groups on a
+// project or domain, driving what actions an identity may perform.
+// Auditing roles surfaces the privilege vocabulary of the cloud (for
+// example admin, member, and reader) so you can reason about who holds
+// elevated access. A role is selected by its UUID, for example
+// openstack.role(id: "9fe2ff9ee4384b1894a90878d3e92bab"). The domain
+// field is null for global roles and set for roles scoped to a single
+// domain.
 private openstack.role @defaults("id name") {
   init(id? string)
   // Role ID (UUID)
@@ -253,6 +269,13 @@ private openstack.role @defaults("id name") {
 }
 
 // OpenStack Keystone domain
+//
+// Top-level identity boundary in Keystone that contains projects, users, and
+// groups, providing administrative separation between tenants. Auditing a
+// domain reveals whether it is enabled and which groups it holds, which
+// together govern the scope of authentication and authorization within it. A
+// domain is selected by its `id`, for example `openstack.domain(id: "default")`
+// for the bootstrap domain.
 private openstack.domain @defaults("id name enabled") {
   init(id? string)
   // Domain ID (UUID, or "default" for the bootstrap domain)
@@ -268,6 +291,13 @@ private openstack.domain @defaults("id name enabled") {
 }
 
 // OpenStack Keystone group
+//
+// Keystone group that aggregates users so roles can be granted collectively
+// rather than to each user individually. Auditing groups reveals who inherits
+// privileged access through membership: the users field lists the members and
+// the roles field reports the effective roles the group confers across project,
+// domain, and system scopes. Select a group by its UUID, for example
+// openstack.group(id: "a1b2c3d4...").
 private openstack.group @defaults("id name") {
   init(id? string)
   // Group ID (UUID)
@@ -329,6 +359,15 @@ private openstack.identity.roleInference @defaults("priorRoleName impliedRoleNam
 }
 
 // OpenStack Nova compute server (instance)
+//
+// Nova virtual machine instance, the primary compute workload in an
+// OpenStack cloud. Query lifecycle and power state through status,
+// vmState, powerState, and taskState; the image and flavor it booted
+// from; and attached securityGroups, ports, floatingIps, and volumes.
+// Boot-time inputs such as keyName, metadata, and userData reveal how the
+// instance was provisioned, and userData is a common place to audit for
+// hardcoded credentials. Use exposure to check public reachability.
+// Select a server by its id with `openstack.compute.server(id: "...")`.
 private openstack.compute.server @defaults("id name status") {
   init(id? string)
   // Server ID (UUID)
@@ -369,7 +408,9 @@ private openstack.compute.server @defaults("id name status") {
   //
   // Admin-only and empty for non-admin tokens. The raw value may embed bootstrap secrets, so auditing it for hardcoded credentials is a common use.
   userData string
-  // Per-network address allocations (network name -> [{addr, version, type, macAddr}])
+  // Per-network address allocations
+  //
+  // Keyed by network name; each value is a list of address entries with `addr`, `version` (4 or 6), `OS-EXT-IPS:type` (fixed or floating), and `OS-EXT-IPS-MAC:mac_addr`.
   addresses dict
   // Free-form server metadata
   metadata map[string]string
@@ -427,6 +468,13 @@ private openstack.compute.server.exposure @defaults("internetReachable publiclyA
 }
 
 // OpenStack Nova flavor (VM size)
+//
+// Nova flavor defining the CPU, memory, and disk a server is allocated at
+// boot. vcpus, ram, disk, swap, and ephemeral set the sizing, while
+// extraSpecs carries scheduler hints and hardware policies (CPU pinning,
+// NUMA placement, hardware acceleration) and isPublic controls whether
+// every project can boot it. Select a flavor by its id with
+// `openstack.compute.flavor(id: "...")`.
 private openstack.compute.flavor @defaults("id name vcpus ram disk") {
   init(id? string)
   // Flavor ID (UUID for v2.55+, integer string for older clouds)
@@ -454,6 +502,12 @@ private openstack.compute.flavor @defaults("id name vcpus ram disk") {
 }
 
 // OpenStack Nova SSH keypair
+//
+// SSH keypair registered with Nova and injectable into a server at boot.
+// fingerprint and publicKey identify the key material and type
+// distinguishes an ssh key from an x509 certificate. Keypairs are scoped
+// per user, so a stale or widely shared key is worth auditing as a
+// persistent access path into instances that booted with it.
 private openstack.compute.keypair @defaults("name type fingerprint") {
   // Keypair name (unique per user)
   name string
@@ -468,6 +522,13 @@ private openstack.compute.keypair @defaults("name type fingerprint") {
 }
 
 // OpenStack Nova server group (affinity / anti-affinity)
+//
+// Nova server group that constrains how its member instances are placed
+// across compute hosts. policies records the scheduling rule (affinity,
+// anti-affinity, soft-affinity, soft-anti-affinity) and members lists the
+// instances bound by it, which matters for availability and blast-radius
+// analysis. Select a server group by its id with
+// `openstack.compute.serverGroup(id: "...")`.
 private openstack.compute.serverGroup @defaults("id name policies") {
   init(id? string)
   // Server group ID
@@ -489,6 +550,18 @@ private openstack.compute.serverGroup @defaults("id name policies") {
 }
 
 // OpenStack Neutron network
+//
+// Layer-2 virtual network in the Neutron networking service, the
+// broadcast domain that ports and subnets attach to. Query it to audit
+// tenant isolation and exposure: `shared` reveals a network usable by
+// other projects, `external` marks a provider network that bridges to
+// the outside world, and `portSecurityEnabled` sets whether ports
+// created on the network get anti-spoofing and security-group
+// enforcement by default. The provider attributes
+// (providerNetworkType, providerPhysicalNetwork,
+// providerSegmentationId) expose the underlying segmentation, and
+// subnets returns the address ranges carved from the network. Select a
+// network by id with `openstack.network(id: "...")`.
 private openstack.network @defaults("id name status") {
   init(id? string)
   // Network ID (UUID)
@@ -530,6 +603,14 @@ private openstack.network @defaults("id name status") {
 }
 
 // OpenStack Neutron subnet
+//
+// IP address range carved out of a Neutron network, defined by its `cidr`,
+// IP version, default gateway, and DHCP behavior. A subnet governs how
+// addresses are handed to ports and which DNS nameservers and host routes
+// instances receive. Selected by ID, for example
+// `openstack.subnet(id: "a1b2c3d4-...")`. Query subnets to confirm CIDR
+// sizing, gateway placement, whether DHCP is enabled, and the IPv6 address
+// and router-advertisement modes.
 private openstack.subnet @defaults("id name cidr") {
   init(id? string)
   // Subnet ID (UUID)
@@ -552,9 +633,17 @@ private openstack.subnet @defaults("id name cidr") {
   ipv6RaMode string
   // DNS nameservers advertised by DHCP
   dnsNameservers []string
-  // Allocation pools ([{start, end}])
+  // Allocation pools
+  //
+  // IP ranges from which addresses are assigned to ports on this subnet.
+  // Each entry is a dict with `start` and `end` keys holding the first and
+  // last IP of the pool.
   allocationPools []dict
-  // Host routes ([{destination, nexthop}])
+  // Host routes
+  //
+  // Additional routes advertised to instances through DHCP. Each entry is a
+  // dict with `destination` (the target CIDR) and `nexthop` (the gateway IP
+  // used to reach it).
   hostRoutes []dict
   // Network this subnet belongs to
   network() openstack.network
@@ -573,13 +662,24 @@ private openstack.subnet @defaults("id name cidr") {
 }
 
 // OpenStack Neutron router
+//
+// A Neutron router that connects tenant networks to each other and to
+// external networks, providing routing, source NAT, and floating-IP
+// gateway services. Query a single router by its UUID, for example
+// openstack.router(id: "a1b2c3d4-..."). Security-relevant surface
+// includes externalGatewayInfo and enableSnat (whether tenant traffic
+// egresses through source NAT), the static routes it advertises, and
+// whether admin state is up. The externalNetwork field resolves the
+// external network used for the gateway.
 private openstack.router @defaults("id name status") {
   init(id? string)
   // Router ID (UUID)
   id string
   // Router name
   name string
-  // Status
+  // Operational status
+  //
+  // One of ACTIVE, DOWN, BUILD, or ERROR.
   status string
   // Whether the router is administratively up
   adminStateUp bool
@@ -606,6 +706,16 @@ private openstack.router @defaults("id name status") {
 }
 
 // OpenStack Neutron port
+//
+// Virtual network interface attached to a server, router, or other network
+// device, carrying the security posture of that attachment. Select a port by
+// its UUID, for example `openstack.port(id: "a1b2c3d4-...")`. The
+// `portSecurityEnabled` flag governs whether MAC/IP anti-spoofing and security
+// group filtering apply at all, `allowedAddressPairs` widens which source
+// addresses bypass that filtering, and `deviceOwner` records what the port is
+// bound to (compute instance, router interface, DHCP agent). Fixed and
+// floating IP bindings, attached security groups, and the owning network,
+// server, router, and project are all reachable from the port.
 private openstack.port @defaults("id name status macAddress") {
   init(id? string)
   // Port ID (UUID)
@@ -655,11 +765,23 @@ private openstack.port @defaults("id name status macAddress") {
 }
 
 // OpenStack Neutron floating IP
+//
+// Public IPv4 address allocated from an external network and mapped
+// through NAT to a private fixed IP on a Neutron port, giving an
+// instance inbound reachability from outside the tenant network.
+// Select a floating IP by its UUID, for example
+// `openstack.floatingIp(id: "a1b2c3d4-...")`. Auditing floating IPs
+// reveals which internal workloads are exposed to the internet, the
+// external network they draw from, the port and router carrying their
+// NAT, and any DNAT port-forwarding rules that publish additional
+// private services.
 private openstack.floatingIp @defaults("id floatingIpAddress status") {
   init(id? string)
   // Floating IP ID (UUID)
   id string
-  // Status (ACTIVE, DOWN)
+  // Status
+  //
+  // One of ACTIVE, DOWN, or ERROR.
   status string
   // The floating (public) IP address
   floatingIpAddress string
@@ -715,6 +837,15 @@ private openstack.floatingIp.portForwarding @defaults("protocol externalPort int
 }
 
 // OpenStack Neutron security group
+//
+// Set of firewall rules that govern ingress and egress traffic for the
+// ports and instances the group is attached to. Audit security groups to
+// find overly permissive access, such as rules that expose services to the
+// public internet. The stateful field distinguishes connection-tracking
+// groups from stateless ones that require explicit return-traffic rules,
+// and allowsPublicIngress flags any group whose ingress rules reach a
+// public source. Select a group by its UUID, for example
+// openstack.securityGroup(id: "9d6f...").
 private openstack.securityGroup @defaults("id name") {
   init(id? string)
   // Security group ID (UUID)
@@ -740,6 +871,15 @@ private openstack.securityGroup @defaults("id name") {
 }
 
 // OpenStack Neutron security group rule
+//
+// Single ingress or egress rule within a security group, defining the
+// protocol, port range, and remote source or destination that traffic is
+// matched against. Audit rules to find open ports and public exposure:
+// includesPublicSource flags a rule whose source or destination reaches
+// the public internet. A rule scopes its remote endpoint by exactly one of
+// remoteIpPrefix (a CIDR), remoteGroup (another security group), or
+// remoteAddressGroupId (an address group), which determines where the rule
+// applies.
 private openstack.securityGroup.rule @defaults("id direction protocol portRangeMin portRangeMax") {
   // Rule ID (UUID)
   id string
@@ -776,6 +916,12 @@ private openstack.securityGroup.rule @defaults("id direction protocol portRangeM
 }
 
 // OpenStack Cinder block-storage volume
+//
+// Cinder block-storage volume backing compute servers or held as
+// standalone storage. Records its encryption-at-rest posture, whether
+// it can attach to multiple servers concurrently, its attachment
+// records, and the project and user that own it. Select a volume by id
+// with `openstack.blockstorage.volume(id: "...")`.
 private openstack.blockstorage.volume @defaults("id name status size") {
   init(id? string)
   // Volume ID (UUID)
@@ -829,6 +975,12 @@ private openstack.blockstorage.volume @defaults("id name status size") {
 }
 
 // OpenStack Cinder volume snapshot
+//
+// Point-in-time snapshot of a Cinder volume, used for backup and clone
+// workflows. Records the source volume, whether the snapshot counts
+// against project quota, and its status through the creation lifecycle.
+// Select a snapshot by id with
+// `openstack.blockstorage.snapshot(id: "...")`.
 private openstack.blockstorage.snapshot @defaults("id name status size") {
   init(id? string)
   // Snapshot ID (UUID)
@@ -862,6 +1014,16 @@ private openstack.blockstorage.snapshot @defaults("id name status size") {
 }
 
 // OpenStack Glance image
+//
+// Virtual machine image registered in Glance, the source template instances
+// boot from. Select one by its UUID, for example
+// `openstack.image(id: "7c9d9e5f-...")`. Audit `visibility` to find images
+// exposed publicly or to the whole community, `protected` and `hidden` to
+// understand lifecycle and listing controls, and the integrity fields
+// (`checksum`, `osHashAlgo`, `osHashValue`) alongside `imageSignature` to
+// confirm images are signed and untampered. The `members` field enumerates
+// the projects a shared image is visible to, and `kernel` and `ramdisk`
+// resolve the AMI-style boot components.
 private openstack.image @defaults("id name status visibility") {
   init(id? string)
   // Image ID (UUID)
@@ -918,7 +1080,15 @@ private openstack.image @defaults("id name status visibility") {
   ramdisk() openstack.image
 }
 
-// OpenStack Barbican secret. The `payload` (raw secret material) is intentionally not exposed.
+// OpenStack Barbican secret
+//
+// Cryptographic secret material held by the Barbican key manager: symmetric
+// keys, public and private keys, passphrases, certificates, and opaque blobs.
+// Select a secret by its `id`, for example `openstack.keymanager.secret(id:
+// "...")`. Query `secretType`, `algorithm`, and `bitLength` to audit what kind
+// of key material is stored, `status` and `expiresAt` to find inactive or
+// expired secrets, and `acl` to see who is allowed to read it. The raw
+// `payload` (the secret material itself) is intentionally not exposed.
 private openstack.keymanager.secret @defaults("id name secretType status") {
   init(id? string)
   // Secret ID (UUID extracted from secretRef)
@@ -953,7 +1123,15 @@ private openstack.keymanager.secret @defaults("id name secretType status") {
   acl() openstack.keymanager.acl
 }
 
-// OpenStack Barbican secret container. Bundles secrets together; certificate-typed containers are what Octavia listeners reference for TLS termination.
+// OpenStack Barbican secret container
+//
+// Bundle of related Barbican secrets grouped under a single reference. Select
+// a container by its `id`, for example `openstack.keymanager.container(id:
+// "...")`. Certificate-typed containers hold a certificate together with its
+// private key and any intermediate CA bundle, and are what Octavia listeners
+// point at for TLS termination. Query `type` to tell generic, rsa, and
+// certificate containers apart, `secrets` for the referenced secret material,
+// and `consumers` to see which services depend on the container.
 private openstack.keymanager.container @defaults("id name type status") {
   init(id? string)
   // Container ID (UUID extracted from containerRef)
@@ -966,7 +1144,12 @@ private openstack.keymanager.container @defaults("id name type status") {
   status string
   // Full Barbican container URL; matches the `default_tls_container_ref` / `sni_container_refs` strings used by Octavia listeners
   containerRef string
-  // Raw secret references on this container ([{name, secret_ref}])
+  // Raw secret references on this container
+  //
+  // One entry per referenced secret as `{name, secret_ref}`, where `name` is
+  // the role within the container (for example certificate, private_key, or
+  // intermediates) and `secret_ref` is the full Barbican secret URL. See
+  // `secrets` for the resolved secret material.
   secretRefs []dict
   // Consumers registered on this container ([{name, url}])
   consumers []dict
@@ -989,6 +1172,13 @@ private openstack.keymanager.container @defaults("id name type status") {
 }
 
 // OpenStack Barbican secret-generation order
+//
+// Asynchronous request that has Barbican generate secret material server-side:
+// a key, an asymmetric key pair, or a certificate. Select an order by its
+// `id`, for example `openstack.keymanager.order(id: "...")`. Query `type` for
+// what is being produced, `status` and `subStatus` to track progress,
+// `errorReason` when generation fails, and `secret` or `container` for the
+// material produced once the order completes.
 private openstack.keymanager.order @defaults("id type status subStatus") {
   init(id? string)
   // Order ID (UUID extracted from orderRef)
@@ -1022,6 +1212,15 @@ private openstack.keymanager.order @defaults("id type status subStatus") {
 }
 
 // OpenStack Octavia load balancer
+//
+// Load balancer fronting backend pools through Octavia, the OpenStack
+// load-balancing service. Query it to audit public reachability, TLS
+// enforcement across its listeners, the VIP's network and subnet
+// placement, and the provider serving traffic (amphora, ovn). Select one
+// by its UUID, for example `openstack.octavia.loadBalancer(id: "8f8a...")`.
+// The exposure field reports whether the VIP is reachable from the
+// internet and which listeners are open to the world, and enforcesTls is
+// true only when every listener uses an encrypted protocol.
 private openstack.octavia.loadBalancer @defaults("id name provisioningStatus operatingStatus vipAddress") {
   init(id? string)
   // Load balancer ID (UUID)
@@ -1091,6 +1290,15 @@ private openstack.octavia.loadBalancer.exposure @defaults("internetReachable pub
 }
 
 // OpenStack Octavia listener
+//
+// Frontend that binds a protocol and port on a load balancer's virtual IP
+// and forwards matching traffic to a default pool or through L7 policies.
+// Query it to audit which ports accept connections, whether traffic is
+// TLS-terminated and with which ciphers, versions, and client
+// authentication mode, and how far the source is restricted through
+// allowedCidrs. The openToWorld field is true when the listener accepts
+// connections from any source. Select one by its UUID, for example
+// `openstack.octavia.listener(id: "...")`.
 private openstack.octavia.listener @defaults("id name protocol protocolPort provisioningStatus") {
   init(id? string)
   // Listener ID (UUID)
@@ -1154,6 +1362,13 @@ private openstack.octavia.listener @defaults("id name protocol protocolPort prov
 }
 
 // OpenStack Octavia backend pool
+//
+// Group of backend members that a listener load-balances across using a
+// selection algorithm. Query it to audit the algorithm in use, whether
+// backend connections are encrypted (tlsEnabled with its ciphers and
+// versions), the session persistence policy, and the health monitor
+// guarding the members. Select one by its UUID, for example
+// `openstack.octavia.pool(id: "...")`.
 private openstack.octavia.pool @defaults("id name lbAlgorithm protocol provisioningStatus") {
   init(id? string)
   // Pool ID (UUID)
@@ -1245,6 +1460,12 @@ private openstack.octavia.member @defaults("id name address protocolPort weight"
 }
 
 // OpenStack Octavia health monitor
+//
+// Probe configuration Octavia uses to test the health of a pool's backend
+// members and remove failing ones from rotation. Query it to audit the
+// probe type, interval and timeout, retry thresholds, and the HTTP method,
+// path, and expected response codes used by HTTP and HTTPS probes. Select
+// one by its UUID, for example `openstack.octavia.healthMonitor(id: "...")`.
 private openstack.octavia.healthMonitor @defaults("id name type delay timeout") {
   init(id? string)
   // Health monitor ID (UUID)
@@ -1288,6 +1509,12 @@ private openstack.octavia.healthMonitor @defaults("id name type delay timeout") 
 }
 
 // OpenStack Octavia L7 policy
+//
+// Layer-7 policy on a listener that inspects HTTP requests and, when all of
+// its rules match, redirects them to a pool or URL or rejects them. Query
+// it to audit the action taken, its evaluation position among sibling
+// policies, any redirect target, and the match rules that trigger it.
+// Select one by its UUID, for example `openstack.octavia.l7Policy(id: "...")`.
 private openstack.octavia.l7Policy @defaults("id name action position provisioningStatus") {
   init(id? string)
   // L7 policy ID (UUID)
@@ -1352,7 +1579,16 @@ private openstack.octavia.l7Rule @defaults("id ruleType compareType value") {
   l7Policy() openstack.octavia.l7Policy
 }
 
-// OpenStack Neutron subnet pool. Admins pre-allocate CIDR ranges; tenant subnets are carved from these.
+// OpenStack Neutron subnet pool
+//
+// Pool of CIDR prefixes that Neutron carves tenant subnets from, so
+// address space is managed centrally instead of assigned ad hoc. The
+// `id` field selects a specific pool, for example
+// `openstack.subnetPool(id: "a1b2c3d4-...")`. Auditing a pool shows the
+// prefixes it can allocate, the allowed prefix-length bounds
+// (minPrefixLen, maxPrefixLen), the per-project address quota, whether
+// the pool is shared across projects, and the address scope it is bound
+// to, all of which govern how much address space each tenant can claim.
 private openstack.subnetPool @defaults("id name ipVersion shared isDefault") {
   init(id? string)
   // Subnet pool ID (UUID)
@@ -1389,7 +1625,16 @@ private openstack.subnetPool @defaults("id name ipVersion shared isDefault") {
   project() openstack.project
 }
 
-// OpenStack Neutron QoS policy. Attaches bandwidth-limit, DSCP, and minimum-bandwidth rules to ports/networks/floating IPs.
+// OpenStack Neutron QoS policy
+//
+// Quality-of-Service policy that attaches traffic-shaping rules to Neutron
+// ports, networks, and floating IPs. Each policy holds a set of rules
+// (bandwidth limits, DSCP marking, minimum guaranteed bandwidth, and
+// packet-rate limits) exposed through `rules`. The `shared` flag governs
+// whether other projects can attach the policy, and `isDefault` marks the
+// policy that new ports inherit, so both are worth auditing when reviewing
+// tenant traffic controls. Select a policy by its UUID, for example
+// `openstack.qosPolicy(id: "d1e2f3a4-...")`.
 private openstack.qosPolicy @defaults("id name shared isDefault") {
   init(id? string)
   // QoS policy ID (UUID)
@@ -1416,7 +1661,16 @@ private openstack.qosPolicy @defaults("id name shared isDefault") {
   project() openstack.project
 }
 
-// OpenStack Neutron trunk. Parent port plus a set of subports identified by VLAN tags.
+// OpenStack Neutron trunk
+//
+// Neutron trunk port that multiplexes traffic from several networks onto a
+// single parent port. Traffic for each attached network arrives on a subport
+// tagged with its own VLAN ID, letting one instance reach many networks over
+// one virtual NIC. Select a trunk by its UUID, for example
+// `openstack.trunk(id: "...")`. Audit trunks to see which ports an instance is
+// bridged onto, whether the trunk is administratively up (adminStateUp), and
+// its operational status. The parentPort and subportPorts accessors resolve the
+// underlying Neutron ports for reachability and security-group analysis.
 private openstack.trunk @defaults("id name status") {
   init(id? string)
   // Trunk ID (UUID)
@@ -1429,7 +1683,13 @@ private openstack.trunk @defaults("id name status") {
   adminStateUp bool
   // Status (ACTIVE, DOWN, BUILD, DEGRADED, ERROR)
   status string
-  // Subport entries ([{port_id, segmentation_type, segmentation_id}])
+  // Subport entries
+  //
+  // Each entry is a dict with keys `port_id` (the Neutron port carried on the
+  // trunk), `segmentation_type` (the tagging scheme, typically `vlan`), and
+  // `segmentation_id` (the VLAN tag that isolates the subport's traffic on the
+  // parent port). See subportPorts for these ports resolved as Neutron port
+  // resources.
   subports []dict
   // Tags
   tags []string
@@ -1445,7 +1705,14 @@ private openstack.trunk @defaults("id name status") {
   subportPorts() []openstack.port
 }
 
-// OpenStack FWaaS v2 firewall group. Binds ingress/egress policies to a set of ports.
+// OpenStack FWaaS v2 firewall group
+//
+// Firewall-as-a-Service v2 group that binds an ingress and an egress
+// policy to a set of Neutron ports, applying stateful packet filtering
+// at the port level. The status field reports the provisioning state
+// (ACTIVE, INACTIVE, PENDING_*, ERROR), adminStateUp reports whether the
+// group is administratively enabled, and shared reports whether other
+// projects can use it. Selected by group ID.
 private openstack.firewall.group @defaults("id name status adminStateUp") {
   init(id? string)
   // Firewall group ID (UUID)
@@ -1470,7 +1737,12 @@ private openstack.firewall.group @defaults("id name status adminStateUp") {
   egressPolicy() openstack.firewall.policy
 }
 
-// OpenStack FWaaS v2 firewall policy. Ordered list of rules used by a firewall group.
+// OpenStack FWaaS v2 firewall policy
+//
+// Firewall-as-a-Service v2 policy holding an ordered list of rules that a
+// firewall group evaluates in sequence. The audited flag records whether
+// an administrator has reviewed the current rule set, and shared reports
+// whether other projects can reference the policy. Selected by policy ID.
 private openstack.firewall.policy @defaults("id name audited shared") {
   init(id? string)
   // Firewall policy ID (UUID)
@@ -1489,7 +1761,14 @@ private openstack.firewall.policy @defaults("id name audited shared") {
   rules() []openstack.firewall.rule
 }
 
-// OpenStack FWaaS v2 firewall rule. Single match-action entry referenced by one or more policies.
+// OpenStack FWaaS v2 firewall rule
+//
+// Firewall-as-a-Service v2 rule, a single match-action entry that one or
+// more policies reference. Matches on protocol, source and destination
+// IP/CIDR, and source and destination port ranges, then applies the
+// action (allow, deny, reject). The enabled flag controls whether the
+// rule is evaluated, and ipVersion selects IPv4 or IPv6. Selected by
+// rule ID.
 private openstack.firewall.rule @defaults("id name action protocol enabled") {
   init(id? string)
   // Firewall rule ID (UUID)
@@ -1556,7 +1835,7 @@ private openstack.vpn.service @defaults("id name status adminStateUp") {
 
 // OpenStack VPNaaS v2 IKE policy
 //
-// Phase 1 (IKE) negotiation parameters referenced by site-to-site
+// IKE key-exchange negotiation parameters referenced by site-to-site
 // connections. The authentication and encryption algorithms, the
 // perfect-forward-secrecy group, the IKE version, the negotiation mode,
 // and the security-association lifetime are the values to audit for weak
@@ -1576,7 +1855,7 @@ private openstack.vpn.ikePolicy @defaults("id name authAlgorithm encryptionAlgor
   encryptionAlgorithm string
   // Perfect forward secrecy group (for example "group2", "group5", "group14")
   pfs string
-  // Phase 1 negotiation mode (for example "main")
+  // IKE key-exchange negotiation mode (for example "main")
   phase1NegotiationMode string
   // IKE protocol version ("v1" or "v2")
   ikeVersion string
@@ -1590,7 +1869,7 @@ private openstack.vpn.ikePolicy @defaults("id name authAlgorithm encryptionAlgor
 
 // OpenStack VPNaaS v2 IPsec policy
 //
-// Phase 2 (IPsec) negotiation parameters referenced by site-to-site
+// IPsec data-channel negotiation parameters referenced by site-to-site
 // connections. The authentication and encryption algorithms, the
 // perfect-forward-secrecy group, the encapsulation mode, the transform
 // protocol, and the security-association lifetime are the values to audit
@@ -1688,9 +1967,9 @@ private openstack.vpn.siteConnection @defaults("id name status peerAddress admin
   dpdInterval int
   // VPN service this connection runs on
   service() openstack.vpn.service
-  // IKE policy used for phase 1 negotiation
+  // IKE policy used for key-exchange negotiation
   ikePolicy() openstack.vpn.ikePolicy
-  // IPsec policy used for phase 2 negotiation
+  // IPsec policy used for data-channel negotiation
   ipsecPolicy() openstack.vpn.ipsecPolicy
   // Local endpoint group (local subnets); null when the connection binds a subnet directly
   localEndpointGroup() openstack.vpn.endpointGroup
@@ -1700,7 +1979,14 @@ private openstack.vpn.siteConnection @defaults("id name status peerAddress admin
   project() openstack.project
 }
 
-// OpenStack Swift object-storage account. Singular per scoped project; aggregates totals across all containers.
+// OpenStack Swift object-storage account
+//
+// Account-level totals for a scoped project's Swift object storage,
+// aggregating byte usage, container count, and object count across
+// every container. There is one account per scoped project. Compare
+// quotaBytes against bytesUsed for capacity planning, and check
+// tempUrlKeySet to confirm whether a temporary-URL signing key is
+// configured on the account.
 private openstack.objectstorage.account @defaults("bytesUsed containerCount objectCount") {
   // Account identifier (Swift account URL path, e.g. AUTH_<project_id>)
   id string
@@ -1719,6 +2005,14 @@ private openstack.objectstorage.account @defaults("bytesUsed containerCount obje
 }
 
 // OpenStack Swift object-storage container
+//
+// Storage container within a Swift account, holding objects along
+// with its own read/write ACLs, storage policy, and versioning
+// settings. The name field selects the container, for example
+// openstack.objectstorage.container(name: "backups"). The public
+// predicate reports whether the read ACL grants unauthenticated read
+// access (the ACL contains ".r:*"), the key check for unintended data
+// exposure.
 private openstack.objectstorage.container @defaults("name objectCount bytes public") {
   init(name? string)
   // Container name (also acts as identifier within the account)
@@ -1748,11 +2042,16 @@ private openstack.objectstorage.container @defaults("name objectCount bytes publ
 }
 
 // OpenStack Swift object stored in a container
+//
+// Individual object within a Swift container, exposing its size,
+// content type, MD5/ETag hash, and last-modification time. Selected
+// by container and object name, for example
+// openstack.objectstorage.object(containerName: "backups", name: "db.sql").
 private openstack.objectstorage.object @defaults("name contentType bytes") {
   init(containerName? string, name? string)
   // Object name (path within the container)
   name string
-  // Container that holds this object
+  // Name of the container that holds this object
   containerName string
   // MIME content type
   contentType string
@@ -1762,11 +2061,20 @@ private openstack.objectstorage.object @defaults("name contentType bytes") {
   hash string
   // Last modification timestamp
   lastModified time
-  // Container that holds this object (typed reference)
+  // Container that holds this object
   container() openstack.objectstorage.container
 }
 
 // OpenStack Designate DNS zone
+//
+// A domain namespace managed by the Designate DNS service, holding the
+// records that resolve names under it. Query a single zone by its id, for
+// example `openstack.dns.zone(id: "a86dba58-0043-4cc6-a1bb-69d5e86f3ca3")`.
+// Audit zones to review which domains a project serves, check the SOA email
+// and default ttl, and spot SECONDARY zones that transfer records from
+// external masters. The type field distinguishes PRIMARY zones from
+// SECONDARY ones, and recordsets returns the individual record collections
+// defined within the zone.
 private openstack.dns.zone @defaults("id name type ttl status") {
   init(id? string)
   // Zone ID (UUID)
@@ -1806,6 +2114,15 @@ private openstack.dns.zone @defaults("id name type ttl status") {
 }
 
 // OpenStack Designate DNS recordset (one or more records sharing a name and type)
+//
+// A collection of DNS records that share the same name and record type
+// within a Designate zone, along with the values they resolve to. Query a
+// single recordset by its id, for example
+// `openstack.dns.recordset(id: "f7b10e9b-0cae-4a91-b162-562bc6096648")`.
+// Audit recordsets to review what a zone resolves, catch entries pointing at
+// unexpected or externally controlled targets, and check the type and ttl.
+// The records field holds the raw values (one per record, formatted per type)
+// and zone links back to the owning zone.
 private openstack.dns.recordset @defaults("id name type ttl") {
   init(id? string)
   // Recordset ID (UUID)
@@ -1836,7 +2153,14 @@ private openstack.dns.recordset @defaults("id name type ttl") {
   zone() openstack.dns.zone
 }
 
-// OpenStack Nova hypervisor (compute host). Admin-only.
+// OpenStack Nova hypervisor (compute host)
+//
+// Compute host as reported by Nova, exposing its capacity and current
+// load: total and used vcpus, memoryMb, and localGb, runningVms,
+// currentWorkload, and cpuInfo. state and status show whether the host is
+// reachable and administratively enabled. Reading it requires an admin
+// token. Select a hypervisor by its id with
+// `openstack.compute.hypervisor(id: "...")`.
 private openstack.compute.hypervisor @defaults("id hostname type state status") {
   init(id? string)
   // Hypervisor ID (Nova-assigned UUID or integer string)
@@ -1873,13 +2197,22 @@ private openstack.compute.hypervisor @defaults("id hostname type state status") 
   runningVms int
   // Current scheduler workload metric
   currentWorkload int
-  // Hypervisor CPU info (model, vendor, features, topology)
+  // Hypervisor CPU information
+  //
+  // Keys: `vendor`, `arch`, `model`, `features` (list of CPU feature flags), and `topology` (with `sockets`, `cores`, and `threads`).
   cpuInfo dict
   // The compute service backing this hypervisor (typically the nova-compute on the same host)
   service() openstack.compute.service
 }
 
-// OpenStack Nova compute service (e.g. nova-compute, nova-scheduler, nova-conductor). Admin-only.
+// OpenStack Nova compute service
+//
+// Nova control-plane or compute daemon (nova-compute, nova-scheduler,
+// nova-conductor, and similar) and its health. state reports whether the
+// daemon is up or down, status reports whether it is administratively
+// enabled or disabled, and disabledReason records why a service was taken
+// out of rotation. Reading it requires an admin token. Select a service
+// by its id with `openstack.compute.service(id: "...")`.
 private openstack.compute.service @defaults("id binary host zone status state") {
   init(id? string)
   // Service ID (Nova-assigned UUID or integer string)
@@ -1902,7 +2235,14 @@ private openstack.compute.service @defaults("id binary host zone status state") 
   updatedAt time
 }
 
-// OpenStack Cinder volume type (storage class). Encryption posture, if any, is exposed via the encryption* fields.
+// OpenStack Cinder volume type
+//
+// Storage class that governs which backend a volume lands on and its
+// encryption posture. When the type is encrypted, the encryption*
+// fields report the provider class, cipher, key size, and where
+// encryption is performed; they are empty on unencrypted types.
+// `extraSpecs` holds the backend-specific configuration. Select a type
+// by id with `openstack.blockstorage.volumeType(id: "...")`.
 private openstack.blockstorage.volumeType @defaults("id name isPublic encryptionProvider") {
   init(id? string)
   // Volume type ID (UUID)
@@ -1931,7 +2271,14 @@ private openstack.blockstorage.volumeType @defaults("id name isPublic encryption
   volumes() []openstack.blockstorage.volume
 }
 
-// OpenStack Cinder volume backup. Backups live in object storage (e.g. Swift) and can be incremental, unlike snapshots.
+// OpenStack Cinder volume backup
+//
+// Backup of a Cinder volume stored in object storage (for example
+// Swift). Unlike snapshots, backups can be incremental and live
+// independently of the source volume. Records the backup status, the
+// source volume or snapshot, and whether other incrementals depend on
+// it. Select a backup by id with
+// `openstack.blockstorage.backup(id: "...")`.
 private openstack.blockstorage.backup @defaults("id name status size createdAt") {
   init(id? string)
   // Backup ID (UUID)
@@ -2012,7 +2359,13 @@ private openstack.applicationCredential @defaults("id name unrestricted expiresA
   unrestricted bool
   // Role names this credential is allowed to assume (subset of the owning user's roles)
   roleNames []string
-  // Access rules ([{id, service, method, path}]) limiting which API endpoints this credential can call; empty means all endpoints the granted roles allow
+  // API endpoint access rules
+  //
+  // Restrictions limiting which API calls the credential may make. Each entry
+  // is a dict with `id` (the rule UUID), `service` (the service type, for
+  // example `compute` or `image`), `method` (the HTTP method, for example
+  // `GET` or `POST`), and `path` (the request path the rule permits). An empty
+  // list means the credential can call every endpoint its granted roles allow.
   accessRules []dict
   // Expiration timestamp; null when the credential never expires
   expiresAt time
@@ -2024,12 +2377,11 @@ private openstack.applicationCredential @defaults("id name unrestricted expiresA
 
 // OpenStack Keystone credential
 //
-// Examine a stored authentication credential — most commonly an EC2-style
-// access/secret key pair (`type` ec2) or an X.509 certificate (`type` cert) —
-// owned by a user and scoped to a project. Select a credential by its `id`.
-// The secret material (the credential blob) is intentionally not exposed;
-// query `type`, `user`, and `project` to audit who holds long-lived
-// credentials.
+// Stored authentication credential owned by a user and scoped to a project,
+// most commonly an EC2-style access/secret key pair (`type` ec2) or an X.509
+// certificate (`type` cert). Select a credential by its `id`. The secret
+// material (the credential blob) is intentionally not exposed; query `type`,
+// `user`, and `project` to audit who holds long-lived credentials.
 private openstack.credential @defaults("id type") {
   init(id? string)
   // Credential ID (UUID)
@@ -2047,10 +2399,11 @@ private openstack.credential @defaults("id type") {
 
 // OpenStack Keystone EC2-compatible credential
 //
-// Examine an EC2-style access credential owned by a user, used by EC2/S3-
-// compatible API clients. Select a credential by its `access` key. The secret
-// key is intentionally not exposed; query `access`, `user`, `project`, and
-// `trust` to audit long-lived programmatic access.
+// EC2-style access credential owned by a user, used by EC2/S3-compatible API
+// clients. Select a credential by its `access` key, for example
+// `openstack.ec2Credential(access: "abc123...")`. The secret key is
+// intentionally not exposed; query `access`, `user`, `project`, and `trust` to
+// audit long-lived programmatic access.
 private openstack.ec2Credential @defaults("access") {
   init(access? string)
   // Access key (UUID) identifying the credential
@@ -2065,11 +2418,12 @@ private openstack.ec2Credential @defaults("access") {
 
 // OpenStack Keystone trust
 //
-// Examine a delegation of authorization from a trustor user to a trustee user,
+// Delegation of authorization from a trustor user to a trustee user,
 // optionally limited to a subset of roles on a project, with optional
-// impersonation and re-delegation. Select a trust by its `id`. Trusts that
-// allow impersonation or unlimited uses grant standing access on the trustor's
-// behalf and should be reviewed closely.
+// impersonation and re-delegation. Select a trust by its `id`, for example
+// `openstack.trust(id: "3d2c...")`. Trusts that allow impersonation or
+// unlimited uses grant standing access on the trustor's behalf and should be
+// reviewed closely.
 private openstack.trust @defaults("id impersonation") {
   init(id? string)
   // Trust ID (UUID)
@@ -2096,8 +2450,8 @@ private openstack.trust @defaults("id impersonation") {
 
 // OpenStack Keystone service-catalog service
 //
-// Examine a registered service in the Keystone catalog — the abstract service
-// (such as `compute`, `identity`, or `network`) that endpoints are attached to.
+// Registered service in the Keystone catalog: the abstract service
+// (such as `compute`, `identity`, or `network`) that endpoints attach to.
 // Select a service by its `id`. Query `type` and `enabled` to inventory which
 // services the deployment advertises.
 private openstack.identity.service @defaults("id name type enabled") {
@@ -2119,7 +2473,7 @@ private openstack.identity.service @defaults("id name type enabled") {
 
 // OpenStack Keystone service-catalog endpoint
 //
-// Examine a single URL at which a service is reachable, for one interface type
+// Single URL at which a service is reachable, for one interface type
 // (public, internal, or admin) in one region. Select an endpoint by its `id`.
 // Auditing which services expose `public` endpoints, and on which URLs, is the
 // primary use.
@@ -2147,7 +2501,7 @@ private openstack.identity.endpoint @defaults("id interface url") {
 
 // OpenStack Keystone region
 //
-// Examine a region — a logical grouping of service endpoints, optionally nested
+// Logical grouping of service endpoints, optionally nested
 // under a parent region. Select a region by its `id`. Query `parentRegion` to
 // walk the region hierarchy.
 private openstack.identity.region @defaults("id parentRegionId") {
@@ -2239,13 +2593,13 @@ private openstack.compute.limits @defaults("maxTotalInstances totalInstancesUsed
 
 // OpenStack Placement resource provider
 //
-// Examine a Placement resource provider — a source of consumable inventory
-// such as a compute node, a shared storage pool, or an accelerator device
-// (GPU/FPGA). Select a provider by its `id` (UUID). Query `inventories` and
-// `traits` to audit accelerator capacity — for example the `VGPU` / `PGPU`
-// resource classes and `HW_GPU_*` traits — and how much of each class is
-// already allocated. Walk `parent` and `root` to traverse nested provider
-// trees, such as a compute node with child GPU providers.
+// Source of consumable inventory in the Placement service, such as a compute
+// node, a shared storage pool, or an accelerator device (GPU/FPGA). Select a
+// provider by its `id` (UUID). The `inventories` and `traits` fields audit
+// accelerator capacity, for example the `VGPU` and `PGPU` resource classes and
+// `HW_GPU_*` traits, and how much of each class is already allocated. The
+// `parent` and `root` fields traverse nested provider trees, such as a compute
+// node with child GPU providers.
 private openstack.placement.resourceProvider @defaults("id name generation") {
   init(id? string)
   // Resource provider ID (UUID)
@@ -2294,7 +2648,14 @@ private openstack.blockstorage.quotaSet @defaults("volumes snapshots gigabytes b
   groups int
 }
 
-// OpenStack Neutron network-service quota for the scoped project (configured maximums; usage values are not exposed by the default API path).
+// OpenStack Neutron network-service quota
+//
+// Per-project ceilings the networking service enforces on Neutron
+// objects: networks, subnets, ports, routers, floating IPs, security
+// groups and their rules, subnet pools, RBAC policies, and trunks.
+// These are the configured maximums; current usage is not exposed by
+// the default API path. The quota applies to the scoped project,
+// reachable through project.
 private openstack.network.quotaSet @defaults("network subnet port floatingIp router") {
   // Project ID the quota applies to
   //
@@ -2324,7 +2685,12 @@ private openstack.network.quotaSet @defaults("network subnet port floatingIp rou
   trunk int
 }
 
-// OpenStack Barbican access control list for a secret or container. Per-operation list of users granted access; operation keys typically include "read".
+// OpenStack Barbican access control list for a secret or container
+//
+// Per-operation grants that override the default project-scoped access to a
+// Barbican secret or container. The `entries` dict is keyed by operation
+// (typically "read") and lists the users allowed to perform it, so you can
+// audit whether secret material has been shared beyond its owning project.
 private openstack.keymanager.acl @defaults("entries") {
   // ACL entries keyed by operation (e.g. "read"); each entry contains `{users: [string], project_access: bool, created, updated}`
   entries dict
@@ -2332,8 +2698,8 @@ private openstack.keymanager.acl @defaults("entries") {
 
 // OpenStack Manila shared file system
 //
-// Examine a shared file system (an NFS or CIFS/SMB export) provisioned by
-// Manila. Select a share by its `id`. Query `isPublic`, `shareProto`, and
+// Shared file system (an NFS or CIFS/SMB export) provisioned by Manila.
+// Select a share by its `id`. Query `isPublic`, `shareProto`, and
 // `accessRules` to audit who can reach the share, and `shareNetwork` to see
 // which Neutron network it is attached to.
 private openstack.sharedfilesystem.share @defaults("id name shareProto status size isPublic") {
@@ -2390,8 +2756,8 @@ private openstack.sharedfilesystem.share @defaults("id name shareProto status si
 
 // OpenStack Manila share access rule
 //
-// Examine a single rule granting a client access to a share — the access type
-// (IP, user, or certificate), the value it matches, and the level (read-only or
+// Single rule granting a client access to a share: the access type (IP,
+// user, or certificate), the value it matches, and the level (read-only or
 // read-write). The access key/secret is intentionally not exposed.
 private openstack.sharedfilesystem.share.accessRule @defaults("id accessType accessTo accessLevel state") {
   // Access rule ID (UUID)
@@ -2420,11 +2786,10 @@ private openstack.sharedfilesystem.share.accessRule @defaults("id accessType acc
 
 // OpenStack Manila security service
 //
-// Examine a security service — the Active Directory, LDAP, or Kerberos
-// configuration that share networks authenticate against. Select a service by
-// its `id`. Stored credentials (the bind password) are intentionally not
-// exposed; query `type`, `server`, `domain`, and `user` to audit directory
-// integration.
+// Active Directory, LDAP, or Kerberos configuration that share networks
+// authenticate against. Select a service by its `id`. Stored credentials
+// (the bind password) are intentionally not exposed; query `type`, `server`,
+// `domain`, and `user` to audit directory integration.
 private openstack.sharedfilesystem.securityService @defaults("id name type status") {
   init(id? string)
   // Security service ID (UUID)
@@ -2463,10 +2828,10 @@ private openstack.sharedfilesystem.securityService @defaults("id name type statu
 
 // OpenStack Manila share network
 //
-// Examine a share network — the binding of Manila shares to a Neutron network
-// and subnet, with the CIDR and segmentation used to reach the share servers.
-// Select a share network by its `id`. Query `network` and `subnet` to trace
-// shares back to their L2/L3 placement.
+// Binding of Manila shares to a Neutron network and subnet, with the CIDR
+// and segmentation used to reach the share servers. Select a share network
+// by its `id`. Query `network` and `subnet` to trace shares back to their
+// L2/L3 placement.
 private openstack.sharedfilesystem.shareNetwork @defaults("id name networkType cidr") {
   init(id? string)
   // Share network ID (UUID)
@@ -2505,11 +2870,12 @@ private openstack.sharedfilesystem.shareNetwork @defaults("id name networkType c
 
 // OpenStack Magnum cluster
 //
-// Examine a container-orchestration cluster (typically Kubernetes) provisioned
-// by Magnum from a cluster template. Select a cluster by its `id`. Query
-// `apiAddress` and `floatingIpEnabled` to see whether the control plane is
-// reachable externally, and `clusterTemplate` for the security posture it was
-// built from (TLS, registry, network).
+// Container-orchestration cluster (typically Kubernetes) provisioned by Magnum
+// from a cluster template. Select a cluster by its `id`, for example
+// `openstack.containerinfra.cluster(id: "...")`. The `apiAddress` and
+// `floatingIpEnabled` fields reveal whether the control plane is reachable
+// externally, and `clusterTemplate` carries the security posture it was built
+// from (TLS, registry, network).
 private openstack.containerinfra.cluster @defaults("id name status nodeCount masterCount") {
   init(id? string)
   // Cluster ID (UUID)
@@ -2574,10 +2940,11 @@ private openstack.containerinfra.cluster @defaults("id name status nodeCount mas
 
 // OpenStack Magnum cluster template
 //
-// Examine a cluster template — the reusable blueprint that defines how Magnum
-// builds clusters (orchestration engine, image, network, TLS, and registry
-// settings). Select a template by its `id`. `tlsDisabled`, `public`, and
-// `floatingIpEnabled` are the key security toggles to audit.
+// Reusable blueprint that defines how Magnum builds clusters (orchestration
+// engine, image, network, TLS, and registry settings). Select a template by
+// its `id`, for example `openstack.containerinfra.clusterTemplate(id: "...")`.
+// The `tlsDisabled`, `public`, and `floatingIpEnabled` fields are the key
+// security toggles to audit.
 private openstack.containerinfra.clusterTemplate @defaults("id name coe tlsDisabled public") {
   init(id? string)
   // Cluster template ID (UUID)
@@ -2652,11 +3019,13 @@ private openstack.containerinfra.clusterTemplate @defaults("id name coe tlsDisab
 
 // OpenStack Trove database instance
 //
-// Examine a managed database instance provisioned by Trove. Select an instance
-// by its `id`. Query `addresses` and `hostname` to see how the database is
-// reachable, and `datastoreType`/`datastoreVersion` to flag outdated engines.
-// The `databases` and `users` accessors enumerate the logical databases and
-// accounts on the instance; user passwords are intentionally not exposed.
+// Managed database instance provisioned by the Trove database service. Select
+// an instance by its `id`, for example `openstack.db.instance(id: "...")`. The
+// `addresses` and `hostname` fields show how the database is reachable, and
+// `datastoreType`/`datastoreVersion` identify the engine and version so you can
+// flag outdated database software. The `databases` and `users` fields enumerate
+// the logical databases and accounts on the instance; user passwords are
+// intentionally not exposed.
 private openstack.db.instance @defaults("id name status datastoreType datastoreVersion") {
   init(id? string)
   // Instance ID (UUID)
@@ -2687,10 +3056,12 @@ private openstack.db.instance @defaults("id name status datastoreType datastoreV
 
 // OpenStack Ironic bare-metal node
 //
-// Examine a physical machine managed by Ironic. Select a node by its `id`
-// (UUID). Query `provisionState`, `maintenance`, and `instance` to see whether
-// the node is in service and which Nova instance (if any) it backs, and
-// `owner`/`lessee` for multi-tenant ownership.
+// Physical machine managed by Ironic, the OpenStack bare-metal provisioning
+// service. Select a node by its `id` (UUID). The `provisionState`,
+// `maintenance`, `powerState`, and `fault` fields report whether the node is
+// in service or has a hardware problem, `instance` links to the Nova instance
+// (if any) that the node backs, and `owner` and `lessee` capture multi-tenant
+// ownership.
 private openstack.baremetal.node @defaults("id name provisionState powerState maintenance") {
   init(id? string)
   // Node ID (UUID)
@@ -2755,8 +3126,10 @@ private openstack.baremetal.node @defaults("id name provisionState powerState ma
 
 // OpenStack Ironic bare-metal port
 //
-// Examine a network port (NIC) on a bare-metal node — its MAC address, PXE
-// setting, and physical-network binding. Select a port by its `id` (UUID).
+// Network port (NIC) on an Ironic bare-metal node, covering its MAC address,
+// PXE setting, and physical-network binding. Select a port by its `id` (UUID).
+// The `pxeEnabled` and `localLinkConnection` fields describe how the port boots
+// and which switch port it connects to.
 private openstack.baremetal.port @defaults("id address nodeUuid pxeEnabled") {
   // Port ID (UUID)
   id string
@@ -2784,10 +3157,12 @@ private openstack.baremetal.port @defaults("id address nodeUuid pxeEnabled") {
 
 // OpenStack Heat orchestration stack
 //
-// Examine a Heat stack — a set of OpenStack resources deployed and managed
-// together from a template (OpenStack's infrastructure-as-code). Select a stack
-// by its `id`. Query `status` to track deployment/drift state and
-// `disableRollback` to flag stacks that won't roll back on failure.
+// Set of OpenStack resources deployed and managed together from a Heat
+// template (OpenStack's infrastructure-as-code). Select a stack by its `id`.
+// The `status` field tracks deployment and drift state (for example
+// `CREATE_COMPLETE`, `UPDATE_FAILED`, or `ROLLBACK_COMPLETE`), and
+// `disableRollback` flags stacks that will not roll back on failure, leaving
+// partially created resources behind.
 private openstack.orchestration.stack @defaults("id name status") {
   init(id? string)
   // Stack ID (UUID)
@@ -2818,6 +3193,12 @@ private openstack.orchestration.stack @defaults("id name status") {
 }
 
 // OpenStack Nova compute quota for the scoped project
+//
+// Configured per-project ceilings Nova enforces on compute consumption:
+// instances, cores, ram, keyPairs, serverGroups, and the legacy
+// nova-network limits. Comparing these caps against actual usage (see
+// openstack.compute.limits) surfaces projects near capacity or with
+// overly permissive quotas.
 private openstack.compute.quotaSet @defaults("instances cores ram") {
   // Project ID the quota applies to
   //
@@ -2857,15 +3238,15 @@ private openstack.compute.quotaSet @defaults("instances cores ram") {
 
 // Neutron RBAC policy
 //
-// Examine a Neutron role-based access control policy, which governs
-// cross-project sharing of a network or QoS policy. The `action`
-// distinguishes `access_as_shared` (other projects may use the object)
-// from `access_as_external` (the network may be used as an external
-// gateway), `objectType` and the typed `network()` / `qosPolicy()`
-// accessors identify the shared object, and `targetProjectId` names the
-// project the share is granted to — the literal `*` meaning every
-// project, a cloud-wide share worth flagging. Select a policy by id with
-// `openstack.network.rbacPolicy(id: "...")`.
+// Role-based access control policy that governs cross-project sharing
+// of a network or QoS policy. The `action` distinguishes
+// `access_as_shared` (other projects may use the object) from
+// `access_as_external` (the network may be used as an external
+// gateway), `objectType` together with the `network` and `qosPolicy`
+// accessors identifies the shared object, and `targetProjectId` names
+// the project the share is granted to. The literal `*` means every
+// project, a cloud-wide share worth flagging. Select a policy by id
+// with `openstack.network.rbacPolicy(id: "...")`.
 private openstack.network.rbacPolicy @defaults("id action objectType targetProjectId") {
   init(id? string)
   // RBAC policy ID (UUID)
@@ -2888,12 +3269,12 @@ private openstack.network.rbacPolicy @defaults("id action objectType targetProje
 
 // Cinder QoS specification
 //
-// Examine a Cinder quality-of-service specification — the IOPS and
+// Quality-of-service specification for Cinder: the IOPS and
 // bandwidth throttling limits a deployment can attach to volume types.
 // `consumer` records where the limits are enforced (`front-end` on the
 // Nova host, `back-end` on the storage system, or `both`), and `specs`
 // holds the rate-limit key/value pairs. Volume types reference a QoS
-// spec through `openstack.blockstorage.volumeType.qosSpec()`. Listing
+// spec through the volumeType `qosSpec` field. Listing
 // QoS specs is admin-only. Select a spec by id with
 // `openstack.blockstorage.qosSpec(id: "...")`.
 private openstack.blockstorage.qosSpec @defaults("id name consumer") {


### PR DESCRIPTION
## What

A documentation pass over `openstack.lr`, applying the pattern established across the provider-wide sweep (starting with S3, #9146). These doc-comments are machine-parsed and rendered onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**35 services, 80 edits.**

## Changes

- **Two-part descriptions added** to the many user-queryable resources that were title-only — compute `server`/`flavor`/`keypair`, blockstorage `volume`/`snapshot`, Octavia `loadBalancer`/`listener`/`pool`/`healthMonitor`/`l7Policy`, keymanager `secret`/`container`/`order`/`acl`, `network`/`port`/`subnet`/`securityGroup`/`router`/`image`, and more — each with a selection-key example and security significance.
- **Documented dict/`[]dict` key shapes** — compute `addresses` and `cpuInfo`, `applicationCredential.accessRules`, subnet `allocationPools`/`hostRoutes`, keymanager `secretRefs` — verified against the Nova/Keystone JSON and Go accessors.
- **Enum value lists** (`floatingIp`, router `status`) and style-rule cleanup: verb-led descriptions, em dashes, `typed` mechanism leaks, call-form `foo()` in prose, and titles that crammed a full description.

## The pattern (same as prior PRs)

Resource descriptions say *what the resource is and why you'd audit it* + the selection key, not a field roll-call. Every `dict`/`map` documents its keys. Security fields explain derivation.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- Automated checks on the added lines: 0 em dashes, no title over the 150-char cap, no mechanism-leak phrases.
- Every doc-comment is structurally valid (regeneration succeeds).

## Method

Produced by a multi-agent audit (one agent per service, cross-checking each field against its Go accessor and the OpenStack/gophercloud SDK), with all edits applied through a verifying script that requires each replacement to match exactly once in the file.
