### PR TITLE
🐛 gcp: fix doubled sqlService and vertexaiService descriptions

### DIFF
--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -2915,13 +2915,6 @@ private gcp.project.storageService.bucket.lifecycleRuleCondition @defaults("age 
 
 // Google Cloud (GCP) Cloud SQL
 //
-// Use this resource as the entry point for Cloud SQL in the project. It
-// hosts the managed-database `instances` — each exposing its database
-// engine and version, connection settings, automated backup configuration,
-// SSL/TLS enforcement, authorized networks, and database flags for
-// relational-database audits.
-// Google Cloud SQL service
-//
 // Entry point for Cloud SQL in the project. The instances collection lists
 // every managed MySQL, PostgreSQL, and SQL Server database instance, from
 // which their databases, users, SSL certificates, backup runs, and
@@ -12602,12 +12595,6 @@ private gcp.project.backupdrService.backupPlan @defaults("name state") {
 }
 
 // Google Cloud (GCP) Vertex AI
-//
-// Use this resource as the entry point for Vertex AI in the project. It
-// hosts the machine-learning surface: `models`, `endpoints`, `datasets`,
-// `customJobs`, `pipelineJobs`, `featureOnlineStores`, `tensorboards`,
-// `metadataStores`, and the vector-search `indexes` and `indexEndpoints`.
-// Google Cloud (GCP) Vertex AI service
 //
 // Vertex AI resources in a project: models, serving endpoints and their
 // deployments, datasets, pipeline and training jobs, tuning and


### PR DESCRIPTION
## What

Fixes a copy-paste artifact in `providers/gcp/resources/gcp.lr` where the `gcp.project.sqlService` and `gcp.project.vertexaiService` resource descriptions were doubled.

## Why

The doc-enrichment pass in #9158 added a new noun-led description above each resource but left the prior `Use this resource as the entry point...` paragraph in place. Because the `.lr` doc-comment parser is positional (line 1 → title, everything after the blank `//` → description), it concatenated both blocks into one field:

> `Use this resource as the entry point for Cloud SQL in the project. ... audits. Google Cloud SQL service  Entry point for Cloud SQL in the project. ...`

This surfaced in the generated resource docs and was flagged by the review bot on the docs regeneration ([mondoohq/docs#1687](https://github.com/mondoohq/docs/pull/1687)).

## Change

Removed the stale `Use this resource...` paragraph and the leftover title line from each resource, keeping only the newer noun-led description. This:
- Matches the style of the sibling `gcp.project.*Service` resources.
- Follows the doc-comment style rules (lead with the noun, not a verb).
- Drops the em dashes that lived in the removed text (not allowed in `.lr` files).

No `.lr.versions` changes (doc-only). Generated `*.resources.json` is a build artifact and regenerates downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)