### PR TITLE
🌟 alicloud: add fine-grained asset discovery (ALB, NLB, VPC, WAF, Cloud Firewall, ACK)

### DIFF
--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -36,6 +36,12 @@ Examples:
 				resources.DiscoveryAuto,
 				resources.DiscoveryAll,
 				resources.DiscoveryAccounts,
+				resources.DiscoveryK8sClusters,
+				resources.DiscoveryAlbs,
+				resources.DiscoveryNlbs,
+				resources.DiscoveryVpcs,
+				resources.DiscoveryWaf,
+				resources.DiscoveryCloudFirewall,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/alicloud/connection/platform.go
+++ b/providers/alicloud/connection/platform.go
@@ -1,0 +1,109 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+const (
+	// Scope options that pin a discovered child connection to a single object.
+	OptionClusterID     = "cluster-id"
+	OptionAlbID         = "alb-id"
+	OptionNlbID         = "nlb-id"
+	OptionVpcID         = "vpc-id"
+	OptionWafInstanceID = "waf-instance-id"
+	OptionCloudFirewall = "cloud-firewall"
+)
+
+const (
+	platformIDAccount       = "//platformid.api.mondoo.app/runtime/alicloud/account/"
+	platformIDAckCluster    = "//platformid.api.mondoo.app/runtime/alicloud/ack/cluster/"
+	platformIDAlb           = "//platformid.api.mondoo.app/runtime/alicloud/alb/loadbalancer/"
+	platformIDNlb           = "//platformid.api.mondoo.app/runtime/alicloud/nlb/loadbalancer/"
+	platformIDVpc           = "//platformid.api.mondoo.app/runtime/alicloud/vpc/network/"
+	platformIDWafInstance   = "//platformid.api.mondoo.app/runtime/alicloud/waf/instance/"
+	platformIDCloudFirewall = "//platformid.api.mondoo.app/runtime/alicloud/cloudfirewall/"
+)
+
+// Platforms is the static catalog of platforms the alicloud provider emits: the
+// account itself, and the per-object platforms produced by fine-grained asset
+// discovery.
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "alicloud", Title: "Alibaba Cloud account", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-ack-cluster", Title: "Alibaba Cloud ACK Cluster", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-alb-loadbalancer", Title: "Alibaba Cloud Application Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-nlb-loadbalancer", Title: "Alibaba Cloud Network Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-vpc", Title: "Alibaba Cloud VPC", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-waf-instance", Title: "Alibaba Cloud Web Application Firewall", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-cloud-firewall", Title: "Alibaba Cloud Cloud Firewall", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}
+
+func newPlatform(name, title string, segments []string) *inventory.Platform {
+	p := &inventory.Platform{}
+	if title != "" {
+		p.Title = title
+	}
+	p.TechnologyUrlSegments = segments
+	PlatformByName(name).Apply(p)
+	return p
+}
+
+// NewAccountPlatform returns the platform for an Alibaba Cloud account asset.
+func NewAccountPlatform(accountID string) *inventory.Platform {
+	return newPlatform("alicloud", "Alibaba Cloud account "+accountID,
+		[]string{"technology=alicloud", "kind=account", "account=" + accountID})
+}
+
+// NewAckClusterPlatform returns the platform for a discovered ACK cluster asset.
+func NewAckClusterPlatform(clusterID string) *inventory.Platform {
+	return newPlatform("alicloud-ack-cluster", "",
+		[]string{"technology=alicloud", "kind=ack-cluster", "cluster=" + clusterID})
+}
+
+// NewAlbPlatform returns the platform for a discovered ALB load balancer asset.
+func NewAlbPlatform(lbID string) *inventory.Platform {
+	return newPlatform("alicloud-alb-loadbalancer", "",
+		[]string{"technology=alicloud", "kind=alb-loadbalancer", "loadbalancer=" + lbID})
+}
+
+// NewNlbPlatform returns the platform for a discovered NLB load balancer asset.
+func NewNlbPlatform(lbID string) *inventory.Platform {
+	return newPlatform("alicloud-nlb-loadbalancer", "",
+		[]string{"technology=alicloud", "kind=nlb-loadbalancer", "loadbalancer=" + lbID})
+}
+
+// NewVpcPlatform returns the platform for a discovered VPC asset.
+func NewVpcPlatform(vpcID string) *inventory.Platform {
+	return newPlatform("alicloud-vpc", "",
+		[]string{"technology=alicloud", "kind=vpc", "vpc=" + vpcID})
+}
+
+// NewWafInstancePlatform returns the platform for a discovered WAF instance asset.
+func NewWafInstancePlatform(instanceID string) *inventory.Platform {
+	return newPlatform("alicloud-waf-instance", "",
+		[]string{"technology=alicloud", "kind=waf-instance", "instance=" + instanceID})
+}
+
+// NewCloudFirewallPlatform returns the platform for the account's Cloud Firewall asset.
+func NewCloudFirewallPlatform(accountID string) *inventory.Platform {
+	return newPlatform("alicloud-cloud-firewall", "",
+		[]string{"technology=alicloud", "kind=cloud-firewall", "account=" + accountID})
+}
+
+func NewAccountIdentifier(accountID string) string       { return platformIDAccount + accountID }
+func NewAckClusterIdentifier(clusterID string) string    { return platformIDAckCluster + clusterID }
+func NewAlbIdentifier(lbID string) string                { return platformIDAlb + lbID }
+func NewNlbIdentifier(lbID string) string                { return platformIDNlb + lbID }
+func NewVpcIdentifier(vpcID string) string               { return platformIDVpc + vpcID }
+func NewWafInstanceIdentifier(instanceID string) string  { return platformIDWafInstance + instanceID }
+func NewCloudFirewallIdentifier(accountID string) string { return platformIDCloudFirewall + accountID }

