### PR TITLE
🌟 vercel: typed cross-resource references for webhooks, integrations, and project domains

### DIFF
--- a/providers/vercel/resources/projects.go
+++ b/providers/vercel/resources/projects.go
@@ -200,6 +200,36 @@ func (c *mqlVercelProject) id() (string, error) {
 	return c.Id.Data, c.Id.Error
 }
 
+// resolveProjectRefs resolves a list of project ids into typed vercel.project
+// references. Ids that no longer resolve (project deleted, or not visible to the
+// token) are skipped rather than failing the whole list; other errors propagate.
+func resolveProjectRefs(runtime *plugin.Runtime, teamID string, projectIDs []string) ([]any, error) {
+	conn := runtime.Connection.(*connection.VercelConnection)
+
+	out := []any{}
+	for _, projectID := range projectIDs {
+		if projectID == "" {
+			continue
+		}
+		var rec projectRecord
+		if err := conn.Get(context.Background(), "/v9/projects/"+projectID, connection.TeamQuery(teamID), &rec); err != nil {
+			if connection.IsForbidden(err) || connection.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		if rec.ID == "" {
+			rec.ID = projectID
+		}
+		project, err := newVercelProject(runtime, teamID, &rec)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, project)
+	}
+	return out, nil
+}
+
 // --- environment variables ------------------------------------------------
 
 type envRecord struct {
@@ -347,6 +377,13 @@ func (c *mqlVercelDeployment) id() (string, error) {
 
 // --- project domains ------------------------------------------------------
 
+// mqlVercelProjectDomainInternal caches the team a project domain belongs to and
+// its apex name, so apexDomain can resolve the typed team-domain reference.
+type mqlVercelProjectDomainInternal struct {
+	teamID   string
+	apexName string
+}
+
 type projectDomainRecord struct {
 	Name               string   `json:"name"`
 	ApexName           string   `json:"apexName"`
@@ -385,7 +422,37 @@ func (c *mqlVercelProject) domains() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, domain)
+		mqlDomain := domain.(*mqlVercelProjectDomain)
+		mqlDomain.teamID = c.teamID
+		mqlDomain.apexName = rec.ApexName
+		res = append(res, mqlDomain)
 	}
 	return res, nil
+}
+
+// apexDomain resolves the apex to the Vercel-managed team domain. Not every apex
+// is Vercel-managed (external or delegated domains exist), so the accessor
+// degrades to null when the domain is not found or not accessible.
+func (c *mqlVercelProjectDomain) apexDomain() (*mqlVercelDomain, error) {
+	if c.apexName == "" {
+		c.ApexDomain.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
+	var wrapper struct {
+		Domain domainRecord `json:"domain"`
+	}
+	if err := conn.Get(context.Background(), "/v5/domains/"+c.apexName, connection.TeamQuery(c.teamID), &wrapper); err != nil {
+		if connection.IsForbidden(err) || connection.IsNotFound(err) {
+			c.ApexDomain.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	rec := wrapper.Domain
+	if rec.Name == "" {
+		rec.Name = c.apexName
+	}
+	return newVercelDomain(c.MqlRuntime, c.teamID, &rec)
 }

--- a/providers/vercel/resources/projects.go
+++ b/providers/vercel/resources/projects.go
@@ -203,6 +203,11 @@ func (c *mqlVercelProject) id() (string, error) {
 // resolveProjectRefs resolves a list of project ids into typed vercel.project
 // references. Ids that no longer resolve (project deleted, or not visible to the
 // token) are skipped rather than failing the whole list; other errors propagate.
+//
+// This makes one project-by-id call per id (N+1); the Vercel API has no
+// filter-by-id-list endpoint, and webhooks / integrations are typically scoped
+// to a handful of projects, so the simple per-id resolve matches the existing
+// store.connectedProjects pattern.
 func resolveProjectRefs(runtime *plugin.Runtime, teamID string, projectIDs []string) ([]any, error) {
 	conn := runtime.Connection.(*connection.VercelConnection)
 

--- a/providers/vercel/resources/stores.go
+++ b/providers/vercel/resources/stores.go
@@ -196,25 +196,5 @@ func storeConnectedToProject(rec *storeRecord, projectID string) bool {
 }
 
 func (s *mqlVercelStore) connectedProjects() ([]any, error) {
-	conn := s.MqlRuntime.Connection.(*connection.VercelConnection)
-
-	out := []any{}
-	for _, projectID := range s.cacheProjectIds {
-		var rec projectRecord
-		if err := conn.Get(context.Background(), "/v9/projects/"+projectID, connection.TeamQuery(s.teamID), &rec); err != nil {
-			if connection.IsForbidden(err) || connection.IsNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-		if rec.ID == "" {
-			rec.ID = projectID
-		}
-		project, err := newVercelProject(s.MqlRuntime, s.teamID, &rec)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, project)
-	}
-	return out, nil
+	return resolveProjectRefs(s.MqlRuntime, s.teamID, s.cacheProjectIds)
 }

--- a/providers/vercel/resources/teams.go
+++ b/providers/vercel/resources/teams.go
@@ -172,6 +172,29 @@ type domainRecord struct {
 	BoughtAt            flexTime `json:"boughtAt"`
 }
 
+func newVercelDomain(runtime *plugin.Runtime, teamID string, rec *domainRecord) (*mqlVercelDomain, error) {
+	renew := rec.Renew != nil && *rec.Renew
+	domain, err := CreateResource(runtime, "vercel.domain", map[string]*llx.RawData{
+		"id":                  llx.StringData(rec.ID),
+		"name":                llx.StringData(rec.Name),
+		"serviceType":         llx.StringData(rec.ServiceType),
+		"verified":            llx.BoolData(rec.Verified),
+		"nameservers":         llx.ArrayData(strSliceToAny(rec.Nameservers), types.String),
+		"intendedNameservers": llx.ArrayData(strSliceToAny(rec.IntendedNameservers), types.String),
+		"cdnEnabled":          llx.BoolData(rec.CdnEnabled),
+		"renewAutomatically":  llx.BoolData(renew),
+		"createdAt":           llx.TimeDataPtr(rec.CreatedAt.Time()),
+		"expiresAt":           llx.TimeDataPtr(rec.ExpiresAt.Time()),
+		"boughtAt":            llx.TimeDataPtr(rec.BoughtAt.Time()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	mqlDomain := domain.(*mqlVercelDomain)
+	mqlDomain.teamID = teamID
+	return mqlDomain, nil
+}
+
 func (c *mqlVercelTeam) domains() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
 	records, err := connection.GetPaged[domainRecord](context.Background(), conn, "/v5/domains", connection.TeamQuery(c.Id.Data), "domains")
@@ -185,25 +208,10 @@ func (c *mqlVercelTeam) domains() ([]any, error) {
 	var res []any
 	for i := range records {
 		rec := records[i]
-		renew := rec.Renew != nil && *rec.Renew
-		domain, err := CreateResource(c.MqlRuntime, "vercel.domain", map[string]*llx.RawData{
-			"id":                  llx.StringData(rec.ID),
-			"name":                llx.StringData(rec.Name),
-			"serviceType":         llx.StringData(rec.ServiceType),
-			"verified":            llx.BoolData(rec.Verified),
-			"nameservers":         llx.ArrayData(strSliceToAny(rec.Nameservers), types.String),
-			"intendedNameservers": llx.ArrayData(strSliceToAny(rec.IntendedNameservers), types.String),
-			"cdnEnabled":          llx.BoolData(rec.CdnEnabled),
-			"renewAutomatically":  llx.BoolData(renew),
-			"createdAt":           llx.TimeDataPtr(rec.CreatedAt.Time()),
-			"expiresAt":           llx.TimeDataPtr(rec.ExpiresAt.Time()),
-			"boughtAt":            llx.TimeDataPtr(rec.BoughtAt.Time()),
-		})
+		mqlDomain, err := newVercelDomain(c.MqlRuntime, c.Id.Data, &rec)
 		if err != nil {
 			return nil, err
 		}
-		mqlDomain := domain.(*mqlVercelDomain)
-		mqlDomain.teamID = c.Id.Data
 		res = append(res, mqlDomain)
 	}
 	return res, nil
@@ -305,6 +313,14 @@ func (c *mqlVercelLogDrain) id() (string, error) {
 
 // --- webhooks -------------------------------------------------------------
 
+// mqlVercelWebhookInternal caches the team a webhook belongs to and the ids of
+// the projects it is scoped to, so projects can resolve typed project
+// references without re-listing the webhook.
+type mqlVercelWebhookInternal struct {
+	teamID          string
+	cacheProjectIds []string
+}
+
 type webhookRecord struct {
 	ID         string   `json:"id"`
 	URL        string   `json:"url"`
@@ -328,17 +344,19 @@ func (c *mqlVercelTeam) webhooks() ([]any, error) {
 	for i := range records {
 		rec := records[i]
 		hook, err := CreateResource(c.MqlRuntime, "vercel.webhook", map[string]*llx.RawData{
-			"id":         llx.StringData(rec.ID),
-			"url":        llx.StringData(rec.URL),
-			"events":     llx.ArrayData(strSliceToAny(rec.Events), types.String),
-			"projectIds": llx.ArrayData(strSliceToAny(rec.ProjectIds), types.String),
-			"createdAt":  llx.TimeDataPtr(rec.CreatedAt.Time()),
-			"updatedAt":  llx.TimeDataPtr(rec.UpdatedAt.Time()),
+			"id":        llx.StringData(rec.ID),
+			"url":       llx.StringData(rec.URL),
+			"events":    llx.ArrayData(strSliceToAny(rec.Events), types.String),
+			"createdAt": llx.TimeDataPtr(rec.CreatedAt.Time()),
+			"updatedAt": llx.TimeDataPtr(rec.UpdatedAt.Time()),
 		})
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, hook)
+		mqlHook := hook.(*mqlVercelWebhook)
+		mqlHook.teamID = c.Id.Data
+		mqlHook.cacheProjectIds = rec.ProjectIds
+		res = append(res, mqlHook)
 	}
 	return res, nil
 }
@@ -347,7 +365,20 @@ func (c *mqlVercelWebhook) id() (string, error) {
 	return c.Id.Data, c.Id.Error
 }
 
+func (c *mqlVercelWebhook) projects() ([]any, error) {
+	return resolveProjectRefs(c.MqlRuntime, c.teamID, c.cacheProjectIds)
+}
+
 // --- integration configurations -------------------------------------------
+
+// mqlVercelIntegrationConfigurationInternal caches the team an integration
+// configuration belongs to and the ids of the projects it is scoped to, so
+// projects can resolve typed project references without re-listing the
+// configuration.
+type mqlVercelIntegrationConfigurationInternal struct {
+	teamID          string
+	cacheProjectIds []string
+}
 
 type integrationConfigurationRecord struct {
 	ID               string   `json:"id"`
@@ -390,20 +421,26 @@ func (c *mqlVercelTeam) integrationConfigurations() ([]any, error) {
 			"scopes":           llx.ArrayData(strSliceToAny(rec.Scopes), types.String),
 			"installationType": llx.StringData(installationType),
 			"projectSelection": llx.StringData(rec.ProjectSelection),
-			"projectIds":       llx.ArrayData(strSliceToAny(rec.Projects), types.String),
 			"createdAt":        llx.TimeDataPtr(rec.CreatedAt.Time()),
 			"updatedAt":        llx.TimeDataPtr(rec.UpdatedAt.Time()),
 		})
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, cfg)
+		mqlCfg := cfg.(*mqlVercelIntegrationConfiguration)
+		mqlCfg.teamID = c.Id.Data
+		mqlCfg.cacheProjectIds = rec.Projects
+		res = append(res, mqlCfg)
 	}
 	return res, nil
 }
 
 func (c *mqlVercelIntegrationConfiguration) id() (string, error) {
 	return c.Id.Data, c.Id.Error
+}
+
+func (c *mqlVercelIntegrationConfiguration) projects() ([]any, error) {
+	return resolveProjectRefs(c.MqlRuntime, c.teamID, c.cacheProjectIds)
 }
 
 // --- access groups (enterprise) -------------------------------------------

--- a/providers/vercel/resources/vercel.lr
+++ b/providers/vercel/resources/vercel.lr
@@ -428,6 +428,10 @@ private vercel.project.domain @defaults("name") {
   name string
   // Apex domain the name belongs to
   apexName string
+  // Team domain the apex belongs to
+  //
+  // Null when the apex is not a Vercel-managed team domain.
+  apexDomain() vercel.domain
   // Redirect target, or null when the domain serves the project directly
   redirect string
   // HTTP status code used for the redirect, or null when not a redirect
@@ -562,10 +566,10 @@ private vercel.webhook @defaults("url") {
   url string
   // Event types the webhook subscribes to
   events []string
-  // Identifiers of projects the webhook is scoped to
+  // Projects the webhook fires on
   //
   // Empty when the webhook applies to the entire team.
-  projectIds []string
+  projects() []vercel.project
   // Time the webhook was created
   createdAt time
   // Time the webhook was last updated
@@ -594,10 +598,10 @@ private vercel.integrationConfiguration @defaults("slug") {
   //
   // One of all or selected.
   projectSelection string
-  // Identifiers of projects the integration is scoped to
+  // Projects the integration can access
   //
   // Empty when the integration can access every project.
-  projectIds []string
+  projects() []vercel.project
   // Time the integration was installed
   createdAt time
   // Time the integration was last updated

--- a/providers/vercel/resources/vercel.lr.go
+++ b/providers/vercel/resources/vercel.lr.go
@@ -594,6 +594,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vercel.project.domain.apexName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelProjectDomain).GetApexName()).ToDataRes(types.String)
 	},
+	"vercel.project.domain.apexDomain": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVercelProjectDomain).GetApexDomain()).ToDataRes(types.Resource("vercel.domain"))
+	},
 	"vercel.project.domain.redirect": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelProjectDomain).GetRedirect()).ToDataRes(types.String)
 	},
@@ -720,8 +723,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vercel.webhook.events": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelWebhook).GetEvents()).ToDataRes(types.Array(types.String))
 	},
