### PR TITLE
✨ snowflake: support programmatic access token (PAT) auth

### DIFF
--- a/providers/snowflake/README.md
+++ b/providers/snowflake/README.md
@@ -13,7 +13,35 @@ Required arguments:
 
 > The easiest way to get the account name and region is to look at the URL when you log in to the Snowflake web interface. When clicking on the account icon you can copy the account URL that included the account name and region.
 
-**Password Authentication**
+**Programmatic Access Token (PAT) — recommended**
+
+A programmatic access token (PAT) is Snowflake's recommended method for tools and automation. It replaces password sign-ins, which Snowflake is phasing out, and can be scoped to a role and governed by a network policy.
+
+Arguments:
+
+- `--token` - The programmatic access token.
+
+```shell
+cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --token <your PAT>
+```
+
+> To generate a PAT, use [Snowsight](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) and assign it to your user. Prefer a token scoped to the least-privileged role that still allows the scan.
+
+**Key-Pair Authentication**
+
+Arguments:
+
+- `--identity-file` (`-i`) - The path to the private key file.
+
+```shell
+cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --identity-file ~/.ssh/id_rsa
+```
+
+> You need to generate a RSA key pair and assign the public key to your user via [Snowsight](https://docs.snowflake.com/en/user-guide/key-pair-auth).
+
+**Password Authentication (legacy)**
+
+Password sign-ins are being deprecated by Snowflake and require MFA for interactive users. Prefer a PAT or key-pair for new setups.
 
 Arguments:
 
@@ -21,22 +49,10 @@ Arguments:
 - `--ask-pass` - Prompt for the Snowflake password.
 
 ```shell
-shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS  --role ACCOUNTADMIN --ask-pass
+cnspec shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS --role ACCOUNTADMIN --ask-pass
 ```
 
 > To create a username and password, use [Snowsight](https://docs.snowflake.com/en/user-guide/admin-user-management#using-snowsight) or using [SQL](https://docs.snowflake.com/en/user-guide/admin-user-management#using-sql).
-
-**Certificate Authentication**
-
-Arguments:
-
-- `--private-key` - The path to the private key file.
-
-```shell
-shell snowflake --account zi12345 --region us-central1.gcp --user CHRIS  --role ACCOUNTADMIN --private-key ~/.ssh/id_rsa
-```
-
-> You need to generate a RSA key pair and assign the public key to your user via [Snowsight](https://docs.snowflake.com/en/user-guide/key-pair-auth).
 
 ## Asset Discovery
 

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -22,13 +22,13 @@ var Config = plugin.Provider{
 			Short: "a Snowflake account",
 			Long: `Use the snowflake provider to query a Snowflake account.
 
-To access a Snowflake account, you must first authenticate with Snowflake. To do so, create an RSA key pair and assign the public key to your user account using Snowsight. To learn how, read https://docs.snowflake.com/en/user-guide/key-pair-auth.
+To access a Snowflake account, you must first authenticate with Snowflake. The recommended method is a programmatic access token (PAT), which replaces password sign-ins that Snowflake is phasing out. Generate a PAT for your user in Snowsight and pass it with --token. Key-pair authentication (--identity-file) is also supported; to learn how, read https://docs.snowflake.com/en/user-guide/key-pair-auth.
 
 Once you successfully authenticate, you can scan or query the Snowflake account.
 
 Example:
-  cnspec shell snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --identity-file <path to your private RSA key>
-  cnspec scan snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --identity-file <path to your private RSA key>
+  cnspec shell snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --token <your PAT>
+  cnspec scan snowflake --account <account id> --region <region> --user <your id> --role <the role you use> --token <your PAT>
 `,
 			Discovery: []string{
 				connection.DiscoveryAuto,
@@ -48,6 +48,14 @@ Example:
 					Type:        plugin.FlagType_Bool,
 					Default:     "false",
 					Desc:        "Prompt for the connection password",
+					ConfigEntry: "-",
+				},
+				{
+					Long:        "token",
+					Type:        plugin.FlagType_String,
+					Default:     "",
+					Desc:        "Set the programmatic access token (PAT)",
+					Option:      plugin.FlagOption_Password,
 					ConfigEntry: "-",
 				},
 				{

--- a/providers/snowflake/connection/connection.go
+++ b/providers/snowflake/connection/connection.go
@@ -79,6 +79,11 @@ func NewSnowflakeConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 			}
 			cfg.PrivateKey = key
 			cfg.Authenticator = gosnowflake.AuthTypeJwt
+		case vault.CredentialType_bearer:
+			// A programmatic access token (PAT) is passed as a bearer token.
+			cfg.User = cred.User
+			cfg.Token = string(cred.Secret)
+			cfg.Authenticator = gosnowflake.AuthTypePat
 		}
 	}
 

--- a/providers/snowflake/provider/provider.go
+++ b/providers/snowflake/provider/provider.go
@@ -47,6 +47,23 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		user = string(x.Value)
 	}
 
+	flagSet := func(name string) bool {
+		x, ok := flags[name]
+		return ok && len(x.Value) != 0
+	}
+	askPass := false
+	if x, ok := flags["ask-pass"]; ok {
+		if b, ok := x.RawData().Value.(bool); ok {
+			askPass = b
+		}
+	}
+
+	// A programmatic access token is a complete authentication method on its own;
+	// combining it with a password is ambiguous, so reject that up front.
+	if flagSet("token") && (flagSet("password") || askPass) {
+		return nil, errors.New("cannot combine --token with --password or --ask-pass; choose one authentication method")
+	}
+
 	if x, ok := flags["token"]; ok && len(x.Value) != 0 {
 		// A programmatic access token (PAT) authenticates as a bearer token.
 		conf.Credentials = append(conf.Credentials, &vault.Credential{

--- a/providers/snowflake/provider/provider.go
+++ b/providers/snowflake/provider/provider.go
@@ -47,6 +47,15 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 		user = string(x.Value)
 	}
 
+	if x, ok := flags["token"]; ok && len(x.Value) != 0 {
+		// A programmatic access token (PAT) authenticates as a bearer token.
+		conf.Credentials = append(conf.Credentials, &vault.Credential{
+			Type:   vault.CredentialType_bearer,
+			User:   user,
+			Secret: x.Value,
+		})
+	}
+
 	if x, ok := flags["password"]; ok && len(x.Value) != 0 {
 		conf.Credentials = append(conf.Credentials, vault.NewPasswordCredential(user, string(x.Value)))
 	}

--- a/providers/snowflake/provider/provider_test.go
+++ b/providers/snowflake/provider/provider_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func parseCLI(t *testing.T, flags map[string]*llx.Primitive) (*plugin.ParseCLIRes, error) {
+	t.Helper()
+	return Init().ParseCLI(&plugin.ParseCLIReq{Connector: "snowflake", Flags: flags})
+}
+
+func TestParseCLI_TokenExcludesPassword(t *testing.T) {
+	_, err := parseCLI(t, map[string]*llx.Primitive{
+		"user":     llx.StringPrimitive("CHRIS"),
+		"token":    llx.StringPrimitive("pat-abc"),
+		"password": llx.StringPrimitive("hunter2"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine --token")
+}
+
+func TestParseCLI_TokenExcludesAskPass(t *testing.T) {
+	_, err := parseCLI(t, map[string]*llx.Primitive{
+		"user":     llx.StringPrimitive("CHRIS"),
+		"token":    llx.StringPrimitive("pat-abc"),
+		"ask-pass": llx.BoolPrimitive(true),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine --token")
+}
+
+// ask-pass explicitly false must not trip the mutual-exclusion check.
+func TestParseCLI_TokenWithAskPassFalse(t *testing.T) {
+	res, err := parseCLI(t, map[string]*llx.Primitive{
+		"user":     llx.StringPrimitive("CHRIS"),
+		"token":    llx.StringPrimitive("pat-abc"),
+		"ask-pass": llx.BoolPrimitive(false),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Asset.Connections[0].Credentials, 1)
+	assert.Equal(t, vault.CredentialType_bearer, res.Asset.Connections[0].Credentials[0].Type)
+}
+
+func TestParseCLI_TokenAloneIsBearerCredential(t *testing.T) {
+	res, err := parseCLI(t, map[string]*llx.Primitive{
+		"user":  llx.StringPrimitive("CHRIS"),
+		"token": llx.StringPrimitive("pat-abc"),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Asset.Connections[0].Credentials, 1)
+	cred := res.Asset.Connections[0].Credentials[0]
+	assert.Equal(t, vault.CredentialType_bearer, cred.Type)
+	assert.Equal(t, "CHRIS", cred.User)
+	assert.Equal(t, "pat-abc", string(cred.Secret))
+}
+
+func TestParseCLI_PasswordAloneIsAllowed(t *testing.T) {
+	res, err := parseCLI(t, map[string]*llx.Primitive{
+		"user":     llx.StringPrimitive("CHRIS"),
+		"password": llx.StringPrimitive("hunter2"),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Asset.Connections[0].Credentials, 1)
+	assert.Equal(t, vault.CredentialType_password, res.Asset.Connections[0].Credentials[0].Type)
+}


### PR DESCRIPTION
## What

Add **Programmatic Access Token (PAT)** authentication to the Snowflake provider, and make it the **recommended/default** method in the docs.

Snowflake is phasing out password sign-ins (MFA enforcement through 2025, programmatic-password deprecation). A PAT is Snowflake's modern replacement for tools and automation: it's tied to a user, scoped to a role, expiring, and governable by a network policy.

## How

- New `--token` flag carries the PAT. It's stored as a `bearer` credential (`FlagOption_Password`, so it's masked and not persisted to config).
- The connection maps a `bearer` credential to gosnowflake's `AuthTypePat` (`cfg.Token`), alongside the existing password (`AuthTypeSnowflake`) and key-pair (`AuthTypeJwt`) paths.
- Docs updated so **PAT leads as the default**:
  - README auth section reordered: PAT (recommended) → key-pair → password (marked legacy).
  - CLI `Long` help + examples now use `--token`.
  - Fixed a stale flag name in the README (`--private-key` → the real flag `--identity-file`).

## Auth methods now supported

| Method | Flag | AuthType |
|--------|------|----------|
| Programmatic Access Token (**recommended**) | `--token` | `AuthTypePat` |
| Key-pair | `--identity-file` | `AuthTypeJwt` |
| Password (legacy) | `--password` / `--ask-pass` | `AuthTypeSnowflake` |

## Testing

- `go build ./...`, `go vet`, and `go test ./...` pass for the provider module.
- No `.lr` changes, so no codegen; no `permissions.json` (Snowflake is role-based).

> Live verification against a real Snowflake account with a PAT is still pending (no test account wired here). The change is a thin mapping onto the already-supported gosnowflake config, but an end-to-end PAT sign-in should be smoke-tested before relying on it.

## Follow-ups (deferred, from the same auth review)

Also available in the pinned driver if there's demand: **Workload Identity Federation** (secretless cloud-workload auth) and **OAuth** (token / client-credentials). Scoped out of this PR to keep it minimal.
