### PR TITLE
📄 os: enrich resource and field documentation across services

### DIFF
--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -17,29 +17,37 @@ alias os.base.services = services
 alias os.unix.sshd = sshd
 
 extend asset {
-  // Common Platform Enumeration (CPE) for the asset
+  // Common Platform Enumeration (CPE) identifiers for the asset
+  //
+  // The list of CPE strings that describe the asset's platform and
+  // software, used to correlate the asset against CPE-indexed
+  // vulnerability data.
   cpes() []core.cpe
   // Advisory and vulnerability report
   //
   // Deprecated in favor of the `vulnmgmt` resource. Will be removed in
   // version 13.0.
   vulnerabilityReport() @maturity("deprecated") dict
-  // Platform URL in the package URL format (as opposed to the CPE format)
+  // Platform identity in package URL (purl) format
+  //
+  // The asset's platform expressed as a package URL rather than a CPE
+  // string, for matching against purl-indexed vulnerability and
+  // software-inventory data.
   purl() string
 }
 
 // Host environment for an AI agent or editor extension
 //
-// Examine the runtime that hosts an AI coding agent or editor extension: the
-// operating system for a standalone agent, the IDE/editor for an editor
-// plugin, or the browser for a browser extension. The `package` field carries
-// the host's software identity — version and package URL (purl) where known —
-// so the host itself can be assessed for vulnerabilities like any other
-// installed software.
+// Runtime that hosts an AI coding agent or editor extension: the operating
+// system for a standalone agent, the IDE or editor for an editor plugin, or
+// the browser for a browser extension. The `package` field carries the
+// host's software identity (version and package URL where known) so the
+// host itself can be assessed for vulnerabilities like any other installed
+// software.
 private extensionRuntime @defaults("package") {
   // Host software package
   //
-  // The host application or operating system represented as a package, carrying
+  // Host application or operating system represented as a package, carrying
   // its version and package URL (purl) where known so it can be looked up in
   // vulnerability data like any other installed software.
   package package
@@ -47,17 +55,17 @@ private extensionRuntime @defaults("package") {
 
 // Operating system end-of-life status
 //
-// Examine the End-of-Life metadata Mondoo publishes for the asset's
-// detected operating system or platform: the EoL date itself, a
-// product-page URL, and a documentation URL. Used by audits to flag
-// hosts whose vendor has stopped issuing security patches and to plan
-// migrations before unsupported software accumulates risk.
+// End-of-Life metadata Mondoo publishes for the asset's detected operating
+// system or platform: the EoL date itself, a product-page URL, and a
+// documentation URL. Used by audits to flag hosts whose vendor has stopped
+// issuing security patches and to plan migrations before unsupported
+// software accumulates risk.
 asset.eol @defaults("date") {
-  // Documentation URL
+  // Documentation URL for the platform's end-of-life policy
   docsUrl string
-  // Product URL
+  // Product page URL for the detected platform
   productUrl string
-  // End-of-Life date
+  // Date after which the vendor no longer provides support or patches
   date time
 }
 
@@ -73,36 +81,35 @@ private mondoo.eol {
 
 // Asset vulnerability assessment
 //
-// Top-level entry point for vulnerability data Mondoo derives for an
-// asset by joining its installed-package inventory and platform identity
-// against the curated CVE / advisory feed. Exposes every CVE affecting
-// the asset, every vendor advisory that mentions one of those CVEs, the
-// affected packages with their currently-installed and patched-available
-// versions, the timestamp of the last assessment run, and the rolled-up
-// CVSS statistics — the surface used to score asset risk and to drive
-// patch-status policies.
+// Vulnerability data Mondoo derives for an asset by joining its
+// installed-package inventory and platform identity against the curated
+// CVE and advisory feed. Exposes every CVE affecting the asset, every
+// vendor advisory that mentions one of those CVEs, the affected packages
+// with their currently-installed and patched-available versions, the
+// timestamp of the last assessment run, and the rolled-up CVSS statistics:
+// the surface used to score asset risk and to drive patch-status policies.
 vulnmgmt {
   // List of all CVEs affecting the asset
   cves() []vuln.cve
-  // List of all Advisories affecting the asset
+  // List of all advisories affecting the asset
   advisories() []vuln.advisory
   // List of all packages affected by vulnerabilities
   packages() []vuln.package
   // Last time the vulnerability information was updated
   lastAssessment() time
-  // Statistics about the vulnerabilities
+  // Rolled-up CVSS statistics across all findings
   stats() audit.cvss
 }
 
 // CVE information
 private vuln.cve @defaults("id") {
-  // CVE ID
+  // CVE ID (e.g., "CVE-2024-3094")
   id string
   // CVE state
   state     string
   // Summary description
   summary   string
-  // Whether the CVE has a CVSS score
+  // Whether the CVE has no assigned CVSS score
   unscored  bool
   // Publication date
   published   time
@@ -132,9 +139,9 @@ private vuln.advisory @defaults("id") {
 private vuln.package @defaults("name version") {
   // Package name
   name string
-  // Package version
+  // Currently installed package version
   version string
-  // Available package version
+  // Fixed package version that resolves the vulnerability, when available
   available string
   // Architecture of this package
   arch string
@@ -142,12 +149,11 @@ private vuln.package @defaults("name version") {
 
 // Platform and package advisories
 //
-// Examine the consolidated list of vendor advisories that affect the
-// asset, plus a worst-case CVSS roll-up across all of them and a
-// statistical breakdown by severity (total, critical, high, medium, low,
-// none, unknown). Use it to drive policies that require zero outstanding
-// critical-severity advisories or that compare an asset's advisory load
-// against a baseline.
+// Consolidated list of vendor advisories that affect the asset, plus a
+// worst-case CVSS roll-up across all of them and a statistical breakdown by
+// severity (total, critical, high, medium, low, none, unknown). Use it to
+// drive policies that require zero outstanding critical-severity advisories
+// or that compare an asset's advisory load against a baseline.
 platform.advisories {
   []audit.advisory
   // Worst CVSS score for all advisories
@@ -158,11 +164,11 @@ platform.advisories {
 
 // Platform and package CVEs
 //
-// Examine the full list of CVEs that affect the asset's installed
-// packages or platform, plus a worst-case CVSS roll-up across them and
-// a per-severity statistical breakdown (total, critical, high, medium,
-// low, none, unknown). Used to enforce ceilings on outstanding critical
-// or high-severity CVEs and to surface the most urgent fixes.
+// Full list of CVEs that affect the asset's installed packages or platform,
+// plus a worst-case CVSS roll-up across them and a per-severity statistical
+// breakdown (total, critical, high, medium, low, none, unknown). Used to
+// enforce ceilings on outstanding critical or high-severity CVEs and to
+// surface the most urgent fixes.
 platform.cves {
   []audit.cve
   // Worst CVSS score for all CVEs
@@ -207,7 +213,7 @@ private audit.cve {
   state     string
   // Summary description
   summary   string
-  // Whether the CVE has a CVSS score
+  // Whether the CVE has no assigned CVSS score
   unscored  bool
   // Publication date
   published   time
@@ -219,22 +225,22 @@ private audit.cve {
 
 // Hardware identity from SMBIOS / DMI
 //
-// Top-level namespace for low-level hardware identity exposed by the
-// firmware. The sub-resources below — `machine.bios`, `machine.system`,
+// Namespace for low-level hardware identity exposed by the firmware. The
+// sub-resources below (`machine.bios`, `machine.system`,
 // `machine.baseboard`, `machine.chassis`, `machine.cpu`, and
-// `machine.secureboot` — surface the SMBIOS / DMI tables (vendor /
-// version / release date for the BIOS, manufacturer / product / SKU /
-// UUID / serial for the system, baseboard and chassis identifiers, CPU
-// socket and core counts) plus the EFI Secure Boot posture read from
-// EFI variables on Linux. Used for inventory, warranty / supply-chain
-// reviews, and platform-firmware compliance.
+// `machine.secureboot`) surface the SMBIOS / DMI tables (vendor, version,
+// and release date for the BIOS; manufacturer, product, SKU, UUID, and
+// serial for the system; baseboard and chassis identifiers; CPU socket and
+// core counts) plus the EFI Secure Boot posture read from EFI variables on
+// Linux. Used for inventory, warranty and supply-chain reviews, and
+// platform-firmware compliance.
 machine {}
 
 // SMBIOS BIOS information
 //
-// Examine the firmware vendor, version string, and release date as reported
-// by SMBIOS Type 1 tables. Used to inventory BIOS versions across a fleet
-// and to flag hosts that have not applied vendor firmware updates.
+// Firmware vendor, version string, and release date as reported by SMBIOS
+// Type 0 tables. Used to inventory BIOS versions across a fleet and to flag
+// hosts that have not applied vendor firmware updates.
 machine.bios {
   // BIOS vendor
   vendor string
@@ -246,9 +252,9 @@ machine.bios {
 
 // SMBIOS system information
 //
-// Examine the manufacturer, product name, version, serial number, UUID,
-// SKU number, and family string as reported in SMBIOS Type 1 tables.
-// Useful for asset inventory, warranty lookups, and supply-chain reviews.
+// Manufacturer, product name, version, serial number, UUID, SKU number, and
+// family string as reported in SMBIOS Type 1 tables. Useful for asset
+// inventory, warranty lookups, and supply-chain reviews.
 machine.system {
   // System manufacturer name (SMBIOS Type 1)
   manufacturer string
@@ -268,9 +274,9 @@ machine.system {
 
 // SMBIOS baseboard (or module) information
 //
-// Examine the baseboard manufacturer, product name, version, serial number,
-// and asset tag as reported in SMBIOS Type 2 tables. Used for hardware
-// inventory and to correlate physical boards with asset tracking systems.
+// Baseboard manufacturer, product name, version, serial number, and asset
+// tag as reported in SMBIOS Type 2 tables. Used for hardware inventory and
+// to correlate physical boards with asset-tracking systems.
 machine.baseboard {
   // Baseboard manufacturer name (SMBIOS Type 2)
   manufacturer string
@@ -286,9 +292,9 @@ machine.baseboard {
 
 // SMBIOS system enclosure or chassis
 //
-// Examine the chassis manufacturer, version, serial number, and asset tag
-// as reported in SMBIOS Type 3 tables. Useful for physical-hardware audits
-// and correlating enclosures with asset-tracking records.
+// Chassis manufacturer, version, serial number, and asset tag as reported
+// in SMBIOS Type 3 tables. Useful for physical-hardware audits and
+// correlating enclosures with asset-tracking records.
 machine.chassis {
   // Manufacturer
   manufacturer string
@@ -302,10 +308,9 @@ machine.chassis {
 
 // CPU information
 //
-// Examine the CPU manufacturer, model name, number of physical processor
-// packages (sockets), and total physical core count as reported by the
-// system. Used for capacity planning, licensing audits, and
-// hardware-baseline policies.
+// CPU manufacturer, model name, number of physical processor packages
+// (sockets), and total physical core count as reported by the system. Used
+// for capacity planning, licensing audits, and hardware-baseline policies.
 machine.cpu @defaults("manufacturer model processorCount coreCount") {
   // CPU manufacturer
   manufacturer string
@@ -319,13 +324,13 @@ machine.cpu @defaults("manufacturer model processorCount coreCount") {
 
 // Secure Boot status
 //
-// Examine whether the system booted in EFI/UEFI mode (`efi`), whether
-// Secure Boot is currently enabled (`enabled`), and whether it is in setup
-// mode (`setupMode`, meaning keys can be modified without authentication).
-// Read from the EFI variables on Linux and from the UEFI firmware on
-// Windows; legacy-BIOS systems resolve to `efi` and `enabled` false rather
-// than erroring. Used to assert that Secure Boot is enforced and that setup
-// mode is not active.
+// EFI Secure Boot posture: whether the system booted in EFI/UEFI mode
+// (`efi`), whether Secure Boot is currently enabled (`enabled`), and
+// whether it is in setup mode (`setupMode`, meaning keys can be modified
+// without authentication). Read from EFI variables on Linux and from the
+// UEFI firmware on Windows; legacy-BIOS systems resolve to `efi` and
+// `enabled` false rather than erroring. Used to assert that Secure Boot is
+// enforced and that setup mode is not active.
 machine.secureboot @defaults("enabled") {
   // Whether the system is booted in EFI/UEFI mode
   efi() bool
@@ -337,15 +342,14 @@ machine.secureboot @defaults("enabled") {
 
 // Operating system information
 //
-// Top-level entry point for operating-system-level facts about the
-// asset. Examine the pretty hostname (or Windows device name), the
-// FQDN-style hostname, the system's machine ID, the hypervisor it's
-// running under (when virtualized), the running environment variables
-// and the resolved PATH list, the current uptime, the list of available
-// OS updates with their categories and severities, whether a reboot is
-// pending after recent installs, and the current system date / timezone.
-// Used as the cross-platform anchor that audits start from when they
-// need OS identity and patch state.
+// Operating-system-level facts about the asset. Exposes the pretty
+// hostname (or Windows device name), the FQDN-style hostname, the system's
+// machine ID, the hypervisor it runs under (when virtualized), the running
+// environment variables and the resolved PATH list, the current uptime, the
+// list of available OS updates with their categories and severities,
+// whether a reboot is pending after recent installs, and the current system
+// date and timezone. The cross-platform anchor that audits start from when
+// they need OS identity and patch state.
 os {
   // Pretty hostname on macOS/Linux or device name on Windows
   name() string
@@ -371,9 +375,9 @@ os {
 
 // Operating system date and timezone information
 //
-// Examine the current system clock time and the configured timezone string
-// (e.g., "America/New_York", "UTC"). Used to verify that clocks are
-// synchronized and that the correct timezone is set.
+// Current system clock time and the configured timezone string (e.g.,
+// "America/New_York", "UTC"). Used to verify that clocks are synchronized
+// and that the correct timezone is set.
 os.date @defaults("time timezone") {
   // Current system time
   time() time
@@ -383,32 +387,32 @@ os.date @defaults("time timezone") {
 
 // Operating system update information
 //
-// Examine a single pending OS update: its name, category, severity,
-// whether it requires a restart, and the package format it belongs to.
-// Iterated from `os.updates()` to audit patch state and prioritize
-// outstanding updates by severity.
+// Single pending OS update: its name, category, severity, whether it
+// requires a restart, and the package format it belongs to. Read from
+// `os.updates` to audit patch state and prioritize outstanding updates by
+// severity.
 os.update @defaults("name")  {
   // Name of the update
   name string
-  // Category of the update
+  // Category of the update (e.g., "security", "bugfix")
   category string
   // Severity of the update
   severity string
-  // Whether a restart is required
+  // Whether a restart is required to complete the update
   restart bool
-  // Package format for this update
+  // Package format for this update (e.g., "rpm", "deb")
   format string
 }
 
 // Generic operating system information common to all platforms
 //
-// Cross-platform OS view that embeds `machine` (firmware / SMBIOS
-// hardware identity) and exposes the fields shared by every supported
-// platform: the pretty hostname (or Windows device name), the
-// FQDN-style hostname, environment variables and the resolved PATH
-// list, uptime, the available-OS-update list, the reboot-pending flag,
-// and the typed `users()` and `groups()` collections. `os.unix` and
-// `os.linux` extend this with platform-specific surfaces.
+// Cross-platform OS view that embeds `machine` (firmware / SMBIOS hardware
+// identity) and exposes the fields shared by every supported platform: the
+// pretty hostname (or Windows device name), the FQDN-style hostname,
+// environment variables and the resolved PATH list, uptime, the
+// available-OS-update list, the reboot-pending flag, and the `users` and
+// `groups` collections. `os.unix` and `os.linux` extend this with
+// platform-specific surfaces.
 os.base {
   embed machine
 
@@ -435,23 +439,22 @@ os.base {
 // Operating system information for Unix-like platforms
 //
 // Extends `os.base` for Unix-family operating systems (macOS, Linux,
-// FreeBSD, and similar). Aliases such as `os.base.user` / `os.base.group`
-// / `os.base.file` / `os.base.command` / `os.base.packages` route to
+// FreeBSD, and similar). Aliases such as `os.base.user`, `os.base.group`,
+// `os.base.file`, `os.base.command`, and `os.base.packages` route to
 // concrete Unix resources, and `os.unix.sshd` aliases to the system-wide
-// `sshd` resource so audits can express "examine sshd on the asset"
-// without knowing the exact platform.
+// `sshd` resource so audits can express "examine sshd on the asset" without
+// knowing the exact platform.
 os.unix {
   embed os.base as base
 }
 
 // Operating system information for Linux platforms
 //
-// Extends `os.unix` (and through it, `os.base`) with Linux-only
-// surfaces: the four supported packet-filter stacks (`iptables`,
-// `ip6tables`, `nftables`, `ufw`, `firewalld`), the `/etc/fstab` mount
-// table, and the AppArmor mandatory-access-control namespace. Use it
-// to write Linux-specific audits without reaching out to global
-// resource handles.
+// Extends `os.unix` (and through it, `os.base`) with Linux-only surfaces:
+// the supported packet-filter stacks (`iptables`, `ip6tables`, `nftables`,
+// `ufw`, `firewalld`), the `/etc/fstab` mount table, and the AppArmor
+// mandatory-access-control namespace. Use it to write Linux-specific audits
+// without reaching out to global resource handles.
 os.linux {
   embed os.unix as unix
 
@@ -473,13 +476,12 @@ os.linux {
 
 // Operating system root certificate trust store
 //
-// Examine the X.509 root certificates that the asset's operating system
-// trusts for TLS validation, derived from the platform-appropriate
-// trust-store files (e.g. `/etc/ssl/certs/ca-certificates.crt` on
-// Debian, `/etc/pki/tls/certs/ca-bundle.crt` on RHEL, the macOS
-// SecTrust store, the Windows Root certificate store). The resource
-// lazily reads each trust-store file and exposes the parsed
-// `network.certificate` list so audits can pin specific issuers,
+// X.509 root certificates that the asset's operating system trusts for TLS
+// validation, derived from the platform-appropriate trust-store files (e.g.
+// `/etc/ssl/certs/ca-certificates.crt` on Debian,
+// `/etc/pki/tls/certs/ca-bundle.crt` on RHEL, the macOS SecTrust store, the
+// Windows Root certificate store). Reads each trust-store file and exposes
+// the parsed `network.certificate` list so audits can pin specific issuers,
 // detect untrusted local additions, or count the trust-store size.
 os.rootCertificates {
   []certificate(content)
@@ -490,16 +492,15 @@ os.rootCertificates {
 
 // Result of running a shell command on the system
 //
-// Provides ad-hoc command execution as an MQL resource. Initialize it
-// with a shell command string; the resource lazily executes the command
-// through the connection (local exec, SSH, container exec, etc.) and
-// surfaces the captured `stdout`, `stderr`, and `exitcode`. Used as a
-// fall-back when there isn't a more specific typed resource for a
-// piece of system state, and for assertions on tool versions or
-// command-line probes.
+// Ad-hoc command execution as an MQL resource. Initialized with a shell
+// command string; the resource executes the command through the connection
+// (local exec, SSH, container exec, and similar) and surfaces the captured
+// `stdout`, `stderr`, and `exitcode`. Used as a fall-back when there isn't a
+// more specific resource for a piece of system state, and for
+// assertions on tool versions or command-line probes.
 command {
   init(command string)
-  // Raw contents of the command
+  // Command string that was run
   command string
   // Standard output from running the command
   stdout(command) string
@@ -511,15 +512,14 @@ command {
 
 // Result of running a PowerShell script on the system
 //
-// Provides ad-hoc PowerShell execution as an MQL resource. Initialize
-// it with a script string; the resource lazily executes the script via
-// PowerShell on the asset and surfaces the captured `stdout`, `stderr`,
-// and `exitcode`. Used as the Windows / cross-platform-PowerShell
-// counterpart to `command` for assertions that need PowerShell-only
-// surface area.
+// Ad-hoc PowerShell execution as an MQL resource. Initialized with a script
+// string; the resource executes the script via PowerShell on the asset and
+// surfaces the captured `stdout`, `stderr`, and `exitcode`. The Windows and
+// cross-platform-PowerShell counterpart to `command` for assertions that
+// need PowerShell-only surface area.
 powershell {
   init(script string)
-  // Raw contents of the script
+  // Script string that was run
   script string
   // Standard output from running the script
   stdout() string
@@ -531,15 +531,15 @@ powershell {
 
 // File on the system
 //
-// Examine a single file referenced by absolute path. Surfaces the path
-// itself, the basename and dirname, an `exists` flag, the lazily-loaded
-// `content` string, the file's size in bytes, an `empty` predicate, the
-// owning `user` and `group` as typed references, and a structured
-// `permissions` resource that explodes the POSIX mode into named user /
-// group / other read / write / execute bits, the SUID / SGID / sticky
-// bits, the `isFile` / `isDirectory` / `isSymlink` discriminators, and
-// a printed mode string. The unit of file-level audits and the building
-// block most config-file resources read through.
+// Single file referenced by absolute path. Surfaces the path itself, the
+// basename and dirname, an `exists` flag, the `content` string, the file's
+// size in bytes, an `empty` predicate, the owning `user` and `group` as
+// references, and a structured `permissions` resource that explodes the
+// POSIX mode into named user / group / other read / write / execute bits,
+// the SUID / SGID / sticky bits, the `isFile` / `isDirectory` / `isSymlink`
+// discriminators, and a printed mode string. The unit of file-level audits
+// and the building block most config-file resources read through. Select a
+// file by path, for example `file("/etc/ssh/sshd_config")`.
 file @defaults("path size permissions.string") {
   init(path string)
   // Location of the file on the system
@@ -554,7 +554,7 @@ file @defaults("path size permissions.string") {
   exists(path) bool
   // Permissions for this file
   permissions(path) file.permissions
-  // Size of this file on disk
+  // Size of this file on disk in bytes
   size(path) int
   // Ownership information about the user
   user() user
@@ -596,11 +596,11 @@ private file.permissions @defaults("string") {
   other_writeable bool
   // Whether the file is executable by others
   other_executable bool
-  // SUID bit indicator
+  // Whether the set-user-ID bit is set (executable runs with the owner's privileges)
   suid bool
-  // SGID bit indicator
+  // Whether the set-group-ID bit is set (executable runs with the group's privileges)
   sgid bool
-  // Sticky bit indicator
+  // Whether the sticky bit is set (only a file's owner may delete it from a shared directory)
   sticky bool
   // Whether the file describes a directory
   isDirectory bool
@@ -608,116 +608,147 @@ private file.permissions @defaults("string") {
   isFile bool
   // Whether the file is a symlink
   isSymlink bool
-  // A simple printed string version of the permissions
+  // Symbolic permission string in ls -l form (e.g., "-rw-r--r--")
   string() string
 }
 
 // File search and discovery namespace
 //
-// Empty top-level namespace whose only purpose is to host
-// `files.find`. Used so audits can write `files.find(...) {...}` to
-// locate files on the asset rather than enumerating known paths.
+// Empty namespace whose only purpose is to host `files.find`, so
+// audits can write `files.find(...) {...}` to locate files on the
+// asset rather than enumerating known paths.
 files {}
 
 // File search results
 //
-// Examine files discovered by a recursive filesystem walk starting at
-// `from`. Narrow results with `type` (file, directory, device, etc.),
-// `regex` (name pattern), `permissions` (octal mode), `name` (exact name),
-// `depth` (traversal depth), and `xdev` (stay on one device). Returns the
-// matching `[]file` list for content or permission audits.
+// Files discovered by a recursive filesystem walk rooted at `from`.
+// Narrow the walk with `type` (file, directory, device, and so on),
+// `regex` (path/name pattern), `permissions` (octal mode floor),
+// `name` (filename glob), `depth` (maximum traversal depth), and
+// `xdev` (whether to cross into other mounted filesystems). Resolves
+// to the matching `[]file` list, so content, ownership, and permission
+// checks can be layered on the result. For example
+// `files.find(from: "/etc", type: "file", permissions: 0o002) { path }`
+// finds every world-writable file under /etc.
 files.find {
   []file
-  // Sets the starting point for the search operation
+  // Directory the recursive search starts from (e.g., "/etc")
   from string
-  // Whether to search across other devices
+  // Whether to descend into directories on other mounted filesystems
+  //
+  // When false (the default) the search stays on the filesystem that
+  // holds `from` (find's -xdev). Set true to cross mount points.
   xdev bool
-  // What types of files to list (directories, files, devices, etc)
+  // Restrict results to a single file type
+  //
+  // One of file, directory, link, character, block, or socket. Empty
+  // matches every type.
   type string
-  // A regular expression for the file search
+  // Regular expression matched against the full path of each candidate
   regex string
-  // What permissions the file matches
+  // Octal mode floor: matches files that have at least these permission bits set
+  //
+  // Given as an octal literal (e.g., 0o002 for world-writable). Defaults
+  // to 0o777, which matches every file.
   permissions int
-  // Search name
+  // Filename glob matched against each file's basename (e.g., "*.conf")
   name string
-  // The depth of the file search.
+  // Maximum directory depth to descend (find's -maxdepth); unset means unlimited
   depth int
 }
 
 // Parse INI configuration files
 //
-// Examine sections and key-value pairs from any INI-formatted file
+// Sections and key-value pairs parsed from any INI-formatted file.
+// Select the file with `parse.ini(path: "/etc/example.ini")`; `sections`
+// exposes a map of section name to its key-value map and `params`
+// exposes the top-level keys that precede any section header. The
+// key-value separator can be overridden for non-standard files.
 parse.ini {
   init(path string, delimiter string)
-  // Symbol that separates keys and values
+  // Symbol that separates keys and values (defaults to "=")
   delimiter string
   // File that is parsed
   file file
   // Raw content of the file that is parsed
   content(file) string
-  // Map of sections and key-value pairs
+  // Map of section name to that section's key-value pairs
   sections(content, delimiter) map[string]map[string]string
-  // Map of parameters that don't belong to sections
+  // Key-value pairs that appear before any section header
   params(sections) map[string]string
 }
 
 // Parse JSON files
 //
-// Examine the parsed structure of any JSON document on disk
+// Parsed structure of any JSON document on disk. Select the file with
+// `parse.json(path: "/etc/example.json")`; `params` holds the decoded
+// document as a dict that MQL can traverse and filter.
 parse.json {
   init(path string)
   // File that is parsed
   file file
   // Raw content of the file that is parsed
   content(file) string
-  // The parsed parameters defined in this file
+  // Decoded JSON document as a traversable dict
   params(content) dict
 }
 
 // Parse XML files
 //
-// Examine the parsed structure of any XML document on disk
+// Parsed structure of any XML document on disk. Select the file with
+// `parse.xml(path: "/etc/example.xml")`; `params` holds the decoded
+// element tree as a dict that MQL can traverse and filter.
 parse.xml {
   init(path string)
   // File that is parsed
   file file
   // Raw content of the file that is parsed
   content(file) string
-  // The parsed parameters defined in this file
+  // Decoded XML element tree as a traversable dict
   params(content) dict
 }
 
 // Parse Apple property list (plist) files
 //
-// Examine the parsed structure of XML or binary plist files
+// Parsed structure of an XML or binary plist file. Select the file with
+// `parse.plist(path: "/Library/Preferences/com.apple.example.plist")`;
+// `params` holds the decoded property list as a dict, so macOS
+// preference and configuration audits can read individual keys.
 parse.plist {
   init(path string)
   // File that is parsed
   file file
   // Raw content of the file that is parsed
   content(file) string
-  // The parsed parameters that are defined in this file
+  // Decoded property list as a traversable dict
   params(content) dict
 }
 
 // Parse YAML files
 //
-// Examine single- or multi-document YAML structures from disk
+// Parsed structure of single- or multi-document YAML files. Select the
+// file with `parse.yaml(path: "/etc/example.yaml")`; `params` holds the
+// first (or only) document as a dict and `documents` holds every
+// document in a multi-document (`---` separated) file as a `[]dict`.
 parse.yaml {
   init(path string)
   // File that is parsed
   file file
   // Raw content of the file that is parsed
   content(file) string
-  // The parsed parameters that are defined in this file
+  // First (or only) YAML document as a traversable dict
   params(content) dict
-  // Parsed yaml documents
+  // Every document in a multi-document YAML file
   documents(content) []dict
 }
 
 // Parse X.509 certificates from files
 //
-// Examine PEM-encoded certificate chains and bundles
+// PEM-encoded certificate chains and bundles parsed into a list of
+// `network.certificate` entries. Select the file with
+// `parse.certificates(path: "/etc/ssl/certs/ca-bundle.crt")`; each
+// resulting certificate exposes its subject, issuer, validity window,
+// key usage, and fingerprints for trust-store and expiry audits.
 parse.certificates {
   []network.certificate(content, path)
   init(path string)
@@ -731,7 +762,11 @@ parse.certificates {
 
 // Parse OpenPGP keys from files
 //
-// Examine OpenPGP entities (keys, identities, subkeys) from key files
+// OpenPGP entities (primary keys, identities, and subkeys) parsed from
+// a key file. Select the file with
+// `parse.openpgp(path: "/etc/pki/rpm-gpg/RPM-GPG-KEY")`; each entity
+// exposes its identities and key material for validating trusted
+// signing keys.
 parse.openpgp {
   []network.openpgp.entity(content)
   init(path string)
@@ -743,42 +778,42 @@ parse.openpgp {
 
 // User account on the system
 //
-// Examine a single local user account: numeric UID and primary GID
-// (Windows SID where applicable), name, home directory, configured
-// login shell, and an `enabled` flag. Surfaces the typed primary
-// `group` reference, the `authorizedkeys` resource that parses the
-// user's `~/.ssh/authorized_keys`, the SSH private keys discovered in
-// the user's home, and a `loggedIn` predicate that reflects whether
-// the user currently has an active session. Used for identity audits,
+// Single local user account: numeric UID and primary GID (Windows SID
+// where applicable), name, home directory, configured login shell, and
+// an `enabled` flag. Surfaces the primary `group` reference, the
+// `authorizedkeys` resource that parses the user's
+// `~/.ssh/authorized_keys`, the SSH private keys discovered in the
+// user's home, and a `loggedIn` predicate that reflects whether the
+// user currently has an active session. Used for identity audits,
 // dormant-account hygiene, and SSH-key inventories.
 user @defaults("name uid gid") {
   // User ID
   uid int
-  // User's group ID
+  // User's primary group ID
   gid int
   // User's security identifier (Windows)
   sid string
   // Name of the user
   name string
-  // Home folder
+  // Home directory path
   home string
-  // Default shell configured
+  // Login shell configured for the user (e.g., /bin/bash, /usr/sbin/nologin)
   shell string
-  // Whether the user is enabled
+  // Whether the account is enabled (not locked or disabled)
   enabled bool
-  // List of authorized keys
+  // Parsed ~/.ssh/authorized_keys for this user
   authorizedkeys(home) authorizedkeys
-  // List of SSH keys
+  // Private SSH keys discovered in the user's home directory
   sshkeys() []privatekey
-  // Group of which user is a member
+  // The user's primary group
   group(gid) group
-  // Whether the user is currently logged in
+  // Whether the user currently has an active login session
   loggedIn() bool
   // Path to this user's NTUSER.DAT registry hive file (Windows)
   //
   // The per-user registry hive on disk, located at `<home>\NTUSER.DAT`. Pass
   // it together with `sid` to `registrykey`/`registrykey.property` to read a
-  // user's HKCU settings even when their hive is not loaded — for example a
+  // user's HKCU settings even when their hive is not loaded, for example a
   // SYSTEM scan running with no interactive session. Empty on non-Windows
   // platforms or when the home directory is unknown.
   ntuserDat(home) string
@@ -786,9 +821,10 @@ user @defaults("name uid gid") {
 
 // Private key on disk
 //
-// Examine a PEM-encoded private key file: the typed `file` reference,
-// the raw PEM `pem` payload, and an `encrypted` flag indicating whether
-// the key uses a passphrase. Used to inventory SSH or service-account
+// PEM-encoded private key file: the `file` reference, the raw PEM `pem`
+// payload, and an `encrypted` flag indicating whether the key is
+// passphrase-protected. `publicKeyAlgorithm` and `publicKeyBits`
+// describe the key material. Used to inventory SSH or service-account
 // keys discovered on the asset and to flag unencrypted private keys
 // stored in user home directories.
 privatekey {
@@ -800,7 +836,7 @@ privatekey {
   path @maturity("deprecated") string
   // File on disk for this private key
   file file
-  // Whether the file is encrypted
+  // Whether the key material is passphrase-encrypted
   encrypted bool
   // Public key algorithm of the key material (e.g., RSA, ECDSA, Ed25519, DSA)
   publicKeyAlgorithm() string
@@ -810,23 +846,23 @@ privatekey {
 
 // All user accounts configured on the system
 //
-// Iterable collection of every local `user` on the asset. Use it as
-// the entry point for fleet-wide identity audits — e.g., asserting
-// that every account with UID < 1000 is enabled, that no account
-// shares another's home directory, or that no human user has the
-// shell set to `/bin/bash` outside an approved list.
+// Collection of every local `user` on the asset. The entry point for
+// fleet-wide identity audits, e.g. asserting that every account with
+// UID < 1000 is enabled, that no account shares another's home
+// directory, or that no human user has the shell set to `/bin/bash`
+// outside an approved list.
 users {
   []user
 }
 
 // SSH authorized_keys file
 //
-// Examine a single `authorized_keys` file: its path, the typed `file`
-// reference, the raw `content` string, and the parsed `entry` list where
-// each entry surfaces the line number, key type, key material, label, and
-// any `command=` / `from=` / `no-port-forwarding` SSH options. Select the
-// file by absolute path — for example
-// `authorizedkeys(path: "/root/.ssh/authorized_keys")` — or reach it per
+// Single `authorized_keys` file: its path, the `file` reference, the
+// raw `content` string, and the parsed `entry` list where each entry
+// surfaces the line number, key type, key material, label, and any
+// `command=` / `from=` / `no-port-forwarding` SSH options. Select the
+// file by absolute path, for example
+// `authorizedkeys(path: "/root/.ssh/authorized_keys")`, or reach it per
 // account through the `user` resource, whose `authorizedkeys` field
 // resolves each user's `~/.ssh/authorized_keys` automatically (for
 // example `users.where(name == "root") { authorizedkeys { list { key } } }`).
@@ -845,19 +881,19 @@ authorizedkeys {
 
 // SSH authorized key
 //
-// Examine a single entry from an `authorized_keys` file: the source line
-// number, key type, key material, label, and any SSH options such as
-// `command=`, `from=`, or `no-port-forwarding`. Used to audit which keys
-// grant SSH access to a user and to flag entries that lack source or
-// command restrictions.
+// Single entry from an `authorized_keys` file: the source line number,
+// key type, key material, label, and any SSH options such as
+// `command=`, `from=`, or `no-port-forwarding`. Used to audit which
+// keys grant SSH access to a user and to flag entries that lack source
+// or command restrictions.
 authorizedkeys.entry @defaults("key") {
-  // Line of the key
+  // Line number of the entry in the key file
   line int
-  // Type of key
+  // Key type (e.g., ssh-rsa, ssh-ed25519, ecdsa-sha2-nistp256)
   type string
-  // Key
+  // Base64-encoded public key material
   key string
-  // Key label
+  // Key label or comment (typically user@host)
   label string
   // SSH key options (e.g., command restrictions, source IP limits)
   options []string
@@ -869,10 +905,10 @@ authorizedkeys.entry @defaults("key") {
 
 // Group on the system
 //
-// Examine a single local group: numeric GID (or SID on Windows), group
-// name, and the typed `members()` list of users in the group. Used to
-// audit privileged-group membership (`sudo`, `wheel`, `docker`, `adm`,
-// etc.) and to confirm only expected accounts are present.
+// Single local group: numeric GID (or SID on Windows), group name, and
+// the `members` list of users in the group. Used to audit
+// privileged-group membership (`sudo`, `wheel`, `docker`, `adm`, and so
+// on) and to confirm only expected accounts are present.
 group @defaults("name gid") {
   init(id string)
   // Group ID
@@ -887,26 +923,25 @@ group @defaults("name gid") {
 
 // All groups configured on the system
 //
-// Iterable collection of every local `group`. Use it as the entry
-// point for fleet-wide group-membership audits (every member of a
-// privileged group, no two groups sharing a GID, no human user in
-// `wheel` outside an approved list, etc.).
+// Collection of every local `group`. The entry point for fleet-wide
+// group-membership audits (every member of a privileged group, no two
+// groups sharing a GID, no human user in `wheel` outside an approved
+// list, and so on).
 groups {
   []group
 }
 
 // Installed package on the platform or OS
 //
-// Examine a single package known to the asset's native package
-// manager (rpm, deb, apk, pkg, msi, nuget, pacman, etc.). Surfaces
-// the package name, description, currently-installed `version`,
-// architecture, epoch, package format, install status, package URL,
-// the CPE list mapping the package to NVD identifiers, the package
-// origin, the latest `available` version known to the package
-// manager, the `installed` and `outdated` flags, the file
-// inventory the package contributed, and the package vendor.
-// The unit of asset-level package audits and the join key for
-// vulnerability correlation.
+// Single package known to the asset's native package manager (rpm, deb,
+// apk, pkg, msi, nuget, pacman, and so on). Surfaces the package name,
+// description, currently-installed `version`, architecture, epoch,
+// package format, install status, package URL, the CPE list mapping the
+// package to NVD identifiers, the package origin, the latest
+// `available` version known to the package manager, the `installed` and
+// `outdated` flags, the file inventory the package contributed, and the
+// package vendor. The unit of asset-level package audits and the join
+// key for vulnerability correlation.
 package @defaults("name version") {
   // May be initialized with the name only, in which case it will look up
   // The package with the given name on the system.
@@ -916,11 +951,11 @@ package @defaults("name version") {
   name string
   // Package description
   description string
-  // Current version of the package
+  // Currently installed version of the package
   version string
-  // Architecture of this package
+  // Architecture of this package (e.g., x86_64, arm64, noarch)
   arch string
-  // Epoch of this package
+  // Epoch of this package (version-comparison tiebreaker; empty when unset)
   epoch string
 
   // Format of this package (e.g., rpm, deb)
@@ -932,7 +967,7 @@ package @defaults("name version") {
   // Status of this package (e.g., if it is needed)
   status() string
 
-  // Package URL
+  // Package URL (purl) identifier for this package
   purl string
 
   // Common Platform Enumeration (CPE) for the package
@@ -946,14 +981,14 @@ package @defaults("name version") {
   // manager-tracked and listed in `packages`.
   origin() string
 
-  // Available version
+  // Latest version the package manager reports as available
   available string
   // Whether the package is installed
   installed bool
-  // Whether the package is outdated
+  // Whether a newer version than the installed one is available
   outdated() bool
 
-  // Package files
+  // Files this package installed on the asset
   files() []pkgFileInfo
 
   // Package vendor
@@ -986,16 +1021,21 @@ private pkgFileInfo @defaults("path") {
 
 // All packages installed on the system
 //
-// Iterable collection of every `package` known to the asset's native
-// package manager(s). Used as the entry point for fleet-wide patch
-// audits, banned-package checks, and inventory exports.
+// Collection of every `package` known to the asset's native package
+// manager(s). The entry point for fleet-wide patch audits,
+// banned-package checks, and inventory exports.
 packages {
   []package
 }
 
 // PAM (pluggable authentication module) configuration
 //
-// Examine /etc/pam.d service entries with their type, control, and module
+// Aggregate view of the /etc/pam.d service configuration (and the
+// legacy single-file /etc/pam.conf). `entries` returns parsed service
+// entries keyed by service, each carrying its type, control, and
+// module; `modules` deduplicates the modules loaded across every
+// service. Used to audit authentication policy, such as which services
+// enforce `pam_faillock` or `pam_pwquality`.
 pam.conf {
   init(path string)
   // Whether PAM configuration is present on the system
@@ -1013,7 +1053,7 @@ pam.conf {
   // Deprecated in favor of `entries`, which returns parsed, structured
   // service entries.
   services(files) @maturity("deprecated") map[string][]string
-  // List of services with parsed entries that are configured via PAM
+  // Parsed service entries keyed by service name
   entries(files) map[string][]pam.conf.serviceEntry
   // All PAM modules loaded across every service (deduplicated by name)
   modules(entries) []pam.module
@@ -1028,9 +1068,9 @@ private pam.conf.serviceEntry @defaults("service module") {
   service string
   // Line number in service file (used for ID)
   lineNumber int
-  // Type for PAM entry, (i.e., auth, password, etc)
+  // PAM entry type (e.g., auth, account, password, session)
   pamType string
-  // Level of control, (i.e., required, requisite, sufficient)
+  // Control field (e.g., required, requisite, sufficient, optional, or a bracketed [value=action] expression)
   control string
   // PAM module used
   module string
@@ -1048,14 +1088,14 @@ private pam.conf.serviceEntry @defaults("service module") {
 
 // PAM service configuration
 //
-// Examine the PAM configuration for a single service selected by name — for
-// example `pam.conf.service(name: "su")` or `pam.conf.service(name: "sshd")`.
-// The service is resolved from its `/etc/pam.d/<name>` file, or from the lines
-// naming it in the legacy single-file `/etc/pam.conf`. `entries` are the
-// parsed lines for that service and `modules` aggregates the modules it loads
-// keyed by name, so audits such as
-// `pam.conf.service(name: "su").modules["pam_wheel"].params["use_uid"]` work
-// without filtering `pam.conf.entries` by file path.
+// PAM configuration for a single service selected by name, for example
+// `pam.conf.service(name: "su")` or `pam.conf.service(name: "sshd")`.
+// The service is resolved from its `/etc/pam.d/<name>` file, or from the
+// lines naming it in the legacy single-file `/etc/pam.conf`. `entries`
+// are the parsed lines for that service and `modules` aggregates the
+// modules it loads keyed by name, so audits such as
+// `pam.conf.service(name: "su").modules["pam_wheel"].params["use_uid"]`
+// work without filtering `pam.conf.entries` by file path.
 private pam.conf.service {
   init(name string)
   // Service name (e.g. `su`, `sshd`, `login`)
@@ -1079,7 +1119,7 @@ private pam.conf.service {
 
 // PAM module aggregated view
 //
-// Examine a single PAM module across every service that loads it. The
+// Single PAM module viewed across every service that loads it. The
 // `params` dict merges `key=value` options from every line that uses
 // this module (last-write-wins per key) so audits like
 // `pam.module("pam_faillock").params["deny"]` work without iterating
@@ -1087,7 +1127,7 @@ private pam.conf.service {
 // the module with a non-skip control.
 //
 // Initialize by module name (e.g. `pam.module(name: "pam_faillock")`)
-// or iterate `pam.modules()` for every distinct module name seen
+// or iterate `pam.modules` for every distinct module name seen
 // across the parsed PAM configuration.
 private pam.module @defaults("name enabled entries.length") {
   init(name string)
@@ -1100,8 +1140,8 @@ private pam.module @defaults("name enabled entries.length") {
   // All key=value options aggregated across every service entry that loads this module
   //
   // The same option key appearing on multiple lines is last-write-wins
-  // in source order (matching how PAM itself evaluates duplicate flags
-  // — the later line wins). Bare options (no `=`) are present in the
+  // in source order (matching how PAM itself evaluates duplicate flags,
+  // where the later line wins). Bare options (no `=`) are present in the
   // map with an empty string value so `params["use_authtok"] != null`
   // works as an existence check.
   params map[string]string
@@ -1109,7 +1149,7 @@ private pam.module @defaults("name enabled entries.length") {
   //
   // True when at least one service entry references this module with a
   // control of `required`, `requisite`, `sufficient`, `optional`, or a
-  // typed control with `default=ok` / `success=ok`. Always false when
+  // bracketed control with `default=ok` / `success=ok`. Always false when
   // every reference is part of a stub or commented-out line.
   enabled bool
   // Every service entry that loads this module
@@ -1123,12 +1163,19 @@ private pam.module @defaults("name enabled entries.length") {
 
 // OpenSSH server (sshd) namespace
 //
-// Use sshd.config to examine the effective server settings and match blocks
+// Namespace hosting `sshd.config`, the entry point for auditing the
+// OpenSSH server's effective settings and Match blocks.
 sshd {}
 
 // OpenSSH server (sshd) configuration
 //
-// Examine ciphers, MACs, KEX algorithms, host keys, and Match blocks
+// OpenSSH server settings parsed from sshd_config (and any Include
+// files), plus the effective values reported by `sshd -T`. Surfaces
+// `ciphers`, `macs`, `kexs`, and `hostkeyalgorithms` for cryptographic
+// hardening checks, `permitRootLogin` for root-access policy, and
+// `blocks` for the conditional Match blocks. Compare the configured
+// values (`ciphers`) against the effective ones (`effectiveCiphers`) to
+// catch overrides applied at runtime.
 sshd.config {
   init(path? string)
   // File of this SSH server configuration
@@ -1161,7 +1208,7 @@ sshd.config {
 
 // A block of SSH server configuration
 private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
-  // The match criteria for this block
+  // The Match criteria that gate this block (e.g., "User root", "Address 10.0.0.0/8")
   criteria string
   // Configuration values in this block
   params map[string]string
@@ -1181,19 +1228,19 @@ private sshd.config.matchBlock @defaults("criteria") @context("file.context") {
 
 // inetd super-server namespace
 //
-// Use inetd.config to examine which network services the inetd super-server
-// launches on demand.
+// Namespace hosting `inetd.config`, the entry point for examining which
+// network services the inetd super-server launches on demand.
 inetd {}
 
 // inetd super-server configuration
 //
-// Examine the services the inetd (or compatible) super-server is configured
-// to launch on demand. Each active entry pairs a service with its socket
+// Services the inetd (or compatible) super-server is configured to
+// launch on demand. Each active entry pairs a service with its socket
 // type, protocol, wait mode, run-as user, and server program. The
-// configuration is assembled from /etc/inetd.conf together with any drop-in
-// files under /etc/inetd.d. A missing configuration yields no entries, so
-// audits such as serviceNames.none("ftp") hold trivially on systems that
-// don't run inetd.
+// configuration is assembled from /etc/inetd.conf together with any
+// drop-in files under /etc/inetd.d. A missing configuration yields no
+// entries, so audits such as serviceNames.none("ftp") hold trivially on
+// systems that don't run inetd.
 inetd.config {
   init(path? string)
   // Primary inetd configuration file
@@ -1210,11 +1257,11 @@ inetd.config {
 
 // inetd service entry
 //
-// Examine a single active inetd service line: the service it exposes and how
-// inetd launches it. The name field selects the service as it appears in the
-// first column of inetd.conf — for example
-// inetd.config.entries.where(name == "ftp"). Entries that are commented out
-// with a leading # are disabled and excluded.
+// Single active inetd service line: the service it exposes and how
+// inetd launches it. The name field selects the service as it appears
+// in the first column of inetd.conf, for example
+// inetd.config.entries.where(name == "ftp"). Entries that are commented
+// out with a leading # are disabled and excluded.
 private inetd.config.entry @defaults("name protocol server") @context("file.context") {
   // Service name or port (first column)
   name string
@@ -1234,16 +1281,17 @@ private inetd.config.entry @defaults("name protocol server") @context("file.cont
 
 // Net-SNMP daemon (snmpd) namespace
 //
-// Use snmpd.config to examine the effective SNMP daemon configuration.
+// Namespace hosting `snmpd.config`, the entry point for examining the
+// effective SNMP daemon configuration.
 snmpd {}
 
 // Net-SNMP daemon (snmpd) configuration
 //
-// Examine the snmpd.conf settings that govern SNMP access — community
-// strings, VACM users, and listen addresses. The configuration is assembled
-// from the main snmpd.conf together with any drop-in files under
-// snmpd.conf.d and files pulled in by includeFile and includeDir directives.
-// A missing configuration yields empty accessors, so audits such as
+// snmpd.conf settings that govern SNMP access: community strings, VACM
+// users, and listen addresses. The configuration is assembled from the
+// main snmpd.conf together with any drop-in files under snmpd.conf.d and
+// files pulled in by includeFile and includeDir directives. A missing
+// configuration yields empty accessors, so audits such as
 // rwCommunities == [] hold trivially on hosts that don't run snmpd.
 snmpd.config {
   init(path? string)
@@ -1267,7 +1315,10 @@ snmpd.config {
 
 // auditd (Linux Audit Daemon) global configuration
 //
-// Examine /etc/audit/auditd.conf parameters
+// /etc/audit/auditd.conf parameters as a key-value map, covering log
+// rotation, disk-space thresholds, and failure actions. `params` keys
+// such as max_log_file, space_left_action, and disk_full_action drive
+// audit-logging hardening checks.
 auditd.config {
   init(path? string)
   // File of this auditd configuration
@@ -1278,15 +1329,21 @@ auditd.config {
 
 // auditd (Linux Audit Daemon) ruleset on disk
 //
-// Examine controls, file watches, and syscall rules from /etc/audit/audit.rules
+// Kernel audit ruleset as loaded from the on-disk rule files, broken
+// out into three families: controls (daemon and buffer settings), file
+// watches, and syscall rules. By default the rule files under
+// /etc/audit/rules.d are read and merged in filename order; pass a path
+// to point at a different file or directory. Use this to confirm that
+// required watches (for example on /etc/shadow or /etc/sudoers) and
+// syscall audits mandated by a hardening baseline are present.
 auditd.rules {
-  // Path to folder to look up rules
+  // Directory or file the rules are read from (defaults to /etc/audit/rules.d)
   path() string
-  // All controls for auditd
+  // Control rules (buffer size, failure mode, and other daemon settings)
   controls(path) []auditd.rule.control
-  // All file rules
+  // File watch rules (-w entries)
   files(path) []auditd.rule.file
-  // All syscall rules
+  // Syscall audit rules (-a entries)
   syscalls(path) []auditd.rule.syscall
 }
 
@@ -1295,33 +1352,38 @@ private auditd.rule {}
 
 // auditd (Linux Audit Daemon) rule for a control
 //
-// We translate these into simple key-value pairs consisting of a flag and a value
-// eg: --backlog_wait_time 60000  =>  {flag: "--backlog_wait_time", value: "60000"}
-// eg: -b 8192                    =>  {flag: "-b", value: "8192"}
-// eg: -D                         =>  {flag: "-D", value: nil}
+// Control setting from the ruleset, split into a flag and an optional
+// value. For example `--backlog_wait_time 60000` becomes
+// {flag: "--backlog_wait_time", value: "60000"}, `-b 8192` becomes
+// {flag: "-b", value: "8192"}, and a valueless `-D` (delete all rules)
+// becomes {flag: "-D", value: nil}.
 private auditd.rule.control @defaults("flag value") {
-  // The flag used for this control, i.e. the first part of the control including any leading `-`
+  // Control flag, the first token including any leading `-` (e.g. "-b", "--backlog_wait_time")
   flag string
-  // The value of the control, which may be specified
+  // Value following the flag, or null for valueless controls like -D
   value string
 }
 
 // auditd (Linux Audit Daemon) rule for a file
 //
-// eg: -w /etc/shadow -p rw -k shadow_access
-//  => {path: "/etc/shadow", permissions: "rw", keyname: "shadow_access"}
+// File watch rule (-w) describing a path auditd monitors, the access
+// types that trigger an event, and the key that tags matching records.
+// For example `-w /etc/shadow -p rw -k shadow_access` becomes
+// {path: "/etc/shadow", permissions: "rw", keyname: "shadow_access"}.
 private auditd.rule.file @defaults("path permissions") {
-  // The path this rule matches as specified by -w
+  // Watched path (the argument to -w)
   path string
-  // The permissions specified by this rule via -p
+  // Access types that trigger the watch (from -p): any of r, w, x, a
   permissions string
-  // The key name for related rules as specified by -k
+  // Key tagging records this rule produces (from -k), for filtering audit logs
   keyname string
 }
 
 // auditd (Linux Audit Daemon) rule for a syscall
 //
-// eg: -a always,exit -F arch=b32 -F auid>=1000 -F auid!=unset
+// Syscall audit rule (-a) that fires on the listed system calls when the
+// field filters match. For example
+// `-a always,exit -F arch=b32 -F auid>=1000 -F auid!=unset` becomes
 //  => {
 //    action: "always",
 //    list: "exit",
@@ -1334,17 +1396,17 @@ private auditd.rule.file @defaults("path permissions") {
 //    keyname: nil,
 // }
 private auditd.rule.syscall @defaults("action list") {
-  // The action specified by -a
+  // Action taken when the rule matches (from -a): "always" or "never"
   action string
-  // The list, the second value specified by -a
+  // Rule list the action applies to (second value of -a): exit, task, user, exclude, or filesystem
   list string
-  // The list of syscalls that this rule matches, specified by -S
+  // System calls this rule matches (from -S); empty when the rule matches all syscalls
   syscalls []string
-  // All field entries as raw values, as specified by -F
+  // Raw field filters (from -F), each entry a {key, op, value} dict
   fields []dict
-  // All inter-field comparisons as specified by -C
+  // Inter-field comparisons (from -C), each entry a {key, op, value} dict
   comparisons []dict
-  // The key name for related rules as specified by -k
+  // Key tagging records this rule produces (from -k), for filtering audit logs
   keyname string
   // CPU architecture this rule is restricted to
   //
@@ -1368,7 +1430,9 @@ private auditd.rule.syscall @defaults("action list") {
 
 // Apache2 HTTP Server
 //
-// Examine server configuration and daemon version
+// Apache HTTP Server daemon version as reported by the apache2/httpd
+// binary. Use apache2.conf for the parsed configuration, including
+// directives, loaded modules, virtual hosts, and access-control blocks.
 apache2 {
   // Apache2 version (e.g., "2.4.62")
   version() string
@@ -1376,7 +1440,12 @@ apache2 {
 
 // Apache2 HTTP Server configuration
 //
-// Examine directives, loaded modules, virtual hosts, and directory blocks
+// Parsed Apache configuration covering flat directives, loaded modules,
+// virtual hosts, and Directory / Location access-control blocks, merged
+// across the main config and every Include fragment. Also surfaces
+// hardening-relevant settings such as ServerTokens, ServerSignature,
+// TraceEnable, and response security headers. Pass `init(path: "...")`
+// to point at a non-default config file.
 apache2.conf {
   init(path? string)
   // Primary configuration file
@@ -1458,21 +1527,21 @@ private apache2.conf.virtualHost @defaults("address serverName ssl") {
 
 // Apache2 Directory block
 private apache2.conf.directory @defaults("path") {
-  // Directory path
+  // Directory path the <Directory> block applies to
   path string
-  // Options directive value
+  // Options directive value (e.g., "Indexes FollowSymLinks")
   options string
-  // AllowOverride directive value
+  // AllowOverride directive value (which .htaccess directives are honored, e.g. "None", "All")
   allowOverride string
-  // Require directive values (one entry per Require line)
+  // Require directive values (one entry per Require line), the access-control grants for the block
   require []string
   // All directives within this Directory block
   params map[string]string
 }
 
-// Apache2 <Location> block — URL-space access rules
+// Apache2 <Location> block: URL-space access rules
 private apache2.conf.location @defaults("path") {
-  // Location path or regex
+  // Location path or regex the block matches
   path string
   // Whether this block was defined with <LocationMatch> (regex form) instead of <Location>
   isMatch bool
@@ -1480,7 +1549,7 @@ private apache2.conf.location @defaults("path") {
   authType string
   // AuthName directive value (realm)
   authName string
-  // Require directive values (one entry per Require line)
+  // Require directive values (one entry per Require line), the access-control grants for the block
   require []string
   // ProxyPass target, if set
   proxyPass string
@@ -1490,7 +1559,9 @@ private apache2.conf.location @defaults("path") {
 
 // Nginx HTTP Server
 //
-// Examine server configuration, daemon version, and compiled-in modules
+// Nginx daemon version and the modules compiled into the binary. Use
+// nginx.conf for the parsed configuration, including server blocks,
+// upstream pools, and listen addresses.
 nginx {
   // Nginx version (e.g., "1.25.3")
   version() string
@@ -1500,7 +1571,11 @@ nginx {
 
 // Nginx HTTP Server configuration
 //
-// Examine directives, server blocks, upstream pools, and listen addresses
+// Parsed Nginx configuration covering flat directives, per-server
+// blocks, upstream backend pools, and listen addresses, merged across
+// the main config and every include fragment. Surfaces TLS settings and
+// response headers per server block for hardening audits. Pass
+// `init(path: "...")` to point at a non-default config file.
 nginx.conf {
   init(path? string)
   // Primary configuration file
@@ -1601,11 +1676,11 @@ private nginx.conf.location @defaults("path") {
 
 // Squid caching proxy
 //
-// Examine the Squid proxy server version reported by the daemon binary.
-// Use `squid.conf` to inspect the full configuration including ACLs,
-// access rules, listen ports, cache peers, refresh patterns, and any
-// fragments pulled in by `include` directives (for example the contents
-// of `/etc/squid/conf.d/*.conf`).
+// Squid proxy server version reported by the daemon binary. Use
+// `squid.conf` to inspect the full configuration including ACLs, access
+// rules, listen ports, cache peers, refresh patterns, and any fragments
+// pulled in by `include` directives (for example the contents of
+// `/etc/squid/conf.d/*.conf`).
 squid {
   // Squid version (e.g., "5.7")
   version() string
@@ -1613,13 +1688,14 @@ squid {
 
 // Squid caching proxy configuration
 //
-// Examine directives, access control lists, listen ports, cache peers,
-// cache directories, refresh patterns, authentication parameters, and
-// access logs from `squid.conf` together with every fragment pulled in
-// by `include` directives. Files matched by glob patterns in include
-// lines (e.g. `include /etc/squid/conf.d/*.conf`) are walked recursively
-// and merged into a single logical configuration, so audits see the
-// flattened directive set the daemon actually runs with.
+// Parsed Squid configuration covering directives, access control lists,
+// listen ports, cache peers, cache directories, refresh patterns,
+// authentication parameters, and access logs from `squid.conf` together
+// with every fragment pulled in by `include` directives. Files matched
+// by glob patterns in include lines (e.g. `include /etc/squid/conf.d/*.conf`)
+// are walked recursively and merged into a single logical configuration,
+// so audits see the flattened directive set the daemon actually runs
+// with.
 squid.conf {
   init(path? string)
   // Primary configuration file
@@ -1684,10 +1760,10 @@ squid.conf {
 
 // Squid listen port (http_port or https_port)
 //
-// Examine a single `http_port` or `https_port` directive: the bind
-// address, port number, parsed mode flags (transparent, intercept,
-// accel, ssl-bump, tproxy), and any `key=value` options including the
-// TLS material (`cert=`, `key=`, `tls-cert=`, `tls-key=`).
+// Single `http_port` or `https_port` directive: the bind address, port
+// number, parsed mode flags (transparent, intercept, accel, ssl-bump,
+// tproxy), and any `key=value` options including the TLS material
+// (`cert=`, `key=`, `tls-cert=`, `tls-key=`).
 private squid.conf.listen @defaults("port address tls") {
   // Directive name this entry came from ("http_port" or "https_port")
   directive string
@@ -1711,7 +1787,7 @@ private squid.conf.listen @defaults("port address tls") {
 
 // Squid Access Control List entry
 //
-// Examine an `acl` definition. ACLs are referenced by name from
+// Single `acl` definition. ACLs are referenced by name from
 // `http_access`, `icp_access`, and the other *_access rules, so the
 // `values` field together with the rule list tells you which clients,
 // URLs, or methods Squid will allow or deny.
@@ -1728,7 +1804,7 @@ private squid.conf.acl @defaults("name type") {
 
 // Squid *_access rule
 //
-// Examine a single allow/deny rule from any of the access directives
+// Single allow/deny rule from any of the access directives
 // (`http_access`, `http_reply_access`, `icp_access`, `miss_access`,
 // `cache`, `always_direct`, `never_direct`, etc.). Rules are evaluated
 // top-down by Squid, so the `index` field reflects source order across
@@ -1748,10 +1824,10 @@ private squid.conf.accessRule @defaults("kind action acls") {
 
 // Squid cache peer
 //
-// Examine a `cache_peer` entry — a parent or sibling cache Squid
-// forwards to. The `host`, `type`, and `httpPort` together identify the
-// peer; the `options` slice carries the remaining flags (`default`,
-// `no-query`, `proxy-only`, `login=...`, `weight=...`, ...).
+// Single `cache_peer` entry, a parent or sibling cache Squid forwards
+// to. The `host`, `type`, and `httpPort` together identify the peer; the
+// `options` slice carries the remaining flags (`default`, `no-query`,
+// `proxy-only`, `login=...`, `weight=...`, ...).
 private squid.conf.cachePeer @defaults("host type httpPort") {
   // Peer hostname or IP
   host string
@@ -1769,10 +1845,10 @@ private squid.conf.cachePeer @defaults("host type httpPort") {
 
 // Squid cache directory
 //
-// Examine a `cache_dir` entry — the on-disk cache storage backing the
-// proxy. Captures the storage `type` (ufs, aufs, diskd, rock), the
-// filesystem `path`, the cache size, the L1/L2 fan-out for hashed
-// stores, and any trailing `key=value` options (e.g., `max-size=`).
+// Single `cache_dir` entry, the on-disk cache storage backing the proxy.
+// Captures the storage `type` (ufs, aufs, diskd, rock), the filesystem
+// `path`, the cache size, the L1/L2 fan-out for hashed stores, and any
+// trailing `key=value` options (e.g., `max-size=`).
 private squid.conf.cacheDir @defaults("type path sizeMb") {
   // Storage scheme (ufs, aufs, diskd, rock, ...)
   type string
@@ -1792,8 +1868,8 @@ private squid.conf.cacheDir @defaults("type path sizeMb") {
 
 // Squid refresh_pattern rule
 //
-// Examine a single `refresh_pattern` directive: the regex Squid uses to
-// match URLs, the freshness window (`min` / `percent` / `max`), and any
+// Single `refresh_pattern` directive: the regex Squid uses to match
+// URLs, the freshness window (`min` / `percent` / `max`), and any
 // trailing flags. Audit hot spots include `ignore-private`,
 // `ignore-no-store`, `override-expire`, and `override-lastmod`, which
 // weaken cache safety guarantees.
@@ -1820,10 +1896,10 @@ private squid.conf.refreshPattern @defaults("pattern min max") {
 
 // Squid access_log entry
 //
-// Examine a single `access_log` directive: where requests are written
-// (file path, daemon module target, or "none"), which logformat is in
-// use, and which ACLs gate the log line. Multiple `access_log` lines
-// produce multiple entries in this list.
+// Single `access_log` directive: where requests are written (file path,
+// daemon module target, or "none"), which logformat is in use, and which
+// ACLs gate the log line. Multiple `access_log` lines produce multiple
+// entries in this list.
 private squid.conf.accessLog @defaults("target format") {
   // Log target ("/var/log/squid/access.log", "daemon:/var/log/...", "stdio:/var/log/...", "syslog:...", or "none" to disable)
   target string
@@ -1837,7 +1913,7 @@ private squid.conf.accessLog @defaults("target format") {
 
 // HAProxy load balancer
 //
-// Examine HAProxy version and configuration. The configuration covers
+// HAProxy daemon version and configuration. The configuration covers
 // the global section, defaults blocks, frontends, backends, listens, the
 // servers behind each backend, and supporting sections (resolvers,
 // userlists, peers).
@@ -1848,10 +1924,11 @@ haproxy {
 
 // HAProxy configuration
 //
-// Examine the parsed haproxy.cfg, any `<configdir>/conf.d/*.cfg` fragments
-// next to it, and every file pulled in by `!include` / `!includeglob`
-// directives (HAProxy 2.4+). Pass `init(path: "...")` to point at a
-// non-default config file.
+// Parsed haproxy.cfg, any `<configdir>/conf.d/*.cfg` fragments next to
+// it, and every file pulled in by `!include` / `!includeglob`
+// directives (HAProxy 2.4+). Exposes each section as a dedicated resource,
+// plus a raw view over every section for types that are not modeled.
+// Pass `init(path: "...")` to point at a non-default config file.
 haproxy.config {
   init(path? string)
   // Primary configuration file (defaults to /etc/haproxy/haproxy.cfg)
@@ -1860,7 +1937,7 @@ haproxy.config {
   files(file) []file
   // Global section
   global(file) haproxy.config.global
-  // Defaults sections — one unnamed block in classic configs, possibly several named blocks in HAProxy 2.4+
+  // Defaults sections: one unnamed block in classic configs, possibly several named blocks in HAProxy 2.4+
   defaults(file) []haproxy.config.defaultsSection
   // Frontend sections
   frontends(file) []haproxy.config.frontend
@@ -1874,14 +1951,14 @@ haproxy.config {
   userlists(file) []haproxy.config.userlist
   // Peers sections (stick-table replication)
   peers(file) []haproxy.config.peersSection
-  // Every parsed section in source order, including types not exposed as typed resources
+  // Every parsed section in source order, including types not exposed as dedicated resources
   sections(file) []haproxy.config.section
 }
 
 // HAProxy configuration section (raw view)
 //
-// Examine an arbitrary section by type and name. Useful for sections we
-// don't model as typed resources (mailers, cache, program, ring,
+// Arbitrary section addressed by type and name. Useful for sections not
+// modeled as their own resources (mailers, cache, program, ring,
 // http-errors, fcgi-app, crt-store) and for low-level audits that need
 // every directive in source order.
 private haproxy.config.section @defaults("type name") {
@@ -1899,7 +1976,7 @@ private haproxy.config.section @defaults("type name") {
   endLine int
   // Flat directive map (name -> joined args; values comma-concatenated when the directive repeats)
   params map[string]string
-  // Every directive in source order — entries: {name, args, line, file, raw}
+  // Every directive in source order (entries: {name, args, line, file, raw})
   directives []dict
   // Raw text of the section including its header line
   raw string
@@ -1907,10 +1984,12 @@ private haproxy.config.section @defaults("type name") {
 
 // HAProxy global section
 //
-// Examine the global section: process settings (daemon, user/group,
-// chroot, pidfile), connection limits, threading, the runtime stats
-// socket, default SSL options applied to every bind and server, and the
-// log destinations.
+// Global section: process settings (daemon, user/group, chroot,
+// pidfile), connection limits, threading, the runtime stats socket, the
+// default SSL options applied to every bind and server, and the log
+// destinations. The default-SSL fields matter for hardening because they
+// set the baseline any bind or server inherits when it doesn't override
+// them locally.
 private haproxy.config.global @defaults("daemon maxconn nbthread") {
   // `daemon` directive present
   daemon bool
@@ -1938,7 +2017,7 @@ private haproxy.config.global @defaults("daemon maxconn nbthread") {
   statsSocketMode string
   // `level` arg on the stats socket line (user, operator, admin)
   statsSocketLevel string
-  // `user`/`group` arg on the stats socket line — UNIX uid/gid the socket is owned by
+  // `user`/`group` arg on the stats socket line: UNIX uid/gid the socket is owned by
   statsSocketUser string
   // `stats timeout` value (string with time unit)
   statsTimeout string
@@ -1978,9 +2057,9 @@ private haproxy.config.global @defaults("daemon maxconn nbthread") {
 
 // HAProxy defaults section
 //
-// Examine the inherited defaults applied to every frontend, backend, and
-// listen that doesn't override a setting locally. HAProxy 2.4+ supports
-// multiple named defaults blocks; `name` selects which one.
+// Inherited defaults applied to every frontend, backend, and listen that
+// doesn't override a setting locally. HAProxy 2.4+ supports multiple
+// named defaults blocks; `name` selects which one.
 private haproxy.config.defaultsSection @defaults("name mode") {
   // Defaults section name (empty for the classic unnamed defaults block)
   name string
@@ -2010,9 +2089,11 @@ private haproxy.config.defaultsSection @defaults("name mode") {
 
 // HAProxy frontend section
 //
-// Examine an inbound traffic acceptor: its `bind` listeners (with TLS
+// Inbound traffic acceptor. Exposes its `bind` listeners (with TLS
 // settings), ACL definitions, request routing rules, the default backend,
-// and the timeout/log/option set applied to client traffic.
+// and the timeout/log/option set applied to client traffic. Useful for
+// auditing which addresses and ports are exposed and whether TLS is
+// enforced on them.
 private haproxy.config.frontend @defaults("name mode") {
   // Frontend name
   name string
@@ -2024,9 +2105,9 @@ private haproxy.config.frontend @defaults("name mode") {
   binds []haproxy.config.bind
   // `default_backend` value
   defaultBackend string
-  // `acl` definitions — entries: {name, criterion, args, line, raw}
+  // `acl` definitions. Entries: {name, criterion, args, line, raw}
   acls []dict
-  // `use_backend` rules — entries: {backend, condition, line, raw}
+  // `use_backend` rules. Entries: {backend, condition, line, raw}
   useBackends []dict
   // `http-request <rule>` lines (raw arg strings, in source order)
   httpRequestRules []string
@@ -2048,24 +2129,25 @@ private haproxy.config.frontend @defaults("name mode") {
   options []string
   // `no option <name>` directives
   disabledOptions []string
-  // `timeout <kind> <value>` map keyed by kind
+  // `timeout <kind> <value>` map keyed by kind (e.g., client, connect)
   timeouts map[string]string
   // `log` directives
   log []string
-  // `maxconn` value (per-frontend limit)
+  // `maxconn` value (per-frontend concurrent connection limit)
   maxconn int
-  // All directives within this frontend
+  // All directives within this frontend, keyed by directive name
   params map[string]string
-  // Source file path
+  // Source file path where this frontend is defined
   file string
 }
 
 // HAProxy backend section
 //
-// Examine a backend pool: the load-balancing algorithm, the servers
+// Backend server pool. Exposes the load-balancing algorithm, the servers
 // behind it, their TLS posture (ssl/verify/ca-file) and health-check
 // configuration (`option httpchk`/`http-check`), `default-server` defaults,
-// stick-table/cookie persistence, request mutators, and timeouts.
+// stick-table/cookie persistence, request mutators, and timeouts. Useful
+// for verifying that backend connections are encrypted and health-checked.
 private haproxy.config.backend @defaults("name mode balance") {
   // Backend name
   name string
@@ -2083,7 +2165,7 @@ private haproxy.config.backend @defaults("name mode balance") {
   defaultServer dict
   // `source` directive arguments (e.g., "0.0.0.0 usesrc clientip")
   source string
-  // Consolidated HTTP health check — keys: {method, uri, version, send[], expect[], disabled}
+  // Consolidated HTTP health check. Keys: {method, uri, version, send[], expect[], disabled}
   httpCheck dict
   // `stick-table` arguments (raw string)
   stickTable string
@@ -2105,23 +2187,24 @@ private haproxy.config.backend @defaults("name mode balance") {
   options []string
   // `no option <name>` directives
   disabledOptions []string
-  // `timeout <kind> <value>` map keyed by kind
+  // `timeout <kind> <value>` map keyed by kind (e.g., server, connect, check)
   timeouts map[string]string
   // `log` directives
   log []string
   // `retries` value (defaults inherited; 0 means unset locally)
   retries int
-  // All directives within this backend
+  // All directives within this backend, keyed by directive name
   params map[string]string
-  // Source file path
+  // Source file path where this backend is defined
   file string
 }
 
 // HAProxy listen section
 //
-// Examine a combined frontend+backend section. The same audit surface as
+// Combined frontend and backend section. Exposes the same audit surface as
 // a backend (servers, balance, health checks) plus the frontend's
-// `bind` listeners and ACL/routing surface.
+// `bind` listeners and ACL/routing surface, for the shorthand where a
+// single section both accepts client traffic and defines its server pool.
 private haproxy.config.listen @defaults("name mode") {
   // Listen section name
   name string
@@ -2159,18 +2242,20 @@ private haproxy.config.listen @defaults("name mode") {
   timeouts map[string]string
   // `log` directives
   log []string
-  // All directives within this listen
+  // All directives within this listen, keyed by directive name
   params map[string]string
-  // Source file path
+  // Source file path where this listen section is defined
   file string
 }
 
 // HAProxy bind listener
 //
-// Examine one listener address produced by a `bind` directive. A
+// Single listener address produced by a `bind` directive. A
 // `bind a:1,b:2 ssl crt foo` directive expands into one of these per
 // address form; the shared parameters (ssl, crt, alpn, verify, etc.)
-// are copied onto each entry.
+// are copied onto each entry. Fields expose the listen address/port and
+// the full TLS posture, so you can assert that exposed listeners require
+// modern TLS and client verification.
 private haproxy.config.bind @defaults("address port ssl") {
   // Raw argument string after the `bind` keyword
   raw string
@@ -2182,7 +2267,7 @@ private haproxy.config.bind @defaults("address port ssl") {
   portRangeStart int
   // End of a port range; 0 if not a range
   portRangeEnd int
-  // `ssl` flag present
+  // Whether the `ssl` flag is present (TLS termination on this listener)
   ssl bool
   // `alpn` argument (comma-separated protocols; e.g., "h2,http/1.1")
   alpn string
@@ -2204,34 +2289,35 @@ private haproxy.config.bind @defaults("address port ssl") {
   sslMinVer string
   // `ssl-max-ver` argument
   sslMaxVer string
-  // `no-sslv3` flag
+  // Whether the `no-sslv3` flag disables SSLv3
   noSslv3 bool
-  // `no-tlsv10` flag
+  // Whether the `no-tlsv10` flag disables TLS 1.0
   noTlsv10 bool
-  // `no-tlsv11` flag
+  // Whether the `no-tlsv11` flag disables TLS 1.1
   noTlsv11 bool
-  // `no-tlsv12` flag
+  // Whether the `no-tlsv12` flag disables TLS 1.2
   noTlsv12 bool
-  // `no-tlsv13` flag
+  // Whether the `no-tlsv13` flag disables TLS 1.3
   noTlsv13 bool
-  // `accept-proxy` flag (require PROXY protocol header from client)
+  // Whether the `accept-proxy` flag requires a PROXY protocol header from the client
   acceptProxy bool
-  // `transparent` flag
+  // Whether the `transparent` flag is set (bind to non-local addresses)
   transparent bool
   // `v4v6` flag (bind on both IPv4 and IPv6 when the socket supports it)
   v4v6 bool
-  // `v6only` flag
+  // Whether the `v6only` flag restricts the socket to IPv6
   v6only bool
-  // All key=value attributes on this bind line (catch-all including ones not surfaced as typed fields)
+  // All key=value attributes on this bind line (catch-all including ones not surfaced as dedicated fields)
   params map[string]string
 }
 
 // HAProxy backend server
 //
-// Examine one backend pool member. Captures the server identity
+// Single member of a backend server pool. Captures the server identity
 // (name/address/port), TLS posture toward the backend (ssl, verify,
 // ca-file, sni, alpn), the health check tuning (inter/rise/fall/observe),
-// connection limits, and persistence hooks.
+// connection limits, and persistence hooks. Useful for confirming that
+// upstream connections are encrypted, verified, and actively health-checked.
 private haproxy.config.server @defaults("name address port check ssl") {
   // Server name
   name string
@@ -2239,11 +2325,11 @@ private haproxy.config.server @defaults("name address port check ssl") {
   address string
   // Server port (0 for unix sockets or address-only declarations)
   port int
-  // `check` flag (active health checking enabled)
+  // Whether the `check` flag enables active health checking
   check bool
-  // `ssl` flag (use TLS to reach this server)
+  // Whether the `ssl` flag enables TLS to reach this server
   ssl bool
-  // `verify` argument (none, required)
+  // `verify` argument for the backend TLS connection (none, required)
   verify string
   // `ca-file` argument (CA bundle for backend cert verification)
   caFile string
@@ -2255,9 +2341,9 @@ private haproxy.config.server @defaults("name address port check ssl") {
   alpn string
   // `weight` value (load-balancing weight; 0 means draining)
   weight int
-  // `backup` flag (only used when no non-backup server is up)
+  // Whether the `backup` flag is set (only used when no non-backup server is up)
   backup bool
-  // `disabled` flag (admin-down)
+  // Whether the `disabled` flag marks the server admin-down
   disabled bool
   // `maxconn` value (per-server concurrent connection cap)
   maxconn int
@@ -2273,33 +2359,33 @@ private haproxy.config.server @defaults("name address port check ssl") {
   rise int
   // `fall` value (consecutive failed checks required to mark DOWN)
   fall int
-  // `slowstart` value
+  // `slowstart` value (ramp-up period after a server comes back up)
   slowStart string
   // `observe` value (passive observation: l4, l7)
   observe string
   // `on-error` value (action on observed errors: fastinter, fail-check, sudden-death, mark-down)
   onError string
-  // `on-marked-up` value
+  // `on-marked-up` value (action when the server transitions to UP)
   onMarkedUp string
-  // `on-marked-down` value
+  // `on-marked-down` value (action when the server transitions to DOWN)
   onMarkedDown string
   // `cookie` value (cookie identifier for stickiness)
   cookie string
   // `resolvers` name (resolvers section used for hostname resolution)
   resolvers string
-  // `init-addr` value
+  // `init-addr` value (address resolution order at startup)
   initAddr string
-  // `send-proxy` flag (send PROXY v1 header to backend)
+  // Whether the `send-proxy` flag sends a PROXY v1 header to the backend
   sendProxy bool
-  // `send-proxy-v2` flag (send PROXY v2 header to backend)
+  // Whether the `send-proxy-v2` flag sends a PROXY v2 header to the backend
   sendProxyV2 bool
-  // `agent-check` flag (enable external agent health check)
+  // Whether the `agent-check` flag enables an external agent health check
   agentCheck bool
   // `agent-port` value
   agentPort int
   // `agent-addr` value
   agentAddr string
-  // `agent-inter` value
+  // `agent-inter` value (agent-check interval)
   agentInter string
   // All key=value flags on the server line (catch-all)
   params map[string]string
@@ -2307,72 +2393,78 @@ private haproxy.config.server @defaults("name address port check ssl") {
 
 // HAProxy resolvers section
 //
-// Examine a DNS resolver pool used by `server` directives that resolve
-// hostnames at runtime via `resolvers <name>`.
+// DNS resolver pool used by `server` directives that resolve
+// hostnames at runtime via `resolvers <name>`. Exposes the configured
+// nameservers, retry/timeout tuning, and caching (`hold`) policy.
 private haproxy.config.resolversSection @defaults("name") {
   // Resolvers section name
   name string
-  // `nameserver <name> <addr>[:<port>]` entries — entries: {name, address, port}
+  // `nameserver <name> <addr>[:<port>]` entries. Entries: {name, address, port}
   nameservers []dict
-  // `resolve_retries` value
+  // `resolve_retries` value (number of retries per nameserver)
   resolveRetries int
   // `timeout <kind> <value>` map (resolve, retry)
   timeouts map[string]string
-  // `accepted_payload_size` value (UDP DNS payload cap)
+  // `accepted_payload_size` value (UDP DNS payload cap in bytes)
   acceptedPayloadSize int
   // `hold <state> <duration>` map keyed by state (valid, nx, refused, timeout, obsolete, other)
   holds map[string]string
-  // All directives within this resolvers section
+  // All directives within this resolvers section, keyed by directive name
   params map[string]string
-  // Source file path
+  // Source file path where this resolvers section is defined
   file string
 }
 
 // HAProxy userlist section
 //
-// Examine an HTTP-auth userlist consumed by `http-request auth` /
+// HTTP-auth userlist consumed by `http-request auth` /
 // `http-request deny unless { http_auth(<list>) }`. Captures users
-// (with hashing flag) and groups.
+// (with a flag indicating whether the password is hashed) and groups,
+// so you can audit for cleartext (`insecure-password`) credentials.
 private haproxy.config.userlist @defaults("name") {
   // Userlist name
   name string
-  // `user <name> (password|insecure-password) <secret> [groups <g1,g2>]` entries — entries: {name, password, hashed, groups}
+  // `user <name> (password|insecure-password) <secret> [groups <g1,g2>]` entries. Entries: {name, password, hashed, groups}
   users []dict
-  // `group <name> [users <u1,u2>]` entries — entries: {name, users}
+  // `group <name> [users <u1,u2>]` entries. Entries: {name, users}
   groups []dict
-  // Source file path
+  // Source file path where this userlist is defined
   file string
 }
 
 // HAProxy peers section
 //
-// Examine a peers section used for stick-table replication between
-// HAProxy instances.
+// Peers section used for stick-table replication between
+// HAProxy instances. Exposes the peer servers and the replicated
+// stick-table definitions.
 private haproxy.config.peersSection @defaults("name") {
   // Peers section name
   name string
-  // `bind` argument (raw — peers binds are simpler than frontend binds)
+  // `bind` argument (raw; peers binds are simpler than frontend binds)
   bind string
-  // `server <name> <addr>:<port>` entries (typed server resources, same shape as backend servers)
+  // `server <name> <addr>:<port>` entries (same shape as backend servers)
   servers []haproxy.config.server
-  // `table <name> ...` entries — entries: {name, type, size, expire, store, raw}
+  // `table <name> ...` entries. Entries: {name, type, size, expire, store, raw}
   tables []dict
-  // All directives within this peers section
+  // All directives within this peers section, keyed by directive name
   params map[string]string
-  // Source file path
+  // Source file path where this peers section is defined
   file string
 }
 
 // systemd journald configuration
 //
-// Examine the [Journal] and other sections of journald.conf
+// Configuration for the systemd journal daemon parsed from
+// journald.conf. Exposes the [Journal] and other sections, letting you
+// audit settings such as log Storage, Compress, retention limits, and
+// forwarding. Access the parsed content through `sections`.
 journald.config {
   init(path? string)
   // File of this journald configuration
   file() file
   // Flattened journald configuration parameters
   //
-  // Deprecated in favor of `sections()`.
+  // Deprecated in favor of `sections`.
   params(file) @maturity("deprecated") map[string]string
   // All sections in this journald configuration
   sections(file) []journald.config.section
@@ -2380,7 +2472,7 @@ journald.config {
 
 // journald configuration section
 //
-// Examine a single named section (e.g., "Journal", "Upload") from the
+// Single named section (e.g., "Journal", "Upload") from the
 // journald configuration, including its `params` list of key-value pairs.
 // Used together with `journald.config` to audit individual journald settings
 // within a specific section.
@@ -2393,7 +2485,7 @@ journald.config.section @defaults("name") {
 
 // journald configuration parameter
 //
-// Examine a single key-value directive within a journald configuration
+// Single key-value directive within a journald configuration
 // section: the parameter `name` (e.g., "Storage", "Compress") and its
 // `value`. Iterated from `journald.config.section.params` to assert
 // specific journald settings.
@@ -2406,7 +2498,10 @@ journald.config.section.param @defaults("name value") {
 
 // Service on the system
 //
-// Examine install, enable, run state, type, and unit metadata
+// Single init/service-manager unit (systemd, SysV, launchd, and others),
+// selected by name (e.g., `service(name: "sshd")`). Exposes install,
+// enable, and run state plus the unit type and mask/static metadata, so
+// you can assert that required services run and unwanted ones stay off.
 service @defaults("name running enabled type") {
   init(name string)
   // Name of the service
@@ -2421,7 +2516,7 @@ service @defaults("name running enabled type") {
   enabled bool
   // Service type (e.g., simple, forking, oneshot, notify)
   type string
-  // Whether the service is masked
+  // Whether the service is masked (symlinked to /dev/null so it cannot start)
   masked bool
   // Whether the service is static (unit file has no [Install] section and cannot be enabled/disabled)
   static bool
@@ -2429,14 +2524,19 @@ service @defaults("name running enabled type") {
 
 // All services configured on the system
 //
-// Iterate every service across the asset's init/service manager
+// Collection of every service across the asset's init/service manager.
+// Filter it to find running-but-unwanted or disabled-but-required
+// services, e.g. `services.where(running == true)`.
 services {
   []service
 }
 
 // systemd timer unit
 //
-// Examine schedule, activation target, enable state, and run status
+// Single systemd timer, selected by name (e.g.,
+// `systemd.timer(name: "logrotate")`). Exposes the schedule, the unit it
+// activates, enable/mask/static state, and whether it is currently
+// running, so you can audit scheduled maintenance and update jobs.
 systemd.timer @defaults("name enabled running") {
   init(name string)
   // Name of the timer unit (without .timer suffix)
@@ -2447,7 +2547,7 @@ systemd.timer @defaults("name enabled running") {
   installed bool
   // Whether the timer is enabled (starts at boot)
   enabled bool
-  // Whether the timer is masked
+  // Whether the timer is masked (symlinked to /dev/null so it cannot start)
   masked bool
   // Whether the timer is static (unit file has no [Install] section)
   static bool
@@ -2463,14 +2563,18 @@ systemd.timer @defaults("name enabled running") {
 
 // All systemd timer units on the system
 //
-// Iterate every timer for filtering by schedule, target, or status
+// Collection of every timer, for filtering by schedule, activation
+// target, or status.
 systemd.timers {
   []systemd.timer
 }
 
 // systemd socket unit
 //
-// Examine listen addresses, activation target, and run state
+// Single socket-activated unit, selected by name (e.g.,
+// `systemd.socket(name: "sshd")`). Exposes the listen addresses/ports,
+// the service it activates, and enable/mask/run state, so you can audit
+// which sockets expose network services.
 systemd.socket @defaults("name enabled running") {
   init(name string)
   // Name of the socket unit (without .socket suffix)
@@ -2481,7 +2585,7 @@ systemd.socket @defaults("name enabled running") {
   installed bool
   // Whether the socket is enabled (starts at boot)
   enabled bool
-  // Whether the socket is masked
+  // Whether the socket is masked (symlinked to /dev/null so it cannot start)
   masked bool
   // Whether the socket is static (unit file has no [Install] section)
   static bool
@@ -2491,20 +2595,21 @@ systemd.socket @defaults("name enabled running") {
   activates() string
   // Addresses, paths, or ports this socket listens on
   listenAddresses() []string
-  // Whether the socket accepts connections (inetd-style)
+  // Whether the socket accepts connections (inetd-style, one service instance per connection)
   accept() bool
 }
 
 // All systemd socket units on the system
 //
-// Iterate every socket-activated unit for listen-address and target audits
+// Collection of every socket-activated unit, for listen-address and
+// activation-target audits.
 systemd.sockets {
   []systemd.socket
 }
 
 // systemd target unit
 //
-// Examine a single systemd target — load state, active state, the unit
+// Single systemd target: its load state, active state, the unit
 // file's enabled/disabled state, fragment path on disk, and the
 // dependency lists (`wants`, `requires`, `after`, `before`) that
 // determine which other units the target pulls in or orders around.
@@ -2536,20 +2641,21 @@ private systemd.target @defaults("name loadState activeState") {
 
 // All systemd target units on the system
 //
-// Iterate every target unit to audit boot ordering, default target, and
-// dependency wiring
+// Collection of every target unit, for auditing boot ordering, the
+// default target, and dependency wiring.
 systemd.targets {
   []systemd.target
 }
 
 // systemd-resolved DNS resolver state
 //
-// Examine the global DNS resolution configuration provided by
+// Global DNS resolution configuration provided by
 // systemd-resolved: whether the daemon is `active`, the effective DNS
 // servers (`dns`) and `fallbackDns`, search `domains`, DNSSEC and
 // DNS-over-TLS modes, LLMNR and multicast-DNS settings, the
 // resolv.conf mode, and whether caching is enabled. Backed by
-// `resolvectl status` for the Global scope.
+// `resolvectl status` for the Global scope. Useful for asserting that
+// DNSSEC or DNS-over-TLS is enforced.
 systemd.resolved @defaults("active dns") {
   // Whether the systemd-resolved daemon is currently active
   active() bool
@@ -2584,12 +2690,13 @@ systemd.resolved @defaults("active dns") {
 
 // systemd-timesyncd NTP client state
 //
-// Examine the SNTP client provided by systemd-timesyncd: whether the
+// SNTP client state provided by systemd-timesyncd: whether the
 // daemon is `active`, whether the system clock is currently
 // `synchronized`, the configured `servers` and `fallbackServers`, the
 // currently selected NTP `serverName` and `serverAddress`, the current
 // poll interval, and the leap-second status. Backed by `timedatectl
-// show` and `timedatectl show-timesync`.
+// show` and `timedatectl show-timesync`. Useful for asserting that time
+// is synchronized to an approved source.
 systemd.timesyncd @defaults("active synchronized serverName") {
   // Whether the systemd-timesyncd daemon is currently active
   active() bool
@@ -2611,15 +2718,17 @@ systemd.timesyncd @defaults("active synchronized serverName") {
 
 // Running kernel and its modules
 //
-// Examine kernel info, sysctl parameters, loaded modules, and installed versions
+// Running kernel and its configuration surface. Exposes kernel version
+// info, sysctl `parameters`, `modules`, installed kernel versions, and,
+// on Linux, hardening state (`cmdline`, `taint`, `lockdown`, `aslr`).
 kernel @defaults("info") {
-  // Active kernel information
+  // Active kernel information (version, path, device, arguments)
   info() dict
-  // Kernel parameters map
+  // Kernel parameters map (sysctl key-value pairs)
   parameters() map[string]string
   // List of kernel modules
   modules() []kernel.module
-  // Installed versions
+  // Installed kernel versions
   installed() []dict
   // Kernel boot command line (Linux only)
   cmdline() kernel.cmdline
@@ -2633,10 +2742,10 @@ kernel @defaults("info") {
 
 // System kernel module information
 //
-// Examine a single kernel module: its `name`, in-memory `size`, and
+// Single kernel module: its `name`, in-memory `size`, and
 // whether it is currently `loaded`. Initialize by name (e.g.,
 // `kernel.module(name: "nf_conntrack")`) to check a specific module,
-// or iterate from `kernel.modules()` to audit the full loaded-module list.
+// or iterate from `kernel.modules` to audit the full loaded-module list.
 // Use `blacklisted`, `installBypass`, and `disabled` to express CIS-style
 // "module must not load" controls without falling back to raw modprobe.d
 // file parsing. Use `onDisk` to tell whether a loadable module file is
@@ -2681,7 +2790,7 @@ kernel.module @defaults("name loaded") {
   // listed in that kernel's `modules.dep` index. This reports presence
   // independently of `loaded`, so it answers "the module is available to
   // load but isn't loaded right now." Modules compiled into the kernel
-  // have no file on disk and report false here — see `builtIn`.
+  // have no file on disk and report false here (see `builtIn`).
   onDisk() bool
   // Whether the module is compiled into the kernel image
   //
@@ -2695,7 +2804,7 @@ kernel.module @defaults("name loaded") {
 
 // Linux kernel boot command line
 //
-// Examine the kernel command line passed by the bootloader at boot
+// Kernel command line passed by the bootloader at boot
 // time (the contents of /proc/cmdline). Use `parameters` for
 // `key=value` directives and `flags` for bare tokens such as `ro`,
 // `quiet`, or `nosmt`. The `raw` string is preserved for direct
@@ -2715,7 +2824,7 @@ private kernel.cmdline @defaults("raw") {
 
 // Linux kernel taint status
 //
-// Examine kernel taint flags as reported by /proc/sys/kernel/tainted.
+// Kernel taint flags as reported by /proc/sys/kernel/tainted.
 // A non-zero bitmask indicates that the kernel has loaded
 // proprietary or out-of-tree modules, hit a hardware error, oopsed,
 // or otherwise entered a state that diverges from a clean reference
@@ -2736,7 +2845,7 @@ private kernel.taint @defaults("tainted reasons") {
 
 // Linux kernel lockdown mode
 //
-// Examine the kernel lockdown LSM state from
+// Kernel lockdown LSM state from
 // /sys/kernel/security/lockdown. Lockdown restricts modifications to
 // a running kernel even from root: `integrity` blocks features that
 // could let userspace modify the kernel (kexec, /dev/mem, etc.) and
@@ -2754,7 +2863,7 @@ private kernel.lockdown @defaults("mode") {
 
 // Linux Address Space Layout Randomization (ASLR) state
 //
-// Examine the kernel's userspace ASLR setting from
+// Kernel userspace ASLR setting from
 // /proc/sys/kernel/randomize_va_space. ASLR randomizes memory layout
 // to make memory-corruption exploits harder; CIS benchmarks require
 // `mode` 2 (full randomization).
@@ -2774,7 +2883,7 @@ private kernel.aslr @defaults("level enabled") {
 
 // Linux control groups (cgroup v2)
 //
-// Examine the cgroup hierarchy, available controllers, and the version
+// cgroup hierarchy, available controllers, and the version
 // of cgroups in use. Modern Linux uses cgroup v2 (a single unified
 // hierarchy at /sys/fs/cgroup); v1 hosts and hybrid setups are
 // detected and reported via `version`, but per-controller hierarchies
@@ -2793,7 +2902,7 @@ cgroups @defaults("version controllers") {
 
 // Linux control group
 //
-// Examine a single cgroup v2 entry: its `path` relative to the cgroup
+// Single cgroup v2 entry: its `path` relative to the cgroup
 // root, the kernel `type` (domain, threaded, etc.), the
 // systemd-inferred `unitType` (slice, scope, service, or other), the
 // controllers enabled on it, memory/CPU/PIDs limits and current
@@ -2841,24 +2950,35 @@ private cgroup @defaults("path unitType memoryMax") {
 
 // Docker host
 //
-// Examine images and containers managed by the Docker daemon
+// Images and containers managed by the local Docker daemon. The `images`
+// field lists every image stored on the host with its ID, tags, digests, size,
+// and labels; `containers` lists running and stopped containers with their
+// state, image, command, and labels. Use it to audit what is deployed on a
+// Docker host, for example `docker.containers.where(status == /Up/)` for
+// currently running workloads.
 docker {
-  // List all Docker images
+  // All Docker images stored on the host
   images() []docker.image
-  // List all Docker containers
+  // All Docker containers on the host, running and stopped
   containers() []docker.container
 }
 
 // Dockerfile parser
 //
-// Examine instructions and per-stage FROM/RUN/COPY/ENV/EXPOSE/USER/HEALTHCHECK
+// Parsed contents of a Dockerfile, giving structured access to every build
+// instruction rather than the raw text. The `stages` field breaks a
+// multi-stage build into its `FROM`/`RUN`/`COPY`/`ENV`/`EXPOSE`/`USER`/
+// `HEALTHCHECK` instructions, `instructions` returns them in file order, and
+// `finalStage` points at the stage that produces the image. Select a file with
+// `docker.file(path: "/path/to/Dockerfile")` and audit it, for example
+// `docker.file("Dockerfile").stages.all(runsAsRoot == false)`.
 docker.file @defaults("file.path instructions.length stages.length") {
   init(path string)
   // File information about this Dockerfile
   embed file
-  // List of instructions in the order they appear
+  // All instructions in the order they appear in the file
   instructions(file) dict
-  // All stages included in this Dockerfile
+  // Build stages defined in this Dockerfile
   stages(file) []docker.file.stage
   // Parser directives declared at the top of the Dockerfile
   //
@@ -2883,45 +3003,52 @@ docker.file @defaults("file.path instructions.length stages.length") {
   finalStage(file) docker.file.stage
 }
 
-// Dockerfile stages
+// Build stage in a Dockerfile
+//
+// One `FROM`-rooted stage of a Dockerfile, with every instruction it contains
+// exposed as a field: base image (`from`), environment (`env`), build
+// arguments (`arg`), labels, commands (`run`, `cmd`, `entrypoint`), file
+// operations (`add`, `copy`), exposed ports, health checks, volumes, and the
+// effective user. The `runsAsRoot`, `hasHealthcheck`, and `final` predicates
+// support common hardening audits such as checking that no stage runs as root.
 private docker.file.stage @defaults("from.name") {
-  // The source of this stage, specified via `FROM` in Dockerfiles
+  // Base image this stage builds on, from its `FROM` instruction
   from docker.file.from
-  // Contains the reference to the Dockerfile this stage belongs to
+  // Dockerfile this stage belongs to
   file docker.file
-  // ENV instructions in this Dockerfile
+  // ENV instructions in this stage
   env []docker.file.env
-  // ARG instructions in the Dockerfile
+  // ARG instructions in this stage
   arg []docker.file.arg
-  // LABEL instructions in the Dockerfile
+  // LABEL instructions in this stage, as key/value pairs
   labels map[string]string
-  // OpenContainer image annotations from this stage's labels
+  // OpenContainer image annotations parsed from this stage's labels
   oci docker.file.oci
-  // RUN instructions in this Dockerfile
+  // RUN instructions in this stage
   run []docker.file.run
-  // CMD instructions in this Dockerfile
+  // CMD instruction in this stage
   cmd docker.file.run
-  // USER instruction in this Dockerfile
+  // USER instruction in this stage
   user docker.file.user
-  // ENTRYPOINT instructions in this Dockerfile
+  // ENTRYPOINT instruction in this stage
   entrypoint docker.file.run
-  // ADD instructions in this Dockerfile
+  // ADD instructions in this stage
   add []docker.file.add
-  // COPY instructions in this Dockerfile
+  // COPY instructions in this stage
   copy []docker.file.copy
-  // EXPOSE instructions in this Dockerfile
+  // EXPOSE instructions in this stage
   expose []docker.file.expose
-  // HEALTHCHECK instruction in this Dockerfile
+  // HEALTHCHECK instruction in this stage
   healthcheck docker.file.healthcheck
-  // VOLUME instructions in this Dockerfile
+  // VOLUME instructions in this stage
   volumes []docker.file.volume
-  // SHELL instruction in this Dockerfile
+  // SHELL instruction in this stage
   shell docker.file.shell
-  // WORKDIR instructions in this Dockerfile
+  // WORKDIR instructions in this stage
   workdir []docker.file.workdir
-  // STOPSIGNAL instruction in this Dockerfile
+  // STOPSIGNAL instruction in this stage
   stopsignal docker.file.stopsignal
-  // ONBUILD instructions in this Dockerfile
+  // ONBUILD instructions in this stage
   //
   // ONBUILD instructions are deferred and run when an image built from this
   // Dockerfile is itself used as the base image of a downstream build.
@@ -2947,18 +3074,17 @@ private docker.file.stage @defaults("from.name") {
 
 // OpenContainer image annotations declared in a build stage
 //
-// Examine the `org.opencontainers.image.*` labels set via `LABEL`
-// instructions in a single build stage. The standard annotations defined by
-// the OpenContainer image specification are surfaced as named fields so you
-// can read provenance and metadata without remembering the full annotation
-// keys — for example the upstream repository (`source`), the commit it was
-// built from (`revision`), the release (`version`), and the SPDX license
-// expression (`licenses`). The `all` field holds every `org.opencontainers.*`
-// label found on the stage, including vendor-specific annotations that have
-// no named field. A field is empty when its annotation is not declared in the
-// stage. Surrounding quotes are removed from values, so a quoted `LABEL`
-// reads back unquoted; the verbatim form remains available in the stage
-// `labels` map.
+// The `org.opencontainers.image.*` labels set via `LABEL` instructions in a
+// single build stage. The standard annotations defined by the OpenContainer
+// image specification are surfaced as named fields so you can read provenance
+// and metadata without remembering the full annotation keys, for example the
+// upstream repository (`source`), the commit it was built from (`revision`),
+// the release (`version`), and the SPDX license expression (`licenses`). The
+// `all` field holds every `org.opencontainers.*` label found on the stage,
+// including vendor-specific annotations that have no named field. A field is
+// empty when its annotation is not declared in the stage. Surrounding quotes
+// are removed from values, so a quoted `LABEL` reads back unquoted; the
+// verbatim form remains available in the stage `labels` map.
 private docker.file.oci @defaults("source version revision") {
   // Date and time the image was built, as an RFC 3339 string (`org.opencontainers.image.created`)
   created string
@@ -2998,7 +3124,11 @@ private docker.file.oci @defaults("source version revision") {
   all map[string]string
 }
 
-// Dockerfile ARG instructions
+// Dockerfile ARG instruction
+//
+// A build argument declared with `ARG`, giving its `name` and optional
+// `default` value. Build arguments are commonly misused to pass secrets, so
+// their names are worth auditing.
 private docker.file.arg @defaults("name default") @context("file.context") {
   // Name of the variable
   name string
@@ -3008,7 +3138,11 @@ private docker.file.arg @defaults("name default") @context("file.context") {
   default string
 }
 
-// Dockerfile ENV instructions
+// Dockerfile ENV instruction
+//
+// An environment variable declared with `ENV`, as a `name`/`value` pair.
+// Because `ENV` values persist into the running container and image history,
+// they are a frequent place for accidentally baked-in secrets.
 private docker.file.env @defaults("name value") @context("file.context") {
   // Name of the variable
   name string
@@ -3018,11 +3152,14 @@ private docker.file.env @defaults("name value") @context("file.context") {
   value string
 }
 
-// Dockerfile USER instructions
+// Dockerfile USER instruction
+//
+// The identity a stage switches to via `USER`, split into `user` and optional
+// `group`, with `isRoot` flagging containers that would run privileged.
 private docker.file.user @defaults("user") @context("file.context") {
-  // Set the user name or UID
+  // User name or UID the stage switches to
   user string
-  // Set the user group or GID (optional)
+  // Group name or GID the stage switches to (optional)
   group string
   // Whether the declared user is root
   //
@@ -3031,6 +3168,10 @@ private docker.file.user @defaults("user") @context("file.context") {
 }
 
 // Dockerfile EXPOSE instruction
+//
+// A network port advertised by `EXPOSE`, with its `port` number and
+// `protocol`. This documents intended listening ports, useful for reconciling
+// against what a container actually binds.
 private docker.file.expose @defaults("port protocol") @context("file.context") {
   // Port that is exposed
   port int
@@ -3038,17 +3179,34 @@ private docker.file.expose @defaults("port protocol") @context("file.context") {
   protocol string
 }
 
-// Dockerfile FROM instructions
+// Dockerfile FROM instruction
+//
+// The base image a stage is built from, parsed into its `image`, `tag`,
+// `digest`, and optional `platform`, plus the stage `name` when written as
+// `FROM ... AS <name>`. Pinning by `digest` rather than a floating `tag` is a
+// common supply-chain requirement.
 private docker.file.from @defaults("name image tag") @context("file.context") {
+  // Target platform for the base image (`--platform=<os>/<arch>`), empty when not set
   platform string
+  // Base image repository, e.g. `alpine` or `docker.io/library/nginx`
   image string
+  // Image tag, e.g. `3.19`; empty when the image is pinned by digest only
   tag string
+  // Image digest, e.g. `sha256:...`; empty when referenced by tag
   digest string
+  // Stage name from `FROM ... AS <name>`, empty for an unnamed stage
   name string
 }
 
-// Dockerfile RUN instructions
+// Dockerfile RUN instruction
+//
+// A command executed at build time via `RUN`, with the raw `script`, its
+// BuildKit flags (`mounts`, `network`, `security`), the shell-versus-exec
+// form, and a parsed `commands` breakdown. Use `commands` to audit the
+// programs invoked and their options, and `mountsSecret`/`mountsSsh` to spot
+// build-time credential handling.
 private docker.file.run @defaults("script") @context("file.context") {
+  // Raw command text of the RUN instruction
   script string
   // `--mount=...` flags applied to this RUN
   //
@@ -3097,8 +3255,8 @@ private docker.file.run @defaults("script") @context("file.context") {
 // Single command parsed from a Dockerfile RUN, CMD, or ENTRYPOINT
 //
 // One entry per command in the instruction's shell pipeline. Select the
-// program with `binary` and, for tools with subcommands, `subcommand` — for
-// example `binary == "apt-get"` and `subcommand == "install"` — then inspect
+// program with `binary` and, for tools with subcommands, `subcommand`, for
+// example `binary == "apt-get"` and `subcommand == "install"`, then inspect
 // `flags` for required options such as `--no-install-recommends`.
 private docker.file.run.command @defaults("binary subcommand") {
   // Executable invoked, e.g. "apt-get", "curl", or "npm"
@@ -3158,11 +3316,19 @@ private docker.file.run.mount @defaults("type target") {
   env string
 }
 
-// Dockerfile ADD instructions
+// Dockerfile ADD instruction
+//
+// Files brought into the image with `ADD`, which unlike `COPY` can fetch
+// remote URLs and auto-extract archives. The `checksum` and `excludes` flags,
+// plus the remote-fetch capability, make `ADD` a frequent audit target.
 private docker.file.add @defaults("src dst") @context("file.context") {
+  // Source paths, URLs, or archives to add
   src []string
+  // Destination path in the image
   dst string
+  // Ownership applied to the copied files (`--chown=<user>:<group>`)
   chown string
+  // Permissions applied to the copied files (`--chmod=<octal>`)
   chmod string
   // Whether `--link` was set, enabling cache-friendly layered copies
   link bool
@@ -3175,7 +3341,11 @@ private docker.file.add @defaults("src dst") @context("file.context") {
   excludes []string
 }
 
-// Dockerfile COPY instructions
+// Dockerfile COPY instruction
+//
+// Files copied into the image with `COPY`, including cross-stage and
+// cross-image copies via `--from`. Auditing `from` reveals which build stages
+// or external images contribute files to the final image.
 private docker.file.copy @defaults("src dst") @context("file.context") {
   // Optional source to copy file(s) from when not using the default build context
   src []string
@@ -3199,6 +3369,10 @@ private docker.file.copy @defaults("src dst") @context("file.context") {
 }
 
 // Dockerfile HEALTHCHECK instruction
+//
+// The container health probe declared with `HEALTHCHECK`: the `test` command
+// and its timing parameters (`interval`, `timeout`, `startPeriod`, `retries`).
+// `none` is true for `HEALTHCHECK NONE`, which disables any inherited check.
 private docker.file.healthcheck @defaults("test") @context("file.context") {
   // The health check test command (e.g., ["CMD-SHELL", "curl -f http://localhost/ || exit 1"])
   test []string
@@ -3217,30 +3391,46 @@ private docker.file.healthcheck @defaults("test") @context("file.context") {
 }
 
 // Dockerfile VOLUME instruction
+//
+// A mount point declared with `VOLUME`, whose contents are excluded from image
+// layers and persist outside the container.
 private docker.file.volume @defaults("path") @context("file.context") {
   // Volume mount path
   path string
 }
 
 // Dockerfile SHELL instruction
+//
+// The default shell used for shell-form `RUN`, `CMD`, and `ENTRYPOINT`
+// instructions, as set by `SHELL`. Adding `-o pipefail` here is a common
+// hardening step.
 private docker.file.shell @defaults("command") @context("file.context") {
   // Shell executable and flags (e.g., ["/bin/bash", "-o", "pipefail", "-c"])
   command []string
 }
 
 // Dockerfile WORKDIR instruction
+//
+// The working directory set by `WORKDIR` for subsequent instructions and the
+// container's default directory at runtime.
 private docker.file.workdir @defaults("path") @context("file.context") {
   // Working directory path
   path string
 }
 
 // Dockerfile STOPSIGNAL instruction
+//
+// The signal Docker sends to the container's main process on stop, as declared
+// by `STOPSIGNAL`.
 private docker.file.stopsignal @defaults("signal") @context("file.context") {
   // Signal name or number sent to the container on stop (e.g., `SIGTERM`, `9`)
   signal string
 }
 
 // Dockerfile ONBUILD instruction
+//
+// A trigger instruction registered with `ONBUILD` that runs later, when an
+// image built from this Dockerfile is used as the base of a downstream build.
 private docker.file.onbuild @defaults("expression") @context("file.context") {
   // The triggered instruction, exactly as written after `ONBUILD`
   //
@@ -3250,56 +3440,76 @@ private docker.file.onbuild @defaults("expression") @context("file.context") {
 
 // Single Docker image on the host
 //
-// Examine ID, tags, repo digests, size, and labels
+// An image stored on the Docker host, with its content-addressable `id`, the
+// `tags` and `repoDigests` it is known by, its `size`, and its `labels`. Use
+// it to inventory images and check provenance, for example
+// `docker.images.where(tags.none(_ == /latest/))` to find images not pinned to
+// a floating tag.
 docker.image {
-  // Image ID
+  // Image ID, the content-addressable digest of the image config
   id string
-  // Image size in kilobytes
+  // Image size in bytes, including all layers
   size int
-  // Repo digests
+  // Repository digests (`repo@sha256:...`) the image is published under
   repoDigests []string
-  // Tag key value pairs
+  // Repository tags (`repo:tag`) referencing this image
   tags []string
-  // Labels key value pairs
+  // Image labels, as key/value pairs
   labels map[string]string
 }
 
 // Single Docker container on the host
 //
-// Examine state, image, command, labels, and the container's embedded OS
+// A container on the Docker host, running or stopped, with its `state`,
+// `status`, source `image`, startup `command`, `labels`, and the embedded
+// Linux operating system running inside it (queryable through `os`).
+// `hostConfig` exposes the daemon-side runtime settings such as privilege,
+// capabilities, and mounts. Filter by state, for example
+// `docker.containers.where(state == "running")`.
 docker.container @defaults("names.first status"){
   embed os.linux as os
   // Container ID
   id string
-  // Container command
+  // Command the container runs as its main process
   command string
-  // Container image
+  // Image reference the container was created from (`repo:tag`)
   image string
-  // Image ID
+  // ID of the image the container was created from
   imageid string
-  // Container names
+  // Names assigned to the container (leading `/` stripped)
   names []string
-  // Container state (e.g., created, running, paused, restarting, exited, dead)
+  // Container lifecycle state (e.g., created, running, paused, restarting, exited, dead)
   state string
-  // Status message
+  // Human-readable status message (e.g., "Up 3 hours", "Exited (0) 2 days ago")
   status string
-  // Label key value pairs
+  // Container labels, as key/value pairs
   labels map[string]string
-  // Container configuration that depends on the host running the container
+  // Host-dependent runtime configuration
+  //
+  // The daemon-side `HostConfig` from container inspection, covering privilege
+  // (`Privileged`), added/dropped Linux capabilities, `NetworkMode`, port
+  // bindings, bind mounts, and restart policy. Central to container-hardening
+  // audits, for example checking `hostConfig["Privileged"] == false`.
   hostConfig() dict
 }
 
 // containerd host
 //
-// Examine containers managed by the containerd runtime
+// Containers managed by the containerd runtime, gathered across all containerd
+// namespaces via the `ctr` CLI. Use it to inventory workloads on hosts that
+// run containerd directly (such as Kubernetes nodes) rather than through the
+// Docker daemon.
 containerd {
-  // List all containerd containers
+  // All containers across every containerd namespace
   containers() []containerd.container
 }
 
 // Single containerd container
 //
-// Examine ID, image, status, namespace, and runtime
+// A container managed by containerd, identified by `id` within its
+// `namespace`, with its `image` reference, lifecycle `status`, process `pid`,
+// `labels`, the `runtime` handling it (e.g. `io.containerd.runc.v2`), and the
+// `snapshotter` providing its filesystem.
 containerd.container @defaults("id status") {
   // Container ID
   id string
@@ -3309,9 +3519,9 @@ containerd.container @defaults("id status") {
   status string
   // Container labels
   labels map[string]string
-  // Container PID (0 if not running)
+  // Process ID of the container's task, 0 when the container is not running
   pid int
-  // containerd namespace
+  // containerd namespace the container belongs to
   namespace string
   // Container runtime (e.g., "io.containerd.runc.v2")
   runtime string
@@ -3321,7 +3531,11 @@ containerd.container @defaults("id status") {
 
 // IPv4 packet filter (iptables)
 //
-// Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
+// The host's IPv4 iptables ruleset: every `tables` entry (filter, nat, mangle,
+// raw) with its chains and rules, plus shortcuts to the filter table's
+// `input`, `output`, and `forward` chains and their default policies. A
+// default `inputPolicy` of `ACCEPT` with no restricting rules is a common
+// firewall-hardening finding.
 iptables {
   // All tables (filter, nat, mangle, raw)
   tables() []iptables.table
@@ -3341,7 +3555,10 @@ iptables {
 
 // IPv6 packet filter (ip6tables)
 //
-// Examine tables, chains, and default INPUT/OUTPUT/FORWARD policies
+// The host's IPv6 ip6tables ruleset: every `tables` entry (filter, nat,
+// mangle, raw) with its chains and rules, plus shortcuts to the filter table's
+// `input`, `output`, and `forward` chains and their default policies. Audit it
+// alongside `iptables` so IPv6 traffic is filtered as strictly as IPv4.
 ip6tables {
   // All tables (filter, nat, mangle, raw)
   tables() []iptables.table
@@ -3360,6 +3577,11 @@ ip6tables {
 }
 
 // iptables table (filter, nat, mangle, raw)
+//
+// One iptables table and the `chains` it contains. The `name` selects the
+// table's purpose: `filter` for packet acceptance/dropping, `nat` for address
+// translation, `mangle` for packet header changes, and `raw` for connection
+// tracking exemptions.
 private iptables.table @defaults("name") {
   // Table name (filter, nat, mangle, raw)
   name string
@@ -3368,6 +3590,11 @@ private iptables.table @defaults("name") {
 }
 
 // iptables chain within a table
+//
+// A chain of ordered `rules` within a table, matched against packets in
+// sequence. Built-in chains (INPUT, OUTPUT, FORWARD, PREROUTING, POSTROUTING)
+// carry a default `policy` applied when no rule matches; user-defined chains
+// have an empty policy and are reached only via a jump target.
 private iptables.chain @defaults("table name policy") {
   // Table this chain belongs to (filter, nat, mangle, raw)
   table string
@@ -3381,11 +3608,13 @@ private iptables.chain @defaults("table name policy") {
 
 // Individual iptables rule entry
 //
-// Examine a single iptables rule: packet and byte counters, target action,
+// A single iptables rule with its packet and byte counters, target action,
 // protocol, input/output interfaces, source and destination addresses,
-// IP options, and the chain/table identifier used as the resource ID.
-// Iterated from `iptables.input()`, `iptables.output()`, or
-// `iptables.forward()` to audit individual packet-filter rules.
+// matched ports, conntrack state, TCP flags, and comment. Reached from
+// `iptables.input`, `iptables.output`, or `iptables.forward` to audit
+// individual packet-filter rules, for example finding rules that accept
+// traffic from anywhere with `iptables.input.where(target == "ACCEPT" &&
+// source == "0.0.0.0/0")`.
 iptables.entry {
   // Line number of statistic, which is used to create the ID
   lineNumber int
@@ -3414,7 +3643,7 @@ iptables.entry {
   // Destination port
   //
   // Single port from `--dport`. Null when the rule does not match by
-  // destination port, or when it matches a range or list — see
+  // destination port, or when it matches a range or list. See
   // `dportRange` for ranges and `dports` for multi-port matches.
   dport int
   // Destination port range, e.g. "1024:65535"
@@ -3470,7 +3699,12 @@ iptables.entry {
 
 // nftables firewall
 //
-// Examine tables, chains, rules, and named sets across all address families
+// The host's nftables ruleset across all address families (ip, ip6, inet, arp,
+// bridge, netdev). Flattened accessors return everything at once: `tables`,
+// `chains` (across all tables), `rules` (across all chains), and named `sets`.
+// nftables is the modern replacement for iptables, so audit it on current
+// distributions to confirm chains have restrictive policies and expected
+// rules.
 nftables @defaults("tables") {
   // nft version string (e.g., "1.0.2")
   version() string
@@ -3485,6 +3719,14 @@ nftables @defaults("tables") {
 }
 
 // nftables table
+//
+// Top-level container in the nftables ruleset, keyed by address family
+// and name. A table holds the chains, rules, and named sets that make up
+// a firewall configuration. The `family` field selects which protocol the
+// table governs (ip for IPv4, ip6 for IPv6, inet for both, arp, bridge,
+// or netdev), and `flags` reports table attributes such as dormant (rules
+// present but not evaluated), owner, or persist. Traverse `chains`, `rules`,
+// and `sets` to audit the packet-filtering policy defined here.
 private nftables.table @defaults("family name") {
   // Address family (ip, ip6, inet, arp, bridge, netdev)
   family string
@@ -3503,6 +3745,14 @@ private nftables.table @defaults("family name") {
 }
 
 // nftables chain
+//
+// Ordered list of rules within a table. A base chain attaches to a kernel
+// hook and carries a type, hook, priority, and default policy, so it decides
+// the fate of packets that fall through all its rules. A regular (non-base)
+// chain is only reached by an explicit jump or goto and leaves those fields
+// empty. Check `isBaseChain` to distinguish the two, and `policy` (accept or
+// drop) to see the default action for a base chain, which is the key setting
+// for a default-deny firewall.
 private nftables.chain @defaults("family table name") {
   // Address family
   family string
@@ -3529,6 +3779,12 @@ private nftables.chain @defaults("family table name") {
 }
 
 // nftables rule
+//
+// Single rule within a chain, identified by its handle number. The matching
+// criteria and the action (accept, drop, jump, log, and so on) are parsed
+// into `expr` as structured expression data, and `comment` carries any inline
+// rule comment. Use `chainRef` and `tableRef` to walk back to the chain and
+// table that contain the rule.
 private nftables.rule @defaults("family table chain handle") {
   // Address family
   family string
@@ -3548,7 +3804,16 @@ private nftables.rule @defaults("family table chain handle") {
   comment string
 }
 
-// nftables named set (or map)
+// nftables named set or map
+//
+// Named collection of elements referenced by rules in a table, keyed by
+// family, table, and name. A plain set holds a group of values (addresses,
+// ports, MAC addresses) that rules match against, while a map (`isMap` true,
+// `valueType` non-empty) associates each key with a value for verdict or NAT
+// lookups. The `keyType` gives the element data type (for example ipv4_addr,
+// inet_service, ether_addr), `flags` reports set attributes (constant,
+// interval, timeout, dynamic), and `elements` lists the current members as
+// strings.
 private nftables.set @defaults("family table name") {
   // Address family
   family string
@@ -3576,7 +3841,13 @@ private nftables.set @defaults("family table name") {
 
 // UFW (Uncomplicated Firewall) state and rules
 //
-// Examine status, default policies, configured rules, and application profiles
+// Uncomplicated Firewall status, default policies, configured rules, and
+// application profiles on Debian and Ubuntu systems. Check `status` to
+// confirm the firewall is active, and the `defaultIncoming` /
+// `defaultOutgoing` / `defaultRouted` policies for the baseline stance
+// (a hardened host typically denies incoming by default). Enumerate `rules`
+// to audit the explicit allow/deny entries and `applications` for the
+// service profiles UFW can reference by name.
 ufw @defaults("status rules") {
   // Whether UFW is active ("active", "inactive", "not installed")
   status() string
@@ -3595,6 +3866,12 @@ ufw @defaults("status rules") {
 }
 
 // Individual UFW rule
+//
+// Single UFW rule as reported by `ufw status`, covering the action taken,
+// the traffic direction, and the addresses, ports, protocol, and interface
+// it matches. The `action` (ALLOW, DENY, REJECT, LIMIT), `direction`, and
+// `port`/`from`/`to` fields together describe what the rule permits or
+// blocks; `ipv6` flags IPv6 rules, and `raw` preserves the original text.
 private ufw.rule @defaults("action direction port") {
   // Rule number (sequential across IPv4 and IPv6 rules; may differ from `ufw status numbered`)
   number int
@@ -3619,6 +3896,11 @@ private ufw.rule @defaults("action direction port") {
 }
 
 // UFW application profile from /etc/ufw/applications.d/
+//
+// Named application profile that maps a service to the ports it needs, so
+// UFW rules can reference it by name instead of listing ports. Each profile
+// carries a `name` (for example "Nginx Full"), a human-readable `title` and
+// `description`, and the `ports` specification it opens.
 private ufw.application @defaults("name ports") {
   // Profile name (e.g., "Nginx Full")
   name string
@@ -3632,7 +3914,11 @@ private ufw.application @defaults("name ports") {
 
 // firewalld dynamic firewall manager (RHEL/CentOS/Fedora)
 //
-// Examine state, default zone, and per-zone services, ports, and rich rules
+// firewalld daemon state, the default zone, and the full set of configured
+// zones on RHEL, CentOS, and Fedora systems. Check `status` to confirm the
+// daemon is running and `defaultZone` for the zone applied to unclassified
+// interfaces and sources. Enumerate `zones` to audit the per-zone services,
+// ports, and rich rules that make up the effective policy.
 firewalld @defaults("status defaultZone") {
   // Whether firewalld is running ("running", "not running", "not installed")
   status() string
@@ -3643,6 +3929,15 @@ firewalld @defaults("status defaultZone") {
 }
 
 // firewalld zone configuration
+//
+// Single firewalld zone: the trust level applied to the interfaces and
+// source addresses bound to it. The `target` is the default action for
+// traffic not otherwise matched (default, ACCEPT, REJECT, or DROP), and
+// `active` indicates whether any interfaces or sources are bound. Audit
+// `services`, `ports`, and `protocols` for what the zone permits,
+// `richRules` for expressive per-source rules, and `masquerade` /
+// `forwardPorts` for NAT behavior. Select a zone by name with
+// `firewalld.zone(name: "public")`.
 private firewalld.zone @defaults("name target") {
   init(name? string)
   // Zone name (e.g., "public", "internal", "dmz")
@@ -3676,6 +3971,13 @@ private firewalld.zone @defaults("name target") {
 }
 
 // firewalld rich rule
+//
+// Single firewalld rich rule parsed into its parts: the address family, the
+// source and destination it matches (each with a negation flag for `NOT`
+// address forms), and the action it takes. The full original rule text is
+// kept in `rule`. Rich rules express finer-grained policy than plain
+// service/port entries, so auditing `source`, `sourceInverted`, and `action`
+// together shows exactly which peers are accepted, rejected, or dropped.
 private firewalld.richrule @defaults("family rule") {
   // Address family ("ipv4" or "ipv6"), empty if not specified
   family string
@@ -3695,7 +3997,11 @@ private firewalld.richrule @defaults("family rule") {
 
 // fstab persistent mount table
 //
-// Examine mount entries with device, mount point, fstype, and options
+// Filesystem mount table (/etc/fstab) that defines which devices are
+// mounted where at boot and with what options. Each `entries` row carries
+// the device, mount point, filesystem type, and mount options, so audits
+// can check for hardening flags (nodev, nosuid, noexec) on sensitive mounts.
+// Select an alternate file with `fstab(path: "...")`.
 fstab @defaults("path") {
   init(path? string)
   path string
@@ -3705,6 +4011,11 @@ fstab @defaults("path") {
 }
 
 // fstab entry for a device and its mount point
+//
+// Single line of the fstab: the device to mount, where it mounts, its
+// filesystem type, the comma-separated mount options, and the dump/fsck
+// controls. The `options` field is the one audits most often assert on
+// (for example requiring nosuid,nodev,noexec on /tmp or /var).
 private fstab.entry @defaults("device mountpoint") {
   // Device referenced in the fstab, e.g., LABEL=rootfs
   device string
@@ -3722,7 +4033,13 @@ private fstab.entry @defaults("device mountpoint") {
 
 // GRUB bootloader configuration
 //
-// Examine /etc/default/grub parameters, menu entries, and password protection
+// GRUB bootloader settings drawn from /etc/default/grub and the generated
+// grub.cfg. The `params` map holds the key-value defaults (for example
+// GRUB_TIMEOUT and GRUB_CMDLINE_LINUX), `entries` lists the boot menu
+// entries with their kernel command lines, and `passwordProtected` reports
+// whether superuser plus password_pbkdf2 protection is configured, a common
+// boot-security check. Override the file locations with
+// `grub.config(defaultsPath: "...", grubPath: "...")`.
 grub.config @defaults("defaultsPath grubPath") {
   init(defaultsPath? string, grubPath? string)
   // Path to /etc/default/grub (key-value defaults)
@@ -3738,6 +4055,12 @@ grub.config @defaults("defaultsPath grubPath") {
 }
 
 // GRUB menu entry
+//
+// Single boot menu entry from grub.cfg: its title, the kernel command line
+// it boots with (`cmdline`), and the initrd it loads. Inspect `cmdline` to
+// audit kernel boot parameters such as audit=1 or console settings.
+// `isSubmenu` marks entries that group other entries rather than boot
+// directly.
 private grub.config.entry @defaults("title") {
   // Menu entry title
   title string
@@ -3751,7 +4074,12 @@ private grub.config.entry @defaults("title") {
 
 // FreeBSD rc.conf system configuration
 //
-// Examine variable assignments across rc.conf and rc.conf.local
+// FreeBSD service and system configuration merged from rc.conf and
+// rc.conf.local. The `entries` accessor exposes each variable assignment as
+// a structured name/value pair (with the file it came from), so audits can
+// assert on individual settings such as sshd_enable or a firewall being
+// turned on. `content` returns the concatenated raw text. Point at a
+// specific file with `sysrc(path: "...")`.
 sysrc @defaults("files") {
   init(path? string)
   // List of rc.conf files that make up the configuration
@@ -3763,6 +4091,10 @@ sysrc @defaults("files") {
 }
 
 // Single rc.conf variable entry
+//
+// One variable assignment from an rc.conf file: its `name`, `value`, and the
+// `file` it was defined in. The source file matters because a setting in
+// rc.conf.local overrides the same name in rc.conf.
 private sysrc.entry @defaults("name value") {
   // Variable name
   name string
@@ -3774,7 +4106,9 @@ private sysrc.entry @defaults("name value") {
 
 // Single process on the system
 //
-// Examine PID, executable, command line, state, and runtime flags
+// Running process identified by its PID. Exposes the executable path, the
+// full command line it was invoked with, its current state, and a map of
+// additional per-process flags. Select a process with `process(pid: 1)`.
 process @defaults("executable pid state") {
   init(pid int)
   // PID (process ID)
@@ -3791,14 +4125,22 @@ process @defaults("executable pid state") {
 
 // All processes running on the system
 //
-// Iterate every process for filtering by executable, user, or state
+// Collection of every running process, for filtering by executable,
+// command line, user, or state. For example
+// `processes.where(executable == "/usr/sbin/sshd")` finds all instances of
+// a daemon, or filter on state to spot zombie or stopped processes.
 processes {
   []process
 }
 
 // Single TCP/UDP port on the system
 //
-// Examine address, state, attached process, and remote peer
+// Single network socket: its protocol, local address and port, connection
+// state, and (where the OS reports it) the owning process and the remote
+// peer. The `state` field distinguishes listening sockets from established
+// connections, `process` links to the program holding the socket, and `tls`
+// probes the endpoint for a TLS configuration. Central to exposure audits,
+// for example finding listening ports bound to a non-loopback address.
 port @defaults("port protocol address process.executable") {
   // Protocol of this port
   protocol string
@@ -3822,7 +4164,10 @@ port @defaults("port protocol address process.executable") {
 
 // All TCP/UDP ports on the system
 //
-// Iterate every port — including the listening() subset for exposure audits
+// Collection of all network sockets, both listening and connected. The
+// `listening` accessor narrows the set to sockets in the listen state, which
+// is the usual starting point for an exposure audit (for example
+// `ports.listening.where(address != "127.0.0.1")`).
 ports {
   []port
   // All listening ports
@@ -3870,7 +4215,13 @@ auditpol.entry  @defaults("subcategory inclusionsetting exclusionsetting") @matu
 
 // Windows local security policy
 //
-// Examine system access, event audit, registry values, and privilege rights
+// Windows local security policy exported via secedit, broken into four
+// maps. `systemaccess` covers password and account-lockout settings (for
+// example MinimumPasswordLength, LockoutBadCount); `eventaudit` holds the
+// legacy audit categories; `registryvalues` exposes security-relevant
+// registry-backed policies; and `privilegerights` maps each user right (for
+// example SeDenyNetworkLogonRight) to the accounts granted it. These are the
+// primary source for CIS-style local policy benchmarks.
 secpol {
   // System access
   systemaccess() map[string]string
@@ -3884,7 +4235,12 @@ secpol {
 
 // NTP daemon configuration
 //
-// Examine servers, restrict directives, fudge entries, and other settings
+// Classic ntpd configuration parsed into structured directives. `servers`
+// lists the configured upstream time sources, `restrict` reports the access
+// control directives that govern which peers and clients may interact with
+// the daemon, and `fudge` carries reference-clock adjustments. `settings`
+// returns every effective directive line. Select a file with
+// `ntp.conf(path: "...")`.
 ntp.conf {
   init(path string)
   // File of the NTP service configuration
@@ -3903,9 +4259,9 @@ ntp.conf {
 
 // Chrony NTP daemon configuration
 //
-// Examine the configuration of chrony, the default NTP implementation on
-// modern RHEL, Fedora, SUSE, and Debian/Ubuntu systems. The typed
-// accessors parse the configuration into structured form so audits can
+// Configuration of chrony, the default NTP implementation on
+// modern RHEL, Fedora, SUSE, and Debian/Ubuntu systems. The parsed
+// fields expose the configuration in structured form so audits can
 // assert on individual directives without regex over the raw text:
 // `servers`, `pools`, and `peers` enumerate the configured time sources;
 // `allow` and `deny` expose the NTP-server access control lists that
@@ -3946,9 +4302,9 @@ chrony.conf {
 
 // Postfix mail transfer agent configuration
 //
-// Examine the effective Postfix configuration. `params` reports parameter
-// values from `postconf` when the binary is available — which includes the
-// built-in defaults for parameters not written to the file — and otherwise
+// Effective Postfix configuration. `params` reports parameter
+// values from `postconf` when the binary is available (which includes the
+// built-in defaults for parameters not written to the file) and otherwise
 // falls back to parsing main.cf directly (file values only, with `$name`
 // interpolation and continuation lines). `inetInterfaces` is the parsed
 // `inet_interfaces` list and `services` are the daemon definitions from
@@ -3974,7 +4330,7 @@ postfix {
 
 // Postfix master.cf service definition
 //
-// Examine a single daemon entry from the Postfix master.cf file: its service
+// Single daemon entry from the Postfix master.cf file: its service
 // name and transport type, the chroot and privilege flags, the wake-up and
 // process limits, and the command it runs. The flag columns carry `y`, `n`,
 // or `-` (use the built-in default). Iterated from `postfix.services`.
@@ -3999,8 +4355,8 @@ private postfix.service @defaults("service type command") {
 
 // Exim mail transfer agent configuration
 //
-// Examine the Exim configuration. `params` holds the macros and main-section
-// options parsed from the active config file — both the Debian
+// Exim configuration. `params` holds the macros and main-section
+// options parsed from the active config file, covering both the Debian
 // `update-exim4.conf.conf` key/value form and the monolithic `exim.conf`
 // main section (options before the first `begin` block). `localInterfaces`
 // normalizes the local interface list, handling the Debian
@@ -4020,10 +4376,10 @@ exim {
 
 // rsyslog daemon configuration
 //
-// Examine effective settings across the main file and included fragments.
-// The typed accessors `modules()`, `inputs()`, `actions()`, and `rules()`
+// Effective settings across the main file and included fragments.
+// The `modules`, `inputs`, `actions`, and `rules` fields
 // parse the configuration into structured form so audits can assert on
-// individual statements without regex over raw text. Each typed entry
+// individual statements without regex over raw text. Each entry
 // carries `sourceFile` and `sourceLine` so findings can point back at the
 // fragment that introduced the directive.
 rsyslog.conf {
@@ -4056,7 +4412,7 @@ rsyslog.conf {
 
 // rsyslog loaded module
 //
-// Examine a single module load: modern `module(load="imtcp" KeepAlive="on")`
+// Single module load: modern `module(load="imtcp" KeepAlive="on")`
 // or legacy `$ModLoad imtcp`. Modern declarations carry their full parameter
 // dict; legacy declarations carry only the module name (parameters is empty).
 // The module name follows rsyslog conventions: `im*` for inputs, `om*` for
@@ -4078,10 +4434,12 @@ private rsyslog.module @defaults("name sourceFile") {
 
 // rsyslog input source
 //
-// Examine a configured input — the module instance that pulls log lines
-// into rsyslog. Surfaces both legacy single-directive forms (e.g.
+// Configured input, the module instance that pulls log lines into
+// rsyslog. Surfaces both legacy single-directive forms (e.g.
 // `$InputTCPServerRun 514`) and modern RainerScript blocks
-// (`input(type="imtcp" port="514" ruleset="…")`).
+// (`input(type="imtcp" port="514" ruleset="…")`). Use it to audit which
+// listeners are open, on what ports and addresses, and whether network
+// inputs accept TLS.
 private rsyslog.input @defaults("type port sourceFile") {
   // Input module type (e.g. imtcp, imudp, imuxsock, imfile)
   type string
@@ -4107,11 +4465,13 @@ private rsyslog.input @defaults("type port sourceFile") {
 
 // rsyslog output action
 //
-// Examine where rsyslog ships matched log lines. Surfaces both modern
+// Destination where rsyslog ships matched log lines. Surfaces both modern
 // `action(type="omfwd" target="…" …)` statements and the legacy
 // selector-with-target form (e.g. `*.* @@host:514`). When this action came
 // from a legacy selector, the `parameters` dict is empty and `target` /
 // `protocol` / `tlsEnabled` are derived from the target token's syntax.
+// Use it to confirm that remote forwarding uses TCP with TLS rather than
+// plaintext UDP.
 private rsyslog.action @defaults("type target sourceFile") {
   // Action module type (e.g. omfwd, omfile, omusrmsg, omhttp, omkafka)
   type string
@@ -4126,7 +4486,7 @@ private rsyslog.action @defaults("type target sourceFile") {
   // Whether TLS is configured for this action
   //
   // True when the modern form sets `StreamDriverMode="1"` (or equivalent
-  // per-driver settings). False for legacy selector forms — those rely on
+  // per-driver settings). False for legacy selector forms, which rely on
   // the `$DefaultNetstreamDriver` / `$ActionSendStreamDriverMode` globals.
   tlsEnabled bool
   // Template name applied to messages, empty when the default is used
@@ -4134,7 +4494,7 @@ private rsyslog.action @defaults("type target sourceFile") {
   // Action-level queue configuration, empty when no queue is configured
   //
   // Carries the modern `queue.*` parameters as `{type, filename, size,
-  // saveOnShutdown, ...}` — the exact key set depends on the queue type.
+  // saveOnShutdown, ...}` (the exact key set depends on the queue type).
   queue dict
   // All parameters as a dict
   //
@@ -4149,10 +4509,10 @@ private rsyslog.action @defaults("type target sourceFile") {
 
 // rsyslog selector rule
 //
-// Examine a legacy `<facility>.<severity> <target>` routing rule — the form
-// that ships in every default rsyslog config. Modern `if … then … {
-// action(…) }` conditionals are not surfaced here; their actions are
-// available via `rsyslog.conf.actions()` only.
+// Legacy `<facility>.<severity> <target>` routing rule, the form that ships
+// in every default rsyslog config. Modern `if … then … { action(…) }`
+// conditionals are not surfaced here; their actions are available via
+// `rsyslog.conf.actions` only.
 //
 // Selector grammar covered:
 //   - Simple: `auth.info /var/log/auth.log`
@@ -4175,11 +4535,11 @@ private rsyslog.rule @defaults("facilities severities target sourceFile") {
   target string
   // Whether the severity is the negation marker (`.none`)
   negate bool
-  // Resolved typed action for this rule
+  // Resolved action for this rule
   //
   // Constructed from `target`: file-path → omfile, `@host` → omfwd/udp,
   // `@@host` → omfwd/tcp, `:omusrmsg:*` → omusrmsg, `~` → discard,
-  // `|name` → ompipe. Legacy rules have no TLS information — the action's
+  // `|name` → ompipe. Legacy rules have no TLS information, so the action's
   // `tlsEnabled` is always false.
   action() rsyslog.action
   // Absolute path of the file this directive was read from
@@ -4190,20 +4550,27 @@ private rsyslog.rule @defaults("facilities severities target sourceFile") {
 
 // Shadow password suite (login.defs) configuration
 //
-// Examine password aging, UID/GID ranges, and login policy parameters
+// Password aging, UID/GID ranges, and login policy parameters parsed from
+// /etc/login.defs. The params map exposes settings such as
+// PASS_MAX_DAYS, PASS_MIN_DAYS, PASS_WARN_AGE, UMASK, and ENCRYPT_METHOD,
+// which drive account and password-policy audits. Point at an alternate
+// file with the `path` argument.
 logindefs {
   init(path string)
   // Current configuration file for resource
   file() file
   // Content of the configuration file
   content(file) string
-  // Parsed logindef parameter
+  // Parsed login.defs parameters as a name/value map (e.g. PASS_MAX_DAYS, UMASK, ENCRYPT_METHOD)
   params(content) map[string]string
 }
 
 // PAM resource limits configuration (limits.conf)
 //
-// Examine soft/hard caps on processes, files, memory, and other resources
+// Soft and hard caps on processes, open files, memory, and other per-user
+// resources, parsed from /etc/security/limits.conf and every .conf file
+// under /etc/security/limits.d. Iterate `entries` to audit for missing or
+// overly permissive limits (e.g. unrestricted core dumps or nofile).
 limits {
   // List of files that make up the limits configuration
   files() []file
@@ -4212,6 +4579,9 @@ limits {
 }
 
 // Resource limit entry
+//
+// Single line from a limits configuration file, giving one domain / type /
+// item / value tuple (e.g. `* hard core 0`).
 private limits.entry @defaults("domain item") {
   // File where this entry is defined
   file file
@@ -4229,13 +4599,12 @@ private limits.entry @defaults("domain item") {
 
 // Sudo binary and runtime metadata
 //
-// Examine the installed `sudo` binary: where it lives on disk, the
-// version it reports under `sudo -V`, which plugins are loaded
-// (policy, I/O, audit, approval), whether the build supports
-// Python-based plugins, and the result of `visudo -c` against the
-// sudoers configuration. For sudoers configuration parsing, use the
-// `sudoers` resource directly, or access it via this resource's
-// `sudoers` field.
+// Installed `sudo` binary: where it lives on disk, the version it reports
+// under `sudo -V`, which plugins are loaded (policy, I/O, audit, approval),
+// whether the build supports Python-based plugins, and the result of
+// `visudo -c` against the sudoers configuration. For sudoers configuration
+// parsing, use the `sudoers` resource directly, or access it via this
+// resource's `sudoers` field.
 sudo @defaults("version path") {
   init(path? string)
   // Path to the sudo binary
@@ -4267,6 +4636,10 @@ sudo @defaults("version path") {
 }
 
 // A sudo plugin reported by `sudo -V`
+//
+// One loaded sudo plugin, identified by name and type (policy, I/O, audit,
+// or approval) with its version and, when reported, the path to the .so
+// file backing it.
 private sudo.plugin @defaults("name type version") {
   // Plugin name (e.g., "sudoers_policy", "sudoers_io")
   name string
@@ -4279,6 +4652,10 @@ private sudo.plugin @defaults("name type version") {
 }
 
 // Result of validating sudoers configuration with `visudo -c`
+//
+// Syntax-check outcome for the sudoers files: `valid` is true when
+// `visudo -c` exits cleanly, and `errors` lists every parse error
+// otherwise.
 private sudo.validation @defaults("valid") {
   // True if `visudo -c` exits 0 with no errors
   valid bool
@@ -4287,6 +4664,9 @@ private sudo.validation @defaults("valid") {
 }
 
 // A single sudoers parse error reported by `visudo -c`
+//
+// One syntax error found by `visudo -c`, locating the problem by file and
+// line and giving the reported message.
 private sudo.validation.error @defaults("file line") {
   // File where the error was found
   file string
@@ -4298,7 +4678,11 @@ private sudo.validation.error @defaults("file line") {
 
 // sudo authorization configuration
 //
-// Examine user specifications, defaults, and aliases across sudoers files
+// User specifications, defaults, and aliases parsed across the sudoers
+// files (/etc/sudoers plus /etc/sudoers.d). Use userSpecs to audit who may
+// run which commands as which users, and defaults to check hardening
+// settings such as env_reset, secure_path, requiretty, and NOPASSWD grants.
+// Point at an alternate root file with the `path` argument.
 sudoers @defaults("files") {
   init(path? string)
   // List of files that make up the sudoers configuration
@@ -4314,6 +4698,10 @@ sudoers @defaults("files") {
 }
 
 // Sudoers user specification (permission entry)
+//
+// Single sudoers permission rule: which users, on which hosts, may run
+// which commands, as which run-as users/groups, under which tags
+// (e.g. NOPASSWD). The building block for auditing privilege grants.
 private sudoers.userSpec @defaults("users hosts commands") {
   // File where this entry is defined
   file string
@@ -4334,6 +4722,10 @@ private sudoers.userSpec @defaults("users hosts commands") {
 }
 
 // Sudoers default setting
+//
+// One `Defaults` directive from the sudoers configuration, giving the
+// parameter, its value and operation, the scope it applies at, and whether
+// it is negated. Covers hardening flags such as env_reset and secure_path.
 private sudoers.default @defaults("parameter") {
   // File where this entry is defined
   file string
@@ -4356,6 +4748,10 @@ private sudoers.default @defaults("parameter") {
 }
 
 // Sudoers alias definition
+//
+// One alias declaration (User_Alias, Host_Alias, Cmnd_Alias, or
+// Runas_Alias) and the members assigned to it, used to expand aliases
+// referenced in user specifications.
 private sudoers.alias @defaults("type name") {
   // File where this entry is defined
   file string
@@ -4371,17 +4767,19 @@ private sudoers.alias @defaults("type name") {
 
 // Unix block devices (lsblk)
 //
-// Examine device names, filesystem types, labels, UUIDs, and mount points
+// Block devices reported by `lsblk`, each carrying its device name,
+// filesystem type, label, UUID, and mount points. Iterate to audit disk
+// layout, filesystem labels, and mount configuration.
 lsblk {
   []lsblk.entry
 }
 
 // Unix block device
 //
-// Examine a single block device reported by `lsblk`: its device `name`,
-// filesystem type (`fstype`), `label`, UUID, and `mountpoints` list. Iterated
-// from `lsblk` to audit disk layout, filesystem labels, and mount
-// configurations.
+// Single block device reported by `lsblk`: its device `name`, filesystem
+// type (`fstype`), `label`, UUID, and `mountpoints` list. Filter to audit
+// disk layout and mount configuration, e.g.
+// `lsblk.where(mountpoints.contains("/"))`.
 lsblk.entry {
   // Device name
   name string
@@ -4397,13 +4795,12 @@ lsblk.entry {
 
 // LUKS-encrypted volumes on the host
 //
-// Use this resource to enumerate block devices that carry a LUKS header,
-// inspect each volume's on-disk format version, cipher, and key-derivation
-// parameters, and audit every keyslot. Both LUKS1 and LUKS2 headers are
-// reported through the same schema; the `version` field on each volume
-// distinguishes them and version-specific fields (label, subsystem, and
-// tokens for LUKS2; AF-splitter stripes for LUKS1) are populated only
-// where they apply.
+// Block devices that carry a LUKS header, exposing each volume's on-disk
+// format version, cipher, key-derivation parameters, and every keyslot.
+// Both LUKS1 and LUKS2 headers are reported through the same schema; the
+// `version` field on each volume distinguishes them and version-specific
+// fields (label, subsystem, and tokens for LUKS2; AF-splitter stripes for
+// LUKS1) are populated only where they apply.
 luks {
   // LUKS-formatted block devices on the host
   volumes() []luks.volume
@@ -4411,11 +4808,10 @@ luks {
 
 // LUKS-encrypted block device
 //
-// Examine a single LUKS-formatted block device — its header version,
-// label, master-key size and offset, cipher, and keyslots. Select a
-// volume by its `uuid` (e.g.,
-// `luks.volumes.where(uuid == "fd44f17a-...")`) or by the underlying
-// block device's `name`.
+// Single LUKS-formatted block device: its header version, label,
+// master-key size and offset, cipher, and keyslots. Select a volume by its
+// `uuid` (e.g., `luks.volumes.where(uuid == "fd44f17a-...")`) or by the
+// underlying block device's `name`.
 luks.volume @defaults("name uuid version") {
   // Path of the underlying block device (e.g., /dev/sda3)
   name string
@@ -4447,11 +4843,11 @@ luks.volume @defaults("name uuid version") {
 
 // LUKS cipher specification
 //
-// Examine the symmetric cipher protecting a LUKS volume's master key.
-// `name` is the cipher family, `mode` is the chaining mode, and `spec`
-// is the combined cryptsetup string (e.g., `aes-xts-plain64`). On
-// LUKS1, `hash` carries the AF-splitter hash; on LUKS2 it is the
-// integrity hash when sector integrity is configured.
+// Symmetric cipher protecting a LUKS volume's master key. `name` is the
+// cipher family, `mode` is the chaining mode, and `spec` is the combined
+// cryptsetup string (e.g., `aes-xts-plain64`). On LUKS1, `hash` carries the
+// AF-splitter hash; on LUKS2 it is the integrity hash when sector integrity
+// is configured.
 private luks.volume.cipher @defaults("spec keySize") {
   // Cipher family (e.g., aes, serpent, twofish)
   name string
@@ -4467,10 +4863,10 @@ private luks.volume.cipher @defaults("spec keySize") {
 
 // LUKS keyslot
 //
-// Examine one keyslot in a LUKS header — its index, state, and the
-// key-derivation parameters used to wrap the master key. Audit for
-// weak KDFs, low iteration or memory costs, and unexpectedly large
-// numbers of active slots.
+// One keyslot in a LUKS header: its index, state, and the key-derivation
+// parameters used to wrap the master key. Audit for weak KDFs, low
+// iteration or memory costs, and unexpectedly large numbers of active slots
+// (each active slot is a passphrase that can unlock the volume).
 luks.keyslot @defaults("index state kdf") {
   // Slot index (0–7 on LUKS1, 0–31 on LUKS2)
   index int
@@ -4500,7 +4896,10 @@ luks.keyslot @defaults("index state kdf") {
 
 // AppArmor mandatory access control
 //
-// Examine status, loaded profiles, and processes under confinement
+// AppArmor status, the loaded profiles and their enforcement modes, and the
+// processes currently under confinement. Use it to confirm AppArmor is
+// active and that security-relevant profiles are in enforce rather than
+// complain or unconfined mode.
 apparmor @defaults("profiles") {
   // AppArmor status output version
   version() string
@@ -4511,6 +4910,9 @@ apparmor @defaults("profiles") {
 }
 
 // AppArmor profile
+//
+// Loaded AppArmor profile and the mode it is running in: enforce (violations
+// blocked), complain (violations logged only), or unconfined.
 private apparmor.profile @defaults("name mode") {
   // Profile name
   name string
@@ -4519,6 +4921,9 @@ private apparmor.profile @defaults("name mode") {
 }
 
 // AppArmor confined process
+//
+// Running process attached to an AppArmor profile, giving its executable
+// path, PID, the applied profile, and the confinement status.
 private apparmor.process @defaults("pid profile status") {
   // Process executable path
   executable string
@@ -4532,7 +4937,11 @@ private apparmor.process @defaults("pid profile status") {
 
 // SELinux mandatory access control
 //
-// Examine enforcement mode, policy type, booleans, and loaded modules
+// SELinux enforcement mode, configured mode, active policy type, tunable
+// booleans, and loaded policy modules. The runtime `mode` (from
+// getenforce, /sys/fs/selinux/enforce, or config) may differ from
+// `configMode`, which is what persists across reboot; compare the two to
+// catch a system left permissive at runtime.
 selinux @defaults("mode") {
   // Whether SELinux is installed on the system
   installed() bool
@@ -4549,6 +4958,10 @@ selinux @defaults("mode") {
 }
 
 // SELinux boolean setting
+//
+// One tunable SELinux boolean and its current runtime value (from
+// `getsebool -a` or /sys/fs/selinux/booleans), e.g.
+// httpd_can_network_connect.
 private selinux.boolean @defaults("name value") {
   // Boolean name (e.g., httpd_can_network_connect)
   name string
@@ -4557,6 +4970,10 @@ private selinux.boolean @defaults("name value") {
 }
 
 // SELinux policy module
+//
+// One installed SELinux policy module from `semodule -l`, with its status
+// (enabled or disabled) and priority (higher priority overrides lower for
+// the same module name).
 private selinux.module @defaults("name status") {
   // Module name
   name string
@@ -4568,7 +4985,10 @@ private selinux.module @defaults("name status") {
 
 // Kernel module configuration (modprobe.d)
 //
-// Examine install, remove, blacklist, options, alias, and softdep directives
+// Install, remove, blacklist, options, alias, and softdep directives parsed
+// from the modprobe configuration files. Use blacklists to verify that
+// risky kernel modules are prevented from loading and options to audit
+// module parameters. Point at an alternate config with the `path` argument.
 modprobe @defaults("blacklists installs") {
   init(path? string)
   // List of files that make up the modprobe configuration
@@ -4588,6 +5008,10 @@ modprobe @defaults("blacklists installs") {
 }
 
 // Install directive for module loading
+//
+// One `install` directive from modprobe.d: the module it applies to and the
+// command run in place of the default insmod. A blacklist technique when
+// the command is `/bin/true` or `/bin/false`.
 private modprobe.install @defaults("module command") {
   // File where this entry is defined
   file string
@@ -4600,6 +5024,9 @@ private modprobe.install @defaults("module command") {
 }
 
 // Remove directive for module unloading
+//
+// One `remove` directive from modprobe.d: the module it applies to and the
+// command run in place of the default rmmod.
 private modprobe.remove @defaults("module command") {
   // File where this entry is defined
   file string
@@ -4611,7 +5038,14 @@ private modprobe.remove @defaults("module command") {
   command string
 }
 
-// Blacklist directive
+// Kernel module blacklist directive
+//
+// A single `blacklist` line from a modprobe configuration file that
+// stops a kernel module from being selected automatically. Auditing
+// these confirms unwanted modules (for example `usb-storage`, `cramfs`,
+// or unused filesystem and protocol drivers) are disabled per CIS
+// hardening guidance. `module` is the blacklisted module name and
+// `file`/`lineNumber` locate the declaration.
 private modprobe.blacklist @defaults("module") {
   // File where this entry is defined
   file string
@@ -4621,21 +5055,34 @@ private modprobe.blacklist @defaults("module") {
   module string
 }
 
-// Module options and parameters
+// Kernel module options directive
+//
+// A single `options` line from a modprobe configuration file that sets
+// load-time parameters for a kernel module. `parameters` is the raw
+// argument string and `params` parses it into key/value pairs. Used to
+// verify security-relevant module settings, for example that a driver
+// is loaded with a hardened option.
 private modprobe.option @defaults("module") {
   // File where this entry is defined
   file string
   // Line number in the file
   lineNumber int
-  // Module name
+  // Module name the options apply to
   module string
-  // Raw parameters string
+  // Raw parameters string as written after the module name
   parameters string
-  // Parsed parameters as key-value pairs
+  // Parsed parameters as key/value pairs (bare flags map to `true`)
   params() map[string]string
 }
 
-// Module alias
+// Kernel module alias directive
+//
+// A single `alias` line from a modprobe configuration file mapping an
+// alias name or wildcard pattern to a target module. The kernel
+// resolves the alias to `module` when the pattern is requested. A
+// common hardening technique points a module's alias at a no-op (for
+// example aliasing an unused network protocol to `off`) to block
+// on-demand loading.
 private modprobe.alias @defaults("alias module") {
   // File where this entry is defined
   file string
@@ -4643,17 +5090,22 @@ private modprobe.alias @defaults("alias module") {
   lineNumber int
   // Alias name (pattern or wildcard)
   alias string
-  // Target module name
+  // Target module the alias resolves to
   module string
 }
 
-// Soft dependency
+// Kernel module soft dependency directive
+//
+// A single `softdep` line from a modprobe configuration file declaring
+// modules to load before (`pre`) and after (`post`) a given module.
+// Soft dependencies are advisory, so a missing dependency does not
+// block the module from loading.
 private modprobe.softdep @defaults("module") {
   // File where this entry is defined
   file string
   // Line number in the file
   lineNumber int
-  // Module name
+  // Module the soft dependency is declared for
   module string
   // Modules to load before (pre: dependencies)
   pre []string
@@ -4663,22 +5115,26 @@ private modprobe.softdep @defaults("module") {
 
 // Unix mount table
 //
-// Iterate every mount point with device, fstype, options, and capacity
+// Every mounted filesystem on the host as a list of `mount.point`
+// entries, each with its backing device, mount path, filesystem type,
+// options, and capacity. Filter it to surface findings such as
+// temporary or removable-media mounts missing `nosuid`, `nodev`, or
+// `noexec` options.
 mount {
   []mount.point
 }
 
 // NFS service local state
 //
-// Examine the local NFS service from two angles: shares declared on
-// this host (`exports`) and NFS volumes the host has mounted
-// (`mounts`). `exports` is parsed from `/etc/exports` using the
-// platform-specific syntax for Linux, FreeBSD, macOS, and AIX; each
-// row is one `(path, client)` pair so audits like
-// `nfs.exports.where(noRootSquash)` work directly. `mounts` filters
-// the system mount table for NFS file systems and parses
-// NFS-specific options into typed fields (protocol `version`,
-// `security` flavor, `hardMount`, `readOnly`).
+// Local NFS service viewed from two angles: shares this host declares
+// (`exports`) and NFS volumes this host has mounted (`mounts`).
+// `exports` is parsed from `/etc/exports` using the platform-specific
+// syntax for Linux, FreeBSD, macOS, and AIX; each row is one
+// `(path, client)` pair so audits like
+// `nfs.exports.where(noRootSquash)` work directly. `mounts` filters the
+// system mount table for NFS file systems and parses NFS-specific
+// options into fields (protocol `version`, `security` flavor,
+// `hardMount`, `readOnly`).
 nfs {
   // NFS exports declared on this host
   exports() []nfs.export
@@ -4688,14 +5144,13 @@ nfs {
 
 // NFS export entry for a single path and client
 //
-// Examine one row of the local NFS export table: the directory being
-// shared (`path`), the client specification it is shared with
-// (`client` — a hostname, IP address, CIDR, wildcard, netgroup, or
-// `*` meaning any client) and the effective export `options` as
-// parsed from `/etc/exports`. `readOnly` is true when the share is
-// exported read-only. `noRootSquash` is true when the share grants
-// remote uid 0 on the share — a classic NFS audit finding. Iterate
-// from `nfs.exports`.
+// One row of the local NFS export table: the directory being shared
+// (`path`), the client specification it is shared with (`client`, a
+// hostname, IP address, CIDR, wildcard, netgroup, or `*` meaning any
+// client) and the effective export `options` as parsed from
+// `/etc/exports`. `readOnly` is true when the share is exported
+// read-only. `noRootSquash` is true when the share grants remote uid 0
+// on the share, a classic NFS audit finding.
 private nfs.export @defaults("path client readOnly noRootSquash") {
   // Exported directory path on the local host
   path string
@@ -4711,18 +5166,16 @@ private nfs.export @defaults("path client readOnly noRootSquash") {
 
 // NFS client mount
 //
-// Examine a single NFS mount currently active on this host. `device`
-// is the NFS source as the kernel sees it (`server:/remote/path`),
-// split into `server` and `remotePath` for convenience.
-// `mountpoint` is where the share is attached locally. `version` is
-// the negotiated NFS protocol version (for example `3`, `4`, `4.1`,
-// `4.2`); empty when the kernel did not report one. `security` is
-// the authentication flavor — one of `sys`, `krb5`, `krb5i`,
-// `krb5p`, or `none`; empty when unspecified. `hardMount` is true
-// when the mount uses hard semantics (the `soft` option is not
-// set). `readOnly` is true when the mount is `ro`. `options` is the
-// full mount option list as reported by the system. Iterate from
-// `nfs.mounts`.
+// One NFS mount currently active on this host. `device` is the NFS
+// source as the kernel sees it (`server:/remote/path`), split into
+// `server` and `remotePath` for convenience. `mountpoint` is where the
+// share is attached locally. `version` is the negotiated NFS protocol
+// version (for example `3`, `4`, `4.1`, `4.2`); empty when the kernel
+// did not report one. `security` is the authentication flavor, one of
+// `sys`, `krb5`, `krb5i`, `krb5p`, or `none`; empty when unspecified.
+// `hardMount` is true when the mount uses hard semantics (the `soft`
+// option is not set). `readOnly` is true when the mount is `ro`.
+// `options` is the full mount option list as reported by the system.
 private nfs.mount @defaults("server remotePath mountpoint version") {
   // NFS source as the kernel sees it (server:/remote/path)
   device string
@@ -4746,21 +5199,21 @@ private nfs.mount @defaults("server remotePath mountpoint version") {
 
 // Unix mount point
 //
-// Examine a single mounted filesystem: the backing `device`, the `path`
-// where it is attached, the `fstype`, mount `options`, whether it is
-// currently `mounted`, and the total, used, and available bytes. Initialize
-// by path (e.g., `mount.point(path: "/var")`) or iterate from `mount`.
+// A single mounted filesystem: the backing `device`, the `path` where
+// it is attached, the `fstype`, mount `options`, whether it is
+// currently `mounted`, and the total, used, and available bytes. Select
+// a mount by path, for example `mount.point(path: "/var")`.
 mount.point @defaults("device path fstype") {
   init(path string)
   // Block device or filesystem source backing the mount (e.g., /dev/sda1)
   device string
   // Mount point path where the filesystem is attached (e.g., /var)
   path string
-  // File system type
+  // File system type (e.g., ext4, xfs, tmpfs, nfs)
   fstype string
-  // Mount options
+  // Mount options as a name-to-value map (flag-only options map to an empty value)
   options map[string]string
-  // Whether the mount point is mounted
+  // Whether the mount point is currently mounted
   mounted bool
   // Total size in bytes
   size() int
@@ -4772,32 +5225,35 @@ mount.point @defaults("device path fstype") {
 
 // Shadow password file (/etc/shadow)
 //
-// Examine per-user password aging, expiration, and lock state
+// Per-user password aging, expiration, and lock state parsed from
+// `/etc/shadow`, one `shadow.entry` per account. Audit password policy
+// compliance and find accounts with no expiry, weak aging settings, or
+// locked/disabled passwords.
 shadow {
   []shadow.entry
 }
 
 // Shadowed password file entry
 //
-// Examine a single line from `/etc/shadow`: the username, hashed password
+// A single line from `/etc/shadow`: the username, hashed password
 // field, date of last change, minimum and maximum password age in days,
 // warning period, inactivity period, and account expiry date. Used to
-// audit password aging policy compliance and detect accounts with no
-// expiry or with locked passwords.
+// audit password aging policy compliance and to detect accounts with no
+// expiry or with locked passwords (a `!` or `*` in the password field).
 shadow.entry {
   // Username from the /etc/shadow entry
   user string
-  // Password
+  // Hashed password field (`*` or `!` marks a locked or disabled login; empty means no password)
   password string
-  // Date of last password change
+  // Date of the last password change
   lastchanged time
-  // Minimum password age in days
+  // Minimum password age in days before it may be changed again
   mindays int
-  // Maximum password age in days
+  // Maximum password age in days before a change is required
   maxdays int
-  // Password warning period in days
+  // Number of days before expiry the user is warned to change the password
   warndays int
-  // Password inactivity period in days
+  // Days after password expiry before the account is disabled
   inactivedays int
   // Account expiration date
   expirydates string
@@ -4807,7 +5263,10 @@ shadow.entry {
 
 // Yum/DNF package manager
 //
-// Examine yum variables and configured repositories
+// Configuration of the yum/dnf package manager on RedHat-family
+// systems. `vars` exposes the variables defined across `/etc/yum.conf`
+// and the `.repo` files (for example `$releasever` and `$basearch`) and
+// `repos` lists every configured repository as `yum.repo` entries.
 yum {
   // Variables defined in Yum configuration files (/etc/yum.conf and all .repo files in the /etc/yum.repos.d/)
   vars() map[string]string
@@ -4815,50 +5274,51 @@ yum {
   repos() []yum.repo
 }
 
-// Yum repository resource
+// Yum repository
 //
-// Examine a single configured Yum/DNF repository: its `id`, human-readable
-// `name`, `status`, `baseurl` list, expiry indicator, configuration `file`,
-// revision, package count, size, mirrors, and whether it is currently
-// `enabled`. Initialize by ID (e.g., `yum.repo(id: "baseos")`) or iterate
-// from `yum.repos()`.
+// A single configured yum/dnf repository as reported by
+// `yum -v repolist all`: its `id`, human-readable `name`, `status`,
+// `baseurl` list, expiry indicator, backing configuration `file`,
+// `revision`, package count, size, mirror list, and whether it is
+// currently `enabled`. Select a repository by ID, for example
+// `yum.repo(id: "baseos")`.
 yum.repo {
   init(id string)
   // Repository ID
   id string
   // Human-readable repository name
   name string
-  // Repository status
+  // Repository status (e.g., enabled or disabled)
   status string
   // URL where the repodata directory of a repository is located
   baseurl []string
-  // Indicator when the repository will expire
+  // Indicator when the repository metadata will expire
   expire string
   // Repository configuration file path
   file file
   // Repository revision
   revision string
-  // Packages in repository
+  // Number of packages available from the repository
   pkgs string
-  // File size of this repository
+  // Total size of the repository
   size string
   // Mirrors for this repository
   mirrors string
-  // Whether the repository is used as package source
+  // Whether the repository is used as a package source (status is enabled)
   enabled() bool
 }
 
 // Yum/DNF global configuration
 //
-// Examine the system-wide package manager configuration — the `[main]`
-// section of `/etc/yum.conf`, or `/etc/dnf/dnf.conf` on dnf-based
-// systems. Use `gpgcheck` and `localPkgGpgcheck` to assert that package
-// signature verification is enforced for every repository and for
-// locally installed packages, a core CIS supply-chain control;
-// `repoGpgcheck` extends that to repository metadata. The bool accessors
-// reflect the explicit directive and are `false` when the directive is
-// absent. `params` exposes every `[main]` directive as a raw string map
-// for settings without a typed accessor. Select an alternate file with
+// System-wide package manager configuration: the `[main]` section of
+// `/etc/yum.conf`, or `/etc/dnf/dnf.conf` on dnf-based systems. Use
+// `gpgcheck` and `localPkgGpgcheck` to assert that package signature
+// verification is enforced for every repository and for locally
+// installed packages, a core CIS supply-chain control; `repoGpgcheck`
+// extends that to repository metadata. The bool accessors reflect the
+// explicit directive and are `false` when the directive is absent.
+// `params` exposes every `[main]` directive as a raw string map for
+// settings without a dedicated accessor. Select an alternate file with
 // `yum.config(path: "...")`.
 yum.config {
   init(path string)
@@ -4880,13 +5340,13 @@ yum.config {
 
 // Advanced Package Tool (APT) configuration
 //
-// Use this as the entry point to the Debian/Ubuntu package management
-// configuration. `repos` enumerates every configured APT repository
-// across `/etc/apt/sources.list` and the `/etc/apt/sources.list.d/`
-// directory, parsing both the classic one-line format and the deb822
-// `.sources` format. Audit repository trust from there — each `apt.repo`
-// reports whether it is marked `trusted` (signature checks bypassed) and
-// the `signedBy` keyring that pins which key may sign it.
+// Debian/Ubuntu package management configuration. `repos` enumerates
+// every configured APT repository across `/etc/apt/sources.list` and
+// the `/etc/apt/sources.list.d/` directory, parsing both the classic
+// one-line format and the deb822 `.sources` format. Audit repository
+// trust from there: each `apt.repo` reports whether it is marked
+// `trusted` (signature checks bypassed) and the `signedBy` keyring that
+// pins which key may sign it.
 apt {
   // All configured APT repositories
   repos() []apt.repo
@@ -4894,15 +5354,15 @@ apt {
 
 // APT software repository
 //
-// Examine a single configured APT repository parsed from a sources list:
-// its package `type` (`deb` for binary or `deb-src` for source), the
-// `url` it fetches from, the `distribution` (suite) and `components` it
-// pulls, and the `file` that declares it. The security-relevant fields
-// are `trusted` — true when the entry carries `[trusted=yes]`, which
-// disables signature verification — and `signedBy`, the keyring path
-// pinning which key may sign the repository. `enabled` is false for
-// entries commented out in a one-line sources file or marked
-// `Enabled: no` in a deb822 file.
+// A single configured APT repository parsed from a sources list: its
+// package `type` (`deb` for binary or `deb-src` for source), the `url`
+// it fetches from, the `distribution` (suite) and `components` it pulls,
+// and the `file` that declares it. The security-relevant fields are
+// `trusted`, true when the entry carries `[trusted=yes]`, which disables
+// signature verification, and `signedBy`, the keyring path pinning which
+// key may sign the repository. `enabled` is false for entries commented
+// out in a one-line sources file or marked `Enabled: no` in a deb822
+// file.
 private apt.repo @defaults("type url distribution") {
   // Package type: `deb` (binary) or `deb-src` (source)
   type string
@@ -4924,7 +5384,12 @@ private apt.repo @defaults("type url distribution") {
 
 // Windows registry key
 //
-// Examine items, child keys, and existence at a given registry path
+// A Windows registry key selected by `path`, exposing its value entries
+// (`items`), child key names (`children`), and whether the key
+// `exists`. Optionally read a specific user's per-user registry (HKCU)
+// by supplying `userSid`, falling back to their `NTUSER.DAT` profile
+// hive (`ntuserDat`) when that hive is not currently loaded. Select a
+// key with `registrykey(path: "...")`.
 registrykey @defaults("path") {
   init(path string, userSid? string, ntuserDat? string)
   // Registry key path
@@ -4940,33 +5405,34 @@ registrykey @defaults("path") {
   // Path to the user's NTUSER.DAT hive file
   //
   // Optional. Used with `userSid` to read a user's registry when their hive
-  // is not currently loaded — for example a SYSTEM scan running with no
+  // is not currently loaded, for example a SYSTEM scan running with no
   // interactive session. Typically populated from `user.ntuserDat`.
   ntuserDat string
-  // Whether the property exists
+  // Whether the registry key exists
   exists() bool
   // Properties of the registry key as a name-to-value map
   //
   // Deprecated in favor of `items`, which returns structured property
   // entries.
   properties() @maturity("deprecated") map[string]string
-  // Registry key items
+  // Value entries in this registry key
   items() []registrykey.property
-  // Registry key children
+  // Names of the immediate child keys under this key
   children() []string
 }
 
 // Windows registry key property
 //
-// Examine a single named value within a registry key: the key `path`, value
-// `name`, whether it `exists`, the registry `type` (e.g., REG_SZ, REG_DWORD),
-// and the parsed `data`. Initialize by path and name to look up a specific
-// value, or iterate from `registrykey.items()`.
+// A single named value within a registry key: the key `path`, value
+// `name`, whether it `exists`, the registry `type` (for example
+// `REG_SZ`, `REG_DWORD`, `REG_BINARY`, or `REG_MULTI_SZ`), and the
+// parsed `data`. Select a specific value by path and name, or iterate
+// from `registrykey.items`.
 registrykey.property @defaults("path name") {
   init(path string, name string, userSid? string, ntuserDat? string)
   // Registry key path
   path string
-  // Registry key name
+  // Registry value name
   name string
   // SID of the user whose registry hive to read
   //
@@ -4982,47 +5448,59 @@ registrykey.property @defaults("path name") {
   exists() bool
   // Registry property value as a string
   //
-  // Deprecated in favor of `data`, the parsed typed value.
+  // Deprecated in favor of `data`, the parsed structured value.
   value() @maturity("deprecated") string
-  // Registry key type
+  // Registry value type (e.g., REG_SZ, REG_DWORD, REG_BINARY)
   type() string
-  // Registry key data
+  // Parsed registry value data
   data() dict
 }
 
 // OCI/Docker container image reference
 //
-// Examine fully-qualified name, tag/digest identifier, and source repository
+// A container image reference broken into its parts: the raw
+// `reference`, the fully-qualified `name`, the `identifier` (the tag or
+// digest portion), the `identifierType` (`tag` or `digest`), and the
+// source `repository`. Records exactly which image a running container
+// or scan target was built from.
 container.image @defaults("name") {
-  // Image reference
+  // Original image reference as provided
   reference string
   // Fully-qualified reference name
   name string
-  // Identifier of type-specific portion of the image reference
+  // Type-specific portion of the image reference (the tag or digest value)
   identifier string
-  // Identifier type: tag or digest
+  // Identifier type: `tag` or `digest`
   identifierType string
-  // Repository used for the container image
+  // Repository the container image is pulled from
   repository() container.repository
 }
 
 // Container registry repository
 //
-// Examine registry, scheme, and full repository name for an image source
+// The source repository of a container image, split into the `registry`
+// host, the URL `scheme`, the repository `name`, and the `fullName`
+// combining host and path. Identifies where an image is pulled from.
 container.repository {
-  // Container registry repository name
+  // Container registry repository name (path portion, without the registry host)
   name string
-  // URL scheme
+  // URL scheme (e.g., https)
   scheme string
-  // Container registry repository URL
+  // Full repository name including the registry host
   fullName string
-  // Container registry URL
+  // Container registry host
   registry string
 }
 
 // Kubernetes kubelet on this node
 //
-// Examine config-file parameters merged with the live process's CLI flags
+// The kubelet agent running on this node, with its security-relevant
+// settings resolved from the config file merged with the live process's
+// CLI flags (CLI flags take precedence). The fields map to CIS
+// Kubernetes benchmark controls: anonymous authentication, authorization
+// mode, client CA, the read-only port, streaming timeouts, certificate
+// rotation, and the TLS cipher/version floor. `configuration` returns
+// the full merged configuration as a dict.
 kubelet {
   // Kubelet config file
   configFile file
@@ -5067,7 +5545,12 @@ kubelet {
 
 // Python package inventory
 //
-// Examine all installed packages plus the explicitly-installed top level
+// Installed Python packages discovered on the host. `packages` lists
+// every package found and `toplevel` narrows that to packages that were
+// explicitly installed rather than pulled in as dependencies. Pass
+// `path` to scan a specific site-packages location instead of the
+// default locations. Used for software inventory and vulnerability
+// correlation.
 python {
   init(path? string)
   // Path to a specific site-packages location to exclusively scan (empty means scan default locations)
@@ -5082,10 +5565,10 @@ python {
 
 // Python package information
 //
-// Examine a single installed Python package: name, version, license, author,
-// summary, required Python version, project URLs, package URL (`purl`), CPEs,
-// and the full transitive `dependencies()` list. Used to inventory Python
-// dependencies and correlate them with vulnerability data.
+// A single installed Python package: name, version, license, author,
+// summary, required Python version, project URLs, package URL (`purl`),
+// CPEs, and the full transitive `dependencies` list. Used to inventory
+// Python dependencies and correlate them with vulnerability data.
 python.package @defaults("name version") {
   init(path? string)
   // ID is the python.package unique identifier
@@ -5118,7 +5601,12 @@ python.package @defaults("name version") {
 
 // npm package inventory
 //
-// Examine the project root, direct dependencies, and full transitive tree
+// npm packages discovered under a project: the `root` package, the
+// `directDependencies`, and the full transitive tree (iterated from the
+// list itself). `scripts` exposes the `package.json` scripts (useful for
+// spotting risky lifecycle hooks) and `files` records which manifests
+// and lockfiles contributed the inventory. Pass `paths` to search
+// specific locations.
 npm.packages {
   []npm.package
 
@@ -5147,10 +5635,10 @@ npm.packages {
 
 // npm package dependency
 //
-// Examine a single npm package: its unique `id`, `name`, `version`,
-// `purl`, CPEs, and the files that contributed it. Iterated from
-// `npm.packages` to audit the full dependency tree or from
-// `npm.packages.directDependencies()` for top-level deps only.
+// A single npm package: its unique `id`, `name`, `version`, `purl`,
+// CPEs, and the files that contributed it. Iterated from `npm.packages`
+// for the full dependency tree or from `directDependencies` for
+// top-level dependencies only.
 npm.package @defaults("name version purl") {
   // ID is the npm.package unique identifier
   id string
@@ -5175,14 +5663,17 @@ npm.package @defaults("name version purl") {
   // Package license
   //
   // SPDX expression from package.json `license`. The deprecated
-  // `licenses` array is not yet supported — the field is empty in that
+  // `licenses` array is not yet supported, so the field is empty in that
   // case.
   license string
 }
 
 // Go module inventory
 //
-// Examine the root module, direct dependencies, and full transitive tree
+// Go modules discovered under a path: the `root` module, the
+// `directDependencies`, and the full transitive tree (iterated from the
+// list itself). Parsed from module metadata such as `go.mod`. Pass
+// `path` to point at a specific project.
 go.packages {
   []go.package
 
@@ -5203,9 +5694,10 @@ go.packages {
 
 // Go module dependency
 //
-// Examine a single Go module: its unique `id`, module path as `name`,
+// A single Go module: its unique `id`, module path as `name`,
 // `version`, `purl`, CPEs, and the files that contributed it. Iterated
-// from `go.packages` or `go.packages.directDependencies()`.
+// from `go.packages` for the full tree or from `directDependencies` for
+// direct dependencies only.
 go.package @defaults("name version purl") {
   // ID is the go.package unique identifier
   id string
@@ -5223,7 +5715,10 @@ go.package @defaults("name version purl") {
 
 // Java package inventory (Maven, Gradle, JAR archives)
 //
-// Examine the root project, direct dependencies, and full transitive tree
+// Java artifacts discovered from Maven, Gradle, or JAR sources: the
+// `root` project, the `directDependencies`, and the full transitive
+// tree (iterated from the list itself). Point `path` at a directory, a
+// JAR, a `pom.xml`, or a `gradle.lockfile`.
 java.packages {
   []java.package
 
@@ -5244,10 +5739,10 @@ java.packages {
 
 // Java package (Maven, Gradle, or JAR archive)
 //
-// Examine a single Java artifact: its unique `id`, `name` in
+// A single Java artifact: its unique `id`, `name` in
 // `groupId:artifactId` form, `version`, `purl`, CPEs, and the files that
-// contributed it. Iterated from `java.packages` or
-// `java.packages.directDependencies()`.
+// contributed it. Iterated from `java.packages` for the full tree or
+// from `directDependencies` for direct dependencies only.
 java.package @defaults("name version purl") {
   // ID is the java.package unique identifier
   id string
@@ -5265,7 +5760,10 @@ java.package @defaults("name version purl") {
 
 // Rust/Cargo crate inventory
 //
-// Examine the root crate, direct dependencies, and full transitive tree
+// Rust crates discovered from Cargo sources: the `root` crate, the
+// `directDependencies`, and the full transitive tree (iterated from the
+// list itself). Parsed from Cargo manifests and lockfiles. Pass `path`
+// to point at a specific project.
 rust.packages {
   []rust.package
 
@@ -5286,27 +5784,29 @@ rust.packages {
 
 // Rust/Cargo crate dependency
 //
-// Examine a single Rust crate: its unique `id`, crate `name`, `version`,
-// `purl`, CPEs, and the files that contributed it. Iterated from
-// `rust.packages` or `rust.packages.directDependencies()`.
+// Single Rust crate in the software inventory, exposing its unique `id`,
+// crate `name`, `version`, `purl` identifier, CPE identifiers for
+// vulnerability matching, and the manifest or lock files that declared it.
 rust.package @defaults("name version purl") {
-  // ID is the rust.package unique identifier
+  // Unique identifier for the crate within the inventory
   id string
   // Name of the crate
   name() string
-  // Version of the crate
+  // Resolved crate version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the crate
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Manifest and lock files that contributed this crate to the inventory
   files() []pkgFileInfo
 }
 
 // .NET / NuGet package inventory
 //
-// Examine the root project, direct dependencies, and full transitive tree
+// NuGet packages resolved from a .NET project, covering the root project,
+// its direct dependencies, and the full transitive dependency tree. Set
+// `path` to point at a specific project or solution directory.
 dotnet.packages {
   []dotnet.package
 
@@ -5327,27 +5827,29 @@ dotnet.packages {
 
 // .NET / NuGet package dependency
 //
-// Examine a single .NET package: its unique `id`, `name`, `version`, `purl`,
-// CPEs, and the files that contributed it. Iterated from `dotnet.packages`
-// or `dotnet.packages.directDependencies()`.
+// Single .NET package in the software inventory, exposing its unique `id`,
+// `name`, `version`, `purl` identifier, CPE identifiers for vulnerability
+// matching, and the manifest or lock files that declared it.
 dotnet.package @defaults("name version purl") {
-  // ID is the dotnet.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Name of the package
   name() string
-  // Version of the package
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Manifest and lock files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // PHP / Composer package inventory
 //
-// Examine the root project, direct dependencies, and full transitive tree
+// Composer packages resolved from a PHP project, covering the root project,
+// its direct dependencies, and the full transitive dependency tree. Set
+// `path` to point at the directory holding the Composer files.
 php.packages {
   []php.package
 
@@ -5368,28 +5870,31 @@ php.packages {
 
 // PHP / Composer package dependency
 //
-// Examine a single PHP package: its unique `id`, `name` in
-// `vendor/package` form, `version`, `purl`, CPEs, and the files that
-// contributed it. Iterated from `php.packages` or
-// `php.packages.directDependencies()`.
+// Single PHP package in the software inventory, exposing its unique `id`,
+// `name` in `vendor/package` form, `version`, `purl` identifier, CPE
+// identifiers for vulnerability matching, and the Composer files that
+// declared it.
 php.package @defaults("name version purl") {
-  // ID is the php.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
-  // Name of the package (vendor/package)
+  // Name of the package in vendor/package form
   name() string
-  // Version of the package
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Composer files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // GitHub Actions workflow dependencies
 //
-// Examine action references (owner/repo@version) used across workflow files
+// Action references (owner/repo@version) pinned across the workflow YAML
+// files in a repository. Useful for auditing which third-party actions and
+// versions a CI pipeline trusts. Set `path` to a workflows directory or a
+// specific .yml file.
 githubactions.packages {
   []githubactions.package
 
@@ -5404,26 +5909,29 @@ githubactions.packages {
 
 // GitHub Actions action reference
 //
-// Examine a single GitHub Actions action used in workflow files: its unique
-// `id`, `name` in `owner/repo` or `owner/repo/path` form, `version` (tag,
-// branch, or commit SHA), `purl`, and the workflow files that reference it.
-// Iterated from `githubactions.packages`.
+// Single GitHub Actions action referenced in a workflow, exposing its
+// unique `id`, `name` in `owner/repo` or `owner/repo/path` form, the
+// pinned `version` (a tag, branch, or commit SHA), `purl` identifier, and
+// the workflow files that reference it. Pinning to a commit SHA rather than
+// a mutable tag is a common supply-chain hardening check.
 githubactions.package @defaults("name version purl") {
-  // ID is the githubactions.package unique identifier
+  // Unique identifier for the action within the inventory
   id string
-  // Name of the action (owner/repo or owner/repo/path)
+  // Name of the action in owner/repo or owner/repo/path form
   name() string
-  // Version (tag, branch, or commit SHA)
+  // Pinned version: a tag, branch, or commit SHA
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the action
   purl() string
-  // Package files
+  // Workflow files that reference this action
   files() []pkgFileInfo
 }
 
 // Swift package inventory (SPM and CocoaPods)
 //
-// Examine all referenced packages with their resolved versions
+// Swift packages referenced by a project through Swift Package Manager or
+// CocoaPods, each with its resolved version. Set `path` to point at the
+// directory holding the Swift package files.
 swift.packages {
   []swift.package
 
@@ -5438,27 +5946,28 @@ swift.packages {
 
 // Swift package dependency
 //
-// Examine a single Swift package: its unique `id`, `name`, `version`,
-// `purl`, CPEs, and the files that contributed it. Iterated from
-// `swift.packages`.
+// Single Swift package in the software inventory, exposing its unique `id`,
+// `name`, `version`, `purl` identifier, CPE identifiers for vulnerability
+// matching, and the package files that declared it.
 swift.package @defaults("name version purl") {
-  // ID is the swift.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Name of the package
   name() string
-  // Version of the package
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Package files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // Terraform provider inventory (SBOM cataloger)
 //
-// Examine provider versions pinned in .terraform.lock.hcl
+// Terraform provider versions pinned in `.terraform.lock.hcl`, useful for
+// auditing which provider versions an infrastructure workspace depends on.
 // Note: the terraform.* namespace is also used by the dedicated Terraform provider
 // for IaC resource scanning. These SBOM resources focus on provider version inventory
 // from .terraform.lock.hcl, not Terraform configuration analysis.
@@ -5476,33 +5985,39 @@ terraform.packages {
 
 // Terraform provider dependency
 //
-// Examine a single Terraform provider pinned in `.terraform.lock.hcl`:
-// its unique `id`, `name` in `namespace/type` form, `version`, `purl`,
-// CPEs, and the lock files that reference it. Iterated from
-// `terraform.packages`.
+// Single Terraform provider pinned in `.terraform.lock.hcl`, exposing its
+// unique `id`, `name` in `namespace/type` form, `version`, `purl`
+// identifier, CPE identifiers for vulnerability matching, and the lock
+// files that reference it.
 terraform.package @defaults("name version purl") {
-  // ID is the terraform.package unique identifier
+  // Unique identifier for the provider within the inventory
   id string
-  // Name of the provider (namespace/type)
+  // Name of the provider in namespace/type form
   name() string
-  // Version of the provider
+  // Pinned provider version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the provider
   purl() string
-  // Common Platform Enumeration (CPE) for the provider
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Lock files that reference this provider
   files() []pkgFileInfo
 }
 
 // Homebrew package inventory (macOS and Linux)
 //
-// Examine installed formulae and casks with version, tap, and update status
+// Homebrew formulae and casks installed on the host, each with version,
+// tap, install path, and update status. Filter for outdated software with
+// `homebrew.packages.where(outdated == true)`.
 homebrew.packages {
   []homebrew.package
 }
 
 // Homebrew package (formula or cask)
+//
+// Single installed Homebrew formula or cask, exposing its version, latest
+// available version, install location, tap, pin state, and whether it is
+// outdated or was pulled in only as a dependency.
 private homebrew.package @defaults("name version type") {
   // Package name (formula name or cask token)
   name string
@@ -5510,7 +6025,7 @@ private homebrew.package @defaults("name version type") {
   version string
   // Latest stable version available (equals version when up-to-date)
   latestVersion string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl string
   // Package description
   description string
@@ -5540,18 +6055,25 @@ private homebrew.package @defaults("name version type") {
 
 // Chocolatey package inventory (Windows)
 //
-// Examine installed packages with version, license, dependencies, and pin state
+// Chocolatey packages installed on a Windows host, each with version,
+// license, dependencies, and pin state. Filter with
+// `chocolatey.packages.where(pinned == true)` to find packages held back
+// from upgrades.
 chocolatey.packages {
   []chocolatey.package
 }
 
 // Chocolatey package
+//
+// Single installed Chocolatey package, exposing its version, license and
+// license URL, project and package URLs, declared dependencies, tags, and
+// whether it is pinned against automatic upgrades.
 private chocolatey.package @defaults("name version") {
   // Package name
   name string
   // Package version
   version string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl string
   // Short description
   summary string
@@ -5577,7 +6099,9 @@ private chocolatey.package @defaults("name version") {
 
 // Jenkins plugin inventory
 //
-// Examine installed plugins with version and inter-plugin dependencies
+// Jenkins plugins installed on a controller, each with its version and the
+// other plugins it depends on. Useful for auditing plugin versions against
+// known vulnerabilities. Set `path` to the Jenkins plugins directory.
 jenkins.packages {
   []jenkins.package
 
@@ -5591,12 +6115,15 @@ jenkins.packages {
 }
 
 // Jenkins plugin
+//
+// Single installed Jenkins plugin, exposing its short name, long
+// display name, version, plugin URL, and the other plugins it depends on.
 private jenkins.package @defaults("name version purl") {
   // Plugin short name
   name string
   // Plugin version
   version string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the plugin
   purl string
   // Plugin long name
   longName string
@@ -5604,13 +6131,16 @@ private jenkins.package @defaults("name version purl") {
   url string
   // Plugin dependencies
   dependencies []string
-  // Package files
+  // Files that contributed this plugin to the inventory
   files []pkgFileInfo
 }
 
 // WordPress plugin inventory
 //
-// Examine installed plugins with version and WordPress compatibility ranges
+// WordPress plugins installed under wp-content/plugins/, each with its
+// version and supported WordPress version range. Useful for spotting
+// plugins that are untested against the running WordPress version. Set
+// `path` to the plugins directory.
 wordpress.packages {
   []wordpress.package
 
@@ -5624,12 +6154,16 @@ wordpress.packages {
 }
 
 // WordPress plugin
+//
+// Single installed WordPress plugin, exposing its slug, display name,
+// version, license, and the minimum required and maximum tested WordPress
+// versions declared in its header.
 private wordpress.package @defaults("name version purl") {
   // Plugin slug (directory name)
   name string
   // Plugin version (from Stable tag)
   version string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the plugin
   purl string
   // Plugin display name
   displayName string
@@ -5639,13 +6173,15 @@ private wordpress.package @defaults("name version purl") {
   requiresWp string
   // Maximum tested WordPress version
   testedUpTo string
-  // Package files
+  // Files that contributed this plugin to the inventory
   files []pkgFileInfo
 }
 
 // Ruby gem inventory
 //
-// Examine the root project, direct dependencies, and full transitive tree
+// Ruby gems resolved from a project's Gemfile.lock, covering the root
+// project, its direct dependencies, and the full transitive dependency
+// tree. Set `path` to the directory holding the Gemfile.lock.
 ruby.packages {
   []ruby.package
 
@@ -5666,27 +6202,30 @@ ruby.packages {
 
 // Ruby gem package
 //
-// Examine a single Ruby gem: its unique `id`, gem `name`, `version`,
-// `purl`, CPEs, and the files that contributed it. Iterated from
-// `ruby.packages` or `ruby.packages.directDependencies()`.
+// Single Ruby gem in the software inventory, exposing its unique `id`, gem
+// `name`, `version`, `purl` identifier, CPE identifiers for vulnerability
+// matching, and the lock files that declared it.
 ruby.package @defaults("name version purl") {
-  // ID is the ruby.package unique identifier
+  // Unique identifier for the gem within the inventory
   id string
   // Gem name
   name() string
-  // Gem version
+  // Resolved gem version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the gem
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Lock files that contributed this gem to the inventory
   files() []pkgFileInfo
 }
 
 // Dart/Flutter package inventory
 //
-// Examine the root project, direct dependencies, and full transitive tree
+// Dart and Flutter packages resolved from a project's pubspec.lock,
+// covering the root project, its direct dependencies, and the full
+// transitive dependency tree. Set `path` to the directory holding the
+// pubspec.lock.
 dart.packages {
   []dart.package
 
@@ -5707,27 +6246,29 @@ dart.packages {
 
 // Dart/Flutter package dependency
 //
-// Examine a single Dart/Flutter package: its unique `id`, `name`, `version`,
-// `purl`, CPEs, and the files that contributed it. Iterated from
-// `dart.packages` or `dart.packages.directDependencies()`.
+// Single Dart or Flutter package in the software inventory, exposing its
+// unique `id`, `name`, `version`, `purl` identifier, CPE identifiers for
+// vulnerability matching, and the lock files that declared it.
 dart.package @defaults("name version purl") {
-  // ID is the dart.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Common Platform Enumeration (CPE) for the package
+  // Common Platform Enumeration (CPE) identifiers for matching against vulnerability advisories
   cpes() []core.cpe
-  // Package files
+  // Lock files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // Haskell package inventory (Stack and Cabal)
 //
-// Examine all locked packages with their resolved versions
+// Haskell packages locked by a project's stack.yaml.lock or
+// cabal.project.freeze, each with its resolved version. Set `path` to the
+// directory holding the lock or freeze file.
 haskell.packages {
   []haskell.package
 
@@ -5742,25 +6283,26 @@ haskell.packages {
 
 // Haskell package dependency
 //
-// Examine a single Haskell package from a Stack or Cabal lock file: its
-// unique `id`, `name`, `version`, `purl`, and the files that contributed it.
-// Iterated from `haskell.packages`.
+// Single Haskell package locked by a Stack or Cabal project, exposing its
+// unique `id`, `name`, `version`, `purl` identifier, and the lock or freeze
+// files that declared it.
 haskell.package @defaults("name version purl") {
-  // ID is the haskell.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Package files
+  // Lock or freeze files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // Elixir Hex package inventory (mix.lock)
 //
-// Examine all locked Hex packages with their resolved versions
+// Elixir Hex packages locked in a project's mix.lock, each with its
+// resolved version. Set `path` to the directory holding the mix.lock.
 elixir.packages {
   []elixir.package
 
@@ -5775,25 +6317,26 @@ elixir.packages {
 
 // Elixir Hex package dependency
 //
-// Examine a single Elixir Hex package from a mix.lock file: its unique
-// `id`, `name`, `version`, `purl`, and the files that contributed it.
-// Iterated from `elixir.packages`.
+// Single Elixir Hex package locked in a mix.lock, exposing its unique
+// `id`, `name`, `version`, `purl` identifier, and the lock files that
+// declared it.
 elixir.package @defaults("name version purl") {
-  // ID is the elixir.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Package files
+  // Lock files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // Erlang Hex package inventory (rebar.lock)
 //
-// Examine all locked Hex packages with their resolved versions
+// Erlang Hex packages locked in a project's rebar.lock, each with its
+// resolved version. Set `path` to the directory holding the rebar.lock.
 erlang.packages {
   []erlang.package
 
@@ -5808,25 +6351,26 @@ erlang.packages {
 
 // Erlang Hex package dependency
 //
-// Examine a single Erlang Hex package from a rebar.lock file: its unique
-// `id`, `name`, `version`, `purl`, and the files that contributed it.
-// Iterated from `erlang.packages`.
+// Single Erlang Hex package locked in a rebar.lock, exposing its unique
+// `id`, `name`, `version`, `purl` identifier, and the lock files that
+// declared it.
 erlang.package @defaults("name version purl") {
-  // ID is the erlang.package unique identifier
+  // Unique identifier for the package within the inventory
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl), a standardized identifier for the package
   purl() string
-  // Package files
+  // Lock files that contributed this package to the inventory
   files() []pkgFileInfo
 }
 
 // SWI-Prolog pack inventory
 //
-// Examine installed packs with their versions
+// SWI-Prolog packs installed on the host, each with its version. Set
+// `path` to the directory holding the installed packs.
 prolog.packages {
   []prolog.package
 
@@ -5841,159 +6385,203 @@ prolog.packages {
 
 // SWI-Prolog pack
 //
-// Examine a single SWI-Prolog pack: its unique `id`, pack `name`,
-// `version`, `purl`, and the files that contributed it. Iterated from
-// `prolog.packages`.
+// Single SWI-Prolog add-on pack installed under the pack directory,
+// keyed by a unique `id`. Exposes the pack `name`, `version`, a
+// `purl` (Package URL) for SBOM and vulnerability matching, and the
+// `files` that make up the pack. Useful for inventorying add-on
+// libraries on SWI-Prolog hosts.
 prolog.package @defaults("name version purl") {
-  // ID is the prolog.package unique identifier
+  // Unique identifier of the pack
   id string
   // Pack name
   name() string
   // Pack version
   version() string
-  // Package URL
+  // Package URL (purl) identifying the pack for SBOM and vulnerability matching
   purl() string
-  // Package files
+  // Files that make up the pack
   files() []pkgFileInfo
 }
 
 // Conda package inventory
 //
-// Examine installed packages from conda-meta or environment.yml
+// Installed conda packages discovered from `conda-meta` directories
+// and `environment.yml` files. With no `path` set, scans common
+// install locations (`/opt/conda`, per-user `miniconda3` and
+// `anaconda3`, and app directories); pass `path` to target a
+// specific project or environment. Each entry exposes name, version,
+// and a `purl` for SBOM and vulnerability matching.
 conda.packages {
   []conda.package
 
   init(path? string)
 
-  // Path to search for conda-meta or environment.yml
+  // Filesystem path searched for conda-meta or environment.yml (empty scans the default install locations)
   path string
 
-  // Files used to determine the packages
+  // Manifest and metadata files used to build the package list
   files() []pkgFileInfo
 }
 
-// Conda package dependency
+// Conda package
+//
+// Single conda package with its `name`, `version`, and `purl`
+// (Package URL) for SBOM and vulnerability matching, plus the
+// `files` that declared it.
 private conda.package @defaults("name version purl") {
-  // ID is the conda.package unique identifier
+  // Unique identifier of the package
   id string
   // Package name
   name() string
   // Package version
   version() string
-  // Package URL
+  // Package URL (purl) identifying the package for SBOM and vulnerability matching
   purl() string
-  // Package files
+  // Files that declared the package
   files() []pkgFileInfo
 }
 
-// Julia package inventory (Manifest.toml)
+// Julia package inventory
 //
-// Examine all locked packages with their resolved versions
+// Locked Julia packages read from `Manifest.toml` with their
+// resolved versions. With no `path` set, scans common app and
+// per-user environment paths (`/usr/src/app`, `/home/*/app`,
+// `/home/*/.julia/environments/v*`); pass `path` to target a
+// specific project directory or `Manifest.toml`. Each entry carries
+// a `purl` for SBOM and vulnerability matching.
 julia.packages {
   []julia.package
 
   init(path? string)
 
-  // Path to search for Manifest.toml
+  // Filesystem path searched for Manifest.toml (empty scans the default paths)
   path string
 
-  // Files used to determine the packages
+  // Manifest files used to build the package list
   files() []pkgFileInfo
 }
 
-// Julia package dependency
+// Julia package
+//
+// Single Julia package resolved from `Manifest.toml`, with its
+// `name`, locked `version`, and a `purl` (Package URL) for SBOM and
+// vulnerability matching, plus the `files` that declared it.
 private julia.package @defaults("name version purl") {
-  // ID is the julia.package unique identifier
+  // Unique identifier of the package
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl) identifying the package for SBOM and vulnerability matching
   purl() string
-  // Package files
+  // Files that declared the package
   files() []pkgFileInfo
 }
 
-// R package inventory (renv.lock)
+// R package inventory
 //
-// Examine all locked packages with their resolved versions
+// Locked R packages read from `renv.lock` with their resolved
+// versions. With no `path` set, scans common app and per-user paths
+// (`/usr/src/app`, `/home/*/app`, `/home/*`); pass `path` to target
+// a specific project directory or `renv.lock` file. Each entry
+// carries a `purl` for SBOM and vulnerability matching.
 r.packages {
   []r.package
 
   init(path? string)
 
-  // Path to search for renv.lock
+  // Filesystem path searched for renv.lock (empty scans the default paths)
   path string
 
-  // Files used to determine the packages
+  // Lock files used to build the package list
   files() []pkgFileInfo
 }
 
-// R package dependency
+// R package
+//
+// Single R package resolved from `renv.lock`, with its `name`,
+// locked `version`, and a `purl` (Package URL) for SBOM and
+// vulnerability matching, plus the `files` that declared it.
 private r.package @defaults("name version purl") {
-  // ID is the r.package unique identifier
+  // Unique identifier of the package
   id string
   // Package name
   name() string
-  // Package version
+  // Resolved package version
   version() string
-  // Package URL
+  // Package URL (purl) identifying the package for SBOM and vulnerability matching
   purl() string
-  // Package files
+  // Files that declared the package
   files() []pkgFileInfo
 }
 
 // Lua/LuaRocks package inventory
 //
-// Examine all installed rocks with their versions
+// Installed LuaRocks rocks with their versions, gathered from the
+// LuaRocks rock trees (`/usr/local/lib/luarocks/rocks-*`,
+// `/usr/share/lua/*`) or `luarocks list`. Pass `path` to search a
+// specific rock tree. Each entry carries a `purl` for SBOM and
+// vulnerability matching.
 lua.packages {
   []lua.package
 
   init(path? string)
 
-  // Path to search for LuaRocks packages
+  // Filesystem path searched for installed LuaRocks rocks (empty scans the default rock trees)
   path string
 
-  // Files used to determine the packages
+  // Files used to build the package list
   files() []pkgFileInfo
 }
 
-// Lua package dependency
+// Lua package
+//
+// Single installed LuaRocks rock with its `name`, `version`, and a
+// `purl` (Package URL) for SBOM and vulnerability matching, plus the
+// `files` that declared it.
 private lua.package @defaults("name version purl") {
-  // ID is the lua.package unique identifier
+  // Unique identifier of the package
   id string
   // Package name
   name() string
   // Package version
   version() string
-  // Package URL
+  // Package URL (purl) identifying the package for SBOM and vulnerability matching
   purl() string
-  // Package files
+  // Files that declared the package
   files() []pkgFileInfo
 }
 
 // macOS-specific operating system surfaces
 //
-// Examine computer name, user defaults, account policies, and system extensions
+// macOS host settings not covered by the cross-platform resources:
+// the machine's `computerName`, per-user and per-host defaults
+// (preferences), the global account/password policy, and installed
+// `systemExtensions`. A starting point for macOS-specific audits
+// alongside the dedicated resources such as firewall, filevault,
+// gatekeeper, and sip.
 macos {
   // macOS computer name
   computerName() string
-  // macOS user defaults
+  // Per-user macOS defaults (preferences), keyed by preference domain
   userPreferences() map[string]dict
-  // macOS user defaults for current host
+  // Per-user, per-host macOS defaults (ByHost preferences), keyed by preference domain
   userHostPreferences() map[string]dict
-  // macOS global account policies
+  // Global account (password) policy directives applied to all local users
   globalAccountPolicies() dict
-  // System extensions
+  // Installed system extensions (network, endpoint security, and driver extensions)
   systemExtensions() []macos.systemExtension
 }
 
 // macOS hardware overview
 //
-// Examine chip type, model, memory, serial, and Activation Lock status
+// Hardware and firmware details reported by `system_profiler`: chip
+// type, model identifiers, installed memory, serial number, and
+// Activation Lock status. Useful for asset inventory and for
+// distinguishing Apple Silicon from Intel Macs in conditional audits.
 macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
-  // Activation Lock security feature
+  // Activation Lock security feature status
   activationLockStatus string
   // Boot ROM (firmware) version identifier
   bootRomVersion string
@@ -6019,9 +6607,12 @@ macos.hardware @defaults("machineName chipType physicalMemory serialNumber") {
   serialNumber string
 }
 
-// macOS application layer firewall — raw ALF preference values
+// macOS application layer firewall (raw ALF preference values)
 //
-// Prefer macos.firewall; this resource exposes the raw integer flags from ALF plist
+// Raw integer flags read from the Application Layer Firewall plist
+// (`/Library/Preferences/com.apple.alf.plist`). Prefer
+// `macos.firewall`, which decodes these into boolean fields; use
+// this resource only when you need the underlying preference values.
 macos.alf {
   // Whether the firewall service allows downloaded software to receive incoming connections
   allowDownloadSignedEnabled int
@@ -6029,7 +6620,7 @@ macos.alf {
   allowSignedEnabled int
   // Whether the firewall is unloaded
   firewallUnload int
-  // Whether the firewall is enabled
+  // Global firewall state (0=off, 1=on for specific services, 2=block all incoming connections)
   globalState int
   // Whether alf.log is used
   loggingEnabled int
@@ -6039,17 +6630,22 @@ macos.alf {
   stealthEnabled int
   // ALF version
   version string
-  // Service exceptions
+  // Per-service firewall exceptions
   exceptions []dict
   // Services explicitly allowed to perform networking
   explicitAuths []string
-  // Applications with exceptions for network blocking
+  // Applications with configured incoming-connection exceptions
   applications []dict
 }
 
 // macOS application layer firewall
 //
-// Examine enable state, stealth mode, signed-app policy, and per-app rules
+// Decoded Application Layer Firewall configuration: whether the
+// firewall is `enabled`, whether it blocks all incoming connections,
+// stealth mode, logging, the signed-app auto-allow policy, and
+// per-application rules. CIS macOS benchmarks expect the firewall
+// enabled with stealth mode on. See `macos.alf` for the raw
+// preference values.
 macos.firewall @defaults("enabled stealthEnabled") {
   // Whether the firewall is enabled
   enabled() bool
@@ -6067,7 +6663,7 @@ macos.firewall @defaults("enabled stealthEnabled") {
   allowDownloadSignedApps() bool
   // ALF version
   version() string
-  // Service exceptions
+  // Per-service firewall exceptions
   exceptions() []dict
   // Services explicitly allowed to perform networking
   explicitAuths() []string
@@ -6084,18 +6680,25 @@ macos.firewall @defaults("enabled stealthEnabled") {
 }
 
 // macOS firewall per-application rule
+//
+// Incoming-connection rule for one application: its `name` (the
+// application path), `bundleId`, and `state` (0 blocks incoming
+// connections, 1 allows them).
 private macos.firewall.app @defaults("name state") {
   // Application path
   name string
-  // Bundle ID
+  // Application bundle identifier
   bundleId string
-  // Whether incoming connections are allowed (0=block, 1=allow)
+  // Incoming-connection policy (0=block, 1=allow)
   state int
 }
 
 // macOS FileVault full-disk encryption
 //
-// Examine enable state, encryption status, and configured recovery keys
+// FileVault full-disk encryption state: whether it is `enabled`, the
+// current `status`, whether personal and institutional recovery keys
+// exist, and the `users` permitted to unlock the encrypted volume at
+// boot. CIS macOS benchmarks require FileVault enabled.
 macos.filevault @defaults("enabled status") {
   // Whether FileVault is enabled
   enabled() bool
@@ -6105,13 +6708,16 @@ macos.filevault @defaults("enabled status") {
   hasPersonalRecoveryKey() bool
   // Whether an institutional recovery key exists
   hasInstitutionalRecoveryKey() bool
-  // Users that can unlock the FileVault encrypted drive
+  // Users authorized to unlock the FileVault-encrypted startup disk at boot
   users() []string
 }
 
 // macOS Gatekeeper application execution policy
 //
-// Examine whether assessments are enabled and the Gatekeeper status message
+// Gatekeeper policy that controls whether downloaded applications may
+// run: whether assessments are `enabled` and the human-readable
+// `status`. Disabling Gatekeeper lets unsigned or unnotarized
+// software launch without a warning, so benchmarks expect it enabled.
 macos.gatekeeper @defaults("enabled status") {
   // Whether Gatekeeper assessments are enabled
   enabled() bool
@@ -6121,7 +6727,11 @@ macos.gatekeeper @defaults("enabled status") {
 
 // macOS System Integrity Protection (SIP)
 //
-// Examine whether SIP is enabled and the system status message
+// System Integrity Protection state, the kernel-level protection that
+// restricts modification of protected system files and processes even
+// by root. Exposes whether SIP is `enabled` and the raw `status`
+// message from `csrutil status`. Disabling SIP is a significant
+// hardening regression.
 macos.sip @defaults("enabled status") {
   // Whether System Integrity Protection is enabled
   enabled() bool
@@ -6131,11 +6741,11 @@ macos.sip @defaults("enabled status") {
 
 // macOS XProtect anti-malware bundle
 //
-// Examine the version and last-modified timestamp of the XProtect
-// signature bundle (and, when present, the legacy Malware Removal
-// Tool). CIS macOS benchmarks expect XProtect signatures to be
-// current; checking `modified` against the auditor's freshness
-// threshold catches devices that have stopped receiving updates.
+// Version and last-modified timestamp of the XProtect signature
+// bundle (and, when present, the legacy Malware Removal Tool). CIS
+// macOS benchmarks expect XProtect signatures to be current; checking
+// `modified` against the auditor's freshness threshold catches
+// devices that have stopped receiving updates.
 //
 // XProtect.bundle lives at
 // `/Library/Apple/System/Library/CoreServices/XProtect.bundle` on
@@ -6159,11 +6769,10 @@ macos.xprotect @defaults("version modified") {
 
 // macOS Sharing service state
 //
-// Examine the unified Sharing panel (System Settings > Sharing on
-// macOS Ventura+, System Preferences > Sharing on older versions).
-// Each field corresponds to one toggle in that panel. CIS macOS
-// benchmarks require most of these to be off unless the device
-// explicitly needs the service. Backed by `system_profiler
+// State of each toggle in the unified Sharing panel (System Settings
+// > Sharing on macOS Ventura+, System Preferences > Sharing on older
+// versions). CIS macOS benchmarks require most of these off unless
+// the device explicitly needs the service. Backed by `system_profiler
 // SPSharingDataType`, so the values match exactly what the System
 // Settings UI displays.
 //
@@ -6197,8 +6806,8 @@ macos.sharing @defaults("screenSharing remoteManagement airplayReceiver") {
 
 // macOS MDM (Mobile Device Management) enrollment state
 //
-// Examine whether this Mac is enrolled in an MDM solution, the
-// enrollment server, and whether the enrollment was performed via
+// MDM enrollment state for this Mac: whether it is enrolled, the
+// enrollment server, and whether enrollment was performed via
 // Automated Device Enrollment (formerly DEP) or user-approved. Use
 // `macos.profiles` to enumerate the configuration profiles delivered
 // to the device. Backed by `profiles status -type enrollment`.
@@ -6222,11 +6831,12 @@ macos.mdm @defaults("enrolled serverUrl") {
 
 // macOS configuration profiles installed on the system
 //
-// Iterate every Configuration Profile delivered to the device — both
-// MDM-delivered and manually installed `.mobileconfig` payloads — to
-// audit what policies are actually in force. Backed by `profiles list
-// -all -output stdout-xml`; requires root to see system-level (`_computerlevel`)
-// profiles, otherwise only the current user's profiles are returned.
+// Every Configuration Profile delivered to the device, both
+// MDM-delivered and manually installed `.mobileconfig` payloads, so
+// you can audit what policies are actually in force. Backed by
+// `profiles list -all -output stdout-xml`; requires root to see
+// system-level (`_computerlevel`) profiles, otherwise only the
+// current user's profiles are returned.
 macos.profiles @defaults("list.length") {
   // All installed Configuration Profiles
   list() []macos.profile
@@ -6234,7 +6844,7 @@ macos.profiles @defaults("list.length") {
 
 // macOS Configuration Profile
 //
-// Examine a single Configuration Profile: its `identifier`, `uuid`,
+// Single Configuration Profile: its `identifier`, `uuid`,
 // human-readable `displayName`, `description`, `organization`,
 // `type`, whether it is install-locked (`removalDisallowed`), the
 // scope it applies to (`scope`: `system` or `user`), and the
@@ -6264,12 +6874,11 @@ private macos.profile @defaults("identifier displayName type") {
 
 // macOS Configuration Profile payload
 //
-// Examine a single payload within a Configuration Profile: the
-// `type` (e.g. `com.apple.security.firewall`,
-// `com.apple.MCXFileVault2`), the payload's reverse-DNS
-// `identifier`, its `uuid`, and the raw policy `content` as a dict.
-// Iterated from `macos.profile.payloads` to audit specific policy
-// directives (e.g. firewall payload settings, FileVault policy).
+// Single payload within a Configuration Profile: the `type` (e.g.
+// `com.apple.security.firewall`, `com.apple.MCXFileVault2`), the
+// payload's reverse-DNS `identifier`, its `uuid`, and the raw policy
+// `content` as a dict. Audit specific policy directives such as
+// firewall payload settings or FileVault policy.
 private macos.profile.payload @defaults("type displayName") {
   // Payload UUID
   uuid string
@@ -6281,7 +6890,7 @@ private macos.profile.payload @defaults("type displayName") {
   displayName string
   // Raw payload content as parsed from the profile plist
   //
-  // The schema of `content` is payload-type specific — a firewall
+  // The schema of `content` is payload-type specific: a firewall
   // payload differs from a Wi-Fi payload differs from a FileVault
   // payload. Inspect `type` to know what fields to expect.
   content dict
@@ -6289,8 +6898,8 @@ private macos.profile.payload @defaults("type displayName") {
 
 // macOS Software Update configuration and pending updates
 //
-// Examine automatic-update policy and the list of updates currently
-// available to install. Policy fields read from
+// Automatic-update policy and the list of updates currently available
+// to install. Policy fields read from
 // `/Library/Preferences/com.apple.SoftwareUpdate.plist` (with
 // `/Library/Managed Preferences/` taking precedence when an MDM
 // configuration profile has been delivered). The `updates` list is
@@ -6318,12 +6927,11 @@ macos.softwareupdate @defaults("autoCheckEnabled autoInstallMacOSUpdates") {
 
 // macOS Software Update entry
 //
-// Examine a single update offered by Software Update: its `label`
-// (the identifier accepted by `softwareupdate --install`), the
+// Single update offered by Software Update: its `label` (the
+// identifier accepted by `softwareupdate --install`), the
 // human-readable `title` and `version`, the estimated download
 // `size`, whether it is `recommended`, and any post-install `action`
-// such as `restart` or `shutdown`. Iterated from
-// `macos.softwareupdate.updates`.
+// such as `restart` or `shutdown`.
 private macos.softwareupdate.entry @defaults("label title recommended") {
   // Update label (the argument to `softwareupdate --install`)
   label string
@@ -6341,16 +6949,21 @@ private macos.softwareupdate.entry @defaults("label title recommended") {
 
 // macOS Time Machine backup configuration
 //
-// Examine destinations, schedule, and exclusion preferences
+// Time Machine backup configuration read from its preferences:
+// configured backup destinations, the automatic backup schedule, and
+// the paths excluded from backups, exposed as the raw `preferences`
+// dict.
 macos.timemachine {
-  // macOS Time Machine preferences
+  // Time Machine preferences (destinations, schedule, and exclusions) as a dict
   preferences() dict
 }
 
 // macOS machine settings via the systemsetup CLI
 //
-// Examine date/time, sleep, remote login, power, and network-time configuration
-// Note: this resource requires at least admin privileges to run.
+// Date/time, sleep and wake, remote login, power, and network-time
+// settings surfaced by the `systemsetup` CLI, with each field mapping
+// to one `systemsetup -get*` query. Requires at least admin
+// privileges to run.
 macos.systemsetup {
   // Current date
   date() string
@@ -6396,7 +7009,11 @@ macos.systemsetup {
 
 // OpenBSM audit_control configuration (macOS and BSD)
 //
-// Examine audit flags, log retention, and policy parameters
+// OpenBSM audit subsystem configuration parsed from the
+// `audit_control` file (pass `path` to override the default
+// location). Exposes the audit event `flags`, log retention
+// (`expireAfter`, `filesz`, `minfree`), and policy parameters that
+// govern which security-relevant events the kernel records.
 openBSMAudit @defaults("path") {
   init(path? string)
   // Path to the audit_control file
@@ -6433,7 +7050,11 @@ openBSMAudit @defaults("path") {
 
 // Windows-specific operating system surfaces
 //
-// Examine computer info, hotfixes, and server / optional features
+// Windows host settings not covered by the cross-platform resources:
+// consolidated `computerInfo`, installed `hotfixes`, Server roles and
+// features, image `optionalFeatures`, scheduled tasks, and hardening
+// controls (Device Guard, Exploit Protection, SmartScreen). A
+// starting point for Windows-specific audits.
 windows {
   // A consolidated object of system and operating system properties
   //
@@ -6463,8 +7084,8 @@ windows {
 
 // Windows Exploit Protection
 //
-// Examine the system-wide Windows Exploit Protection (the successor to EMET)
-// configuration reported by `Get-ProcessMitigation -System`. Five mitigations
+// System-wide Windows Exploit Protection (the successor to EMET)
+// configuration, reported by `Get-ProcessMitigation -System`. Five mitigations
 // are supported system-wide: data execution prevention (`dep`), address space
 // layout randomization (`aslr`), Control Flow Guard (`controlFlowGuard`),
 // structured exception handling overwrite protection (`sehop`), and heap
@@ -6555,7 +7176,7 @@ private windows.exploitProtection.heap @defaults("terminateOnError") {
 
 // Microsoft Defender SmartScreen
 //
-// Examine the Microsoft Defender SmartScreen policy configuration across its
+// Microsoft Defender SmartScreen policy configuration across its
 // three surfaces: Windows / File Explorer (which checks apps and files), the
 // Microsoft Edge browser, and Microsoft Store apps. SmartScreen is configured
 // through Group Policy registry values rather than a dedicated cmdlet; a value
@@ -6583,15 +7204,16 @@ windows.smartScreen @defaults("explorerEnabled explorerLevel edgeEnabled") {
 
 // Windows Task Scheduler task
 //
-// Examine a registered task from the Windows Task Scheduler: its identity
+// Registered task from the Windows Task Scheduler: its identity
 // (`name`, `path`, `uri`), run `state`, whether it is `enabled`, descriptive
 // metadata (`description`, `author`), and the security context it runs under
 // via `principal`. The `actions` it executes, the `triggers` that launch it,
 // and its full `settings` are exposed as nested resources, while `lastRunTime`,
 // `nextRunTime`, `lastTaskResult`, and `missedRuns` report the most recent
-// run-time information. Iterated from `windows.scheduledTasks` to audit
-// which tasks run, as whom, and on what schedule — for example
-// `windows.scheduledTasks.where(enabled).where(principal.runLevel == "Highest")`.
+// run-time information. Audit which tasks run, as whom, and on what schedule,
+// for example
+// `windows.scheduledTasks.where(enabled).where(principal.runLevel == "Highest")`
+// surfaces enabled tasks running with the highest available privileges.
 private windows.scheduledTask @defaults("path name state enabled") {
   // Task name (the leaf identifier within its folder)
   name string
@@ -6637,10 +7259,11 @@ private windows.scheduledTask @defaults("path name state enabled") {
 
 // Security context of a Windows scheduled task
 //
-// Examine the account a task runs as: the `userId` or `groupId` it is
+// Account a task runs as: the `userId` or `groupId` it is
 // associated with, the `logonType` used to obtain credentials, and the
 // `runLevel` that determines whether it runs with the highest available
-// privileges.
+// privileges. A task whose `runLevel` is "Highest" and whose principal is a
+// privileged account is a common privilege-escalation surface.
 private windows.scheduledTask.principal @defaults("userId logonType runLevel") {
   // User account the task runs as
   userId string
@@ -6661,9 +7284,10 @@ private windows.scheduledTask.principal @defaults("userId logonType runLevel") {
 
 // Action performed by a Windows scheduled task
 //
-// Examine a single executable action a task performs: the program it runs
+// Single executable action a task performs: the program it runs
 // (`execute`), the command-line `arguments` passed to it, and the
-// `workingDirectory` it runs in.
+// `workingDirectory` it runs in. Inspect `execute` to spot tasks that launch
+// scripts, interpreters, or binaries from writable or unexpected locations.
 private windows.scheduledTask.action @defaults("execute arguments") {
   // Program or command the action runs
   execute string
@@ -6675,10 +7299,10 @@ private windows.scheduledTask.action @defaults("execute arguments") {
 
 // Trigger that launches a Windows scheduled task
 //
-// Examine a single condition that starts a task. The `type` discriminates
+// Single condition that starts a task. The `type` discriminates
 // the kind of trigger ("daily", "weekly", "monthly", "monthlyDOW", "boot",
 // "logon", "registration", "time", "event", "idle", or "sessionStateChange")
-// and determines which of the schedule fields apply — `daysInterval` and
+// and determines which of the schedule fields apply: `daysInterval` and
 // `randomDelay` for daily, `weeksInterval`/`daysOfWeek` for weekly, `delay`
 // for boot/logon/event triggers, and so on. Common fields cover whether the
 // trigger is `enabled`, its active window (`startBoundary`, `endBoundary`),
@@ -6719,7 +7343,7 @@ private windows.scheduledTask.trigger @defaults("type enabled startBoundary") {
 
 // Conditions and behavior governing a Windows scheduled task
 //
-// Examine the settings that control how a task runs: whether it is `enabled`
+// Settings that control how a task runs: whether it is `enabled`
 // or `hidden`, how it behaves on battery power (`disallowStartIfOnBatteries`,
 // `stopIfGoingOnBatteries`), what happens when an instance is already running
 // (`multipleInstances`), restart-on-failure behavior (`restartCount`,
@@ -6778,6 +7402,14 @@ private windows.scheduledTask.settings @defaults("enabled hidden priority") {
 }
 
 // macOS system extension
+//
+// Installed system extension read from /Library/SystemExtensions/db.plist:
+// its `identifier`, `uuid`, `version`, `teamID` of the signing developer,
+// declared `categories` (such as network or endpoint-security extensions),
+// and `bundlePath`. The `state` string reports the extension's lifecycle,
+// with `enabled` and `active` derived from it. `mdmManaged` is true when the
+// extension or its team is allowlisted by an MDM system-extension policy,
+// which distinguishes centrally approved extensions from user-installed ones.
 private macos.systemExtension @defaults("teamID identifier version state"){
   // Identifier of the system extension
   identifier string
@@ -6787,7 +7419,7 @@ private macos.systemExtension @defaults("teamID identifier version state"){
   version string
   // Categories of the system extension
   categories []string
-  // State of the system extension
+  // Lifecycle state string reported by the extension (contains "enabled" and/or "activated")
   state string
   // Whether the system extension is enabled
   enabled() bool
@@ -6803,7 +7435,9 @@ private macos.systemExtension @defaults("teamID identifier version state"){
 
 // Safari browser (macOS only)
 //
-// Examine all installed Safari extensions across users
+// Safari web browser on macOS. The `extensions` collection lists every
+// installed Safari extension across all user accounts on the host, letting
+// audits flag unknown or disabled extensions and verify their provenance.
 safari {
   // All installed Safari extensions
   extensions() []safari.extension
@@ -6835,7 +7469,10 @@ private safari.extension @defaults("name version identifier") {
 
 // macOS launchd job configurations
 //
-// Examine system, library, and user daemons / agents from their plist files
+// launchd service manager on macOS. The `jobs` collection parses daemon and
+// agent job definitions from their plist files across the system, library, and
+// per-user launchd directories, so audits can review autostarted programs,
+// the accounts they run as, and their launch conditions in one place.
 launchd {
   // All launchd jobs from system and user directories
   jobs() []launchd.job
@@ -6899,10 +7536,12 @@ private launchd.job @defaults("label type") {
 
 // Windows hotfix
 //
-// Examine a single installed Windows hotfix: its `hotfixId` (e.g., "KB5034441"),
-// hotfix `description` type, knowledge-base `caption` URL, installation
-// date, and the user who installed it. Iterated from `windows.hotfixes()`
-// to audit patch compliance.
+// Single installed Windows hotfix (a Quick Fix Engineering update): its
+// `hotfixId` (for example "KB5034441"), the `description` type of the fix,
+// the knowledge-base `caption` URL, the `installedOn` date, and the account
+// that installed it. Audit patch compliance across
+// `windows.hotfixes`, for example
+// `windows.hotfixes.where(installedOn > time.now - 30*time.day)`.
 windows.hotfix {
   init(hotfixId string)
   // Hotfix ID
@@ -6919,11 +7558,11 @@ windows.hotfix {
 
 // Windows Update Agent
 //
-// Use to examine how a Windows host receives updates and what it has applied
+// How a Windows host receives updates and what it has applied
 // or has pending. The `config` field surfaces Windows Update Agent
-// configuration and freshness — the effective catalog source, WSUS settings,
+// configuration and freshness (the effective catalog source, WSUS settings,
 // the last successful detection / download / install times, and whether a
-// reboot is pending. `installed` lists the updates the agent has applied
+// reboot is pending). `installed` lists the updates the agent has applied
 // (the installed-KB history), and `available` lists updates the agent has
 // found but not yet installed. Configuration is read from the registry and
 // works even on connections that cannot run commands; the installed and
@@ -6945,12 +7584,13 @@ windows.update {
 
 // Windows update record
 //
-// Examine a single update reported by the Windows Update Agent — the `kbId`
-// (e.g., "KB5034441"), human-readable `title`, `classification` (such as
+// Single update reported by the Windows Update Agent: the `kbId`
+// (for example "KB5034441"), human-readable `title`, `classification` (such as
 // "Security Updates", "Critical Updates", or "Definition Updates"), the
-// support URL, and the CVEs it addresses. Installed updates carry the install
-// `date` and `operation`; available updates carry the `severity` and whether
-// they require a reboot.
+// support URL, and the `cveIds` it addresses. Installed updates carry the
+// install `date` and `operation`; available updates carry the `severity` and
+// whether they require a reboot. Filter `windows.update.available` on
+// `severity` or `cveIds` to find outstanding security-relevant updates.
 private windows.update.entry @defaults("kbId title classification") {
   // Update identity (Windows Update Agent UpdateID GUID, or package name when read from the registry)
   updateId string
@@ -6982,7 +7622,7 @@ private windows.update.entry @defaults("kbId title classification") {
 
 // Windows Update Agent configuration and freshness
 //
-// Examine where a Windows host gets its updates and whether the Windows
+// Where a Windows host gets its updates and whether the Windows
 // Update Agent is healthy. `catalogSource` summarizes the effective source
 // ("windowsUpdate", "wsus", "windowsUpdateForBusiness", "disabled", or
 // "unknown"); `wsusServerUrl` / `useWUServer` reveal WSUS configuration; the
@@ -7030,7 +7670,7 @@ private windows.update.config @defaults("catalogSource rebootPending") {
 
 // Windows Update for Business and Automatic Updates group policy
 //
-// Examine the managed Windows Update policy as configured through group
+// Managed Windows Update policy as configured through group
 // policy (the "Windows Components > Windows Update" administrative templates).
 // Every value is read directly from the registry under
 // `HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate` and its `AU`
@@ -7070,43 +7710,64 @@ private windows.update.policy @defaults("automaticUpdatesEnabled noAutoUpdate sc
   disablePauseUXAccess bool
 }
 
-// Windows Server feature resource
+// Windows Server role, role service, or feature
+//
+// Installable Windows Server component reported by
+// `Get-WindowsFeature`. Select one by its command name, for example
+// `windows.serverFeature(name: "Web-Server")`, to check whether a role such
+// as IIS, DNS, or Hyper-V is present. `installed` is the simple boolean check,
+// while `installState` distinguishes fully installed from removed or
+// available-for-install states.
 private windows.serverFeature @defaults("name") {
   init(name string)
   // Feature full path
   path string
-  // Command IDs of role, role service, or feature
+  // Command name (ID) of the role, role service, or feature (for example "Web-Server")
   name string
-  // Feature name
+  // Human-readable display name of the feature
   displayName string
   // Feature description
   description string
   // Whether the feature is installed
   installed bool
   // Feature installation state
+  //
+  // The ServerManager InstallState value from Get-WindowsFeature,
+  // distinguishing installed, available (not installed), and removed
+  // (payload removed from the image) features.
   installState int
 }
 
-// Windows optional feature resource (desktop-only)
+// Windows optional feature (desktop-only)
+//
+// Windows optional feature reported by `Get-WindowsOptionalFeature -Online`,
+// the desktop equivalent of server roles. Select one by its feature name, for
+// example `windows.optionalFeature(name: "SMB1Protocol")`, to check whether a
+// legacy or risky feature (such as SMBv1, Telnet client, or PowerShell v2) is
+// turned on. `enabled` is the simple boolean; `state` carries the underlying
+// DISM feature state for more granular checks.
 private windows.optionalFeature @defaults("name") {
   init(name string)
-  // Command ID of optional feature
+  // Feature name (ID) of the optional feature (for example "SMB1Protocol")
   name string
-  // Feature name
+  // Human-readable display name of the feature
   displayName string
   // Feature description
   description string
   // Whether the feature is enabled
   enabled bool
-  // Feature installation state
+  // Feature state
+  //
+  // The DISM feature state: 0 = Disabled, 1 = Enabled, 2 = Disable pending,
+  // 3 = Enable pending (a pending state takes effect after the next reboot).
   state int
 }
 
 // Windows Event Log channel configuration
 //
-// Examine the size and retention policy of a single Windows Event Log
+// Size and retention policy of a single Windows Event Log
 // channel. The `name` field selects the channel as it appears under the
-// EventLog registry tree — for example `windows.eventlog(name: "Security")`
+// EventLog registry tree, for example `windows.eventlog(name: "Security")`
 // or `windows.eventlog(name: "Application")`. `maxSizeKB` reports the
 // maximum log file size in KB and `retention` decodes how the channel
 // behaves when that size is reached. Each field resolves the Group Policy
@@ -7130,14 +7791,14 @@ windows.eventlog @defaults("name") {
 
 // Windows Remote Desktop / Terminal Services configuration
 //
-// Examine the effective Remote Desktop (Terminal Services) policy posture:
+// Effective Remote Desktop (Terminal Services) policy posture:
 // whether Network Level Authentication is required, the negotiated security
 // layer and minimum client encryption level, device and resource redirection
 // toggles, credential handling, and session idle / disconnection time limits.
 // Each field resolves the Group Policy value (HKLM\SOFTWARE\Policies\Microsoft
 // \Windows NT\Terminal Services) first, then the per-listener configuration
 // (HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp),
-// and finally the documented Windows default when neither is set — so audits
+// and finally the documented Windows default when neither is set, so audits
 // can assert the effective state without handling missing registry values.
 windows.rdp {
   // Whether Network Level Authentication is required (UserAuthentication)
@@ -7200,7 +7861,7 @@ windows.rdp {
 
 // Windows Remote Management (WinRM)
 //
-// Examine the effective WinRM (Windows Remote Management) policy posture for
+// Effective WinRM (Windows Remote Management) policy posture for
 // both the WinRM client and service, plus the WinRS remote shell setting and
 // the WinRM service start mode. The client and service settings are read from
 // the Group Policy key HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM; these
@@ -7222,7 +7883,7 @@ windows.winrm {
 
 // WinRM client policy
 //
-// Examine the WinRM client policy under HKLM\SOFTWARE\Policies\Microsoft
+// WinRM client policy under HKLM\SOFTWARE\Policies\Microsoft
 // \Windows\WinRM\Client. These are GPO-only values; when a value is absent the
 // documented Windows default applies.
 private windows.winrm.client @defaults("allowBasic allowUnencryptedTraffic") {
@@ -7245,7 +7906,7 @@ private windows.winrm.client @defaults("allowBasic allowUnencryptedTraffic") {
 
 // WinRM service policy
 //
-// Examine the WinRM service policy under HKLM\SOFTWARE\Policies\Microsoft
+// WinRM service policy under HKLM\SOFTWARE\Policies\Microsoft
 // \Windows\WinRM\Service (and the WinRS subkey). These are GPO-only values;
 // when a value is absent the documented Windows default applies.
 private windows.winrm.service @defaults("allowBasic allowUnencryptedTraffic") {
@@ -7278,7 +7939,7 @@ private windows.winrm.service @defaults("allowBasic allowUnencryptedTraffic") {
 
 // Windows Device Guard policy (Virtualization-Based Security, HVCI, and Credential Guard)
 //
-// Examine the Device Guard Group Policy values under HKLM\SOFTWARE\Policies
+// Device Guard Group Policy values under HKLM\SOFTWARE\Policies
 // \Microsoft\Windows\DeviceGuard. These configure Virtualization-Based
 // Security (VBS), Hypervisor-Enforced Code Integrity (HVCI / Memory
 // Integrity), Credential Guard, System Guard Secure Launch, and kernel-mode
@@ -7318,11 +7979,11 @@ private windows.deviceGuard @defaults("virtualizationBasedSecurityEnabled hyperv
 
 // Windows Local Security Authority (LSA) security policy
 //
-// Examine the Local Security Authority configuration that backs the
-// "Network access", "Network security", and related security options under
+// Local Security Authority configuration that backs the "Network access",
+// "Network security", and related security options under
 // HKLM\SYSTEM\CurrentControlSet\Control\Lsa. These values control anonymous
 // access restrictions, blank-password use, LAN Manager authentication level,
-// NTLM hashing, LSA protection (RunAsPPL), and audit behaviour. On/off settings
+// NTLM hashing, LSA protection (RunAsPPL), and audit behavior. On/off settings
 // are exposed as booleans and graded settings (such as the LAN Manager
 // authentication level) as integers. NTLM (MSV1_0 and WDigest) settings are
 // grouped under `ntlm` and the Netlogon secure-channel settings under
@@ -7339,6 +8000,9 @@ windows.lsa {
   // Whether local accounts with blank passwords are limited to console logon (Lsa\LimitBlankPasswordUse)
   limitBlankPasswordUse() bool
   // LAN Manager authentication level (Lsa\LmCompatibilityLevel; 0-5, higher is stronger)
+  //
+  // 0 sends LM and NTLM responses; 5 sends NTLMv2 only and refuses LM and
+  // NTLM. Higher values are more secure; CIS baselines require 5.
   lmCompatibilityLevel() int
   // Whether the LAN Manager (LM) hash of new passwords is not stored (Lsa\NoLMHash)
   noLmHash() bool
@@ -7367,7 +8031,7 @@ windows.lsa {
 
 // Windows LSA NTLM authentication settings
 //
-// Examine the NTLM security settings under
+// NTLM security settings under
 // HKLM\SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0 together with the WDigest
 // provider's UseLogonCredential value under
 // HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest. These
@@ -7389,6 +8053,9 @@ private windows.lsa.ntlm {
   // Restriction level for outgoing NTLM traffic to remote servers (MSV1_0\RestrictSendingNTLMTraffic; 0 allow, 1 audit, 2 deny-all)
   restrictSendingNtlmTraffic int
   // Whether WDigest caches plaintext credentials in memory (WDigest\UseLogonCredential)
+  //
+  // When enabled, WDigest keeps clear-text passwords in LSASS memory where
+  // credential-theft tools can read them. The hardened state is false (0).
   useLogonCredential bool
   // Whether online identities (PKU2U) may authenticate to this computer (Lsa\pku2u\AllowOnlineID)
   allowOnlineId bool
@@ -7396,10 +8063,10 @@ private windows.lsa.ntlm {
 
 // Windows LSA Netlogon secure-channel settings
 //
-// Examine the Netlogon secure-channel (domain member) settings under
+// Netlogon secure-channel (domain member) settings under
 // HKLM\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters. These control
 // digital signing and sealing of secure-channel data, the machine account
-// password change behaviour and maximum age, strong session keys, NETBIOS
+// password change behavior and maximum age, strong session keys, NETBIOS
 // discovery, the vulnerable-channel allow list, and inbound NTLM auditing in
 // the domain. BlockNetbiosDiscovery is read from the GPO location
 // HKLM\SOFTWARE\Policies\Microsoft\Netlogon\Parameters. On/off settings are
@@ -7426,12 +8093,15 @@ private windows.lsa.secureChannel {
   // Whether secure-channel data is digitally signed when possible (Netlogon\Parameters\SignSecureChannel)
   signSecureChannel bool
   // Allow list of vulnerable Netlogon secure channels (Netlogon\Parameters\vulnerablechannelallowlist, REG_SZ)
+  //
+  // Machine names exempted from secure RPC enforcement (Zerologon / CVE-2020-1472
+  // mitigation). A hardened system has an empty allow list.
   vulnerableChannelAllowList string
 }
 
 // Windows Schannel TLS configuration
 //
-// Examine the Schannel (Secure Channel) TLS cipher-suite and supported-group
+// Schannel (Secure Channel) TLS cipher-suite and supported-group
 // configuration that backs the Microsoft TLS/SSL stack, read from the effective
 // local Schannel store under
 // HKLM\SYSTEM\CurrentControlSet\Control\Cryptography\Configuration\Local\SSL.
@@ -7441,8 +8111,8 @@ private windows.lsa.secureChannel {
 // and Windows Server 2025 the supported-group list is where post-quantum ML-KEM
 // key-exchange groups (for example secp256r1_mlkem768) appear once enabled.
 //
-// When a key or value is absent — the common case on older Windows, on systems
-// using the default order, and on non-Windows platforms — the list accessors
+// When a key or value is absent (the common case on older Windows, on systems
+// using the default order, and on non-Windows platforms) the list accessors
 // resolve to an empty list and pqcKeyExchangeEnabled resolves to false rather
 // than failing.
 windows.schannel {
@@ -7456,18 +8126,21 @@ windows.schannel {
 
 // Windows Print Spooler security configuration
 //
-// Examine the hardening-relevant state of the Windows Print Spooler and
-// printing subsystem. The fields are sourced from the Group Policy printer
+// Hardening-relevant state of the Windows Print Spooler and printing
+// subsystem. The fields are sourced from the Group Policy printer
 // keys under
 // HKLM\SOFTWARE\Policies\Microsoft\Windows NT\Printers (and its
 // PointAndPrint, RPC, IPP, and WPP subkeys), the machine-wide
 // HKLM\SYSTEM\CurrentControlSet\Control\Print key, and the spooler service
 // start configuration under HKLM\SYSTEM\CurrentControlSet\Services\Spooler.
+// These controls address the PrintNightmare and related spooler
+// vulnerabilities: whether the service is disabled, whether remote RPC is
+// accepted, and how Point-and-Print driver installation is restricted.
 //
 // Integer settings that are not present in the registry resolve to null so
-// "not configured" is distinguishable from an explicit value of 0 — important
-// because several controls (for example registerRemoteRpcEndpoint == 0) are
-// compliant precisely when set to 0. Boolean settings resolve to their
+// "not configured" is distinguishable from an explicit value of 0 (important
+// because several controls, for example registerRemoteRpcEndpoint == 0, are
+// compliant precisely when set to 0). Boolean settings resolve to their
 // documented Windows default when the value is absent.
 windows.spooler {
   // Print Spooler service start type (HKLM\SYSTEM\CurrentControlSet\Services\Spooler\Start)
@@ -7588,7 +8261,7 @@ private windows.spooler.ipp @defaults("requireIpps") {
 
 // Windows diagnostic data (telemetry) and consumer cloud-content policy
 //
-// Examine the effective Windows privacy and telemetry posture read from the
+// Effective Windows privacy and telemetry posture read from the
 // Group Policy keys HKLM\SOFTWARE\Policies\Microsoft\Windows\DataCollection and
 // HKLM\SOFTWARE\Policies\Microsoft\Windows\CloudContent. These are GPO-only
 // DWORD values. The diagnostic data level is a graded integer; the remaining
@@ -7633,7 +8306,7 @@ windows.telemetry {
 
 // Windows PowerShell logging policy
 //
-// Examine the PowerShell logging settings configured via Group Policy under
+// PowerShell logging settings configured via Group Policy under
 // HKLM\SOFTWARE\Policies\Microsoft\Windows\PowerShell: Script Block Logging,
 // Transcription, and the machine execution policy. These are GPO-only values
 // with no effective fallback, so when a value is absent the corresponding field
@@ -7653,8 +8326,10 @@ windows.powershell {
 
 // PowerShell Script Block Logging policy
 //
-// Examine the Script Block Logging policy under HKLM\SOFTWARE\Policies
-// \Microsoft\Windows\PowerShell\ScriptBlockLogging. This is a GPO-only value;
+// Script Block Logging policy under HKLM\SOFTWARE\Policies
+// \Microsoft\Windows\PowerShell\ScriptBlockLogging. Script block logging
+// records the deobfuscated contents of scripts and commands to the event log,
+// a key control for detecting malicious PowerShell. This is a GPO-only value;
 // when it is absent the field is null, distinguishable from an explicit 0.
 private windows.powershell.scriptBlockLogging @defaults("enabled") {
   // Whether script block logging is enabled (EnableScriptBlockLogging); null when the value is absent
@@ -7663,9 +8338,10 @@ private windows.powershell.scriptBlockLogging @defaults("enabled") {
 
 // PowerShell Transcription policy
 //
-// Examine the Transcription policy under HKLM\SOFTWARE\Policies\Microsoft
-// \Windows\PowerShell\Transcription. This is a GPO-only value; when it is
-// absent the field is null, distinguishable from an explicit 0.
+// Transcription policy under HKLM\SOFTWARE\Policies\Microsoft
+// \Windows\PowerShell\Transcription. Transcription writes a record of every
+// PowerShell session (input and output) to text files. This is a GPO-only
+// value; when it is absent the field is null, distinguishable from an explicit 0.
 private windows.powershell.transcription @defaults("enabled") {
   // Whether PowerShell transcription is enabled (EnableTranscripting); null when the value is absent
   enabled bool
@@ -7673,12 +8349,12 @@ private windows.powershell.transcription @defaults("enabled") {
 
 // Windows Trusted Platform Module (TPM)
 //
-// Examine the Trusted Platform Module state: whether a TPM is present,
+// Trusted Platform Module state: whether a TPM is present,
 // ready for use, enabled, and activated, along with its major specification
 // version and manufacturer version string. Presence and a 2.0 specification
 // version are prerequisites for Windows 11 readiness and several BitLocker
 // and device-health controls. On a system without a TPM the fields resolve
-// cleanly — present is false — rather than erroring.
+// cleanly (present is false) rather than erroring.
 windows.tpm {
   // Whether a TPM is present on the system
   present() bool
@@ -7696,13 +8372,13 @@ windows.tpm {
 
 // Windows advanced audit policy
 //
-// Examine the effective Windows advanced audit policy: every audit
+// Effective Windows advanced audit policy: every audit
 // subcategory together with whether success and failure events are
 // audited. Subcategory names and categories are reported in English
 // regardless of the OS display language, so the same audit works
 // unchanged on localized systems. Iterate the subcategories to assert
-// audit coverage — for example
-// `windows.auditPolicy.where(category == "Account Logon").all(success)` —
+// audit coverage, for example
+// `windows.auditPolicy.where(category == "Account Logon").all(success)`,
 // or select a single subcategory with windows.auditPolicy.subcategory.
 windows.auditPolicy {
   []windows.auditPolicy.subcategory
@@ -7710,15 +8386,15 @@ windows.auditPolicy {
 
 // Windows audit policy subcategory
 //
-// Examine the audit settings of a single advanced audit policy
+// Audit settings of a single advanced audit policy
 // subcategory. The `name` field selects the subcategory by its English
-// name — for example `windows.auditPolicy.subcategory(name: "Logon")` —
+// name, for example `windows.auditPolicy.subcategory(name: "Logon")`,
 // and also accepts a subcategory GUID or the localized name the system
 // reports. `success` and `failure` indicate whether the subcategory
 // audits success and failure events, derived from the reported audit
 // setting independent of the OS display language. A subcategory that is
-// not present on the system audits nothing — `success` and `failure` are
-// false and the reported fields are null — so checks against it fail
+// not present on the system audits nothing (`success` and `failure` are
+// false and the reported fields are null) so checks against it fail
 // rather than error.
 windows.auditPolicy.subcategory @defaults("name success failure") {
   init(name string)
@@ -7745,9 +8421,14 @@ windows.auditPolicy.subcategory @defaults("name success failure") {
 
 // Windows Firewall (Advanced Security)
 //
-// Examine global settings, per-profile defaults, and individual firewall rules
+// Windows Firewall with Advanced Security posture: the global settings, the
+// per-profile defaults (Domain, Private, Public), and every configured
+// firewall rule. Use `profiles` to assert that the firewall is enabled and
+// blocks inbound traffic by default on each profile, and `rules` to audit
+// which allow/block rules are active. Backed by the `Get-NetFirewallProfile`
+// and `Get-NetFirewallRule` PowerShell cmdlets.
 windows.firewall {
-  // Global firewall settings
+  // Global firewall settings (Get-NetFirewallSetting), as a dictionary of setting name to value
   settings() dict
   // Settings that apply to the per-profile configurations of the Windows Firewall with Advanced Security
   profiles() []windows.firewall.profile
@@ -7757,20 +8438,20 @@ windows.firewall {
 
 // Windows Firewall profile entry
 //
-// Examine the per-profile firewall settings for one of the three Windows
+// Per-profile firewall settings for one of the three Windows
 // Firewall profiles (Domain, Private, Public): whether the firewall is
 // enabled, default inbound and outbound actions, local rule merge policies,
 // unicast response behavior, stealth mode for IPsec, and log settings
 // including max log size, allowed/blocked packet logging, and log file name.
 windows.firewall.profile {
   instanceID string
-  // Name of the profile
+  // Name of the profile (Domain, Private, or Public)
   name string
-  // Whether the firewall is enabled on this profile
+  // Whether the firewall is enabled on this profile (1 = enabled, 0 = disabled)
   enabled int
-  // Default action for inbound traffic
+  // Default action for inbound traffic (2 = allow, 4 = block)
   defaultInboundAction int
-  // Default action for outbound traffic
+  // Default action for outbound traffic (2 = allow, 4 = block)
   defaultOutboundAction int
   // Whether administrators can create firewall rules that allow unsolicited inbound traffic (if 0, such rules are ignored)
   allowInboundRules int
@@ -7788,7 +8469,7 @@ windows.firewall.profile {
   notifyOnListen int
   // Whether to use stealth mode for IPsec-protected traffic
   enableStealthModeForIPsec int
-  // Maximum size the log file can reach before being rotated
+  // Maximum size the log file can reach before being rotated, in kilobytes
   logMaxSizeKilobytes int
   // Whether to log allowed packets
   logAllowed int
@@ -7802,10 +8483,10 @@ windows.firewall.profile {
 
 // Windows Firewall rule entry
 //
-// Examine a single Windows Firewall rule: its unique `instanceID`, display
+// Single Windows Firewall rule: its unique `instanceID`, display
 // name, description, group, enabled state, traffic direction (inbound/
 // outbound), action (allow/block), edge traversal policy, and enforcement
-// status. Iterated from `windows.firewall.rules()` to audit which rules are
+// status. Iterated from `windows.firewall.rules` to audit which rules are
 // active and whether they match expected policy.
 windows.firewall.rule {
   // A string that uniquely identifies this instance within the policy store
@@ -7827,6 +8508,9 @@ windows.firewall.rule {
   // Values: inbound (1), outbound (2).
   direction int
   // Specifies the action to take on traffic that matches this rule
+  //
+  // Values: block, allow, or allow only if secure (reported as the integer
+  // action code returned by Get-NetFirewallRule).
   action int
   // Specifies how this firewall rule will handle edge traversal cases
   //
@@ -7852,9 +8536,11 @@ windows.firewall.rule {
 
 // Windows SMB (Server Message Block) server
 //
-// Examine SMB shares published by the host, active inbound client sessions,
-// and outbound connections to other SMB servers. Backed by the `Get-SmbShare`,
-// `Get-SmbSession`, and `Get-SmbConnection` PowerShell cmdlets.
+// SMB shares published by the host, active inbound client sessions,
+// and outbound connections to other SMB servers, along with the server and
+// client registry hardening configuration and whether the deprecated SMBv1
+// driver is still enabled. Backed by the `Get-SmbShare`, `Get-SmbSession`,
+// and `Get-SmbConnection` PowerShell cmdlets plus registry reads.
 windows.smb {
   // SMB shares published by this host
   shares() []windows.smb.share
@@ -8003,7 +8689,7 @@ private windows.smb.clientConfiguration {
 
 // Windows SMB share
 //
-// A single SMB share published by the host: its `name`, the local filesystem
+// Single SMB share published by the host: its `name`, the local filesystem
 // `path` it exposes, a `description`, the `scopeName` it is published under,
 // and its `shareType`. Iterated from `windows.smb.shares`.
 private windows.smb.share @defaults("name path") {
@@ -8021,7 +8707,7 @@ private windows.smb.share @defaults("name path") {
 
 // Windows SMB session
 //
-// A single inbound SMB session: the connecting client's computer name and
+// Single inbound SMB session: the connecting client's computer name and
 // user, the SMB `dialect` negotiated, and the number of files the client has
 // open. Iterated from `windows.smb.sessions`.
 private windows.smb.session @defaults("clientComputerName clientUserName") {
@@ -8037,7 +8723,7 @@ private windows.smb.session @defaults("clientComputerName clientUserName") {
 
 // Windows SMB connection
 //
-// A single outbound SMB connection from this host to an SMB server: the
+// Single outbound SMB connection from this host to an SMB server: the
 // `serverName`, `shareName`, authenticated `userName`, and negotiated
 // `dialect`. Iterated from `windows.smb.connections`.
 private windows.smb.connection @defaults("serverName shareName") {
@@ -8053,7 +8739,10 @@ private windows.smb.connection @defaults("serverName shareName") {
 
 // Windows BitLocker drive encryption
 //
-// Examine encryption, lock, and protection status across BitLocker volumes
+// BitLocker Drive Encryption state across volumes: the encryption,
+// lock, and protection status of each `volume`, plus the BitLocker Group
+// Policy (FVE) settings under `policy`. Use it to verify that OS and data
+// drives are encrypted and protected.
 windows.bitlocker {
   // Windows BitLocker volumes
   volumes() []windows.bitlocker.volume
@@ -8063,7 +8752,7 @@ windows.bitlocker {
 
 // Windows BitLocker Group Policy (FVE) settings
 //
-// Examine the BitLocker Drive Encryption Group Policy settings stored under
+// BitLocker Drive Encryption Group Policy settings stored under
 // `HKLM\SOFTWARE\Policies\Microsoft\FVE`. Global settings are exposed
 // directly; per-drive-type settings are grouped under `operatingSystemDrives`,
 // `fixedDataDrives`, and `removableDataDrives`. A field is null when the
@@ -8089,7 +8778,7 @@ windows.bitlocker.policy {
 
 // Windows BitLocker per-drive-type Group Policy (FVE) settings
 //
-// Examine the BitLocker policy values that apply to a single drive type
+// BitLocker policy values that apply to a single drive type
 // (operating system, fixed data, or removable data). Fields that the drive
 // type does not define, or that are not configured, are null. For example,
 // operating system drives have no `allowUserCert`, and only removable data
@@ -8138,11 +8827,11 @@ private windows.bitlocker.policy.driveSettings {
 
 // Windows BitLocker volume
 //
-// Examine a single BitLocker-managed volume: the `deviceID`, `driveLetter`,
+// Single BitLocker-managed volume: the `deviceID`, `driveLetter`,
 // `conversionStatus` (encryption/decryption progress), `encryptionMethod`
 // (algorithm and key size), `lockStatus` (0 = accessible, 1 = locked),
 // `persistentVolumeID`, `protectionStatus` (0 = off, 1 = on, 2 = unknown),
-// and BitLocker `version`. Iterated from `windows.bitlocker.volumes()`.
+// and BitLocker `version`. Iterated from `windows.bitlocker.volumes`.
 windows.bitlocker.volume {
   // Unique identifier for the volume
   deviceID string
@@ -8171,32 +8860,44 @@ windows.bitlocker.volume {
 
 // Windows registered security products
 //
-// Examine antivirus, anti-spyware, and firewall providers from Security Center
+// Antivirus, anti-spyware, and firewall providers registered with the
+// Windows Security Center. Use `products` to verify that an up-to-date,
+// enabled security product is present, for example
+// `windows.security.products.where(type == "antivirus").any(productState == "on")`.
 windows.security {
   products() []windows.security.product
 }
 
-// Private Windows security product
+// Windows security product registered with Security Center
+//
+// A single antivirus, anti-spyware, or firewall product reported by the
+// Windows Security Center, including its human-readable name, GUID, and the
+// decoded product and signature state. Iterated from
+// `windows.security.products`.
 private windows.security.product {
-  // Type of product
+  // Product category: antivirus, antispyware, or firewall
   type string
-  // Product GUID
+  // Product GUID assigned by Security Center
   guid string
-  // Product name
+  // Product name (e.g. "Windows Defender")
   name string
-  // Product state
+  // Raw product state bitfield reported by Security Center
   state int
-  // Product state
+  // Decoded product state (e.g. on, off, snoozed, expired)
   productState string
-  // Signature state
+  // Decoded signature/definition state (e.g. up-to-date or out-of-date)
   signatureState string
-  // Time stamp
+  // Time the product state was last reported
   timestamp time
 }
 
 // Windows Security Center health
 //
-// Examine firewall, antivirus, anti-spyware, Auto-Update, UAC, and IE settings
+// Aggregate protection status reported by the Windows Security Center:
+// firewall, antivirus, anti-spyware, Automatic Updates, User Account
+// Control (UAC), Internet Explorer security settings, and the Security
+// Center service itself. Each control is exposed as a dict so audits can
+// assert on whether it is present, enabled, and up to date.
 windows.security.health {
   // Windows Firewall status and configuration
   firewall dict
@@ -8216,19 +8917,19 @@ windows.security.health {
 
 // Microsoft Defender Antivirus
 //
-// Examine the complete runtime status and configuration of Microsoft Defender
-// Antivirus so policies can assert on every Defender security control. The
-// `status` accessor exposes the live engine, signature, and protection state
-// reported by `Get-MpComputerStatus` (real-time protection, behavior
-// monitoring, network inspection, tamper protection, scan ages, and signature
-// freshness). The `preferences` accessor exposes the configurable policy
-// reported by `Get-MpPreference`, grouped into scan, real-time, cloud-delivered
-// protection, signature-update, threat-action, controlled-folder-access,
-// network-protection, and remediation settings, plus exclusions and Attack
-// Surface Reduction rules. The `threats` and `threatDetections` accessors
-// expose the recorded threat history. On systems without Defender (for example
-// servers running a third-party antivirus) the accessors resolve to null
-// rather than failing the query.
+// Complete runtime status and configuration of Microsoft Defender
+// Antivirus, so policies can assert on every Defender security control.
+// The `status` field exposes the live engine, signature, and protection
+// state reported by Get-MpComputerStatus (real-time protection, behavior
+// monitoring, network inspection, tamper protection, scan ages, and
+// signature freshness). The `preferences` field exposes the configurable
+// policy reported by Get-MpPreference, grouped into scan, real-time,
+// cloud-delivered protection, signature-update, threat-action,
+// controlled-folder-access, network-protection, and remediation settings,
+// plus exclusions and Attack Surface Reduction rules. The `threats` and
+// `threatDetections` fields expose the recorded threat history. On systems
+// without Defender (for example servers running a third-party antivirus)
+// these fields resolve to null rather than failing the query.
 windows.defender @defaults("enabled") {
   // Whether the Defender antimalware service and real-time antivirus and antispyware protection are all active
   enabled() bool
@@ -8244,13 +8945,14 @@ windows.defender @defaults("enabled") {
 
 // Microsoft Defender Antivirus runtime status
 //
-// Examine the live state reported by `Get-MpComputerStatus`: whether the
-// antimalware service and each protection component (real-time, behavior
-// monitoring, IOAV, on-access, network inspection) are enabled, the engine
-// and signature versions and their ages, the most recent quick and full scan
-// times and whether they are overdue, tamper-protection state and source, and
-// whether a reboot or signature update is pending. Reached through
-// `windows.defender.status`.
+// Live state reported by Get-MpComputerStatus: whether the antimalware
+// service and each protection component (real-time, behavior monitoring,
+// IOAV, on-access, network inspection) are enabled, the engine and
+// signature versions and their ages, the most recent quick and full scan
+// times and whether they are overdue, tamper-protection state and source,
+// and whether a reboot or signature update is pending. This is the "is
+// Defender actually protecting the host right now" view, complementing the
+// policy in windows.defender.preferences.
 windows.defender.status @defaults("antivirusEnabled realTimeProtectionEnabled isTamperProtected") {
   // Antimalware engine version
   amEngineVersion string
@@ -8356,13 +9058,14 @@ windows.defender.status @defaults("antivirusEnabled realTimeProtectionEnabled is
 
 // Microsoft Defender Antivirus preferences
 //
-// Examine the configurable Defender policy reported by `Get-MpPreference`,
-// grouped into typed accessors so audits can assert on individual controls:
-// `scan` (schedule and scan behavior), `realTimeProtection`, `cloudProtection`
-// (MAPS / cloud-delivered protection), `signatureUpdates`, `threatActions`
-// (per-severity default actions), `controlledFolderAccess`, `networkProtection`,
-// `remediation`, `exclusions`, and `attackSurfaceReductionRules`. Reached
-// through `windows.defender.preferences`.
+// Configurable Defender policy reported by Get-MpPreference, grouped so
+// audits can assert on individual controls: `scan` (schedule and scan
+// behavior), `realTimeProtection`, `cloudProtection` (MAPS /
+// cloud-delivered protection), `signatureUpdates`, `threatActions`
+// (per-severity default actions), `controlledFolderAccess`,
+// `networkProtection`, `remediation`, `exclusions`, and
+// `attackSurfaceReductionRules`. This is the intended policy; pair it with
+// windows.defender.status to confirm the policy is actually in effect.
 windows.defender.preferences @defaults("puaProtection") {
   // Scan schedule and scan-behavior settings
   scan() windows.defender.scanSettings
@@ -8404,10 +9107,11 @@ windows.defender.preferences @defaults("puaProtection") {
 
 // Microsoft Defender scan settings
 //
-// Examine the scheduled-scan and scan-behavior preferences: the schedule day
-// and time, the quick-scan time, CPU load factor, and the toggles that disable
-// scanning of archives, email, removable drives, mapped network drives, and
-// network files. Reached through `windows.defender.preferences.scan`.
+// Scheduled-scan and scan-behavior preferences: the schedule day and time,
+// the quick-scan time, CPU load factor, and the toggles that disable
+// scanning of archives, email, removable drives, mapped network drives,
+// and network files. Useful for auditing whether periodic scans are
+// scheduled and whether scanning coverage has been narrowed.
 windows.defender.scanSettings @defaults("scanParameters scanScheduleDay") {
   // Default scan type (1 = quick scan, 2 = full scan)
   scanParameters int
@@ -8453,11 +9157,11 @@ windows.defender.scanSettings @defaults("scanParameters scanScheduleDay") {
 
 // Microsoft Defender real-time protection settings
 //
-// Examine the real-time protection preferences: the master real-time
-// monitoring toggle, behavior monitoring, downloaded-file (IOAV) scanning,
-// script scanning, on-access protection, the intrusion-prevention system, the
-// scan direction, and file-hash computation. Reached through
-// `windows.defender.preferences.realTimeProtection`.
+// Real-time protection preferences: the master real-time monitoring
+// toggle, behavior monitoring, downloaded-file (IOAV) scanning, script
+// scanning, on-access protection, the intrusion-prevention system, the
+// scan direction, and file-hash computation. The toggles are phrased as
+// "disable" flags, so false generally means the protection is on.
 windows.defender.realTimeSettings @defaults("disableRealtimeMonitoring") {
   // Whether real-time monitoring is disabled
   disableRealtimeMonitoring bool
@@ -8479,10 +9183,11 @@ windows.defender.realTimeSettings @defaults("disableRealtimeMonitoring") {
 
 // Microsoft Defender cloud-delivered protection settings
 //
-// Examine the Microsoft Active Protection Service (MAPS) and cloud-delivered
-// protection preferences: the reporting membership level, the sample-submission
-// consent, the cloud block level and extended timeout, and the block-at-first-
-// seen toggle. Reached through `windows.defender.preferences.cloudProtection`.
+// Microsoft Active Protection Service (MAPS) and cloud-delivered
+// protection preferences: the reporting membership level, the
+// sample-submission consent, the cloud block level and extended timeout,
+// and the block-at-first-seen toggle. Together these control how much
+// Defender relies on the cloud for rapid detection of new threats.
 windows.defender.cloudSettings @defaults("mapsReporting cloudBlockLevel") {
   // MAPS reporting membership level
   //
@@ -8505,10 +9210,11 @@ windows.defender.cloudSettings @defaults("mapsReporting cloudBlockLevel") {
 
 // Microsoft Defender signature and platform update settings
 //
-// Examine the definition, engine, and platform update preferences: the update
-// schedule and interval, the catch-up interval, the fallback source order,
-// file-share sources, and the release channels for definitions, engine, and
-// platform. Reached through `windows.defender.preferences.signatureUpdates`.
+// Definition, engine, and platform update preferences: the update schedule
+// and interval, the catch-up interval, the fallback source order,
+// file-share sources, and the release channels for definitions, engine,
+// and platform. Useful for confirming signatures update frequently enough
+// and from trusted sources.
 windows.defender.signatureSettings @defaults("signatureUpdateInterval") {
   // Day of the week scheduled signature updates run
   signatureScheduleDay int
@@ -8540,9 +9246,10 @@ windows.defender.signatureSettings @defaults("signatureUpdateInterval") {
 
 // Microsoft Defender default threat actions
 //
-// Examine the default remediation action applied to threats of each severity
-// (severe, high, moderate, low, and unknown) plus any per-threat-ID action
-// overrides. Reached through `windows.defender.preferences.threatActions`.
+// Default remediation action applied to threats of each severity (severe,
+// high, moderate, low, and unknown) plus any per-threat-ID action
+// overrides. Audits use this to confirm that severe and high threats are
+// quarantined or removed rather than allowed or left to user choice.
 windows.defender.threatActionSettings @defaults("severeThreatDefaultAction highThreatDefaultAction") {
   // Default action for severe-severity threats
   //
@@ -8563,9 +9270,10 @@ windows.defender.threatActionSettings @defaults("severeThreatDefaultAction highT
 
 // Microsoft Defender per-threat-ID action override
 //
-// Examine a single override that pins the remediation action for a specific
-// threat ID, pairing the `threatId` with the configured `action`. Iterated
-// from `windows.defender.preferences.threatActions.idActions`.
+// Single override that pins the remediation action for a specific threat
+// ID, pairing the `threatId` with the configured `action`. Overrides let
+// an administrator handle one known threat differently from its severity
+// default.
 windows.defender.threatIdAction @defaults("threatId action") {
   // Threat ID the override applies to
   threatId string
@@ -8578,10 +9286,10 @@ windows.defender.threatIdAction @defaults("threatId action") {
 
 // Microsoft Defender controlled folder access settings
 //
-// Examine the controlled-folder-access (ransomware protection) configuration:
-// whether it is enabled or in audit mode, the applications allowed to write to
-// protected folders, and the list of additional protected folders. Reached
-// through `windows.defender.preferences.controlledFolderAccess`.
+// Controlled-folder-access (ransomware protection) configuration: whether
+// it is enabled or in audit mode, the applications allowed to write to
+// protected folders, and the list of additional protected folders beyond
+// the system defaults.
 windows.defender.controlledFolderAccess @defaults("enabled") {
   // Controlled folder access mode
   //
@@ -8596,10 +9304,10 @@ windows.defender.controlledFolderAccess @defaults("enabled") {
 
 // Microsoft Defender network protection settings
 //
-// Examine the network-protection configuration: the enforcement mode and the
-// toggles that extend protection to Windows Server, down-level clients, and
-// datagram processing, plus DNS sinkhole enforcement. Reached through
-// `windows.defender.preferences.networkProtection`.
+// Network-protection configuration: the enforcement mode and the toggles
+// that extend protection to Windows Server, down-level clients, and
+// datagram processing, plus DNS sinkhole enforcement. Network protection
+// blocks outbound connections to malicious domains and IP addresses.
 windows.defender.networkProtectionSettings @defaults("enableNetworkProtection") {
   // Network protection enforcement mode
   //
@@ -8617,12 +9325,11 @@ windows.defender.networkProtectionSettings @defaults("enableNetworkProtection") 
 
 // Microsoft Defender behavioral network block settings
 //
-// Examine the behavioral network protection preferences that block attacks
-// observed from the network: brute-force protection (against password-guessing
+// Behavioral network protection preferences that block attacks observed
+// from the network: brute-force protection (against password-guessing
 // attacks) and remote-encryption protection (against remote ransomware
-// encryption). Each exposes its configured state, aggressiveness, and maximum
-// block time. Reached through
-// `windows.defender.preferences.behavioralNetworkBlocks`.
+// encryption). Each exposes its configured state, aggressiveness, and
+// maximum block time.
 windows.defender.behavioralNetworkBlockSettings @defaults("bruteForceProtectionConfiguredState remoteEncryptionProtectionConfiguredState") {
   // Brute-force protection configured state
   //
@@ -8648,11 +9355,10 @@ windows.defender.behavioralNetworkBlockSettings @defaults("bruteForceProtectionC
 
 // Microsoft Defender local setting overrides
 //
-// Examine whether a locally configured preference is allowed to override the
-// corresponding Group Policy setting. When an override is disabled (false) the
-// policy value is enforced and users cannot change it locally; CIS benchmarks
-// generally require these overrides to be disabled. Reached through
-// `windows.defender.preferences.localSettingOverrides`.
+// Whether a locally configured preference is allowed to override the
+// corresponding Group Policy setting. When an override is disabled (false)
+// the policy value is enforced and users cannot change it locally; CIS
+// benchmarks generally require these overrides to be disabled.
 windows.defender.localSettingOverrides @defaults("spynetReporting realtimeMonitoring") {
   // Whether a local setting may override MAPS (SpyNet) reporting
   spynetReporting bool
@@ -8676,10 +9382,9 @@ windows.defender.localSettingOverrides @defaults("spynetReporting realtimeMonito
 
 // Microsoft Defender remediation settings
 //
-// Examine the threat-remediation preferences: the scheduled remediation day
-// and time, how long quarantined items are retained, and whether system
-// restore points are created before remediation. Reached through
-// `windows.defender.preferences.remediation`.
+// Threat-remediation preferences: the scheduled remediation day and time,
+// how long quarantined items are retained before purging, and whether
+// system restore points are created before remediation.
 windows.defender.remediationSettings @defaults("quarantinePurgeItemsAfterDelay") {
   // Day of the week scheduled remediation runs
   remediationScheduleDay int
@@ -8693,10 +9398,11 @@ windows.defender.remediationSettings @defaults("quarantinePurgeItemsAfterDelay")
 
 // Microsoft Defender scan exclusions
 //
-// Examine every configured scan exclusion: file and folder `paths`, file
-// `extensions`, `processes`, and `ipAddresses`. Empty lists mean no exclusions
-// of that kind are configured. Reached through
-// `windows.defender.preferences.exclusions`.
+// Every configured scan exclusion: file and folder `paths`, file
+// `extensions`, `processes`, and `ipAddresses`. Empty lists mean no
+// exclusions of that kind are configured. Exclusions are a common
+// misconfiguration and malware-persistence vector, so audits often verify
+// that these lists are empty or tightly scoped.
 windows.defender.exclusions @defaults("paths extensions processes") {
   // Excluded file and folder paths
   paths []string
@@ -8710,11 +9416,10 @@ windows.defender.exclusions @defaults("paths extensions processes") {
 
 // Microsoft Defender Attack Surface Reduction rule
 //
-// Examine a single Attack Surface Reduction (ASR) rule: its `id` (the rule
-// GUID), the friendly `name` when the GUID is recognized, and the configured
-// `action`. The `id` selects the rule — for example
+// Single Attack Surface Reduction (ASR) rule: its `id` (the rule GUID),
+// the friendly `name` when the GUID is recognized, and the configured
+// `action`. The `id` selects the rule, for example
 // `windows.defender.preferences.attackSurfaceReductionRules.where(id == "...")`.
-// Iterated from `windows.defender.preferences.attackSurfaceReductionRules`.
 windows.defender.asrRule @defaults("id name action") {
   // Attack Surface Reduction rule GUID
   id string
@@ -8729,10 +9434,10 @@ windows.defender.asrRule @defaults("id name action") {
 
 // Microsoft Defender recorded threat
 //
-// Examine a single threat recorded in the Defender threat history: its
-// `threatId`, `name`, `severityID`, `categoryID`, whether it `isActive` and
-// whether it executed, and the affected `resources`. Iterated from
-// `windows.defender.threats`.
+// Single threat recorded in the Defender threat history: its `threatId`,
+// `name`, `severityID`, `categoryID`, whether it `isActive` and whether it
+// executed, and the affected `resources`. Useful for reviewing what
+// Defender has detected on the host over time.
 windows.defender.threat @defaults("name severityID isActive") {
   // Numeric threat identifier
   threatId int
@@ -8754,11 +9459,10 @@ windows.defender.threat @defaults("name severityID isActive") {
 
 // Microsoft Defender threat detection
 //
-// Examine a single detection event recorded by Defender: the `detectionId`,
-// the associated `threatId`, the `processName` and `domainUser` involved, the
-// detection source and status, the action taken and whether it succeeded, and
-// the detection and remediation timestamps. Iterated from
-// `windows.defender.threatDetections`.
+// Single detection event recorded by Defender: the `detectionId`, the
+// associated `threatId`, the `processName` and `domainUser` involved, the
+// detection source and status, the action taken and whether it succeeded,
+// and the detection and remediation timestamps.
 windows.defender.threatDetection @defaults("threatId processName actionSuccess") {
   // Unique detection identifier
   detectionId string
@@ -8790,7 +9494,10 @@ windows.defender.threatDetection @defaults("threatId processName actionSuccess")
 
 // Cloud-asset metadata
 //
-// Examine the cloud provider and exposed instance metadata
+// Cloud provider hosting the asset and the instance metadata it exposes.
+// The `provider` field names the platform (aws, azure, gcp), and
+// `instance` reaches the per-instance metadata read from the cloud's
+// metadata service.
 cloud @defaults("provider") {
   // Cloud provider (e.g. aws, azure, gcp)
   provider() string
@@ -8799,6 +9506,10 @@ cloud @defaults("provider") {
 }
 
 // Cloud instance metadata
+//
+// Per-instance identity and networking read from the cloud provider's
+// instance metadata service: the public and private hostnames, the public
+// and private IPv4 addresses, and the raw metadata document.
 private cloudInstance @defaults("publicHostname privateHostname") {
   // Cloud instance public hostname
   publicHostname() string
@@ -8814,7 +9525,9 @@ private cloudInstance @defaults("publicHostname privateHostname") {
 
 // IP address (v4 or v6) with networking details
 //
-// Examine the address itself plus subnet, CIDR, broadcast, and gateway
+// IP address plus its network context: the address itself, the subnet it
+// belongs to, the address in CIDR notation, the broadcast address, and the
+// gateway. Works for both IPv4 and IPv6.
 ipAddress @defaults("ip") {
   // Unique number that identifies a device on a network (e.g. 172.31.24.71 or 2001:0:2851:782c:869:1f7d:a331:f3e1)
   ip ip
@@ -8830,7 +9543,10 @@ ipAddress @defaults("ip") {
 
 // Network configuration of this system
 //
-// Examine interfaces, routes, and detected IPv4 / IPv6 addresses
+// Host networking view: the network interfaces and their addresses, the
+// routing table (including default routes), the IPv4 and IPv6 addresses
+// detected across interfaces, the primary addresses chosen by the default
+// route, and the ARP / NDP neighbor cache.
 network {
   // Network interfaces
   interfaces() []networkInterface
@@ -8856,12 +9572,12 @@ network {
 
 // Network neighbor (ARP / NDP cache entry)
 //
-// A single entry from the system's ARP (IPv4) or NDP (IPv6) neighbor cache:
+// Single entry from the system's ARP (IPv4) or NDP (IPv6) neighbor cache:
 // the neighbor's `ip`, its `mac` (link-layer address, empty for incomplete
 // entries), the `interface` it was observed on, and the cache `state`
-// (e.g. reachable, stale, permanent, incomplete). Backed by `ip -j neigh` /
-// `/proc/net/arp` on Linux, `arp -an` on macOS, and `Get-NetNeighbor` on
-// Windows. Iterated from `network.neighbors`.
+// (e.g. reachable, stale, permanent, incomplete). Backed by `ip -j neigh`
+// or `/proc/net/arp` on Linux, `arp -an` on macOS, and Get-NetNeighbor on
+// Windows.
 private networkNeighbor @defaults("ip mac interface state") {
   // Neighbor IP address (v4 or v6)
   ip ip
@@ -8874,6 +9590,11 @@ private networkNeighbor @defaults("ip mac interface state") {
 }
 
 // Detailed information of a network interface
+//
+// Single network interface and its properties: the `name`, the hardware
+// `mac` address and its `vendor`, the assigned IPv4 and IPv6 addresses, the
+// `mtu`, the interface `flags`, whether it is `active`, and whether it is a
+// `virtual` interface.
 private networkInterface @defaults("name mac active") {
   // Name of the network interface
   name string
@@ -8893,7 +9614,10 @@ private networkInterface @defaults("name mac active") {
   virtual bool
 }
 
-// Collection of routing table entries on the system.
+// Collection of routing table entries on the system
+//
+// All routes in the system routing table, with `defaults` returning just
+// the default routes (those matching any destination).
 private networkRoutes {
   []networkRoute
   // Default routes found on the machine
@@ -8901,6 +9625,10 @@ private networkRoutes {
 }
 
 // Network route information
+//
+// Single routing-table entry: the `destination` network, the `gateway` it
+// forwards through, the route `flags` (e.g. 'UG' for up/gateway), and the
+// `iface` the route applies to.
 private networkRoute @defaults("destination flags"){
   // Destination network or destination subnet for this route
   destination string
@@ -8914,7 +9642,12 @@ private networkRoute @defaults("destination flags"){
 
 // Chromium-family browsers (Chrome, Brave, Edge variants)
 //
-// Examine installed extensions and their content scripts across users and profiles
+// Installed browser extensions across all users and profiles for
+// Chromium-based browsers. The `extensions` field lists every extension
+// with its manifest metadata and permissions, and
+// `extensionContentScripts` lists the content scripts those extensions
+// inject into web pages. Useful for auditing risky permissions and
+// unexpected or side-loaded extensions.
 chrome {
   // All installed Chrome extensions across all profiles and users
   extensions() []chrome.extension
@@ -8923,6 +9656,13 @@ chrome {
 }
 
 // Chrome browser extension
+//
+// Single installed Chromium-family browser extension and its manifest
+// metadata: the `identifier`, `name`, `version`, requested `permissions`
+// and `optionalPermissions`, on-disk `path`, owning `profile` and
+// `browser`, whether it came from the Web Store, whether it is `enabled`,
+// and the declared content scripts. Audits use the permissions and
+// `fromWebstore` fields to flag over-privileged or unvetted extensions.
 private chrome.extension @defaults("name version identifier browser") {
   // Unique extension identifier (32-character string)
   identifier string
@@ -8973,6 +9713,13 @@ private chrome.extension @defaults("name version identifier browser") {
 }
 
 // Chrome extension content script
+//
+// Content script declared by a Chrome-family extension: a JavaScript
+// file the extension injects into pages whose URLs match a pattern. Each
+// record ties the injected `script` to the `match` pattern that triggers
+// it and to the owning extension (`identifier`, `version`) and user
+// (`uid`), so you can audit which extensions run code against which sites
+// and flag broad patterns such as `<all_urls>`.
 private chrome.extensionContentScript @defaults("script match") {
   // Parent extension identifier
   identifier string
@@ -8984,7 +9731,7 @@ private chrome.extensionContentScript @defaults("script match") {
   uid int
   // JavaScript content script filename
   script string
-  // URL match pattern where the script executes
+  // URL match pattern where the script executes (e.g., "https://*/*", "<all_urls>")
   match string
   // Full path to the Chrome profile directory
   profilePath string
@@ -8994,13 +9741,26 @@ private chrome.extensionContentScript @defaults("script match") {
 
 // Firefox-family browsers
 //
-// Examine installed addons across all users and profiles
+// Installed browser addons discovered across every user account and
+// profile for Firefox and its derivatives (Firefox Developer Edition,
+// Nightly, LibreWolf, Waterfox, Floorp, Zen, Tor Browser, and Mullvad
+// Browser). Iterate `addons` to inventory extensions and themes, spot
+// disabled or side-loaded addons, and review the API permissions and
+// host origins each addon requests. Mozilla-shipped system addons,
+// locales, and dictionaries are filtered out.
 firefox {
   // All installed Firefox addons across all profiles and users
   addons() []firefox.addon
 }
 
 // Firefox browser addon
+//
+// Single addon installed in a Firefox-family profile, parsed from the
+// profile's extensions.json. Beyond `name`, `version`, and `type`, the
+// record exposes enablement state (`active`, `userDisabled`, `disabled`),
+// where it came from (`sourceUri`, `location`), whether auto-update is on
+// (`autoupdate`), and the combined API `permissions` and host origins it
+// was granted, so you can audit addon trust and overreach per user.
 private firefox.addon @defaults("name version active browser") {
   // Unique addon identifier (e.g., "{uuid}" or "addon@example.com")
   identifier string
@@ -9041,6 +9801,10 @@ private firefox.addon @defaults("name version active browser") {
   // Install location (e.g., "app-profile", "app-system-defaults", "app-builtin")
   location string
   // Combined API permissions and host origins
+  //
+  // Merged list of the addon's requested WebExtension API permissions
+  // (e.g. "tabs", "webRequest") and host origin patterns (e.g.
+  // "https://*/*"). Broad host access is a useful audit signal.
   permissions []string
   // UID of the user who owns this addon
   uid int
@@ -9048,13 +9812,22 @@ private firefox.addon @defaults("name version active browser") {
 
 // USB device inventory (experimental)
 //
-// Examine attached USB devices with vendor, product, class, and serial
+// USB devices attached to the host, each with its vendor and product IDs,
+// manufacturer, serial number, device class, and connection speed.
+// The `devices` list inventories connected peripherals so you can flag
+// removable storage or unexpected hardware.
 usb @maturity("experimental") {
   // List of USB devices
   devices() []usb.device
 }
 
 // Experimental: USB device
+//
+// Single attached USB device. `vendorId` and `productId` identify the
+// hardware model, `class`/`className` give its function (e.g. mass
+// storage, HID, hub), `serial` uniquely identifies the unit where the
+// device reports one, and `isRemovable` distinguishes hot-pluggable
+// peripherals from fixed internal devices.
 private usb.device @defaults("manufacturer name") @maturity("experimental") {
   // USB device vendor id
   vendorId string
@@ -9070,7 +9843,7 @@ private usb.device @defaults("manufacturer name") @maturity("experimental") {
   version string
   // USB speed
   speed string
-  // USB device class
+  // USB device class code (e.g., "08" for mass storage, "03" for HID)
   class string
   // USB device class name
   className string
@@ -9084,7 +9857,13 @@ private usb.device @defaults("manufacturer name") @maturity("experimental") {
 
 // Crontab schedule on the system
 //
-// Examine cron entries from system, user, and /etc/cron.* sources
+// Scheduled cron jobs collected from every source on the host: the system
+// crontab (/etc/crontab), drop-in files under /etc/cron.d, and per-user
+// crontabs (/var/spool/cron, /var/spool/cron/crontabs, /usr/lib/cron/tabs).
+// The `entries` list shows what runs on a schedule, as which `user`, and
+// with what `command`. Use `entries.where(user == "root")` to focus on
+// privileged jobs. `files` lists the source files the entries were parsed
+// from.
 crontab {
   // All cron entries from system and user crontabs
   entries() []crontab.entry
@@ -9093,6 +9872,13 @@ crontab {
 }
 
 // Individual crontab entry
+//
+// Single scheduled job parsed from a crontab source. The five schedule
+// fields (`minute`, `hour`, `dayOfMonth`, `month`, `dayOfWeek`) hold the
+// raw cron expressions, `user` is the account the job runs as (taken from
+// the entry for system crontabs, or from the filename for per-user
+// crontabs), and `command` is the line executed. `file` and `lineNumber`
+// locate the entry in its source.
 private crontab.entry @defaults("user command") {
   // Line number in the source file
   lineNumber int
@@ -9116,7 +9902,11 @@ private crontab.entry @defaults("user command") {
 
 // Visual Studio Code (and forks)
 //
-// Examine installed extensions across VS Code, Cursor, Windsurf, and similar editors
+// Installed editor extensions discovered across all users for VS Code and
+// compatible forks (Cursor, Windsurf, and similar). Iterate `extensions`
+// to inventory what is installed per editor, review publishers and
+// versions, and identify untrusted or outdated extensions. `paths` lists
+// the extension directories that were searched.
 vscode {
   // All installed VS Code extensions across all users
   extensions() []vscode.extension
@@ -9125,6 +9915,11 @@ vscode {
 }
 
 // Visual Studio Code extension
+//
+// Single installed editor extension, read from its package.json. Records
+// the `identifier` (publisher.name), `version`, `publisher`, and the
+// `editor` it belongs to, plus a Package URL (`purl`) for correlating the
+// extension against vulnerability and advisory feeds.
 private vscode.extension @defaults("editor name version") {
   // Unique extension identifier (publisher.name format)
   identifier string
@@ -9156,7 +9951,12 @@ private vscode.extension @defaults("editor name version") {
 
 // logrotate configuration
 //
-// Examine global directives and per-log rotation entries across logrotate.d
+// Log rotation configuration parsed from the main logrotate.conf and the
+// fragments under logrotate.d. `globalConfig` holds the directives that
+// apply outside any log block, `entries` holds the per-log-path rotation
+// rules, and `files` lists the configuration files read. Audit rotation
+// frequency, retention counts, and compression to confirm logs are kept
+// long enough and pruned safely.
 logrotate {
   // List of configuration files (main + logrotate.d fragments)
   files() []file
@@ -9167,6 +9967,11 @@ logrotate {
 }
 
 // Logrotate configuration entry for a specific log path
+//
+// Rotation rule for one log path or glob. `path` is the log the block
+// applies to and `config` holds every directive inside the block as
+// key-value pairs (e.g. "rotate", "daily", "compress", "maxage"). `file`
+// and `lineNumber` locate the block in its source configuration file.
 private logrotate.entry @defaults("path") {
   // Configuration file where this entry is defined
   file file
@@ -9180,7 +9985,7 @@ private logrotate.entry @defaults("path") {
 
 // Linux Logical Volume Manager
 //
-// Examine LVM block-device storage on Linux: physical volumes initialized
+// LVM block-device storage on Linux: physical volumes initialized
 // for LVM, volume groups that aggregate them, and the logical volumes
 // carved out of those groups. Iterate `physicalVolumes`, `volumeGroups`,
 // and `logicalVolumes` to audit LVM layout, free capacity, thin-pool
@@ -9196,10 +10001,10 @@ lvm @defaults("volumeGroups") {
 
 // LVM physical volume
 //
-// Examine a single block device initialized as an LVM physical volume:
+// Single block device initialized as an LVM physical volume:
 // device path (`name`), `uuid`, the volume group it belongs to
 // (`volumeGroupName`, empty if unassigned), on-disk `format`, attribute
-// flags, and total/free byte counts. Iterated from `lvm.physicalVolumes`.
+// flags, and total/free byte counts.
 private lvm.physicalVolume @defaults("name volumeGroupName sizeBytes") {
   // Physical volume device path (e.g., /dev/sda1)
   name string
@@ -9222,10 +10027,10 @@ private lvm.physicalVolume @defaults("name volumeGroupName sizeBytes") {
 
 // LVM volume group
 //
-// Examine a single LVM volume group: `name`, `uuid`, attribute flags,
+// Single LVM volume group: `name`, `uuid`, attribute flags,
 // total and free byte counts, and the counts of physical volumes,
-// logical volumes, and snapshots it contains. Iterated from
-// `lvm.volumeGroups` to audit capacity and group-level policy.
+// logical volumes, and snapshots it contains. Useful for auditing
+// capacity headroom and group-level policy.
 private lvm.volumeGroup @defaults("name sizeBytes freeBytes") {
   // Volume group name
   name string
@@ -9251,11 +10056,11 @@ private lvm.volumeGroup @defaults("name sizeBytes freeBytes") {
 
 // LVM logical volume
 //
-// Examine a single LVM logical volume: `name`, full device `path`,
+// Single LVM logical volume: `name`, full device `path`,
 // `uuid`, parent volume group (`volumeGroupName`), attribute flags,
 // size in bytes, snapshot `origin`, and thin-pool data usage. For
 // thin volumes, `poolName` is set; for snapshots, `origin` is the
-// source LV name. Iterated from `lvm.logicalVolumes`.
+// source LV name.
 private lvm.logicalVolume @defaults("name volumeGroupName sizeBytes") {
   // Logical volume name
   name string
@@ -9283,13 +10088,23 @@ private lvm.logicalVolume @defaults("name volumeGroupName sizeBytes") {
 
 // Linux software RAID arrays (mdadm)
 //
-// Examine arrays with their RAID level, state, member devices, and resync progress
+// Software RAID arrays managed by mdadm, each with its RAID level, health
+// state, device counts, and resync progress. Iterate `arrays` to audit
+// redundancy and spot degraded or rebuilding arrays. Use
+// `arrays.where(state == "degraded")` to find arrays that have lost a
+// member.
 mdadm @defaults("arrays") {
   // List of all discovered RAID arrays
   arrays() []mdadm.array
 }
 
 // Linux software RAID array
+//
+// Single mdadm array. `level` is the RAID level, `state` is its health,
+// and the device counts (`activeDevices`, `workingDevices`,
+// `failedDevices`, `spareDevices`) together with `resyncProgress` reveal
+// whether the array is healthy, degraded, or rebuilding. `devices` lists
+// the member block devices.
 private mdadm.array @defaults("name level state") {
   // Device name (e.g., /dev/md0)
   name string
@@ -9316,6 +10131,10 @@ private mdadm.array @defaults("name level state") {
 }
 
 // Member device in a software RAID array
+//
+// Single member of an mdadm array. `name` is the block device path,
+// `role` is its slot number in the array layout, and `state` reports its
+// condition (e.g. "active sync", "spare", "faulty").
 private mdadm.device @defaults("name state") {
   // Device path (e.g., /dev/sda1)
   name string
@@ -9327,7 +10146,11 @@ private mdadm.device @defaults("name state") {
 
 // ZFS storage pools and datasets
 //
-// Examine pool health and capacity, vdev topology, and dataset properties
+// ZFS storage on the host: the installed `version`, the storage `pools`
+// with their health and capacity, and every `dataset` (filesystems,
+// volumes, snapshots, and bookmarks). Iterate to audit pool health, free
+// capacity, vdev topology, and dataset properties such as compression and
+// encryption.
 zfs @defaults("pools") {
   // ZFS version string
   version() string
@@ -9339,12 +10162,12 @@ zfs @defaults("pools") {
 
 // ZFS storage pool
 //
-// Examine a single ZFS storage pool: `name`, `guid`, health status,
+// Single ZFS storage pool: `name`, `guid`, health status,
 // total/allocated/free bytes, fragmentation percentage, space utilization,
 // deduplication ratio, read-only flag, auto-expand/replace/trim settings,
-// the top-level `vdevs()` topology, and the full `properties()` map.
+// the top-level `vdevs` topology, and the full `properties` map.
 // Initialize by name (e.g., `zfs.pool(name: "tank")`) or iterate from
-// `zfs.pools()`.
+// `zfs.pools`.
 zfs.pool @defaults("name health sizeBytes") {
   init(name string)
   // Pool name
@@ -9375,17 +10198,17 @@ zfs.pool @defaults("name health sizeBytes") {
   autotrim bool
   // Top-level virtual device groups (mirrors, raidz, etc.)
   vdevs() []zfs.pool.vdev
-  // All pool properties (lazy-loaded via zpool get all)
+  // All pool properties reported by "zpool get all"
   properties() map[string]string
 }
 
 // ZFS virtual device (vdev) in a pool's topology
 //
-// Examine a single vdev within a pool: its `name` (e.g., "raidz2-0",
+// Single vdev within a pool: its `name` (e.g., "raidz2-0",
 // "mirror-0"), `type`, `state`, device `path` (for leaf vdevs),
 // read/write/checksum error counts, slow I/O count, number of child
-// devices, and the nested `devices` list. Iterated from
-// `zfs.pool.vdevs()`.
+// devices, and the nested `devices` list. Nonzero error counts or a
+// non-ONLINE `state` indicate a failing device.
 zfs.pool.vdev @defaults("name type state numDevices") {
   // Vdev name (e.g., "raidz2-0", "mirror-0", "sda")
   name string
@@ -9411,12 +10234,12 @@ zfs.pool.vdev @defaults("name type state numDevices") {
 
 // ZFS dataset (filesystem, volume, snapshot, or bookmark)
 //
-// Examine a single ZFS dataset: full `name`, `type` (filesystem, volume,
+// Single ZFS dataset: full `name`, `type` (filesystem, volume,
 // snapshot, bookmark), used/available/referenced bytes, `mountpoint`,
 // compression algorithm and ratio, `mounted` flag, record size, quota,
 // reservation, `origin` snapshot for clones, creation time, encryption
-// algorithm, full `properties()` map, and `snapshots()` list. Initialize
-// by name or iterate from `zfs.datasets()`.
+// algorithm, full `properties` map, and `snapshots` list. Initialize
+// by name or iterate from `zfs.datasets`.
 zfs.dataset @defaults("name type usedBytes") {
   init(name string)
   // Full dataset name (pool/path or pool/path@snap)
@@ -9449,7 +10272,7 @@ zfs.dataset @defaults("name type usedBytes") {
   creation time
   // Encryption algorithm (off, aes-256-gcm, etc.)
   encryption string
-  // All dataset properties (lazy-loaded via zfs get all)
+  // All dataset properties reported by "zfs get all"
   properties() map[string]string
   // Snapshots of this dataset
   snapshots() []zfs.dataset
@@ -9457,10 +10280,10 @@ zfs.dataset @defaults("name type usedBytes") {
 
 // AI Model Cache
 //
-// Examine locally cached AI models from tools such as Ollama, Hugging Face
-// Hub, LM Studio, GPT4All, PyTorch Hub, Keras, TensorFlow Hub, and Jan.
-// Iterate over all discovered models to audit what AI models are present
-// on the system, their sizes, formats, and sources.
+// Locally cached AI models discovered from tools such as Ollama, Hugging
+// Face Hub, LM Studio, GPT4All, PyTorch Hub, Keras, TensorFlow Hub, and
+// Jan. Iterate `models` to audit which AI models are present on the
+// system, their sizes, file formats, publishers, and licenses.
 ai @maturity("preview") {
   // All locally cached AI models across all supported sources
   models() []ai.model
@@ -9468,12 +10291,12 @@ ai @maturity("preview") {
 
 // AI Model
 //
-// Examine a single locally cached AI model. The `name` field identifies
-// the model and `source` indicates which tool cached it — for example
+// Single locally cached AI model. The `name` field identifies
+// the model and `source` indicates which tool cached it (for example
 // `"ollama"`, `"huggingface"`, `"lmstudio"`, `"gpt4all"`, `"pytorch"`,
-// `"keras"`, `"tfhub"`, or `"jan"`. Use `ai.models.where(source == "ollama")` to filter by
-// source, or inspect `size` and `modifiedAt` to find the largest or most
-// recently used models on the system.
+// `"keras"`, `"tfhub"`, or `"jan"`). Use `ai.models.where(source == "ollama")`
+// to filter by source, or inspect `size` and `modifiedAt` to find the
+// largest or most recently used models on the system.
 private ai.model @defaults("name source") @maturity("preview") {
   // Model name (e.g., "llama3:latest", "meta-llama/Llama-2-7b-hf")
   name string
@@ -9515,7 +10338,13 @@ private ai.model @defaults("name source") @maturity("preview") {
 
 // Claude Code (Anthropic CLI agent) instance
 //
-// Examine account, plugins, skills, projects, and configured MCP servers
+// Claude Code installation on the host, exposing the account it is signed
+// into (`email`, `organization`, `role`, `subscription`), the installing
+// `package` and host `runtime`, and the agent's configured surface:
+// `enabledPlugins`, `plugins`, `skills`, `projects`, and `mcpServers`.
+// Audit which plugins, skills, and MCP servers are configured, and which
+// projects the agent can access. The `configPath` selects the
+// configuration directory when it is not the default.
 // URL: https://claude.ai/code
 claude.code @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9538,7 +10367,7 @@ claude.code @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Account email
@@ -9568,6 +10397,11 @@ claude.code @defaults("configPath") @maturity("preview") {
 }
 
 // Claude Code installed plugin
+//
+// Single plugin installed into Claude Code. Records the plugin `name`,
+// `version`, install `scope` (user or project), on-disk `installPath`,
+// install and update timestamps, the pinned `gitCommitSha`, and whether
+// it is currently `enabled`.
 private claude.code.plugin @defaults("name") @maturity("preview") {
   // Plugin name (e.g. "gopls-lsp@claude-plugins-official")
   name string
@@ -9588,6 +10422,11 @@ private claude.code.plugin @defaults("name") @maturity("preview") {
 }
 
 // Claude Code skill
+//
+// Single skill available to Claude Code. Exposes the skill `name` and
+// `description`, the `allowedTools` it may invoke, its `source` path, the
+// full `content` of the definition, and a `sha256` of that content for
+// integrity checks.
 private claude.code.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -9606,6 +10445,10 @@ private claude.code.skill @defaults("name") @maturity("preview") {
 }
 
 // Claude Code project
+//
+// Single project directory Claude Code is configured to work in. `path`
+// is the filesystem location and `hasMemory` reports whether persistent
+// memory is configured for it.
 private claude.code.project @defaults("path") @maturity("preview") {
   // Original filesystem path the project maps to
   path string
@@ -9614,6 +10457,11 @@ private claude.code.project @defaults("path") @maturity("preview") {
 }
 
 // Claude Code MCP server
+//
+// Single Model Context Protocol server configured for Claude Code.
+// `name` identifies the server, `needsAuth` reports whether it requires
+// authentication, and `lastChecked` is when its auth state was last
+// verified.
 private claude.code.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
@@ -9625,7 +10473,12 @@ private claude.code.mcpServer @defaults("name") @maturity("preview") {
 
 // OpenAI Codex CLI instance
 //
-// Examine auth mode, plugins, skills, MCP servers, and OAuth connectors
+// OpenAI Codex CLI installation on the host, exposing the `authMode` and
+// `accountId` it is signed in with, the installed `version`, and the
+// agent's configured surface: `plugins`, `skills`, `mcpServers`, and
+// OAuth `connectors`. Audit which plugins, MCP servers, and connectors
+// are configured. The `configPath` selects the configuration directory
+// when it is not the default.
 // URL: https://openai.com/index/introducing-codex/
 openai.codex @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9648,7 +10501,7 @@ openai.codex @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Authentication mode (e.g. "chatgpt")
@@ -9670,6 +10523,12 @@ openai.codex @defaults("configPath") @maturity("preview") {
 }
 
 // OpenAI Codex installed plugin
+//
+// Plugin dropped into the Codex plugins directory, extending the agent
+// with skills, MCP servers, and hooks. Notable fields for auditing:
+// capabilities and skillNames describe what the plugin can do, while
+// hasMcp and hasHooks flag whether it wires in external MCP servers or
+// executes shell hooks, both of which widen the agent's trust boundary.
 private openai.codex.plugin @defaults("name") @maturity("preview") {
   // Plugin name
   name string
@@ -9679,41 +10538,59 @@ private openai.codex.plugin @defaults("name") @maturity("preview") {
   description string
   // Plugin author name
   author string
-  // Plugin category (e.g. "Coding", "Productivity", "Design")
+  // Plugin category
+  //
+  // Category declared in the plugin manifest, for example "Coding",
+  // "Productivity", or "Design".
   category string
-  // Plugin capabilities (e.g. "Read", "Write", "Interactive")
+  // Plugin capabilities
+  //
+  // Capability tokens declared by the plugin, for example "Read",
+  // "Write", or "Interactive". These indicate the level of access the
+  // plugin requests.
   capabilities []string
-  // Plugin skill names
+  // Names of skills bundled by the plugin
   skillNames []string
-  // Whether the plugin has MCP servers configured
+  // Whether the plugin configures one or more MCP servers
   hasMcp bool
-  // Whether the plugin has hooks configured
+  // Whether the plugin configures hooks (shell commands run on agent events)
   hasHooks bool
 }
 
 // OpenAI Codex skill
+//
+// Skill defined by a SKILL.md file, giving the agent packaged
+// instructions for a task. The name and description come from the file's
+// YAML frontmatter, content holds the full markdown body, and plugin
+// records which plugin supplied the skill (empty for system skills).
+// Use sha256 to detect tampering with skill content.
 private openai.codex.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
   // Skill description
   description string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
   // Plugin that provides this skill (empty for system skills)
   plugin string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // OpenAI Codex MCP server
+//
+// Model Context Protocol server a Codex plugin connects to, giving the
+// agent access to external tools and data. The url is the endpoint the
+// agent reaches out to and plugin records which plugin declared it, both
+// relevant when auditing what external services the agent can invoke.
 private openai.codex.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
-  // Server type (e.g. "http")
+  // Server transport type, for example "http"
   type string
-  // Server URL
+  // Server endpoint URL the agent connects to
   url string
   // Optional note describing the server
   note string
@@ -9722,10 +10599,15 @@ private openai.codex.mcpServer @defaults("name") @maturity("preview") {
 }
 
 // OpenAI Codex OAuth app connector
+//
+// OAuth application connector declared by a Codex plugin, granting the
+// agent delegated access to a third-party service. The id identifies the
+// connected app (for example "connector_..." or "asdk_app_...") and
+// plugin records which plugin declared it.
 private openai.codex.connector @defaults("name") @maturity("preview") {
   // Connector name (matches plugin name)
   name string
-  // Connector ID (e.g. "connector_..." or "asdk_app_...")
+  // Connector ID, for example "connector_..." or "asdk_app_..."
   id string
   // Plugin that provides this connector
   plugin string
@@ -9733,7 +10615,11 @@ private openai.codex.connector @defaults("name") @maturity("preview") {
 
 // Cursor editor (AI-powered) instance
 //
-// Examine MCP servers, global and project rules, and installed skills
+// Cursor AI code editor installed on the host. Queryable through it are
+// the configured MCP servers, the global and project rules that steer the
+// assistant, and any installed skills, along with the package that
+// installed the editor and the runtime it executes in. Useful for
+// auditing what tools and instructions govern the AI assistant.
 // URL: https://www.cursor.com/
 cursor @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9756,42 +10642,57 @@ cursor @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // MCP servers
+  // MCP servers the editor connects to
   mcpServers() []cursor.mcpServer
-  // Cursor rules (global and project-scoped)
+  // Cursor rules (global and project-scoped) that steer the assistant
   rules() []cursor.rule
   // Installed skills
   skills() []cursor.skill
 }
 
 // Cursor MCP server configuration
+//
+// Model Context Protocol server Cursor is configured to use. Stdio
+// servers run a local command; sse and streamable-http servers connect to
+// a url. The hasEnv flag reports whether environment variables (often
+// holding API keys or tokens) are configured for the server.
 private cursor.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
-  // Server command (for stdio type)
+  // Local command launched for stdio-type servers
   command string
-  // Server URL (for sse/streamable-http type)
+  // Endpoint URL for sse or streamable-http servers
   url string
-  // Server arguments
+  // Command-line arguments passed to the server command
   args []string
-  // Whether environment variables are configured
+  // Whether environment variables (for example API keys) are configured
   hasEnv bool
 }
 
 // Cursor rule file
+//
+// Rule file that injects standing instructions into the Cursor
+// assistant's context, either globally or scoped to a project. The
+// content field holds the full rule text, which shapes how the AI behaves
+// and is worth reviewing for injected or unexpected directives.
 private cursor.rule @defaults("name") @maturity("preview") {
   // Rule name (derived from filename)
   name string
   // Full content of the rule file
   content string
-  // Source path of the rule file
+  // Path to the rule file
   source string
 }
 
 // Cursor skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the assistant. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private cursor.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -9799,19 +10700,23 @@ private cursor.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // GitHub Copilot CLI instance
 //
-// Examine authenticated accounts, MCP servers, and installed skills
+// GitHub Copilot command-line tool installed on the host. Queryable
+// through it are the authenticated GitHub accounts, the configured MCP
+// servers, and any installed skills, along with the package that
+// installed the tool and the runtime it executes in. Useful for auditing
+// which identities and external tools the AI assistant can reach.
 // URL: https://github.com/features/copilot
 github.copilot @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9834,38 +10739,52 @@ github.copilot @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Authenticated GitHub accounts
   accounts() []github.copilot.account
-  // MCP servers
+  // MCP servers the tool connects to
   mcpServers() []github.copilot.mcpServer
   // Installed skills
   skills() []github.copilot.skill
 }
 
 // GitHub Copilot authenticated account
+//
+// GitHub account authenticated for use with Copilot on the host. The user
+// field is the GitHub username and githubAppId identifies the GitHub App
+// backing the session, useful for reviewing which identities have active
+// Copilot access.
 private github.copilot.account @defaults("user") @maturity("preview") {
   // GitHub username
   user string
-  // GitHub App ID
+  // GitHub App ID backing the authenticated session
   githubAppId string
 }
 
 // GitHub Copilot MCP server configuration
+//
+// Model Context Protocol server Copilot is configured to use. Stdio-type
+// servers launch a local command with the given args to expose external
+// tools and data to the assistant.
 private github.copilot.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
-  // Server type (e.g. "stdio")
+  // Server transport type, for example "stdio"
   type string
-  // Server command
+  // Local command launched for the server
   command string
-  // Server arguments
+  // Command-line arguments passed to the server command
   args []string
 }
 
 // GitHub Copilot skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the assistant. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private github.copilot.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -9873,19 +10792,23 @@ private github.copilot.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Goose AI agent (Block) instance
 //
-// Examine the active provider/model, telemetry, extensions, and skills
+// Goose AI agent from Block installed on the host. Queryable through it
+// are the active provider and model, whether telemetry is enabled, the
+// configured extensions, and any installed skills, along with the package
+// that installed the agent and the runtime it executes in. Useful for
+// auditing which model backend and extensions the agent uses.
 // URL: https://block.github.io/goose/
 goose @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9908,14 +10831,14 @@ goose @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Active AI provider name
+  // Active AI provider name (the configured model backend)
   provider() string
   // Active model name
   model() string
-  // Whether telemetry is enabled
+  // Whether usage telemetry is enabled
   telemetryEnabled() bool
   // Configured extensions
   extensions() []goose.extension
@@ -9924,22 +10847,33 @@ goose @defaults("configPath") @maturity("preview") {
 }
 
 // Goose extension
+//
+// Extension configured for the Goose agent, adding tools or integrations.
+// The type distinguishes a "platform" extension (external process) from a
+// "builtin" one, bundled reports whether it ships with Goose, enabled
+// reports whether it is active, and timeout is its execution limit in
+// seconds (0 means no timeout).
 private goose.extension @defaults("name") @maturity("preview") {
   // Extension name
   name string
   // Whether the extension is enabled
   enabled bool
-  // Extension type (platform or builtin)
+  // Extension type: "platform" or "builtin"
   type string
   // Extension description
   description string
-  // Whether the extension is bundled with Goose
+  // Whether the extension ships bundled with Goose
   bundled bool
-  // Extension timeout in seconds (0 = no timeout)
+  // Extension execution timeout in seconds (0 means no timeout)
   timeout int
 }
 
 // Goose skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the agent. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private goose.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -9947,19 +10881,24 @@ private goose.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Gemini CLI (Google) instance
 //
-// Examine auth type, settings, MCP servers, and installed skills
+// Google Gemini command-line tool installed on the host. Queryable
+// through it are the authentication type, the settings dictionary, the
+// configured MCP servers, and any installed skills, along with the
+// package that installed the tool and the runtime it executes in. Useful
+// for auditing how the assistant authenticates and what tools it can
+// reach.
 // URL: https://github.com/google-gemini/gemini-cli
 gemini @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -9982,32 +10921,42 @@ gemini @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Authentication type
+  // Authentication type configured for the assistant
   authType() string
-  // Settings dictionary
+  // Full settings dictionary parsed from the Gemini configuration
   settings() dict
-  // MCP servers
+  // MCP servers the tool connects to
   mcpServers() []gemini.mcpServer
   // Installed skills
   skills() []gemini.skill
 }
 
 // Gemini MCP server configuration
+//
+// Model Context Protocol server Gemini is configured to use. The command
+// and args launch the server to expose external tools and data to the
+// assistant, and hasEnv reports whether environment variables (often
+// holding API keys or tokens) are configured for it.
 private gemini.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
-  // Server command
+  // Local command launched for the server
   command string
-  // Server arguments
+  // Command-line arguments passed to the server command
   args []string
-  // Whether environment variables are configured
+  // Whether environment variables (for example API keys) are configured
   hasEnv bool
 }
 
 // Gemini skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the assistant. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private gemini.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -10015,19 +10964,22 @@ private gemini.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Windsurf editor (Codeium) instance
 //
-// Examine global rules / memories, MCP servers, and installed skills
+// Windsurf AI code editor from Codeium installed on the host. Queryable
+// through it are the global rules and memories that steer the assistant,
+// the configured MCP servers, and any installed skills, along with the
+// package that installed the editor and the runtime it executes in.
 // URL: https://windsurf.com/
 windsurf @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10050,40 +11002,55 @@ windsurf @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Global rules / memories
+  // Global rules and memories that steer the assistant
   rules() []windsurf.rule
-  // MCP servers
+  // MCP servers the editor connects to
   mcpServers() []windsurf.mcpServer
   // Installed skills
   skills() []windsurf.skill
 }
 
 // Windsurf rule / memory file
+//
+// Rule or memory file that injects standing instructions into the
+// Windsurf assistant's context. The content field holds the full text,
+// which shapes how the AI behaves and is worth reviewing for injected or
+// unexpected directives.
 private windsurf.rule @defaults("name") @maturity("preview") {
   // Rule name (derived from filename)
   name string
   // Full content of the rule file
   content string
-  // Source path of the rule file
+  // Path to the rule file
   source string
 }
 
 // Windsurf MCP server configuration
+//
+// Model Context Protocol server Windsurf is configured to use. The
+// command and args launch the server to expose external tools and data to
+// the assistant, and hasEnv reports whether environment variables (often
+// holding API keys or tokens) are configured for it.
 private windsurf.mcpServer @defaults("name") @maturity("preview") {
   // Server name
   name string
-  // Server command
+  // Local command launched for the server
   command string
-  // Server arguments
+  // Command-line arguments passed to the server command
   args []string
-  // Whether environment variables are configured
+  // Whether environment variables (for example API keys) are configured
   hasEnv bool
 }
 
 // Windsurf skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the assistant. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private windsurf.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -10091,19 +11058,22 @@ private windsurf.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Zed editor instance
 //
-// Examine workspace settings and installed extensions
+// Zed code editor installed on the host. Queryable through it are the
+// workspace settings dictionary and the names of installed extensions,
+// along with the package that installed the editor and the runtime it
+// executes in.
 // URL: https://zed.dev/
 zed @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10126,18 +11096,20 @@ zed @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Settings dictionary
+  // Full settings dictionary parsed from the Zed configuration
   settings() dict
-  // Extension names installed
+  // Names of installed extensions
   extensions() []string
 }
 
 // Roo Code editor instance
 //
-// Examine installed skills
+// Roo Code AI coding agent installed on the host. Queryable through it are
+// the installed skills, along with the package that installed the tool and
+// the runtime it executes in.
 // URL: https://roocode.com/
 roo @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10160,7 +11132,7 @@ roo @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Installed skills
@@ -10168,6 +11140,11 @@ roo @defaults("configPath") @maturity("preview") {
 }
 
 // Roo Code skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the agent. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private roo.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -10175,19 +11152,22 @@ private roo.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Cline AI agent instance
 //
-// Examine installed skills
+// Cline AI coding agent installed on the host. Queryable through it are
+// the installed skills (read from the shared ~/.agents/skills directory),
+// along with the package that installed the agent and the runtime it
+// executes in.
 // URL: https://cline.bot/
 cline @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10210,7 +11190,7 @@ cline @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Installed skills
@@ -10218,6 +11198,11 @@ cline @defaults("configPath") @maturity("preview") {
 }
 
 // Cline skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the agent. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private cline.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -10225,19 +11210,21 @@ private cline.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Kiro CLI (AWS) instance
 //
-// Examine installed skills
+// Kiro AI coding agent from AWS installed on the host. Queryable through
+// it are the installed skills, along with the package that installed the
+// tool and the runtime it executes in.
 // URL: https://kiro.dev/
 kiro @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10260,7 +11247,7 @@ kiro @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional, null when the host cannot be
   // determined.
   runtime() extensionRuntime
   // Installed skills
@@ -10268,6 +11255,11 @@ kiro @defaults("configPath") @maturity("preview") {
 }
 
 // Kiro skill
+//
+// Skill defined by a SKILL.md file that packages task instructions for
+// the agent. The allowedTools list bounds which tools the skill may
+// invoke, argumentHint documents its expected arguments, and content
+// holds the full definition. Use sha256 to detect tampering.
 private kiro.skill @defaults("name") @maturity("preview") {
   // Skill name
   name string
@@ -10275,19 +11267,24 @@ private kiro.skill @defaults("name") @maturity("preview") {
   description string
   // Tools the skill is allowed to use
   allowedTools []string
-  // Hint for expected arguments
+  // Hint describing the skill's expected arguments
   argumentHint string
-  // Source path of the skill definition
+  // Path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full markdown content of the skill definition
   content string
-  // SHA-256 hash of the skill content
+  // SHA-256 hash of the skill content, for integrity checks
   sha256() string
 }
 
 // Continue (open-source AI coding assistant) instance
 //
-// Examine installed skills
+// Continue, an open-source AI coding assistant, installed on the target.
+// Reports its presence and version via package, the host it runs in via
+// runtime, and the SKILL.md definitions installed for it via skills. Skills
+// are scanned under the configuration directory (default .continue in the
+// user's home); pass configPath to target a non-default install. Auditing
+// this resource shows whether the agent is present and what skills extend it.
 // URL: https://continue.dev/
 continuedev @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10310,34 +11307,65 @@ continuedev @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []continuedev.skill
 }
 
 // Continue skill
+//
+// A single SKILL.md definition discovered for the Continue agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private continuedev.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Trae AI assistant (ByteDance) instance
 //
-// Examine installed skills
+// Trae, ByteDance's AI-powered IDE assistant, installed on the target.
+// Reports its presence and version via package, the host it runs in via
+// runtime, and the SKILL.md definitions installed for it via skills. Skills
+// are scanned under the configuration directory (default .trae in the user's
+// home); pass configPath to target a non-default install. Auditing this
+// resource shows whether the agent is present and what skills extend it.
 // URL: https://trae.ai/
 trae @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10360,34 +11388,66 @@ trae @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []trae.skill
 }
 
 // Trae skill
+//
+// A single SKILL.md definition discovered for the Trae agent. Each skill is a
+// Markdown file with YAML frontmatter that adds instructions and tool access
+// to the assistant; auditing them surfaces the capabilities granted.
 private trae.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // OpenCode AI coding assistant instance
 //
-// Examine installed skills
+// OpenCode, an open-source terminal AI coding assistant, installed on the
+// target. Reports its presence and version via package, the host it runs in
+// via runtime, and the SKILL.md definitions installed for it via skills.
+// Skills are scanned under the configuration directory (default
+// .config/opencode in the user's home); pass configPath to target a
+// non-default install. Auditing this resource shows whether the agent is
+// present and what skills extend it.
 // URL: https://opencode.ai/
 opencode @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10410,34 +11470,65 @@ opencode @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []opencode.skill
 }
 
 // OpenCode skill
+//
+// A single SKILL.md definition discovered for the OpenCode agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private opencode.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Pi AI agent instance
 //
-// Examine installed skills
+// Pi, an AI coding agent, installed on the target. Reports its presence and
+// version via package, the host it runs in via runtime, and the SKILL.md
+// definitions installed for it via skills. Skills are scanned under the
+// configuration directory (default .pi/agent in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://pi.dev/
 pi @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10460,34 +11551,65 @@ pi @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []pi.skill
 }
 
 // Pi skill
+//
+// A single SKILL.md definition discovered for the Pi agent. Each skill is a
+// Markdown file with YAML frontmatter that adds instructions and tool access
+// to the assistant; auditing them surfaces the capabilities granted.
 private pi.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Mistral Vibe (Mistral AI) instance
 //
-// Examine installed skills
+// Mistral Vibe, Mistral AI's coding assistant, installed on the target.
+// Reports its presence and version via package, the host it runs in via
+// runtime, and the SKILL.md definitions installed for it via skills. Skills
+// are scanned under the configuration directory (default .vibe in the user's
+// home); pass configPath to target a non-default install. Auditing this
+// resource shows whether the agent is present and what skills extend it.
 // URL: https://docs.mistral.ai/tools/vibe/
 mistral.vibe @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10510,34 +11632,67 @@ mistral.vibe @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []mistral.vibe.skill
 }
 
 // Mistral Vibe skill
+//
+// A single SKILL.md definition discovered for the Mistral Vibe agent. Each
+// skill is a Markdown file with YAML frontmatter that adds instructions and
+// tool access to the assistant; auditing them surfaces the capabilities
+// granted.
 private mistral.vibe.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Antigravity (Google) instance
 //
-// Examine installed skills
+// Antigravity, Google's agentic development platform, installed on the
+// target. Reports its presence and version via package, the host it runs in
+// via runtime, and the SKILL.md definitions installed for it via skills.
+// Skills are scanned under the configuration directory (default
+// .gemini/antigravity in the user's home); pass configPath to target a
+// non-default install. Auditing this resource shows whether the agent is
+// present and what skills extend it.
 // URL: https://antigravity.google/
 antigravity @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10560,34 +11715,66 @@ antigravity @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []antigravity.skill
 }
 
 // Antigravity skill
+//
+// A single SKILL.md definition discovered for the Antigravity agent. Each
+// skill is a Markdown file with YAML frontmatter that adds instructions and
+// tool access to the assistant; auditing them surfaces the capabilities
+// granted.
 private antigravity.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // IBM Bob instance
 //
-// Examine installed skills
+// IBM Bob, IBM's AI development assistant, installed on the target. Reports
+// its presence and version via package, the host it runs in via runtime, and
+// the SKILL.md definitions installed for it via skills. Skills are scanned
+// under the configuration directory (default .bob in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://www.ibm.com/products/bob
 ibm.bob @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10610,34 +11797,65 @@ ibm.bob @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []ibm.bob.skill
 }
 
 // IBM Bob skill
+//
+// A single SKILL.md definition discovered for the IBM Bob agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private ibm.bob.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // OpenClaw AI agent instance
 //
-// Examine installed skills
+// OpenClaw, an AI coding agent, installed on the target. Reports its presence
+// and version via package, the host it runs in via runtime, and the SKILL.md
+// definitions installed for it via skills. Skills are scanned under the
+// configuration directory (default .openclaw in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://openclaw.ai/
 openclaw @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10660,34 +11878,66 @@ openclaw @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []openclaw.skill
 }
 
 // OpenClaw skill
+//
+// A single SKILL.md definition discovered for the OpenClaw agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private openclaw.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Snowflake Cortex Code instance
 //
-// Examine installed skills
+// Snowflake Cortex Code, Snowflake's AI coding assistant, installed on the
+// target. Reports its presence and version via package, the host it runs in
+// via runtime, and the SKILL.md definitions installed for it via skills.
+// Skills are scanned under the configuration directory (default
+// .snowflake/cortex in the user's home); pass configPath to target a
+// non-default install. Auditing this resource shows whether the agent is
+// present and what skills extend it.
 // URL: https://www.snowflake.com/en/product/features/cortex-code/
 snowflake.cortex @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10710,34 +11960,66 @@ snowflake.cortex @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []snowflake.cortex.skill
 }
 
 // Snowflake Cortex Code skill
+//
+// A single SKILL.md definition discovered for the Snowflake Cortex Code
+// agent. Each skill is a Markdown file with YAML frontmatter that adds
+// instructions and tool access to the assistant; auditing them surfaces the
+// capabilities granted.
 private snowflake.cortex.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Junie (JetBrains AI agent) instance
 //
-// Examine installed skills
+// Junie, JetBrains' AI coding agent, installed on the target. Reports its
+// presence and version via package, the host it runs in via runtime, and the
+// SKILL.md definitions installed for it via skills. Skills are scanned under
+// the configuration directory (default .junie in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://www.jetbrains.com/junie/
 junie @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10760,34 +12042,65 @@ junie @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []junie.skill
 }
 
 // Junie skill
+//
+// A single SKILL.md definition discovered for the Junie agent. Each skill is
+// a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private junie.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Augment Code instance
 //
-// Examine installed skills
+// Augment Code, an AI coding assistant, installed on the target. Reports its
+// presence and version via package, the host it runs in via runtime, and the
+// SKILL.md definitions installed for it via skills. Skills are scanned under
+// the configuration directory (default .augment in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://www.augmentcode.com/
 augment @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10810,34 +12123,65 @@ augment @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []augment.skill
 }
 
 // Augment skill
+//
+// A single SKILL.md definition discovered for the Augment agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private augment.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Warp AI terminal instance
 //
-// Examine installed skills
+// Warp, an AI-powered terminal, installed on the target. Reports its presence
+// and version via package, the host it runs in via runtime, and the SKILL.md
+// definitions installed for it via skills. Warp reads skills from the shared
+// .agents/skills directory in each user's home rather than its own .warp
+// config directory; pass configPath to target a non-default install. Auditing
+// this resource shows whether the agent is present and what skills extend it.
 // URL: https://www.warp.dev/
 warp @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10860,34 +12204,66 @@ warp @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []warp.skill
 }
 
 // Warp skill
+//
+// A single SKILL.md definition discovered for Warp under the shared
+// .agents/skills directory. Each skill is a Markdown file with YAML
+// frontmatter that adds instructions and tool access to the assistant;
+// auditing them surfaces the capabilities granted.
 private warp.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Kilo Code AI agent instance
 //
-// Examine installed skills
+// Kilo Code, an open-source AI coding agent, installed on the target. Reports
+// its presence and version via package, the host it runs in via runtime, and
+// the SKILL.md definitions installed for it via skills. Skills are scanned
+// under the configuration directory (default .kilocode in the user's home);
+// pass configPath to target a non-default install. Auditing this resource
+// shows whether the agent is present and what skills extend it.
 // URL: https://kilocode.ai/
 kilocode @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10910,34 +12286,66 @@ kilocode @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []kilocode.skill
 }
 
 // Kilo Code skill
+//
+// A single SKILL.md definition discovered for the Kilo Code agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private kilocode.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // OpenHands AI agent instance (formerly OpenDevin)
 //
-// Examine installed skills
+// OpenHands (formerly OpenDevin), an open-source AI software-engineering
+// agent, installed on the target. Reports its presence and version via
+// package, the host it runs in via runtime, and the SKILL.md definitions
+// installed for it via skills. Skills are scanned under the configuration
+// directory (default .openhands in the user's home); pass configPath to
+// target a non-default install. Auditing this resource shows whether the
+// agent is present and what skills extend it.
 // URL: https://www.all-hands.dev/
 openhands @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -10960,34 +12368,65 @@ openhands @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []openhands.skill
 }
 
 // OpenHands skill
+//
+// A single SKILL.md definition discovered for the OpenHands agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private openhands.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }
 
 // Qwen Code (Alibaba) instance
 //
-// Examine installed skills
+// Qwen Code, Alibaba's AI coding assistant, installed on the target. Reports
+// its presence and version via package, the host it runs in via runtime, and
+// the SKILL.md definitions installed for it via skills. Skills are scanned
+// under the configuration directory (default .qwen in the user's home); pass
+// configPath to target a non-default install. Auditing this resource shows
+// whether the agent is present and what skills extend it.
 // URL: https://qwen.ai/qwencode
 qwen.code @defaults("configPath") @maturity("preview") {
   init(configPath? string)
@@ -11010,27 +12449,53 @@ qwen.code @defaults("configPath") @maturity("preview") {
   // agent, the IDE/editor for an editor plugin, or the browser for a browser
   // extension. The runtime's `package` carries the host's software identity
   // (version and purl where known) so its own version and vulnerabilities can be
-  // looked up like any other software. Optional — null when the host cannot be
+  // looked up like any other software. Optional; null when the host cannot be
   // determined.
   runtime() extensionRuntime
-  // Installed skills
+  // Skills installed for the agent, one resource per discovered SKILL.md file
   skills() []qwen.code.skill
 }
 
 // Qwen Code skill
+//
+// A single SKILL.md definition discovered for the Qwen Code agent. Each skill
+// is a Markdown file with YAML frontmatter that adds instructions and tool
+// access to the assistant; auditing them surfaces the capabilities granted.
 private qwen.code.skill @defaults("name") @maturity("preview") {
   // Skill name
+  //
+  // Name from the SKILL.md YAML frontmatter `name` field, falling back to
+  // the skill's directory name when the frontmatter omits it.
   name string
   // Skill description
+  //
+  // Free-text summary from the frontmatter `description` field, stating what
+  // the skill does and when the agent should invoke it.
   description string
   // Tools the skill is allowed to use
+  //
+  // Tool identifiers parsed from the frontmatter `allowed-tools` field (a
+  // comma-separated list), naming the capabilities the skill may invoke such
+  // as file edits, shell commands, or web access. Empty when the skill
+  // declares no restriction. The key field for reviewing what an installed
+  // skill is permitted to do.
   allowedTools []string
   // Hint for expected arguments
+  //
+  // Usage hint from the frontmatter `argument-hint` field, shown when the
+  // skill is invoked. Empty when unset.
   argumentHint string
-  // Source path of the skill definition
+  // Filesystem path to the SKILL.md file that defines the skill
   source string
-  // Full content of the skill definition
+  // Full raw content of the SKILL.md file
+  //
+  // Complete Markdown body of the skill, including the YAML frontmatter and
+  // the prose instructions the agent follows. Inspect it to review exactly
+  // what an installed skill tells the agent to do.
   content string
   // SHA-256 hash of the skill content
+  //
+  // Hex-encoded SHA-256 digest of content, for detecting drift or pinning a
+  // known-good skill definition against a baseline.
   sha256() string
 }


### PR DESCRIPTION
📄 os: enrich resource and field documentation across services

Documentation pass over os.lr, applying the pattern established across the
provider-wide sweep (#9146 and following). These doc-comments render onto the
docs website, so this is user-facing content teaching what each resource is,
what is queryable, and why the data matters for auditing.

os.lr is the largest schema in the repo (474 resources); the pass went beyond
mechanical style fixes to make each comment genuinely more complete and
useful, grounding every description in the Go implementation:

- Rewrite resource descriptions to lead with the noun instead of
  "Examine"/"Iterate"/"Use", and drop parent-navigation hints.
- Expand title-only and thin one-line comments into full two-part
  descriptions covering queryable fields, audit significance, and concrete
  .where(...)/selection examples (e.g. ports.listening, firewalld.zone,
  scheduledTask, docker.file stages, the language package inventories).
- Document field semantics grounded in the code: enum value sets, units,
  and null/available semantics, plus several factual corrections
  (docker.image size in bytes not KB, auditd rules.d default path, SMBIOS
  vs BIOS, Windows InstallState/DISM enums, macOS ALF globalState values).
- Fix style-rule violations: em dashes, call-form foo() in prose, and
  "typed" mechanism leaks.

Comment-only change: regenerating produces no schema or .lr.versions churn.

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