-	"vercel.webhook.projectIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlVercelWebhook).GetProjectIds()).ToDataRes(types.Array(types.String))
+	"vercel.webhook.projects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVercelWebhook).GetProjects()).ToDataRes(types.Array(types.Resource("vercel.project")))
 	},
 	"vercel.webhook.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelWebhook).GetCreatedAt()).ToDataRes(types.Time)
@@ -744,8 +747,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"vercel.integrationConfiguration.projectSelection": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelIntegrationConfiguration).GetProjectSelection()).ToDataRes(types.String)
 	},
-	"vercel.integrationConfiguration.projectIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlVercelIntegrationConfiguration).GetProjectIds()).ToDataRes(types.Array(types.String))
+	"vercel.integrationConfiguration.projects": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlVercelIntegrationConfiguration).GetProjects()).ToDataRes(types.Array(types.Resource("vercel.project")))
 	},
 	"vercel.integrationConfiguration.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlVercelIntegrationConfiguration).GetCreatedAt()).ToDataRes(types.Time)
@@ -1424,6 +1427,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlVercelProjectDomain).ApexName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"vercel.project.domain.apexDomain": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVercelProjectDomain).ApexDomain, ok = plugin.RawToTValue[*mqlVercelDomain](v.Value, v.Error)
+		return
+	},
 	"vercel.project.domain.redirect": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlVercelProjectDomain).Redirect, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1608,8 +1615,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlVercelWebhook).Events, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"vercel.webhook.projectIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlVercelWebhook).ProjectIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"vercel.webhook.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVercelWebhook).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vercel.webhook.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1644,8 +1651,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlVercelIntegrationConfiguration).ProjectSelection, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"vercel.integrationConfiguration.projectIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlVercelIntegrationConfiguration).ProjectIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"vercel.integrationConfiguration.projects": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlVercelIntegrationConfiguration).Projects, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"vercel.integrationConfiguration.createdAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3235,9 +3242,10 @@ func (c *mqlVercelCertificate) GetExpiresAt() *plugin.TValue[*time.Time] {
 type mqlVercelProjectDomain struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVercelProjectDomainInternal it will be used here
+	mqlVercelProjectDomainInternal
 	Name               plugin.TValue[string]
 	ApexName           plugin.TValue[string]
+	ApexDomain         plugin.TValue[*mqlVercelDomain]
 	Redirect           plugin.TValue[string]
 	RedirectStatusCode plugin.TValue[int64]
 	GitBranch          plugin.TValue[string]
@@ -3284,6 +3292,22 @@ func (c *mqlVercelProjectDomain) GetName() *plugin.TValue[string] {
 
 func (c *mqlVercelProjectDomain) GetApexName() *plugin.TValue[string] {
 	return &c.ApexName
+}
+
+func (c *mqlVercelProjectDomain) GetApexDomain() *plugin.TValue[*mqlVercelDomain] {
+	return plugin.GetOrCompute[*mqlVercelDomain](&c.ApexDomain, func() (*mqlVercelDomain, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vercel.project.domain", c.__id, "apexDomain")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlVercelDomain), nil
+			}
+		}
+
+		return c.apexDomain()
+	})
 }
 
 func (c *mqlVercelProjectDomain) GetRedirect() *plugin.TValue[string] {
@@ -3623,13 +3647,13 @@ func (c *mqlVercelLogDrain) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlVercelWebhook struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVercelWebhookInternal it will be used here
-	Id         plugin.TValue[string]
-	Url        plugin.TValue[string]
-	Events     plugin.TValue[[]any]
-	ProjectIds plugin.TValue[[]any]
-	CreatedAt  plugin.TValue[*time.Time]
-	UpdatedAt  plugin.TValue[*time.Time]
+	mqlVercelWebhookInternal
+	Id        plugin.TValue[string]
+	Url       plugin.TValue[string]
+	Events    plugin.TValue[[]any]
+	Projects  plugin.TValue[[]any]
+	CreatedAt plugin.TValue[*time.Time]
+	UpdatedAt plugin.TValue[*time.Time]
 }
 
 // createVercelWebhook creates a new instance of this resource
