### PR TITLE
✨ fex: add HttpRequest evidence type for DAST findings

### DIFF
--- a/providers-sdk/v1/upstream/fex/fex.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex.pb.go
@@ -1833,6 +1833,7 @@ type Evidence struct {
 	//	*Evidence_Kubernetes
 	//	*Evidence_RegistryKey
 	//	*Evidence_Connection
+	//	*Evidence_HttpRequest
 	Details isEvidence_Details `protobuf_oneof:"details"`
 	// Additional properties specific to this evidence
 	Properties    map[string]string `protobuf:"bytes,4,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
@@ -1961,6 +1962,15 @@ func (x *Evidence) GetConnection() *Connection {
 	return nil
 }
 
+func (x *Evidence) GetHttpRequest() *HttpRequest {
+	if x != nil {
+		if x, ok := x.Details.(*Evidence_HttpRequest); ok {
+			return x.HttpRequest
+		}
+	}
+	return nil
+}
+
 func (x *Evidence) GetProperties() map[string]string {
 	if x != nil {
 		return x.Properties
@@ -2000,6 +2010,10 @@ type Evidence_Connection struct {
 	Connection *Connection `protobuf:"bytes,26,opt,name=connection,proto3,oneof"`
 }
 
+type Evidence_HttpRequest struct {
+	HttpRequest *HttpRequest `protobuf:"bytes,27,opt,name=http_request,json=httpRequest,proto3,oneof"`
+}
+
 func (*Evidence_User) isEvidence_Details() {}
 
 func (*Evidence_File) isEvidence_Details() {}
@@ -2013,6 +2027,8 @@ func (*Evidence_Kubernetes) isEvidence_Details() {}
 func (*Evidence_RegistryKey) isEvidence_Details() {}
 
 func (*Evidence_Connection) isEvidence_Details() {}
+
+func (*Evidence_HttpRequest) isEvidence_Details() {}
 
 // Experimental. File information
 type File struct {
@@ -2518,6 +2534,108 @@ func (x *Connection) GetProtocol() Connection_ConnectionProtocol {
 	return Connection_UNSPECIFIED
 }
 
+// HttpRequest captures the web request that triggered a finding. It is the
+// first-class evidence for DAST scanners (e.g. OWASP ZAP, Burp Suite), which
+// otherwise have to stash this context in the generic properties map.
+type HttpRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The HTTP method, e.g. GET or POST.
+	Method string `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
+	// The full request URL.
+	Url string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	// The request parameter that was tested, if any.
+	Param string `protobuf:"bytes,3,opt,name=param,proto3" json:"param,omitempty"`
+	// The attack payload sent, if any.
+	Attack string `protobuf:"bytes,4,opt,name=attack,proto3" json:"attack,omitempty"`
+	// The evidence matched in the response that confirms the finding.
+	Evidence string `protobuf:"bytes,5,opt,name=evidence,proto3" json:"evidence,omitempty"`
+	// Optional. The full raw HTTP request.
+	Request string `protobuf:"bytes,6,opt,name=request,proto3" json:"request,omitempty"`
+	// Optional. The full raw HTTP response.
+	Response      string `protobuf:"bytes,7,opt,name=response,proto3" json:"response,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HttpRequest) Reset() {
+	*x = HttpRequest{}
+	mi := &file_fex_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HttpRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HttpRequest) ProtoMessage() {}
+
+func (x *HttpRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fex_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HttpRequest.ProtoReflect.Descriptor instead.
+func (*HttpRequest) Descriptor() ([]byte, []int) {
+	return file_fex_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *HttpRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetParam() string {
+	if x != nil {
+		return x.Param
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetAttack() string {
+	if x != nil {
+		return x.Attack
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetEvidence() string {
+	if x != nil {
+		return x.Evidence
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetRequest() string {
+	if x != nil {
+		return x.Request
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetResponse() string {
+	if x != nil {
+		return x.Response
+	}
+	return ""
+}
+
 // AttackTactic is used to identify the tactic used in an attack.
 // Typically this refers to identifier on the MITRE ATT&CK framework.
 type AttackTactic struct {
@@ -2534,7 +2652,7 @@ type AttackTactic struct {
 
 func (x *AttackTactic) Reset() {
 	*x = AttackTactic{}
-	mi := &file_fex_proto_msgTypes[22]
+	mi := &file_fex_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2546,7 +2664,7 @@ func (x *AttackTactic) String() string {
 func (*AttackTactic) ProtoMessage() {}
 
 func (x *AttackTactic) ProtoReflect() protoreflect.Message {
-	mi := &file_fex_proto_msgTypes[22]
+	mi := &file_fex_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2559,7 +2677,7 @@ func (x *AttackTactic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttackTactic.ProtoReflect.Descriptor instead.
 func (*AttackTactic) Descriptor() ([]byte, []int) {
-	return file_fex_proto_rawDescGZIP(), []int{22}
+	return file_fex_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *AttackTactic) GetId() string {
@@ -2599,7 +2717,7 @@ type AttackTechnique struct {
 
 func (x *AttackTechnique) Reset() {
 	*x = AttackTechnique{}
-	mi := &file_fex_proto_msgTypes[23]
+	mi := &file_fex_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2611,7 +2729,7 @@ func (x *AttackTechnique) String() string {
 func (*AttackTechnique) ProtoMessage() {}
 
 func (x *AttackTechnique) ProtoReflect() protoreflect.Message {
-	mi := &file_fex_proto_msgTypes[23]
+	mi := &file_fex_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2624,7 +2742,7 @@ func (x *AttackTechnique) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttackTechnique.ProtoReflect.Descriptor instead.
 func (*AttackTechnique) Descriptor() ([]byte, []int) {
-	return file_fex_proto_rawDescGZIP(), []int{23}
+	return file_fex_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *AttackTechnique) GetId() string {
@@ -2663,7 +2781,7 @@ type Kubernetes_Pod struct {
 
 func (x *Kubernetes_Pod) Reset() {
 	*x = Kubernetes_Pod{}
-	mi := &file_fex_proto_msgTypes[30]
+	mi := &file_fex_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2675,7 +2793,7 @@ func (x *Kubernetes_Pod) String() string {
 func (*Kubernetes_Pod) ProtoMessage() {}
 
 func (x *Kubernetes_Pod) ProtoReflect() protoreflect.Message {
-	mi := &file_fex_proto_msgTypes[30]
+	mi := &file_fex_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2725,7 +2843,7 @@ type Kubernetes_Node struct {
 
 func (x *Kubernetes_Node) Reset() {
 	*x = Kubernetes_Node{}
-	mi := &file_fex_proto_msgTypes[31]
+	mi := &file_fex_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2737,7 +2855,7 @@ func (x *Kubernetes_Node) String() string {
 func (*Kubernetes_Node) ProtoMessage() {}
 
 func (x *Kubernetes_Node) ProtoReflect() protoreflect.Message {
-	mi := &file_fex_proto_msgTypes[31]
+	mi := &file_fex_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2921,7 +3039,7 @@ const file_fex_proto_rawDesc = "" +
 	"\x0fCATEGORY_THREAT\x10\x04\x12\x14\n" +
 	"\x10CATEGORY_MALWARE\x10\x05\x12\x1a\n" +
 	"\x16CATEGORY_INFORMATIONAL\x10\x06\x12\x13\n" +
-	"\x0fCATEGORY_SECRET\x10\a\"\xa9\x05\n" +
+	"\x0fCATEGORY_SECRET\x10\a\"\xe7\x05\n" +
 	"\bEvidence\x120\n" +
 	"\x06tactic\x18\x01 \x01(\v2\x18.mql.fex.v1.AttackTacticR\x06tactic\x129\n" +
 	"\ttechnique\x18\x02 \x01(\v2\x1b.mql.fex.v1.AttackTechniqueR\ttechnique\x126\n" +
@@ -2938,7 +3056,8 @@ const file_fex_proto_rawDesc = "" +
 	"\fregistry_key\x18\x19 \x01(\v2\x17.mql.fex.v1.RegistryKeyH\x00R\vregistryKey\x128\n" +
 	"\n" +
 	"connection\x18\x1a \x01(\v2\x16.mql.fex.v1.ConnectionH\x00R\n" +
-	"connection\x12D\n" +
+	"connection\x12<\n" +
+	"\fhttp_request\x18\x1b \x01(\v2\x17.mql.fex.v1.HttpRequestH\x00R\vhttpRequest\x12D\n" +
 	"\n" +
 	"properties\x18\x04 \x03(\v2$.mql.fex.v1.Evidence.PropertiesEntryR\n" +
 	"properties\x1a=\n" +
@@ -3001,7 +3120,15 @@ const file_fex_proto_rawDesc = "" +
 	"\vUNSPECIFIED\x10\x00\x12\b\n" +
 	"\x04ICMP\x10\x01\x12\a\n" +
 	"\x03TCP\x10\x06\x12\a\n" +
-	"\x03UDP\x10\x11\"T\n" +
+	"\x03UDP\x10\x11\"\xb7\x01\n" +
+	"\vHttpRequest\x12\x16\n" +
+	"\x06method\x18\x01 \x01(\tR\x06method\x12\x10\n" +
+	"\x03url\x18\x02 \x01(\tR\x03url\x12\x14\n" +
+	"\x05param\x18\x03 \x01(\tR\x05param\x12\x16\n" +
+	"\x06attack\x18\x04 \x01(\tR\x06attack\x12\x1a\n" +
+	"\bevidence\x18\x05 \x01(\tR\bevidence\x12\x18\n" +
+	"\arequest\x18\x06 \x01(\tR\arequest\x12\x1a\n" +
+	"\bresponse\x18\a \x01(\tR\bresponse\"T\n" +
 	"\fAttackTactic\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -3053,7 +3180,7 @@ func file_fex_proto_rawDescGZIP() []byte {
 }
 
 var file_fex_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_fex_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_fex_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_fex_proto_goTypes = []any{
 	(Status)(0),                        // 0: mql.fex.v1.Status
 	(ScoringMethod)(0),                 // 1: mql.fex.v1.ScoringMethod
@@ -3084,43 +3211,44 @@ var file_fex_proto_goTypes = []any{
 	(*Kubernetes)(nil),                 // 26: mql.fex.v1.Kubernetes
 	(*RegistryKey)(nil),                // 27: mql.fex.v1.RegistryKey
 	(*Connection)(nil),                 // 28: mql.fex.v1.Connection
-	(*AttackTactic)(nil),               // 29: mql.fex.v1.AttackTactic
-	(*AttackTechnique)(nil),            // 30: mql.fex.v1.AttackTechnique
-	nil,                                // 31: mql.fex.v1.Reference.MetadataEntry
-	nil,                                // 32: mql.fex.v1.Component.IdentifiersEntry
-	nil,                                // 33: mql.fex.v1.Component.PropertiesEntry
-	nil,                                // 34: mql.fex.v1.FindingDetail.PropertiesEntry
-	nil,                                // 35: mql.fex.v1.Evidence.PropertiesEntry
-	nil,                                // 36: mql.fex.v1.User.PropertiesEntry
-	(*Kubernetes_Pod)(nil),             // 37: mql.fex.v1.Kubernetes.Pod
-	(*Kubernetes_Node)(nil),            // 38: mql.fex.v1.Kubernetes.Node
-	(*timestamppb.Timestamp)(nil),      // 39: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),            // 40: google.protobuf.Struct
+	(*HttpRequest)(nil),                // 29: mql.fex.v1.HttpRequest
+	(*AttackTactic)(nil),               // 30: mql.fex.v1.AttackTactic
+	(*AttackTechnique)(nil),            // 31: mql.fex.v1.AttackTechnique
+	nil,                                // 32: mql.fex.v1.Reference.MetadataEntry
+	nil,                                // 33: mql.fex.v1.Component.IdentifiersEntry
+	nil,                                // 34: mql.fex.v1.Component.PropertiesEntry
+	nil,                                // 35: mql.fex.v1.FindingDetail.PropertiesEntry
+	nil,                                // 36: mql.fex.v1.Evidence.PropertiesEntry
+	nil,                                // 37: mql.fex.v1.User.PropertiesEntry
+	(*Kubernetes_Pod)(nil),             // 38: mql.fex.v1.Kubernetes.Pod
+	(*Kubernetes_Node)(nil),            // 39: mql.fex.v1.Kubernetes.Node
+	(*timestamppb.Timestamp)(nil),      // 40: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),            // 41: google.protobuf.Struct
 }
 var file_fex_proto_depIdxs = []int32{
 	9,  // 0: mql.fex.v1.FindingDocument.vex:type_name -> mql.fex.v1.VulnerabilityExchange
 	19, // 1: mql.fex.v1.FindingDocument.fex:type_name -> mql.fex.v1.FindingExchange
 	7,  // 2: mql.fex.v1.FindingsUploadRequest.findings:type_name -> mql.fex.v1.FindingDocument
-	39, // 3: mql.fex.v1.FindingsUploadRequest.import_started_at:type_name -> google.protobuf.Timestamp
+	40, // 3: mql.fex.v1.FindingsUploadRequest.import_started_at:type_name -> google.protobuf.Timestamp
 	12, // 4: mql.fex.v1.VulnerabilityExchange.details:type_name -> mql.fex.v1.VulnerabilityDetails
 	11, // 5: mql.fex.v1.VulnerabilityExchange.source:type_name -> mql.fex.v1.Source
 	16, // 6: mql.fex.v1.VulnerabilityExchange.ratings:type_name -> mql.fex.v1.Rating
-	39, // 7: mql.fex.v1.VulnerabilityExchange.first_seen:type_name -> google.protobuf.Timestamp
-	39, // 8: mql.fex.v1.VulnerabilityExchange.remediated:type_name -> google.protobuf.Timestamp
+	40, // 7: mql.fex.v1.VulnerabilityExchange.first_seen:type_name -> google.protobuf.Timestamp
+	40, // 8: mql.fex.v1.VulnerabilityExchange.remediated:type_name -> google.protobuf.Timestamp
 	13, // 9: mql.fex.v1.VulnerabilityExchange.affects:type_name -> mql.fex.v1.Affects
 	0,  // 10: mql.fex.v1.VulnerabilityExchange.status:type_name -> mql.fex.v1.Status
 	10, // 11: mql.fex.v1.VulnerabilityExchange.references:type_name -> mql.fex.v1.Reference
 	18, // 12: mql.fex.v1.VulnerabilityExchange.remediations:type_name -> mql.fex.v1.Remediation
-	40, // 13: mql.fex.v1.VulnerabilityExchange.database_specific:type_name -> google.protobuf.Struct
+	41, // 13: mql.fex.v1.VulnerabilityExchange.database_specific:type_name -> google.protobuf.Struct
 	21, // 14: mql.fex.v1.VulnerabilityExchange.evidences:type_name -> mql.fex.v1.Evidence
-	31, // 15: mql.fex.v1.Reference.metadata:type_name -> mql.fex.v1.Reference.MetadataEntry
-	39, // 16: mql.fex.v1.VulnerabilityDetails.created:type_name -> google.protobuf.Timestamp
-	39, // 17: mql.fex.v1.VulnerabilityDetails.published:type_name -> google.protobuf.Timestamp
-	39, // 18: mql.fex.v1.VulnerabilityDetails.updated:type_name -> google.protobuf.Timestamp
+	32, // 15: mql.fex.v1.Reference.metadata:type_name -> mql.fex.v1.Reference.MetadataEntry
+	40, // 16: mql.fex.v1.VulnerabilityDetails.created:type_name -> google.protobuf.Timestamp
+	40, // 17: mql.fex.v1.VulnerabilityDetails.published:type_name -> google.protobuf.Timestamp
+	40, // 18: mql.fex.v1.VulnerabilityDetails.updated:type_name -> google.protobuf.Timestamp
 	14, // 19: mql.fex.v1.Affects.component:type_name -> mql.fex.v1.Component
 	14, // 20: mql.fex.v1.Affects.sub_components:type_name -> mql.fex.v1.Component
-	32, // 21: mql.fex.v1.Component.identifiers:type_name -> mql.fex.v1.Component.IdentifiersEntry
-	33, // 22: mql.fex.v1.Component.properties:type_name -> mql.fex.v1.Component.PropertiesEntry
+	33, // 21: mql.fex.v1.Component.identifiers:type_name -> mql.fex.v1.Component.IdentifiersEntry
+	34, // 22: mql.fex.v1.Component.properties:type_name -> mql.fex.v1.Component.PropertiesEntry
 	15, // 23: mql.fex.v1.Component.file:type_name -> mql.fex.v1.FileComponent
 	11, // 24: mql.fex.v1.Rating.source:type_name -> mql.fex.v1.Source
 	1,  // 25: mql.fex.v1.Rating.method:type_name -> mql.fex.v1.ScoringMethod
@@ -3129,9 +3257,9 @@ var file_fex_proto_depIdxs = []int32{
 	3,  // 28: mql.fex.v1.Severity.rating:type_name -> mql.fex.v1.SeverityRating
 	4,  // 29: mql.fex.v1.Remediation.category:type_name -> mql.fex.v1.Remediation.Category
 	20, // 30: mql.fex.v1.FindingExchange.details:type_name -> mql.fex.v1.FindingDetail
-	39, // 31: mql.fex.v1.FindingExchange.first_seen_at:type_name -> google.protobuf.Timestamp
-	39, // 32: mql.fex.v1.FindingExchange.last_seen_at:type_name -> google.protobuf.Timestamp
-	39, // 33: mql.fex.v1.FindingExchange.remediated_at:type_name -> google.protobuf.Timestamp
+	40, // 31: mql.fex.v1.FindingExchange.first_seen_at:type_name -> google.protobuf.Timestamp
+	40, // 32: mql.fex.v1.FindingExchange.last_seen_at:type_name -> google.protobuf.Timestamp
+	40, // 33: mql.fex.v1.FindingExchange.remediated_at:type_name -> google.protobuf.Timestamp
 	0,  // 34: mql.fex.v1.FindingExchange.status:type_name -> mql.fex.v1.Status
 	11, // 35: mql.fex.v1.FindingExchange.source:type_name -> mql.fex.v1.Source
 	13, // 36: mql.fex.v1.FindingExchange.affects:type_name -> mql.fex.v1.Affects
@@ -3141,9 +3269,9 @@ var file_fex_proto_depIdxs = []int32{
 	17, // 40: mql.fex.v1.FindingDetail.severity:type_name -> mql.fex.v1.Severity
 	2,  // 41: mql.fex.v1.FindingDetail.confidence:type_name -> mql.fex.v1.Confidence
 	10, // 42: mql.fex.v1.FindingDetail.references:type_name -> mql.fex.v1.Reference
-	34, // 43: mql.fex.v1.FindingDetail.properties:type_name -> mql.fex.v1.FindingDetail.PropertiesEntry
-	29, // 44: mql.fex.v1.Evidence.tactic:type_name -> mql.fex.v1.AttackTactic
-	30, // 45: mql.fex.v1.Evidence.technique:type_name -> mql.fex.v1.AttackTechnique
+	35, // 43: mql.fex.v1.FindingDetail.properties:type_name -> mql.fex.v1.FindingDetail.PropertiesEntry
+	30, // 44: mql.fex.v1.Evidence.tactic:type_name -> mql.fex.v1.AttackTactic
+	31, // 45: mql.fex.v1.Evidence.technique:type_name -> mql.fex.v1.AttackTechnique
 	2,  // 46: mql.fex.v1.Evidence.confidence:type_name -> mql.fex.v1.Confidence
 	23, // 47: mql.fex.v1.Evidence.user:type_name -> mql.fex.v1.User
 	22, // 48: mql.fex.v1.Evidence.file:type_name -> mql.fex.v1.File
@@ -3152,21 +3280,22 @@ var file_fex_proto_depIdxs = []int32{
 	26, // 51: mql.fex.v1.Evidence.kubernetes:type_name -> mql.fex.v1.Kubernetes
 	27, // 52: mql.fex.v1.Evidence.registry_key:type_name -> mql.fex.v1.RegistryKey
 	28, // 53: mql.fex.v1.Evidence.connection:type_name -> mql.fex.v1.Connection
-	35, // 54: mql.fex.v1.Evidence.properties:type_name -> mql.fex.v1.Evidence.PropertiesEntry
-	36, // 55: mql.fex.v1.User.properties:type_name -> mql.fex.v1.User.PropertiesEntry
-	22, // 56: mql.fex.v1.Process.binary:type_name -> mql.fex.v1.File
-	22, // 57: mql.fex.v1.Process.script:type_name -> mql.fex.v1.File
-	23, // 58: mql.fex.v1.Process.user:type_name -> mql.fex.v1.User
-	24, // 59: mql.fex.v1.Process.parent:type_name -> mql.fex.v1.Process
-	37, // 60: mql.fex.v1.Kubernetes.pods:type_name -> mql.fex.v1.Kubernetes.Pod
-	38, // 61: mql.fex.v1.Kubernetes.nodes:type_name -> mql.fex.v1.Kubernetes.Node
-	6,  // 62: mql.fex.v1.Connection.protocol:type_name -> mql.fex.v1.Connection.ConnectionProtocol
-	25, // 63: mql.fex.v1.Kubernetes.Pod.containers:type_name -> mql.fex.v1.Container
-	64, // [64:64] is the sub-list for method output_type
-	64, // [64:64] is the sub-list for method input_type
-	64, // [64:64] is the sub-list for extension type_name
-	64, // [64:64] is the sub-list for extension extendee
-	0,  // [0:64] is the sub-list for field type_name
+	29, // 54: mql.fex.v1.Evidence.http_request:type_name -> mql.fex.v1.HttpRequest
+	36, // 55: mql.fex.v1.Evidence.properties:type_name -> mql.fex.v1.Evidence.PropertiesEntry
+	37, // 56: mql.fex.v1.User.properties:type_name -> mql.fex.v1.User.PropertiesEntry
+	22, // 57: mql.fex.v1.Process.binary:type_name -> mql.fex.v1.File
+	22, // 58: mql.fex.v1.Process.script:type_name -> mql.fex.v1.File
+	23, // 59: mql.fex.v1.Process.user:type_name -> mql.fex.v1.User
+	24, // 60: mql.fex.v1.Process.parent:type_name -> mql.fex.v1.Process
+	38, // 61: mql.fex.v1.Kubernetes.pods:type_name -> mql.fex.v1.Kubernetes.Pod
+	39, // 62: mql.fex.v1.Kubernetes.nodes:type_name -> mql.fex.v1.Kubernetes.Node
+	6,  // 63: mql.fex.v1.Connection.protocol:type_name -> mql.fex.v1.Connection.ConnectionProtocol
+	25, // 64: mql.fex.v1.Kubernetes.Pod.containers:type_name -> mql.fex.v1.Container
+	65, // [65:65] is the sub-list for method output_type
+	65, // [65:65] is the sub-list for method input_type
+	65, // [65:65] is the sub-list for extension type_name
+	65, // [65:65] is the sub-list for extension extendee
+	0,  // [0:65] is the sub-list for field type_name
 }
 
 func init() { file_fex_proto_init() }
@@ -3189,6 +3318,7 @@ func file_fex_proto_init() {
 		(*Evidence_Kubernetes)(nil),
 		(*Evidence_RegistryKey)(nil),
 		(*Evidence_Connection)(nil),
+		(*Evidence_HttpRequest)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -3196,7 +3326,7 @@ func file_fex_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fex_proto_rawDesc), len(file_fex_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   32,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/providers-sdk/v1/upstream/fex/fex.proto
+++ b/providers-sdk/v1/upstream/fex/fex.proto
@@ -364,6 +364,7 @@ message Evidence {
     Kubernetes kubernetes = 24;
     RegistryKey registry_key = 25;
     Connection connection = 26;
+    HttpRequest http_request = 27;
   }
   // Additional properties specific to this evidence
   map<string, string> properties = 4;
@@ -483,6 +484,26 @@ message Connection {
   int32 source_port = 4;
   // Protocol used in the connection
   ConnectionProtocol protocol = 5;
+}
+
+// HttpRequest captures the web request that triggered a finding. It is the
+// first-class evidence for DAST scanners (e.g. OWASP ZAP, Burp Suite), which
+// otherwise have to stash this context in the generic properties map.
+message HttpRequest {
+  // The HTTP method, e.g. GET or POST.
+  string method = 1;
+  // The full request URL.
+  string url = 2;
+  // The request parameter that was tested, if any.
+  string param = 3;
+  // The attack payload sent, if any.
+  string attack = 4;
+  // The evidence matched in the response that confirms the finding.
+  string evidence = 5;
+  // Optional. The full raw HTTP request.
+  string request = 6;
+  // Optional. The full raw HTTP response.
+  string response = 7;
 }
 
 // AttackTactic is used to identify the tactic used in an attack.

--- a/providers-sdk/v1/upstream/fex/fex_test.go
+++ b/providers-sdk/v1/upstream/fex/fex_test.go
@@ -63,3 +63,29 @@ func TestNewRemediation(t *testing.T) {
 	assert.Equal(t, "bump to 1.2.3", r.GetDetails())
 	assert.Equal(t, "https://example.com/advisory", r.GetUrl())
 }
+
+func TestHttpRequestEvidenceRoundTrip(t *testing.T) {
+	f := &FindingExchange{
+		Id: "xss-1",
+		Evidences: []*Evidence{{
+			Details: &Evidence_HttpRequest{HttpRequest: &HttpRequest{
+				Method:   "GET",
+				Url:      "https://example.com/search?q=x",
+				Param:    "q",
+				Attack:   "<script>alert(1)</script>",
+				Evidence: "<script>alert(1)</script>",
+			}},
+		}},
+	}
+	data, err := f.MarshalVT()
+	require.NoError(t, err)
+
+	out := &FindingExchange{}
+	require.NoError(t, out.UnmarshalVT(data))
+
+	hr := out.GetEvidences()[0].GetHttpRequest()
+	require.NotNil(t, hr)
+	assert.Equal(t, "GET", hr.GetMethod())
+	assert.Equal(t, "q", hr.GetParam())
+	assert.Equal(t, "https://example.com/search?q=x", hr.GetUrl())
+}

--- a/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
@@ -1594,6 +1594,33 @@ func (m *Evidence_Connection) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	}
 	return len(dAtA) - i, nil
 }
+func (m *Evidence_HttpRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *Evidence_HttpRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.HttpRequest != nil {
+		size, err := m.HttpRequest.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	} else {
+		i = protohelpers.EncodeVarint(dAtA, i, 0)
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0xda
+	}
+	return len(dAtA) - i, nil
+}
 func (m *File) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -2140,6 +2167,88 @@ func (m *Connection) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.DestinationAddress)
 		copy(dAtA[i:], m.DestinationAddress)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DestinationAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *HttpRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HttpRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *HttpRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Response) > 0 {
+		i -= len(m.Response)
+		copy(dAtA[i:], m.Response)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Response)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.Request) > 0 {
+		i -= len(m.Request)
+		copy(dAtA[i:], m.Request)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Request)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.Evidence) > 0 {
+		i -= len(m.Evidence)
+		copy(dAtA[i:], m.Evidence)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Evidence)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Attack) > 0 {
+		i -= len(m.Attack)
+		copy(dAtA[i:], m.Attack)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Attack)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Param) > 0 {
+		i -= len(m.Param)
+		copy(dAtA[i:], m.Param)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Param)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Url) > 0 {
+		i -= len(m.Url)
+		copy(dAtA[i:], m.Url)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Url)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Method) > 0 {
+		i -= len(m.Method)
+		copy(dAtA[i:], m.Method)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Method)))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -2935,6 +3044,20 @@ func (m *Evidence_Connection) SizeVT() (n int) {
 	}
 	return n
 }
+func (m *Evidence_HttpRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.HttpRequest != nil {
+		l = m.HttpRequest.SizeVT()
+		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	} else {
+		n += 3
+	}
+	return n
+}
 func (m *File) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -3153,6 +3276,44 @@ func (m *Connection) SizeVT() (n int) {
 	}
 	if m.Protocol != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Protocol))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *HttpRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Method)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Url)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Param)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Attack)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Evidence)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Request)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Response)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -7520,6 +7681,47 @@ func (m *Evidence) UnmarshalVT(dAtA []byte) error {
 				m.Details = &Evidence_Connection{Connection: v}
 			}
 			iNdEx = postIndex
+		case 27:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HttpRequest", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if oneof, ok := m.Details.(*Evidence_HttpRequest); ok {
+				if err := oneof.HttpRequest.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				v := &HttpRequest{}
+				if err := v.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+				m.Details = &Evidence_HttpRequest{HttpRequest: v}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -9055,6 +9257,281 @@ func (m *Connection) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HttpRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HttpRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HttpRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Method", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Method = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Url", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Url = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Param", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Param = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Attack", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Attack = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Evidence", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Evidence = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Request", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Request = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Response", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Response = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])


### PR DESCRIPTION
## What

Adds an `HttpRequest` evidence type to the FEX proto and wires it into the `Evidence` oneof (field 27).

```proto
message HttpRequest {
  string method = 1;    // GET, POST, ...
  string url = 2;
  string param = 3;     // tested parameter
  string attack = 4;    // payload sent
  string evidence = 5;  // matched evidence in the response
  string request = 6;   // optional raw request
  string response = 7;  // optional raw response
}
```

## Why

The ZAP and Burp DAST converters (cnspec `upload --format zap|burp`) currently stash per-request context (method/param/attack/evidence) in the generic `properties` map because FEX had no structured home for it. This gives DAST findings a **first-class evidence type**, so those converters can carry request/response as real evidence.

Part of ADR-062's field-fidelity proto-extension backlog (Tier 2 — DAST/HTTP request evidence).

## Compatibility

Additive and backward-compatible (new message + new oneof arm). Follow-ups: mirror this in the server's `etl` proto so the evidence persists end-to-end, then switch the cnspec ZAP/Burp converters from `properties` to `HttpRequest`.

## Verification

- `go generate` reproduces pb/vtproto; protolint / gofmt / golangci-lint clean
- `go test ./providers-sdk/v1/upstream/fex/...` — added an HttpRequest round-trip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)