### PR TITLE
📄 ipinfo: enrich resource documentation

### DIFF
--- a/providers/ipinfo/resources/ipinfo.lr
+++ b/providers/ipinfo/resources/ipinfo.lr
@@ -6,11 +6,13 @@ option go_package = "go.mondoo.com/mql/v13/providers/ipinfo/resources"
 
 // IP information from the ipinfo.io service
 //
-// Top-level entry point for IP lookups. Given an IP (or your own public
-// IP if none is supplied), examine the resolved hostname, geographic
-// location (city, region, country, EU flag, geocode coordinates, postal,
-// timezone), the owning organization (ASN + name), and whether the address
-// is in a special-use bogon range.
+// Geolocation and network-ownership details for an IP address, resolved
+// through ipinfo.io. When no IP is supplied the lookup targets the caller's
+// own public IP. The result covers the resolved hostname, geographic
+// location (city, region, country, EU flag, geocode coordinates, postal
+// code, timezone), the owning organization (ASN plus name), and whether
+// the address falls in a special-use bogon range. Supply an IP to look one
+// up, for example ipinfo(ip: "8.8.8.8").
 ipinfo @defaults("returned_ip hostname city") {
   init(ip ip)
   // The IP address that was requested (empty if querying for your public IP)


### PR DESCRIPTION
Documentation pass over `ipinfo.lr` (part of the provider-wide sweep, S3 #9146 onward). Rewrote the `ipinfo` resource description to lead with the noun instead of "Top-level entry point"/"examine" jargon and added an `ipinfo(ip: "8.8.8.8")` selection example.

**Verification:** comment-only diff (0 non-comment lines), no `.lr.go`/`.lr.versions` churn, 0 em dashes, regeneration succeeds.