@@ -3681,8 +3705,20 @@ func (c *mqlVercelWebhook) GetEvents() *plugin.TValue[[]any] {
 	return &c.Events
 }
 
-func (c *mqlVercelWebhook) GetProjectIds() *plugin.TValue[[]any] {
-	return &c.ProjectIds
+func (c *mqlVercelWebhook) GetProjects() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Projects, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vercel.webhook", c.__id, "projects")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.projects()
+	})
 }
 
 func (c *mqlVercelWebhook) GetCreatedAt() *plugin.TValue[*time.Time] {
@@ -3697,13 +3733,13 @@ func (c *mqlVercelWebhook) GetUpdatedAt() *plugin.TValue[*time.Time] {
 type mqlVercelIntegrationConfiguration struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVercelIntegrationConfigurationInternal it will be used here
+	mqlVercelIntegrationConfigurationInternal
 	Id               plugin.TValue[string]
 	Slug             plugin.TValue[string]
 	Scopes           plugin.TValue[[]any]
 	InstallationType plugin.TValue[string]
 	ProjectSelection plugin.TValue[string]
-	ProjectIds       plugin.TValue[[]any]
+	Projects         plugin.TValue[[]any]
 	CreatedAt        plugin.TValue[*time.Time]
 	UpdatedAt        plugin.TValue[*time.Time]
 }
@@ -3765,8 +3801,20 @@ func (c *mqlVercelIntegrationConfiguration) GetProjectSelection() *plugin.TValue
 	return &c.ProjectSelection
 }
 
