### PR TITLE
✨ fex: add code-location line/column to FileComponent

### DIFF
--- a/providers-sdk/v1/upstream/fex/fex.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex.pb.go
@@ -1223,7 +1223,16 @@ type FileComponent struct {
 	// File format or type
 	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
 	// File size in bytes
-	Size          int64 `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
+	Size int64 `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
+	// Optional. 1-based line where the finding starts (0 = unset). SAST/SARIF
+	// tools report the code location here.
+	StartLine int32 `protobuf:"varint,5,opt,name=start_line,json=startLine,proto3" json:"start_line,omitempty"`
+	// Optional. 1-based line where the finding ends (0 = unset).
+	EndLine int32 `protobuf:"varint,6,opt,name=end_line,json=endLine,proto3" json:"end_line,omitempty"`
+	// Optional. 1-based column where the finding starts (0 = unset).
+	StartColumn int32 `protobuf:"varint,7,opt,name=start_column,json=startColumn,proto3" json:"start_column,omitempty"`
+	// Optional. 1-based column where the finding ends (0 = unset).
+	EndColumn     int32 `protobuf:"varint,8,opt,name=end_column,json=endColumn,proto3" json:"end_column,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1282,6 +1291,34 @@ func (x *FileComponent) GetFormat() string {
 func (x *FileComponent) GetSize() int64 {
 	if x != nil {
 		return x.Size
+	}
+	return 0
+}
+
+func (x *FileComponent) GetStartLine() int32 {
+	if x != nil {
+		return x.StartLine
+	}
+	return 0
+}
+
+func (x *FileComponent) GetEndLine() int32 {
+	if x != nil {
+		return x.EndLine
+	}
+	return 0
+}
+
+func (x *FileComponent) GetStartColumn() int32 {
+	if x != nil {
+		return x.StartColumn
+	}
+	return 0
+}
+
+func (x *FileComponent) GetEndColumn() int32 {
+	if x != nil {
+		return x.EndColumn
 	}
 	return 0
 }
@@ -2965,12 +3002,18 @@ const file_fex_proto_rawDesc = "" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\t\n" +
-	"\adetails\"c\n" +
+	"\adetails\"\xdf\x01\n" +
 	"\rFileComponent\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x16\n" +
 	"\x06format\x18\x03 \x01(\tR\x06format\x12\x12\n" +
-	"\x04size\x18\x04 \x01(\x03R\x04size\"\xb1\x01\n" +
+	"\x04size\x18\x04 \x01(\x03R\x04size\x12\x1d\n" +
+	"\n" +
+	"start_line\x18\x05 \x01(\x05R\tstartLine\x12\x19\n" +
+	"\bend_line\x18\x06 \x01(\x05R\aendLine\x12!\n" +
+	"\fstart_column\x18\a \x01(\x05R\vstartColumn\x12\x1d\n" +
+	"\n" +
+	"end_column\x18\b \x01(\x05R\tendColumn\"\xb1\x01\n" +
 	"\x06Rating\x12*\n" +
 	"\x06source\x18\x01 \x01(\v2\x12.mql.fex.v1.SourceR\x06source\x12\x14\n" +
 	"\x05score\x18\x02 \x01(\x02R\x05score\x12\x1a\n" +

--- a/providers-sdk/v1/upstream/fex/fex.proto
+++ b/providers-sdk/v1/upstream/fex/fex.proto
@@ -193,6 +193,19 @@ message FileComponent {
 
   // File size in bytes
   int64 size = 4;
+
+  // Optional. 1-based line where the finding starts (0 = unset). SAST/SARIF
+  // tools report the code location here.
+  int32 start_line = 5;
+
+  // Optional. 1-based line where the finding ends (0 = unset).
+  int32 end_line = 6;
+
+  // Optional. 1-based column where the finding starts (0 = unset).
+  int32 start_column = 7;
+
+  // Optional. 1-based column where the finding ends (0 = unset).
+  int32 end_column = 8;
 }
 
 // Rating is used to provide a score for the vulnerability.

--- a/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
@@ -822,6 +822,26 @@ func (m *FileComponent) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.EndColumn != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.EndColumn))
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.StartColumn != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.StartColumn))
+		i--
+		dAtA[i] = 0x38
+	}
+	if m.EndLine != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.EndLine))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.StartLine != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.StartLine))
+		i--
+		dAtA[i] = 0x28
+	}
 	if m.Size != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Size))
 		i--
@@ -2708,6 +2728,18 @@ func (m *FileComponent) SizeVT() (n int) {
 	}
 	if m.Size != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.Size))
+	}
+	if m.StartLine != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.StartLine))
+	}
+	if m.EndLine != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.EndLine))
+	}
+	if m.StartColumn != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.StartColumn))
+	}
+	if m.EndColumn != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.EndColumn))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5680,6 +5712,82 @@ func (m *FileComponent) UnmarshalVT(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Size |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartLine", wireType)
+			}
+			m.StartLine = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StartLine |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 6:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EndLine", wireType)
+			}
+			m.EndLine = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EndLine |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartColumn", wireType)
+			}
+			m.StartColumn = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.StartColumn |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EndColumn", wireType)
+			}
+			m.EndColumn = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.EndColumn |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}


### PR DESCRIPTION
## What

Adds `start_line`, `end_line`, `start_column`, `end_column` to `FileComponent` in the FEX proto.

## Why

SAST/SARIF findings identify a specific location in a file, but `FileComponent` only had `path` — so the SARIF converter (cnspec `upload --format sarif`) currently drops the region line info. This gives file-based findings a first-class home for the code location, and sets up SAST source/sink locations.

Part of ADR-062's field-fidelity proto-extension backlog (Tier 1, code location).

## Compatibility

Additive and backward-compatible (`0` = unset). Follow-ups: mirror in the server `etl` proto (same as the HttpRequest change), then have the SARIF converter populate the lines from SARIF `region.startLine`/`startColumn`.

## Verification

- `go generate` reproduces pb/vtproto; protolint / gofmt / golangci-lint clean; tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)