### PR TITLE
🎉 atlassian-13.4.0

### DIFF
--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.3.9",
+	Version:   "13.4.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### atlassian (13.4.0)
- ✨ atlassian: add confluence blogpost and attachment resources (#9209)
- ✨ atlassian: add fields to jira, confluence, and scim resources (#9203)
- 📄 atlassian: enrich resource and field documentation across services (#9188)