-func (c *mqlVercelIntegrationConfiguration) GetProjectIds() *plugin.TValue[[]any] {
-	return &c.ProjectIds
+func (c *mqlVercelIntegrationConfiguration) GetProjects() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Projects, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("vercel.integrationConfiguration", c.__id, "projects")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.projects()
+	})
 }
 
 func (c *mqlVercelIntegrationConfiguration) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/vercel/resources/vercel.lr.versions
+++ b/providers/vercel/resources/vercel.lr.versions
@@ -104,8 +104,8 @@ vercel.integrationConfiguration 13.0.0
 vercel.integrationConfiguration.createdAt 13.0.0
 vercel.integrationConfiguration.id 13.0.0
 vercel.integrationConfiguration.installationType 13.0.0
-vercel.integrationConfiguration.projectIds 13.0.0
 vercel.integrationConfiguration.projectSelection 13.0.0
+vercel.integrationConfiguration.projects 13.0.1
 vercel.integrationConfiguration.scopes 13.0.0
 vercel.integrationConfiguration.slug 13.0.0
 vercel.integrationConfiguration.updatedAt 13.0.0
@@ -125,6 +125,7 @@ vercel.project.cronJobs 13.0.0
 vercel.project.deployments 13.0.0
 vercel.project.devCommand 13.0.0
 vercel.project.domain 13.0.0