--- a/providers/alicloud/connection/platform_test.go
+++ b/providers/alicloud/connection/platform_test.go
@@ -1,0 +1,37 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAlicloudPlatforms verifies every catalog entry is retrievable by name and
+// that each constructor produces a platform consistent with its catalog entry.
+func TestAlicloudPlatforms(t *testing.T) {
+	for _, pi := range Platforms {
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+	}
+	assert.True(t, PlatformByName("alicloud").Consistent(NewAccountPlatform("1234567890")))
+	assert.True(t, PlatformByName("alicloud-ack-cluster").Consistent(NewAckClusterPlatform("c-abc")))
+	assert.True(t, PlatformByName("alicloud-alb-loadbalancer").Consistent(NewAlbPlatform("alb-abc")))
+	assert.True(t, PlatformByName("alicloud-nlb-loadbalancer").Consistent(NewNlbPlatform("nlb-abc")))
+	assert.True(t, PlatformByName("alicloud-vpc").Consistent(NewVpcPlatform("vpc-abc")))
+	assert.True(t, PlatformByName("alicloud-waf-instance").Consistent(NewWafInstancePlatform("waf-abc")))
+	assert.True(t, PlatformByName("alicloud-cloud-firewall").Consistent(NewCloudFirewallPlatform("1234567890")))
+}
+
+// TestAlicloudIdentifiers pins the stable platform-id formats used for asset
+// deduplication; changing them would orphan previously-scanned assets.
+func TestAlicloudIdentifiers(t *testing.T) {
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/account/1234567890", NewAccountIdentifier("1234567890"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/ack/cluster/c-abc", NewAckClusterIdentifier("c-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/alb/loadbalancer/alb-abc", NewAlbIdentifier("alb-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/nlb/loadbalancer/nlb-abc", NewNlbIdentifier("nlb-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/vpc/network/vpc-abc", NewVpcIdentifier("vpc-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/waf/instance/waf-abc", NewWafInstanceIdentifier("waf-abc"))
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/alicloud/cloudfirewall/1234567890", NewCloudFirewallIdentifier("1234567890"))
+}

--- a/providers/alicloud/provider/discover.go
+++ b/providers/alicloud/provider/discover.go
@@ -1,0 +1,31 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/alicloud/connection"
+	"go.mondoo.com/mql/v13/providers/alicloud/resources"
+)
+
+// discover runs fine-grained asset discovery for the account connection,
+// returning one child asset per discovered service object. It is a no-op when
+// discovery is disabled on the connection.
+func (s *Service) discover(conn *connection.AlicloudConnection) (*inventory.Inventory, error) {
+	conns := conn.Asset().Connections
+	if len(conns) == 0 {
+		return nil, nil
+	}
+	conf := conns[0]
+	if conf.Discover == nil {
+		return nil, nil
+	}
+
+	runtime, err := s.GetRuntime(conn.ID())
+	if err != nil {
+		return nil, err
+	}
+
+	return resources.Discover(runtime, conf)
+}

--- a/providers/alicloud/provider/provider.go
+++ b/providers/alicloud/provider/provider.go
@@ -113,11 +113,16 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		}
 	}
 
