### PR TITLE
📄 atlassian: enrich resource and field documentation across services

### DIFF
--- a/providers/atlassian/resources/atlassian.lr
+++ b/providers/atlassian/resources/atlassian.lr
@@ -6,10 +6,10 @@ option go_package = "go.mondoo.com/mql/v13/providers/atlassian/resources"
 
 // Atlassian SCIM (System for Cross-domain Identity Management) directory
 //
-// Entry point for the SCIM provisioning surface — the source of record for
-// users and groups synced into Atlassian Cloud from an external IdP. Use it
-// to inventory provisioned identities and detect orphans, drift between the
-// IdP and Atlassian, or unexpected group membership.
+// The SCIM provisioning surface: the source of record for users and groups
+// synced into Atlassian Cloud from an external identity provider. Inventory
+// the provisioned identities and their group membership to detect orphaned
+// accounts, drift between the IdP and Atlassian, or unexpected access.
 atlassian.scim {
   // Provisioned SCIM users
   users() []atlassian.scim.user
@@ -19,9 +19,11 @@ atlassian.scim {
 
 // Atlassian SCIM provisioned user
 //
-// Examine the SCIM identifier, login name, display name, organization
-// membership, and job title for a user provisioned through the SCIM
-// directory.
+// User account provisioned into Atlassian Cloud through SCIM, carrying the
+// SCIM identifier, login name, display name, organization membership, and
+// job title. Audit these to reconcile provisioned identities against the
+// external identity provider and spot accounts that should have been
+// deprovisioned.
 atlassian.scim.user @defaults("displayName") {
   // SCIM user ID
   id string
@@ -37,8 +39,10 @@ atlassian.scim.user @defaults("displayName") {
 
 // Atlassian SCIM provisioned group
 //
-// Examine the SCIM group ID and name for a group provisioned through the
-// SCIM directory.
+// Group provisioned into Atlassian Cloud through SCIM, carrying the SCIM
+// group ID and its display name. Audit these to confirm that group-based
+// access mirrors the external identity provider and that no unexpected
+// groups have been synced.
 atlassian.scim.group @defaults("name") {
   // SCIM group ID
   id string
@@ -48,11 +52,11 @@ atlassian.scim.group @defaults("name") {
 
 // Atlassian Admin organization
 //
-// Top-level entry point for Atlassian Admin. Examine the org's identity and
-// type, the security and data-residency policies it enforces, the verified
-// domains it owns, and the users it manages — the surface auditors check
-// for org-wide identity controls (IP allowlists, data residency, verified
-// domains, managed accounts) and access reviews.
+// Organization that anchors Atlassian Admin: its identity and type, the
+// security and data-residency policies it enforces, the verified domains it
+// owns, and the accounts it manages. This is the surface auditors check for
+// org-wide identity controls such as IP allowlists, data residency,
+// verified domains, and managed-account access reviews.
 atlassian.admin.organization @defaults("name") {
   // Organization ID
   id string
@@ -70,11 +74,12 @@ atlassian.admin.organization @defaults("name") {
 
 // Atlassian Admin managed user
 //
-// Examine a user managed by an Atlassian organization: account type
-// (atlassian / customer / app), email, status (active / inactive / closed),
-// last-active timestamp, per-product access, the parent organization, and
-// any outstanding API tokens — the granularity needed for managed-account
-// access reviews, dormant-account cleanup, and stale-token cleanup.
+// User managed by an Atlassian organization, including account type
+// (atlassian, customer, or app), email, status (active, inactive, or
+// closed), last-active timestamp, per-product access, the parent
+// organization, and any outstanding API tokens. This is the granularity
+// needed for managed-account access reviews, dormant-account cleanup, and
+// stale-token cleanup.
 atlassian.admin.organization.managedUser @defaults("name") {
   // User ID
   id string
@@ -89,6 +94,10 @@ atlassian.admin.organization.managedUser @defaults("name") {
   // Last activity timestamp
   lastActive time
   // Product access permissions
+  //
+  // Each entry has `Name` (the product the user can access, e.g., jira or
+  // confluence) and `LastActive` (the timestamp the user was last active in
+  // that product, or null if never recorded).
   productAccess []dict
   // ID of the parent Atlassian organization that manages this user
   organizationId string
@@ -98,10 +107,10 @@ atlassian.admin.organization.managedUser @defaults("name") {
 
 // API token issued to a managed Atlassian account
 //
-// Examine an outstanding API token issued to a managed user: its identity,
-// the label set at creation, the creation timestamp, and the last access
-// timestamp. Use this to find dormant or unrotated tokens that should be
-// revoked as part of a credential-hygiene audit.
+// Outstanding API token issued to a managed user: its identity, the label
+// set at creation, the creation timestamp, and the last access timestamp.
+// Use this to find dormant or unrotated tokens that should be revoked as
+// part of a credential-hygiene audit.
 private atlassian.admin.organization.managedUser.apiToken @defaults("label createdAt lastAccess") {
   // Token ID
   id string
@@ -115,12 +124,12 @@ private atlassian.admin.organization.managedUser.apiToken @defaults("label creat
 
 // Atlassian Admin organization policy
 //
-// Examine an organization-level policy (e.g., IP allowlist, data residency,
-// two-step verification, mobile-app management) — its identity, type,
-// enabled / disabled status, lifecycle timestamps, and the resources
-// (workspaces / managed accounts) the policy applies to. Used to verify
-// the policies an organization is supposed to enforce are present, enabled,
-// and scoped to the right resources.
+// Organization-level policy such as an IP allowlist, data residency,
+// two-step verification, or mobile-app management, including its identity,
+// type, enabled or disabled status, lifecycle timestamps, and the resources
+// (workspaces or managed accounts) the policy applies to. Used to verify
+// that the policies an organization is supposed to enforce are present,
+// enabled, and scoped to the right resources.
 atlassian.admin.organization.policy @defaults("name policyType status") {
   // Policy ID
   id string
@@ -146,9 +155,9 @@ atlassian.admin.organization.policy @defaults("name policyType status") {
 
 // Atlassian Admin verified domain
 //
-// Examine a verified email domain attached to an Atlassian organization —
-// its name and verification type — used to scope which user accounts the
-// organization controls.
+// Verified email domain attached to an Atlassian organization, with its
+// name and verification type. Scopes which user accounts the organization
+// controls.
 atlassian.admin.organization.domain @defaults("name") {
   // Domain ID
   id string
@@ -160,11 +169,11 @@ atlassian.admin.organization.domain @defaults("name") {
 
 // Atlassian Jira instance
 //
-// Top-level entry point for a Jira Cloud / Server / Data Center instance.
-// Examine deployment metadata via serverInfos, all users / groups /
-// projects / issues, and the recent audit-log records — the surface
-// auditors check for least-privilege project permissions, dormant users,
-// and suspicious admin activity.
+// Root of a Jira Cloud, Server, or Data Center instance. Deployment
+// metadata is available via serverInfos, along with all users, groups,
+// projects, and issues, and the recent audit-log records. This is the
+// surface auditors check for least-privilege project permissions, dormant
+// users, and suspicious admin activity.
 atlassian.jira {
   // All Jira users
   users() []atlassian.jira.user
@@ -190,10 +199,10 @@ atlassian.jira {
 
 // Jira saved filter
 //
-// Examine a saved JQL filter: its identity, the JQL it runs, the owning
+// Saved JQL filter with its identity, the JQL it runs, the owning
 // account, the view URL, the favourite count, the share-permission entries,
 // and any email subscriptions attached to it. Filters are a common
-// data-disclosure surface — a filter shared with `loggedin` or `global`
+// data-disclosure surface: a filter shared with `loggedin` or `global`
 // effectively exposes its results to every authenticated user, and
 // subscriptions email those results to whoever the owner enumerated.
 atlassian.jira.filter @defaults("name owner.name") {
@@ -227,7 +236,7 @@ atlassian.jira.filter @defaults("name owner.name") {
 
 // Jira dashboard
 //
-// Examine a Jira dashboard: identity, owning account, the popularity
+// Jira dashboard with its identity, owning account, the popularity
 // counter, the view URL, and the share-permission and edit-permission
 // entries. Dashboards aggregate gadgets that query Jira data, so a
 // dashboard shared with `loggedin` or `global` can expose summarized data
@@ -258,9 +267,9 @@ atlassian.jira.dashboard @defaults("name owner.name") {
 
 // Jira audit log record
 //
-// Examine an entry from Jira's audit log: the audited action and category,
+// Entry from Jira's audit log: the audited action and category,
 // event source, the principal who triggered it, the originating IP, the
-// target object, and any recorded property changes — the input for
+// target object, and any recorded property changes. This is the input for
 // detecting privileged-action sequences and authentication anomalies.
 atlassian.jira.auditRecord @defaults("summary createdAt") {
   // Audit record ID
@@ -289,13 +298,13 @@ atlassian.jira.auditRecord @defaults("summary createdAt") {
 
 // Jira issue (ticket)
 //
-// Examine the full state of a single issue: identity (key, summary,
+// Full state of a single issue: identity (key, summary,
 // description), workflow state and resolution, parent project, type,
 // priority, labels, the lifecycle timestamps (created, updated, resolved,
-// due), the typed creator / assignee / reporter user references, the
+// due), the creator, assignee, and reporter user references, the
 // components and fix versions it belongs to, the issue-security level
-// applied to it, and the watcher / vote counters and comment list — the
-// inputs auditors use to look for stale, mis-secured, or
+// applied to it, and the watcher and vote counters and comment list. These
+// are the inputs auditors use to look for stale, mis-secured, or
 // inappropriately-disclosed tickets.
 atlassian.jira.issue @defaults("key summary status") {
   // Issue ID
@@ -355,9 +364,9 @@ atlassian.jira.issue @defaults("key summary status") {
 
 // Jira server information
 //
-// Examine deployment metadata for the connected Jira instance: base URL,
-// build number, server title, and deployment type (Cloud / Server / Data
-// Center) — useful for version-driven branching in policies.
+// Deployment metadata for the connected Jira instance: base URL,
+// build number, server title, and deployment type (Cloud, Server, or Data
+// Center). Useful for version-driven branching in policies.
 atlassian.jira.serverInfo @defaults("serverTitle") {
   // Jira instance base URL
   baseUrl string
@@ -371,8 +380,8 @@ atlassian.jira.serverInfo @defaults("serverTitle") {
 
 // Jira user account
 //
-// Examine an Atlassian account as it appears in Jira: account ID, display
-// name, account type (atlassian / app / customer), avatar, email, active
+// Atlassian account as it appears in Jira: account ID, display
+// name, account type (atlassian, app, or customer), avatar, email, active
 // status, timezone, locale, group memberships, and the application roles
 // the user is granted (e.g., jira-software-users).
 atlassian.jira.user @defaults("name active") {
@@ -400,7 +409,7 @@ atlassian.jira.user @defaults("name active") {
 
 // Jira application role
 //
-// Examine an application-role assignment: its key (e.g., jira-software,
+// Application-role assignment with its key (e.g., jira-software,
 // jira-servicedesk) and display name. Application roles control which
 // Atlassian products a user is licensed to access.
 atlassian.jira.applicationRole @defaults("name") {
@@ -412,11 +421,11 @@ atlassian.jira.applicationRole @defaults("name") {
 
 // Jira project
 //
-// Examine a project's identity (id, key, name, UUID, URL, email), its
-// project-type key (software / service_desk / business), privacy / archived
-// / deleted state, custom properties, the project lead, the typed
+// Project identity (id, key, name, UUID, URL, email), its
+// project-type key (software, service_desk, or business), privacy,
+// archived, and deleted state, custom properties, the project lead, the
 // permission scheme attached to it, and the components and versions defined
-// on the project — the unit of access control for project-level audits.
+// on the project. The unit of access control for project-level audits.
 atlassian.jira.project @defaults("name projectTypeKey") {
   // Project ID
   id string
@@ -454,8 +463,8 @@ atlassian.jira.project @defaults("name projectTypeKey") {
 
 // Jira project component
 //
-// Examine a component defined on a Jira project: identity, description, the
-// default assignee strategy, and the typed lead and assignee users.
+// Component defined on a Jira project: identity, description, the
+// default assignee strategy, and the lead and assignee users.
 // Components categorize issues within a project and can drive default
 // assignment, so they appear in audits that verify ownership of issue
 // categories.
@@ -478,8 +487,8 @@ private atlassian.jira.project.component @defaults("name") {
 
 // Jira project version
 //
-// Examine a version defined on a Jira project: identity, name, description,
-// release / archived flags, the release date, and whether the unreleased
+// Version defined on a Jira project: identity, name, description,
+// release and archived flags, the release date, and whether the unreleased
 // version is overdue. Versions drive fix-version tracking and release
 // reports.
 private atlassian.jira.project.version @defaults("name released") {
@@ -503,7 +512,7 @@ private atlassian.jira.project.version @defaults("name released") {
 
 // Jira permission scheme
 //
-// Examine a permission scheme: identity, description, and the list of
+// Permission scheme with its identity, description, and the list of
 // permission grants it contains. Use it to verify that schemes attached to
 // projects only grant the permissions they should.
 atlassian.jira.permissionScheme @defaults("name") {
@@ -519,7 +528,7 @@ atlassian.jira.permissionScheme @defaults("name") {
 
 // Individual permission grant within a Jira permission scheme
 //
-// Examine the permission key being granted (e.g., CREATE_ISSUES,
+// Permission key being granted (e.g., CREATE_ISSUES,
 // ADMINISTER_PROJECTS), the holder type (user, group, projectRole,
 // applicationRole, anyone), and the holder parameter that selects who
 // receives it. The unit of grant-level project-permission audits.
@@ -536,7 +545,7 @@ atlassian.jira.permissionScheme.grant @defaults("permission holderType") {
 
 // Jira project custom property
 //
-// Examine the key of a custom property attached to a project — used by
+// Key of a custom property attached to a project. Used by
 // Jira apps and integrations to attach scoped configuration to a project.
 atlassian.jira.project.property @defaults("id") {
   // Property key
@@ -545,13 +554,13 @@ atlassian.jira.project.property @defaults("id") {
 
 // Jira project role
 //
-// Examine a role on a Jira project and the actors (users and groups)
+// Role on a Jira project and the actors (users and groups)
 // assigned to it. Project roles are the unit of project-level RBAC:
 // permission scheme grants name a role (`Administrators`, `Developers`,
 // ...) and the role determines who can take which action on that
 // project. `actors` lists every assignment with its `type` (`atlassian-user-role-actor`
 // or `atlassian-group-role-actor`), `name`, `displayName`, and
-// `accountId` (for users) — the input audits use to verify least
+// `accountId` (for users). This is the input audits use to verify least
 // privilege at the project level.
 private atlassian.jira.project.role @defaults("projectKey name") {
   // Composite identifier (projectKey/roleId)
@@ -580,7 +589,7 @@ private atlassian.jira.project.role @defaults("projectKey name") {
 
 // Jira custom field
 //
-// Examine a custom field defined on the Jira instance. Each field has an
+// Custom field defined on the Jira instance. Each field has an
 // `id` (`customfield_10001`-style key used in JQL and the REST API), a
 // `name` shown in the UI, the `schemaType` and `schemaCustom` that
 // determine its data shape and editor (e.g., `com.atlassian.jira.plugin.system.customfieldtypes:textarea`),
@@ -627,7 +636,7 @@ private atlassian.jira.customField @defaults("id name schemaType") {
 
 // Jira workflow
 //
-// Examine a workflow defined on the Jira instance — the state machine
+// Workflow defined on the Jira instance, the state machine
 // that issues move through. `name` and `id` (the entity ID) identify the
 // workflow; `isDefault` flags Jira's built-in default workflow.
 // `statuses` lists every status the workflow uses (initial state through
@@ -652,15 +661,15 @@ private atlassian.jira.workflow @defaults("name isDefault") {
   // origin status names; empty for global transitions), `to` (destination
   // status name), and the rule lists `conditions`, `validators`,
   // `actions` (post-functions), and `triggers`. Use for change-management
-  // audits — e.g., asserting that a transition into `Done` requires a
+  // audits. For example, asserting that a transition into `Done` requires a
   // specific validator or approver condition.
   transitions []dict
 }
 
 // Jira user group
 //
-// Examine a user group used by Jira permission schemes and application
-// roles — its identity and name. Group membership drives most of Jira's
+// User group used by Jira permission schemes and application
+// roles, with its identity and name. Group membership drives most of Jira's
 // access control.
 atlassian.jira.group @defaults("name") {
   // Group ID
@@ -671,9 +680,9 @@ atlassian.jira.group @defaults("name") {
 
 // Atlassian Confluence instance
 //
-// Top-level entry point for a Confluence Cloud / Server / Data Center
-// instance. Examine all users and all spaces — the surface auditors use
-// to find unprotected content (anonymous- or unlicensed-accessible spaces),
+// Confluence Cloud, Server, or Data Center instance, the entry point for
+// auditing all users and all spaces. Surfaces the data auditors use to find
+// unprotected content (anonymous- or unlicensed-accessible spaces),
 // inappropriate space-level permissions, and page-level restrictions.
 atlassian.confluence {
   // All Confluence users
@@ -684,8 +693,8 @@ atlassian.confluence {
 
 // Confluence user account
 //
-// Examine an Atlassian account as it appears in Confluence: account ID,
-// display name, and account type (atlassian / app / customer).
+// Atlassian account as it appears in Confluence, covering the account ID,
+// display name, and account type (atlassian, app, or customer).
 atlassian.confluence.user @defaults("name") {
   // Atlassian account ID
   id string
@@ -697,7 +706,7 @@ atlassian.confluence.user @defaults("name") {
 
 // Confluence user group
 //
-// Examine a Confluence group. Note: the `id` field may be either the group key
+// Confluence group. The `id` field may be either the group key
 // or the display name depending on the source API. Space permissions expose
 // the group key as `subjectKey`, while page restrictions only expose the
 // display name. As a result, the same group surfaced via both code paths will
@@ -712,12 +721,11 @@ private atlassian.confluence.group @defaults("id name") {
 
 // Confluence space
 //
-// Examine a single Confluence space: identity (key, name, id), type
-// (global / personal), status (current / archived), whether anonymous or
-// unlicensed users have any access, the raw permission entries, the typed
-// users and groups they reference, the homepage, the creator and creation
-// timestamp, and the pages within the space — everything needed for
-// space-level access reviews.
+// Confluence space and its access posture: the space type (global or
+// personal), status (current or archived), whether anonymous or unlicensed
+// users have any access, the raw permission entries and the users and groups
+// they reference, the homepage, the creator, the creation timestamp, and the
+// pages within the space. Everything needed for space-level access reviews.
 atlassian.confluence.space @defaults("name key type") {
   // Numeric space ID
   id int
@@ -733,11 +741,17 @@ atlassian.confluence.space @defaults("name key type") {
   anonymousAccess bool
   // Whether unlicensed users (e.g., JSM customers) have any access to this space
   unlicensedAccess bool
-  // Permission entries for this space (operation, targetType, subjectType, subjectKey)
+  // Permission entries for this space
+  //
+  // Each entry is a dict with keys `operation` (the granted operation, e.g.
+  // read or administer), `targetType` (the object the operation applies to,
+  // e.g. space or page), `subjectType` (one of user, group, or anonymous),
+  // and `subjectKey` (the user account ID or group ID, empty for anonymous
+  // entries).
   permissions []dict
-  // Distinct users referenced by space permissions (typed)
+  // Distinct users referenced by space permissions
   permissionUsers() []atlassian.confluence.user
-  // Distinct groups referenced by space permissions (typed)
+  // Distinct groups referenced by space permissions
   permissionGroups() []atlassian.confluence.group
   // Homepage of the space. Null when no homepage is set.
   homepage atlassian.confluence.page
@@ -751,12 +765,12 @@ atlassian.confluence.space @defaults("name key type") {
 
 // Confluence page (content with type=page)
 //
-// Examine a single page: identity, status (current / trashed / draft), the
-// space it lives in, the current version number, the creator and last
-// update timestamps, the typed creator user, the typed parent page (when
-// the page is nested), the labels applied to it, whether any explicit read
-// or update restrictions are applied, and the per-operation restriction
-// set with its users and groups — the unit of page-level access reviews.
+// Confluence page (content with type page) and its access posture: status
+// (current, trashed, or draft), the space it lives in, the current version
+// number, the creator and last-update timestamps, the parent page when the
+// page is nested, the labels applied to it, whether any explicit read or
+// update restrictions are applied, and the per-operation restriction set
+// with its users and groups. The unit of page-level access reviews.
 atlassian.confluence.page @defaults("title status") {
   // Content ID
   id string
@@ -788,9 +802,9 @@ atlassian.confluence.page @defaults("title status") {
 
 // Per-operation restriction on a Confluence page
 //
-// Examine which Atlassian accounts and groups hold read or update access on
-// a page that has explicit restrictions configured, both as raw IDs / names
-// and as typed user / group references.
+// Atlassian accounts and groups that hold read or update access on a page
+// with explicit restrictions configured, available both as raw account IDs
+// and group names and as resolved user and group references.
 atlassian.confluence.page.restriction @defaults("operation") {
   // Identifier of the restriction, unique per (page, operation) pair
   id string
@@ -800,9 +814,9 @@ atlassian.confluence.page.restriction @defaults("operation") {
   userIds []string
   // Group names with this operation restriction
   groupNames []string
-  // Users with this operation restriction (typed)
+  // Users with this operation restriction
   users() []atlassian.confluence.user
-  // Groups with this operation restriction (typed)
+  // Groups with this operation restriction
   //
   // Identified by display name only — see atlassian.confluence.group.id
   // for cache-key caveats.


### PR DESCRIPTION
## What

A documentation pass over `atlassian.lr`, applying the pattern established across the provider-wide sweep (starting with S3, #9146). These doc-comments render onto Mondoo's docs website, so this is user-facing content teaching what each resource is, what's queryable, and why the data matters for auditing.

**~32 resources across the admin, confluence, jira, and scim groups, 37 edits.**

## Changes

- **Resource descriptions** rewritten to lead with the noun and drop `Examine`/`Top-level entry point` jargon.
- **Documented `[]dict` key shapes** — admin `productAccess`, confluence `permissions`.
- **Style-rule cleanup** — em dashes and `typed`/`(typed)` mechanism leaks throughout.

## Verification

- **Comment-only diff**: 0 non-comment lines changed. `mqlr generate` produces no `.lr.go` or `.lr.versions` churn.
- 0 em dashes, no over-cap titles; regeneration succeeds.

## Method

Multi-agent audit (one agent per group, cross-checking each field against its Go accessor), edits applied through a verifying script that requires each replacement to match exactly once.