+vercel.project.domain.apexDomain 13.0.1
 vercel.project.domain.apexName 13.0.0
 vercel.project.domain.createdAt 13.0.0
 vercel.project.domain.gitBranch 13.0.0
@@ -235,6 +236,6 @@ vercel.webhook 13.0.0
 vercel.webhook.createdAt 13.0.0
 vercel.webhook.events 13.0.0
 vercel.webhook.id 13.0.0
-vercel.webhook.projectIds 13.0.0
+vercel.webhook.projects 13.0.1
 vercel.webhook.updatedAt 13.0.0
 vercel.webhook.url 13.0.0


### PR DESCRIPTION
## Summary

Convert raw project-id string fields in the `vercel` provider into typed accessors so MQL can traverse within the provider (e.g. `vercel.team.webhooks.first.projects { name }`).

## Changes

**Breaking renames** (the provider is unreleased, so no deprecation is needed):

1. **`vercel.webhook`**: removed `projectIds []string`, added `projects() []vercel.project`. The webhook now caches its team id and the scoped project ids in a new `mqlVercelWebhookInternal` struct; the accessor resolves each id to a typed project.
2. **`vercel.integrationConfiguration`**: removed `projectIds []string`, added `projects() []vercel.project`. Same mechanics via a new `mqlVercelIntegrationConfigurationInternal` struct.

**Additive:**

3. **`vercel.project.domain`**: kept `apexName string`, added `apexDomain() vercel.domain`, resolving the apex via `GET /v5/domains/{apexName}` and mapping to the existing `vercel.domain` model. A new `mqlVercelProjectDomainInternal` caches the team id and apex name.

## Resolver / degrade decisions

- Both list accessors share a new `resolveProjectRefs` helper (also adopted by `vercel.store.connectedProjects`, which previously inlined the same logic). It resolves ids via `GET /v9/projects/{id}`, **skips** ids that return 403/404 (deleted or not visible to the token) rather than failing the whole list, and propagates other errors.
- `apexDomain()` **degrades to null** on 403/404 with `ApexDomain.State = plugin.StateIsSet | plugin.StateIsNull; return nil, nil`, because not every apex is a Vercel-managed team domain (external/delegated domains exist). This mirrors the `project()` accessor on `vercel.accessGroup.project`.

## Verification

Build + codegen only. `make providers/build/vercel` passes and both codegen passes ran (the second to embed the new `Internal` structs). Live verification against a real Vercel account was **not** performed.