+	inv, err := s.discover(conn)
+	if err != nil {
+		return nil, err
+	}
+
 	return &plugin.ConnectRes{
 		Id:        conn.ID(),
 		Name:      conn.Name(),
 		Asset:     req.Asset,
-		Inventory: nil,
+		Inventory: inv,
 	}, nil
 }
 
@@ -174,17 +179,8 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AlicloudConnec
 
 	asset.Id = "alicloud/" + accountID
 	asset.Name = "Alibaba Cloud account " + accountID
-
-	asset.Platform = &inventory.Platform{
-		Name:                  "alicloud",
-		Family:                []string{"alicloud"},
-		Kind:                  "api",
-		Runtime:               "alicloud",
-		Title:                 "Alibaba Cloud account " + accountID,
-		TechnologyUrlSegments: []string{"technology=alicloud", "kind=account", "account=" + accountID},
-	}
-
-	asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/alicloud/account/" + accountID}
+	asset.Platform = connection.NewAccountPlatform(accountID)
+	asset.PlatformIds = []string{connection.NewAccountIdentifier(accountID)}
 	return nil
 }
 

--- a/providers/alicloud/resources/discovery.go
+++ b/providers/alicloud/resources/discovery.go
@@ -3,12 +3,265 @@
 
 package resources
 
