### PR TITLE
📄 network: enrich resource and field documentation across services

### DIFF
--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -6,9 +6,9 @@ option go_package = "go.mondoo.com/mql/v13/providers/network/resources"
 
 // Network socket
 //
-// Examine an addressable network endpoint by `protocol`, `port`, and
-// `address`. Used as a building block for higher-level resources like
-// `tls` that need to know "what to talk to".
+// Addressable network endpoint identified by its transport `protocol`,
+// `port`, and `address`. Serves as a building block for higher-level
+// resources such as `tls` that need to know what to connect to.
 socket @defaults("protocol port address") {
   // Transport protocol (e.g., tcp, udp)
   protocol string
@@ -20,20 +20,20 @@ socket @defaults("protocol port address") {
 
 // HTTP endpoint
 //
-// Empty namespace for HTTP probing. Use `http.get(url: "https://...")`
+// Entry point for HTTP probing. Use `http.get(rawUrl: "https://...")`
 // to perform a GET against a URL and inspect the response status,
-// headers (parsed into typed sub-resources for HSTS, CSP, cookies,
-// etc.), and body.
+// headers (parsed into sub-resources for HSTS, CSP, cookies, and other
+// security headers), and body.
 http {}
 
 // HTTP GET request
 //
-// Examine the result of an HTTP GET against a URL. Initialize with
-// `http.get(rawUrl: "https://example.com", followRedirects: true)`.
-// Surfaces the parsed `url`, the `statusCode`, the HTTP `version`,
-// the response `body`, and a typed `header` sub-resource exposing
-// HSTS, CSP, X-Frame-Options, X-XSS-Protection, X-Content-Type-Options,
-// Referrer-Policy, Content-Type, and Set-Cookie semantics.
+// Result of an HTTP GET against a URL, for probing how a web endpoint
+// responds. Initialize with `http.get(rawUrl: "https://example.com",
+// followRedirects: true)`. The `header` sub-resource parses the
+// response's security headers (HSTS, CSP, X-Frame-Options,
+// X-XSS-Protection, X-Content-Type-Options, Referrer-Policy,
+// Content-Type, and Set-Cookie) into individually queryable values.
 http.get @defaults("url statusCode") {
   init(rawUrl string, followRedirects bool)
   // URL for this request
@@ -52,7 +52,12 @@ http.get @defaults("url statusCode") {
 
 // HTTP header
 private http.header @defaults("length=params.length") {
-  // Raw list of parameters for this header
+  // Raw response headers, keyed by header name
+  //
+  // Each key is a canonical response header name (for example
+  // `Content-Type` or `Set-Cookie`) and each value is the list of values
+  // sent for that header. The other fields on this resource parse
+  // individual headers out of this map into structured values.
   params map[string][]string
   // HTTP Strict-Transport-Security (HSTS) header
   sts() http.header.sts
@@ -63,12 +68,23 @@ private http.header @defaults("length=params.length") {
   // X-Content-Type-Options header: nosniff
   xContentTypeOptions() string
   // Referrer-Policy header
+  //
+  // Controls how much referrer information the browser sends with
+  // requests. One of no-referrer, no-referrer-when-downgrade, origin,
+  // origin-when-cross-origin, same-origin, strict-origin,
+  // strict-origin-when-cross-origin, or unsafe-url. Empty when no
+  // Referrer-Policy header is sent.
   referrerPolicy() string
   // Content-Type header
   contentType() http.header.contentType
   // Set-Cookie header
   setCookie() http.header.setCookie
-  // Content-Security-Policy header
+  // Content-Security-Policy header directives
+  //
+  // The parsed Content-Security-Policy header, keyed by directive name
+  // lowercased (for example `default-src`, `script-src`, or
+  // `frame-ancestors`) with that directive's source list as the value.
+  // Null when no Content-Security-Policy header is present.
   csp() map[string]string
   // Server header value, e.g. "nginx" or "Apache/2.4.62"
   //
@@ -90,9 +106,11 @@ private http.header.sts @defaults("maxAge includeSubDomains preload") {
 
 // HTTP header X-XSS-Protection
 //
-// Now outdated (replaced by Content Security Policy) and may even cause
-// security vulnerabilities. Examine `enabled`, `mode`, and `report` to
-// see how a server is configuring the legacy XSS filter.
+// Configuration of the legacy browser XSS filter, parsed from the
+// X-XSS-Protection response header. Now outdated (replaced by
+// Content-Security-Policy) and, when enabled, capable of introducing
+// security vulnerabilities of its own, so hardening policies generally
+// expect it disabled.
 private http.header.xssProtection @defaults("enabled mode report") {
   // Whether the header is enabled (Enabled when the header value is set to 1; disabled if set to 0)
   enabled bool
@@ -106,7 +124,11 @@ private http.header.xssProtection @defaults("enabled mode report") {
 private http.header.contentType @defaults("type") {
   // MIME type for the content
   type string
-  // Additional parameters for this content type
+  // Content-Type parameters, keyed by parameter name
+  //
+  // Parameters that follow the media type, keyed by name lowercased (for
+  // example `charset` or `boundary`) with the parameter value. Empty when
+  // the Content-Type header carries no parameters.
   params map[string]string
 }
 
@@ -116,13 +138,18 @@ private http.header.setCookie @defaults("name value") {
   name string
   // Value of the cookie to set
   value string
-  // Additional parameters for setting this cookie
+  // Cookie attributes, keyed by attribute name
+  //
+  // Attributes set on the cookie, keyed by name lowercased (for example
+  // `path`, `domain`, `secure`, `httponly`, `samesite`, `max-age`, or
+  // `expires`) with the attribute value. Flag attributes such as `secure`
+  // and `httponly` carry an empty value.
   params map[string]string
 }
 
 // Parsed URL
 //
-// Examine a parsed URL, generally represented as
+// URL broken into its components, generally represented as
 // `[scheme:][//[user[:password]@]host[:port]][/]path[?query][#fragment]`.
 // Initialize with `url(raw: "https://user:pass@host:443/p?q=1#f")` and
 // inspect any of the parsed components individually: scheme, user /
@@ -154,13 +181,13 @@ url @defaults("string") {
 
 // TLS/SSL connection inspection
 //
-// Examine the TLS posture of a network endpoint. Initialize with
+// TLS posture of a network endpoint. Initialize with
 // `tls(target: "host:port")` (an optional `domainName` enables SNI
 // testing). Surfaces every TLS / SSL version the endpoint accepts,
-// the cipher suites and extensions advertised, the version / cipher
-// / key-exchange group a modern client actually negotiates, and the
-// served certificate chain — both the SNI-aware chain and the
-// non-SNI fallback. The resource an audit uses to find weak protocol
+// the cipher suites and extensions advertised, the version, cipher,
+// and key-exchange group a modern client actually negotiates, and the
+// served certificate chain (both the SNI-aware chain and the
+// non-SNI fallback). Use it to find weak protocol
 // versions, weak ciphers, expired certs, and missing OCSP / SCT
 // support.
 tls @defaults("socket domainName") {
@@ -169,7 +196,12 @@ tls @defaults("socket domainName") {
   socket socket
   // An optional domain name to test
   domainName string
-  // List of all parameters for this TLS/SSL connection
+  // Raw TLS/SSL handshake findings for this connection
+  //
+  // Dict with three keys: `versions`, `ciphers`, and `extensions`. Each
+  // maps a protocol version, cipher suite, or extension name to a bool
+  // recording whether the endpoint accepts it. The versions, ciphers, and
+  // extensions fields expose the accepted entries drawn from this bag.
   params(socket, domainName) dict
   // Version of TLS/SSL that is being used
   versions(params) []string
@@ -241,9 +273,11 @@ private tls.cipher @defaults("name") {
 
 // X.509 certificate bundle
 //
-// Examine a list of certificates parsed from PEM content. Use it to
-// iterate over a chain and apply per-certificate checks, or to
-// extract the underlying `pem` source.
+// Certificates parsed from PEM content, typically a full chain of a
+// leaf, its intermediates, and a root. The list supports per-certificate
+// checks across the chain (validity window, key usage, signing
+// algorithm, revocation, and expiration), and the raw `pem` field
+// returns the original source.
 certificates {
   []certificate
   // PEM content
@@ -252,25 +286,24 @@ certificates {
 
 // X.509 certificate
 //
-// Examine a single X.509 certificate parsed from PEM. Surfaces the
-// raw PEM, every SHA-1 / SHA-256 fingerprint, the serial number, the
-// subject and authority key identifiers, the parsed PKIX subject and
-// issuer distinguished names, version, validity window
-// (`notBefore`, `notAfter`, `expiresIn`), signature and signing
-// algorithm, the `isCA` flag, key usages and extended key usages, the
-// raw and SAN extensions, policy identifiers, CRL distribution points,
-// OCSP server and issuing-certificate URLs, the revoked / verified /
-// expired flags, public-key algorithm and bit length, the
-// `hasSCTs` flag (Certificate Transparency) and the maximum CA chain
-// path length.
+// Single X.509 certificate parsed from its PEM encoding, exposing the
+// identity and trust properties auditors care about: the subject and
+// issuer distinguished names, the validity window (notBefore, notAfter,
+// and the expiresIn countdown), the public-key algorithm and bit length,
+// the isCA and key-usage constraints, and the revocation, verification,
+// and expiration status. Useful for flagging weak keys, expired or
+// soon-to-expire leaf certificates, and untrusted or revoked chains.
 certificate @defaults("serial subject.commonName subject.dn") {
   // PEM content
   pem string
   // Certificate fingerprints
+  //
+  // Keyed by hash algorithm: `sha1`, `sha256`, and `md5`, each mapping to
+  // the hex-encoded digest of the certificate's DER encoding.
   fingerprints() map[string]string
   // Serial number
   serial() string
-  // Subject unique identifier
+  // Subject key identifier
   subjectKeyID() string
   // Authority key identifier
   authorityKeyID() string
@@ -280,9 +313,9 @@ certificate @defaults("serial subject.commonName subject.dn") {
   issuer() pkix.name
   // Version number
   version() int
-  // Validity period validity period
+  // Start of the validity period, before which the certificate is not valid
   notBefore() time
-  // Validity period not after
+  // End of the validity period, after which the certificate has expired
   notAfter() time
   // Expiration duration
   expiresIn() time
@@ -290,7 +323,7 @@ certificate @defaults("serial subject.commonName subject.dn") {
   signature() string
   // Signature algorithm ID
   signingAlgorithm() string
-  // Whether the certificate is from a certificate authority
+  // Whether the certificate is a certificate authority (CA) certificate
   isCA() bool
   // Key usage
   keyUsage() []string
@@ -328,15 +361,16 @@ certificate @defaults("serial subject.commonName subject.dn") {
 
 // X.509 PKIX name
 //
-// Examine a parsed RFC 5280 distinguished name (DN) — the structured
-// form of a certificate's subject or issuer. Surfaces the canonical
-// DN string, common name, country, organization and organizational
-// unit, locality, province, street address, postal code, serial
-// number, and any extra named attributes.
+// Distinguished name (DN) parsed per RFC 5280: the structured identity
+// of a certificate's subject or issuer. Exposes the canonical DN string,
+// common name, country, organization and organizational unit, locality,
+// province, street address, postal code, serial number, and any
+// additional named attributes, so you can audit who a certificate was
+// issued to and who issued it.
 pkix.name @defaults("id dn commonName") {
   // Cache key derived from the distinguished name
   id string
-  // Distinguished name qualifier
+  // Canonical distinguished name (DN) string
   dn string
   // Serial number
   serialNumber string
@@ -348,6 +382,7 @@ pkix.name @defaults("id dn commonName") {
   organization []string
   // Organizational unit
   organizationalUnit []string
+  // Locality or city
   locality []string
   // State or province
   province []string
@@ -355,15 +390,26 @@ pkix.name @defaults("id dn commonName") {
   streetAddress []string
   // Postal code
   postalCode []string
+  // Distinguished name attributes by OID
+  //
+  // All relative distinguished name (RDN) attributes parsed from the DN,
+  // keyed by attribute OID (for example "2.5.4.3" for commonName or
+  // "2.5.4.10" for organization) with the attribute value as the value.
   names      map[string]string
+  // Non-standard distinguished name attributes by OID
+  //
+  // RDN attributes beyond the dedicated fields (commonName, country,
+  // organization, and so on), keyed by attribute OID with the attribute
+  // value as the value.
   extraNames map[string]string
 }
 
 // X.509 PKIX extension
 //
-// Examine a single extension carried by an X.509 certificate: its
-// OID identifier (e.g., 2.5.29.37 for extKeyUsage), the `critical`
-// flag, and the raw extension value.
+// Single extension carried by an X.509 certificate, identified by its
+// OID (for example 2.5.29.37 for extKeyUsage). The `critical` flag marks
+// whether a client that does not recognize the extension must reject the
+// certificate, and `value` holds the raw extension bytes.
 pkix.extension @defaults("id") {
   // Cache key derived from the extension identifier
   id string
@@ -446,6 +492,10 @@ private openpgp.signature {
   // Signature version
   version int
   // Signature type
+  //
+  // One of binary, text, generic_cert, persona_cert, casual_cert,
+  // positive_cert, subkey_binding, primary_key_binding, direct_signature,
+  // key_revocation, subkey_revocation, or cert_revocation.
   signatureType string
   // Public-key algorithm of the signing key (e.g., RSA, ECDSA, Ed25519)
   keyAlgorithm string
@@ -463,16 +513,18 @@ private openpgp.signature {
 
 // Domain name
 //
-// Examine a parsed FQDN. Initialize with `domainName(fqdn: "x.example.com")`.
-// Surfaces the FQDN itself, the effective TLD plus one (the
-// registrable domain), the TLD, an `tldIcannManaged` flag indicating
-// whether the TLD is in the ICANN-managed list, and the individual
-// dot-separated labels.
+// Parsed view of a fully qualified domain name, broken into its
+// registrable parts. Select the name with `domainName(fqdn:
+// "x.example.com")`. Use it to reason about the registrable domain
+// (the effective TLD plus one label) and the top-level domain
+// independently of subdomain labels, for example to group hosts by
+// their owning domain or to check whether a name sits under an
+// ICANN-managed TLD.
 domainName @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
   fqdn string
-  // effectiveTLDPlusOne returns the effective top level domain plus one more label
+  // Effective top-level domain plus one label (the registrable domain)
   effectiveTLDPlusOne string
   // Top-level domain
   tld string
@@ -484,15 +536,21 @@ domainName @defaults("fqdn") {
 
 // DNS resource
 //
-// Examine the DNS records published for a fully-qualified domain
-// name. Initialize with `dns(fqdn: "example.com")`. Surfaces every
-// resolved record, the MX record list, and a parsed view of any DKIM
-// public-key records discovered for the domain.
+// DNS records published for a fully-qualified domain name.
+// Select a domain with `dns(fqdn: "example.com")`. Surfaces every
+// resolved record, the MX record list, DNSSEC signing state, and
+// parsed SPF, DMARC, and DKIM policy records, so mail-authentication
+// and zone-signing audits run without hand-building DNS lookups.
 dns @defaults("fqdn") {
   init(fqdn string)
   // Fully qualified domain name (FQDN)
   fqdn string
-  // Params is a list of all parameters for DNS FQDN
+  // DNS query results keyed by record type
+  //
+  // Map keyed by DNS record type (such as `A`, `AAAA`, `MX`, or `TXT`),
+  // where each value carries that query's `name`, `ttl`, `class`, `type`,
+  // `rData` payload, and `rCode` response status. The `records`, `mx`,
+  // `dkim`, `spf`, `dmarc`, and `dnssec` fields parse this into records.
   params(fqdn) dict
   // Successful DNS records
   records(params) []dns.record
@@ -517,7 +575,7 @@ dns @defaults("fqdn") {
 
 // DNS record
 //
-// Examine a single resolved DNS record: name, type, class, TTL, and
+// Single resolved DNS record: name, type, class, TTL, and
 // the rdata payload (IP addresses, hostnames, or other values
 // depending on the record type).
 dns.record @defaults("name type") {
@@ -535,9 +593,9 @@ dns.record @defaults("name type") {
 
 // DNS MX record
 //
-// Examine a single MX record: the record name, the resolved target
-// `domainName`, and the `preference` value used to choose between
-// multiple MX records.
+// Mail-exchange (MX) record for the domain: the record name, the
+// resolved target `domainName`, and the `preference` value used to
+// choose between multiple MX records.
 dns.mxRecord @defaults("domainName") {
   // Record name
   name string
@@ -549,7 +607,7 @@ dns.mxRecord @defaults("domainName") {
 
 // DNSSEC configuration for a domain
 //
-// Examine whether a domain is signed with DNSSEC and how. Reports whether
+// DNSSEC signing state for a domain. Reports whether
 // the domain publishes DNSKEY records, the parsed signing keys, and the
 // distinct algorithm numbers in use, so audits can require DNSSEC and flag
 // weak or deprecated algorithms without parsing raw DNSKEY rdata. `enabled`
@@ -570,7 +628,7 @@ dns.dnssecConfig @defaults("enabled") {
 
 // DNSKEY record (RFC 4034)
 //
-// Examine a single published DNSSEC key: its flags, protocol, algorithm
+// Single published DNSSEC key: its flags, protocol, algorithm
 // number, and base64-encoded public key. `keySigningKey` is true for a
 // key-signing key — the one whose SEP flag is set (flags value 257) — as
 // opposed to a zone-signing key (flags value 256).
@@ -589,7 +647,7 @@ private dns.dnssecKey @defaults("algorithm keySigningKey") {
 
 // SPF policy record (RFC 7208)
 //
-// Examine a parsed Sender Policy Framework record from a domain's TXT records:
+// Parsed Sender Policy Framework record from a domain's TXT records:
 // the version, the ordered list of mechanisms, and the qualifier on the
 // terminating `all` mechanism that decides how unauthorized senders are
 // handled. Select a domain's records with `dns(fqdn: "example.com").spf`.
@@ -615,7 +673,7 @@ private dns.spfRecord @defaults("dnsTxt allQualifier") {
 
 // DMARC policy record (RFC 7489)
 //
-// Examine a parsed DMARC record from a domain's `_dmarc` TXT record: the policy
+// Parsed DMARC record from a domain's `_dmarc` TXT record: the policy
 // applied to failing mail, the subdomain policy, the aggregate and forensic
 // report destinations, the percentage of mail the policy covers, and the
 // SPF/DKIM identifier alignment modes. Reachable as
@@ -648,7 +706,7 @@ private dns.dmarcRecord @defaults("policy") {
 
 // DKIM public-key DNS record (RFC 6376)
 //
-// Examine a parsed DKIM TXT record: the raw DNS text, the selector
+// Parsed DKIM TXT record: the raw DNS text, the selector
 // domain, the version, the acceptable hash algorithms, the key type,
 // the base64-encoded public-key data, the service-type restrictions,
 // the DKIM flags, free-form notes, and a `valid()` predicate that


### PR DESCRIPTION
Documentation pass over `network.lr` (the TLS/PKIX/DNS/HTTP/OpenPGP/URL primitives shared across providers; part of the sweep, S3 #9146 onward). Rewrote resource descriptions to lead with the noun and convey audit/security significance (certificates, TLS parameters, HTTP security headers); documented raw dict/map key shapes (certificate `fingerprints`, dns `params`, http `params`/`csp`/`setCookie`, tls `versions`/`ciphers`/`extensions`, pkix `names`/`extraNames`) verified against the Go accessors; added enum values (http Referrer-Policy, openpgp signatureType) and fixed several misleading/copy-pasted field comments (certificate `subjectKeyID`/`notBefore`/`isCA`, domainName `effectiveTLDPlusOne`, pkix dn qualifier).

**Verification:** comment-only diff (0 non-comment lines), no `.lr.go`/`.lr.versions` churn, 0 em dashes, no over-cap titles, regeneration succeeds.