-// Discovery targets recognized by the alicloud provider. `auto` and `all`
-// resolve to the account asset today; per-resource asset discovery (turning
-// each ECS instance, RDS instance, etc. into its own scannable asset) is layered
-// on top of these constants as it is implemented.
-const (
-	DiscoveryAuto     = "auto"
-	DiscoveryAll      = "all"
-	DiscoveryAccounts = "accounts"
+import (
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/alicloud/connection"
+	"go.mondoo.com/mql/v13/utils/stringx"
 )
+
+// Discovery targets recognized by the alicloud provider. `accounts` yields the
+// account asset the connection targets; the fine-grained targets turn each
+// major service object into its own scannable asset. `auto` and `all` expand to
+// every fine-grained target.
+const (
+	DiscoveryAuto          = "auto"
+	DiscoveryAll           = "all"
+	DiscoveryAccounts      = "accounts"
+	DiscoveryK8sClusters   = "k8s-clusters"
+	DiscoveryAlbs          = "albs"
+	DiscoveryNlbs          = "nlbs"
+	DiscoveryVpcs          = "vpcs"
+	DiscoveryWaf           = "waf"
+	DiscoveryCloudFirewall = "cloud-firewall"
+)
+
+// Discover enumerates the major service objects in the account and returns one
+// child asset per object, scoped to that object's region with further discovery
+// disabled. The account itself is always the connected root asset, so the
+// `accounts` target produces no discovered children.
+func Discover(runtime *plugin.Runtime, conf *inventory.Config) (*inventory.Inventory, error) {
+	conn := runtime.Connection.(*connection.AlicloudConnection)
+
+	in := &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: []*inventory.Asset{}}}
+	if conf.Discover == nil || len(conf.Discover.Targets) == 0 {
+		return in, nil
+	}
+
+	for _, target := range handleTargets(conf.Discover.Targets) {
+		var assets []*inventory.Asset
+		var err error
+		switch target {
+		case DiscoveryK8sClusters:
+			assets, err = discoverAckClusters(runtime, conn, conf)
+		case DiscoveryAlbs:
+			assets, err = discoverAlbs(runtime, conn, conf)
+		case DiscoveryNlbs:
+			assets, err = discoverNlbs(runtime, conn, conf)
+		case DiscoveryVpcs:
+			assets, err = discoverVpcs(runtime, conn, conf)
+		case DiscoveryWaf:
+			assets, err = discoverWaf(runtime, conn, conf)
+		case DiscoveryCloudFirewall:
+			assets, err = discoverCloudFirewall(runtime, conn, conf)
+		case DiscoveryAccounts:
+			// the account is already returned as the connected root asset, so it
+			// contributes no discovered child assets
+			continue
+		default:
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		in.Spec.Assets = append(in.Spec.Assets, assets...)
+	}
+
+	return in, nil
+}
+
+// handleTargets expands `auto`/`all` into every fine-grained target.
+func handleTargets(targets []string) []string {
+	if stringx.ContainsAnyOf(targets, DiscoveryAll, DiscoveryAuto) {
+		return []string{
+			DiscoveryK8sClusters,
+			DiscoveryAlbs,
+			DiscoveryNlbs,
+			DiscoveryVpcs,
+			DiscoveryWaf,
+			DiscoveryCloudFirewall,
+		}
+	}
+	return targets
+}
+
+func discoverAckClusters(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.cs", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	clusters, err := res.(*mqlAlicloudCs).clusters()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(clusters))
+	for _, ic := range clusters {
+		cluster := ic.(*mqlAlicloudCsCluster)
+		id := cluster.ClusterId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), cluster.RegionId.Data,
+			connection.NewAckClusterIdentifier(id), connection.NewAckClusterPlatform(id),
+			nameOr(cluster.Name.Data, id), connection.OptionClusterID, id))
+	}
+	return assets, nil
+}
+
+func discoverAlbs(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.alb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	lbs, err := res.(*mqlAlicloudAlb).loadBalancers()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(lbs))
+	for _, il := range lbs {
+		lb := il.(*mqlAlicloudAlbLoadBalancer)
+		id := lb.LoadBalancerId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), lb.RegionId.Data,
+			connection.NewAlbIdentifier(id), connection.NewAlbPlatform(id),
+			nameOr(lb.Name.Data, id), connection.OptionAlbID, id))
+	}
+	return assets, nil
+}
+
+func discoverNlbs(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.nlb", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	lbs, err := res.(*mqlAlicloudNlb).loadBalancers()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(lbs))
+	for _, il := range lbs {
+		lb := il.(*mqlAlicloudNlbLoadBalancer)
+		id := lb.LoadBalancerId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), lb.RegionId.Data,
+			connection.NewNlbIdentifier(id), connection.NewNlbPlatform(id),
+			nameOr(lb.Name.Data, id), connection.OptionNlbID, id))
+	}
+	return assets, nil
+}
+
+func discoverVpcs(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.vpc", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	networks, err := res.(*mqlAlicloudVpc).networks()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(networks))
+	for _, in := range networks {
+		vpc := in.(*mqlAlicloudVpcNetwork)
+		id := vpc.VpcId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), vpc.RegionId.Data,
+			connection.NewVpcIdentifier(id), connection.NewVpcPlatform(id),
+			nameOr(vpc.VpcName.Data, id), connection.OptionVpcID, id))
+	}
+	return assets, nil
+}
+
+func discoverWaf(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.waf", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	instances, err := res.(*mqlAlicloudWaf).instances()
+	if err != nil {
+		return nil, err
+	}
+	assets := make([]*inventory.Asset, 0, len(instances))
+	for _, ii := range instances {
+		inst := ii.(*mqlAlicloudWafInstance)
+		id := inst.InstanceId.Data
+		if id == "" {
+			continue
+		}
+		assets = append(assets, newChildAsset(conf, conn.ID(), inst.RegionId.Data,
+			connection.NewWafInstanceIdentifier(id), connection.NewWafInstancePlatform(id),
+			"WAF "+inst.RegionId.Data, connection.OptionWafInstanceID, id))
+	}
+	return assets, nil
+}
+
+func discoverCloudFirewall(runtime *plugin.Runtime, conn *connection.AlicloudConnection, conf *inventory.Config) ([]*inventory.Asset, error) {
+	res, err := CreateResource(runtime, "alicloud.cloudFirewall", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	// Cloud Firewall is account-global; emit a single asset only when the
+	// service is provisioned for the account (edition > 0).
+	edition, err := res.(*mqlAlicloudCloudFirewall).edition()
+	if err != nil {
+		return nil, err
+	}
+	if edition == 0 {
+		return nil, nil
+	}
+	// The account id is already cached on the connection from the detect step,
+	// so this avoids a redundant STS call; fall back to Identify only if unset.
+	accountID := conn.AccountID()
+	if accountID == "" {
+		accountID, err = conn.Identify()
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Cloud Firewall is a center service, so no region is stamped on the scope.
+	asset := newChildAsset(conf, conn.ID(), "",
+		connection.NewCloudFirewallIdentifier(accountID), connection.NewCloudFirewallPlatform(accountID),
+		"Cloud Firewall "+accountID, connection.OptionCloudFirewall, accountID)
+	return []*inventory.Asset{asset}, nil
+}
+
+// newChildAsset builds a discovered child asset with a scoped connection config.
+func newChildAsset(conf *inventory.Config, parentID uint32, region, platformID string, platform *inventory.Platform, name, scopeKey, scopeValue string) *inventory.Asset {
+	return &inventory.Asset{
+		PlatformIds: []string{platformID},
+		Name:        name,
+		Platform:    platform,
+		Labels:      map[string]string{},
+		Connections: []*inventory.Config{scopedConfig(conf, parentID, region, scopeKey, scopeValue)},
+	}
+}
+
+// nameOr returns name when non-empty, otherwise the fallback id.
+func nameOr(name, fallback string) string {
+	if name == "" {
+		return fallback
+	}
+	return name
+}
+
+// scopedConfig clones the base connection config for a discovered child asset,
+// disabling further discovery, recording the parent connection, narrowing the
+// region fan-out to the object's region, and stamping the scope id so the child
+// asset resolves to a single object.
+func scopedConfig(conf *inventory.Config, parentID uint32, region, scopeKey, scopeValue string) *inventory.Config {
+	clone := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(parentID))
+	if clone.Options == nil {
+		clone.Options = map[string]string{}
+	}
+	clone.Options[scopeKey] = scopeValue
+	if region != "" {
+		clone.Options[connection.OptionRegions] = region
+	}
+	return clone
+}

--- a/providers/alicloud/resources/discovery_test.go
+++ b/providers/alicloud/resources/discovery_test.go
@@ -1,0 +1,27 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHandleTargets covers the discovery-target expansion: auto and all expand
+// to every fine-grained target, while explicit targets pass through unchanged.
+func TestHandleTargets(t *testing.T) {
+	fineGrained := []string{
+		DiscoveryK8sClusters, DiscoveryAlbs, DiscoveryNlbs,
+		DiscoveryVpcs, DiscoveryWaf, DiscoveryCloudFirewall,
+	}
+
+	assert.ElementsMatch(t, fineGrained, handleTargets([]string{DiscoveryAuto}))
+	assert.ElementsMatch(t, fineGrained, handleTargets([]string{DiscoveryAll}))
+	assert.ElementsMatch(t, fineGrained, handleTargets([]string{DiscoveryAuto, DiscoveryAlbs}))
+
+	assert.Equal(t, []string{DiscoveryAlbs}, handleTargets([]string{DiscoveryAlbs}))
+	assert.Equal(t, []string{DiscoveryVpcs}, handleTargets([]string{DiscoveryVpcs}))
+	assert.Equal(t, []string{DiscoveryAccounts}, handleTargets([]string{DiscoveryAccounts}))
+}


### PR DESCRIPTION
## What

Adds **fine-grained asset discovery** to the Alibaba Cloud provider. Previously the provider only ever produced the account asset; now discovery enumerates each major **network and security object** as its own scannable asset with a distinct platform and stable platform id.

Discovered asset types:

| Target | Object | Platform |
|---|---|---|
| `albs` | Application Load Balancers | `alicloud-alb-loadbalancer` |
| `nlbs` | Network Load Balancers | `alicloud-nlb-loadbalancer` |
| `vpcs` | VPCs | `alicloud-vpc` |
| `waf` | WAF instances (per center) | `alicloud-waf-instance` |
| `cloud-firewall` | the account's Cloud Firewall | `alicloud-cloud-firewall` |
| `k8s-clusters` | ACK clusters | `alicloud-ack-cluster` |

`auto`/`all` expand to all of them. The **account** is always the connected root asset, so `accounts` yields no discovered children.

This follows the established provider-discovery pattern (mirrors the nutanix provider): each discovered object becomes an `inventory.Asset` with a **scoped connection config** — discovery disabled, region narrowed to the object's region, and a scope id stamped for identity.

## How it works

- **`connection/platform.go`** — a static platform catalog (`PlatformByName`) with typed platform + stable identifier constructors for each object type. The ACK cluster platform is named **`alicloud-ack-cluster`** to follow the managed-Kubernetes product-brand convention (`aws-eks-cluster` / `gcp-gke-cluster`), not the internal `cs` API service code.
- **`resources/discovery.go`** — `Discover(runtime, conf)` lists `alicloud.cs.clusters`, `alicloud.alb`/`nlb` `loadBalancers`, `alicloud.vpc.networks`, `alicloud.waf.instances`, and the account's Cloud Firewall, building one child asset each. Cloud Firewall is account-global, so a single asset is emitted **only when the service is provisioned** (`edition > 0`), reusing the connection's cached account id.
- **`provider/`** — `Connect` returns the discovered inventory (`discover.go`); `detect()` reuses the shared account-platform constructor.
- **`config`** — exposes the discovery targets.

Usage:

```
cnspec scan alicloud --discover vpcs                 # each VPC as an asset
cnspec scan alicloud --discover albs,nlbs            # each load balancer as an asset
cnspec scan alicloud --discover waf,cloud-firewall
cnspec scan alicloud                                 # auto => all of the above, plus the account
```

## Notes

- Each regional child asset's connection carries `regions=<object's region>` so its resource fan-out is narrowed to the object's region, plus the scope id for a stable identity. Cloud Firewall is a center service, so no region is stamped. `--discover accounts` keeps account-only behavior.
- `Discover` guards a nil/empty `Discover` config and an empty `Connections` slice, so it is safe to call directly (not only through the current `Connect` path).
- No `.lr` or dependency changes — this is purely the discovery subsystem. Only `dist/` regenerates (gitignored).
- Unit tests cover the target expansion (`auto`/`all` -> fine-grained) and the stable platform-id formats (changing those would orphan previously-scanned assets).
- The framework generalizes: adding another discoverable object is a new target constant + a `discoverX` helper + a catalog entry.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...`, `make providers/build/alicloud`, `gofmt -s` — all pass

Live validation batched via the provider-verification flow.
