### PR TITLE
🌟 databricks: typed cross-resource references

### DIFF
--- a/providers/databricks/resources/account.go
+++ b/providers/databricks/resources/account.go
@@ -14,8 +14,10 @@ import (
 )
 
 type mqlDatabricksWorkspaceInternal struct {
-	cacheNetworkId               string
-	cachePrivateAccessSettingsId string
+	cacheNetworkId                    string
+	cachePrivateAccessSettingsId      string
+	cacheManagedServicesCustomerKeyId string
+	cacheStorageCustomerKeyId         string
 }
 
 func (r *mqlDatabricks) workspaces() ([]any, error) {
@@ -42,20 +44,18 @@ func (r *mqlDatabricks) workspaces() ([]any, error) {
 
 func newMqlDatabricksWorkspace(runtime *plugin.Runtime, ws provisioning.Workspace) (*mqlDatabricksWorkspace, error) {
 	res, err := CreateResource(runtime, "databricks.workspace", map[string]*llx.RawData{
-		"__id":                                llx.StringData("databricks.workspace/" + strconv.FormatInt(ws.WorkspaceId, 10)),
-		"workspaceId":                         llx.IntData(ws.WorkspaceId),
-		"name":                                llx.StringData(ws.WorkspaceName),
-		"deploymentName":                      llx.StringData(ws.DeploymentName),
-		"status":                              llx.StringData(string(ws.WorkspaceStatus)),
-		"statusMessage":                       llx.StringData(ws.WorkspaceStatusMessage),
-		"pricingTier":                         llx.StringData(string(ws.PricingTier)),
-		"cloud":                               llx.StringData(ws.Cloud),
-		"awsRegion":                           llx.StringData(ws.AwsRegion),
-		"location":                            llx.StringData(ws.Location),
-		"managedServicesCustomerManagedKeyId": llx.StringData(ws.ManagedServicesCustomerManagedKeyId),
-		"storageCustomerManagedKeyId":         llx.StringData(ws.StorageCustomerManagedKeyId),
-		"customTags":                          llx.MapData(strMap(ws.CustomTags), types.String),
-		"creationTime":                        llx.TimeDataPtr(epochMsTime(ws.CreationTime)),
+		"__id":           llx.StringData("databricks.workspace/" + strconv.FormatInt(ws.WorkspaceId, 10)),
+		"workspaceId":    llx.IntData(ws.WorkspaceId),
+		"name":           llx.StringData(ws.WorkspaceName),
+		"deploymentName": llx.StringData(ws.DeploymentName),
+		"status":         llx.StringData(string(ws.WorkspaceStatus)),
+		"statusMessage":  llx.StringData(ws.WorkspaceStatusMessage),
+		"pricingTier":    llx.StringData(string(ws.PricingTier)),
+		"cloud":          llx.StringData(ws.Cloud),
+		"awsRegion":      llx.StringData(ws.AwsRegion),
+		"location":       llx.StringData(ws.Location),
+		"customTags":     llx.MapData(strMap(ws.CustomTags), types.String),
+		"creationTime":   llx.TimeDataPtr(epochMsTime(ws.CreationTime)),
 	})
 	if err != nil {
 		return nil, err
@@ -63,7 +63,36 @@ func newMqlDatabricksWorkspace(runtime *plugin.Runtime, ws provisioning.Workspac
 	mqlWorkspace := res.(*mqlDatabricksWorkspace)
 	mqlWorkspace.cacheNetworkId = ws.NetworkId
 	mqlWorkspace.cachePrivateAccessSettingsId = ws.PrivateAccessSettingsId
+	mqlWorkspace.cacheManagedServicesCustomerKeyId = ws.ManagedServicesCustomerManagedKeyId
+	mqlWorkspace.cacheStorageCustomerKeyId = ws.StorageCustomerManagedKeyId
 	return mqlWorkspace, nil
+}
+
+// managedServicesCustomerManagedKey resolves the customer-managed key that
+// protects the workspace's control-plane managed services, hydrated by id
+// through the customer-managed key's init.
+func (r *mqlDatabricksWorkspace) managedServicesCustomerManagedKey() (*mqlDatabricksCustomerManagedKey, error) {
+	return r.resolveCustomerManagedKey(r.cacheManagedServicesCustomerKeyId, &r.ManagedServicesCustomerManagedKey.State)
+}
+
+// storageCustomerManagedKey resolves the customer-managed key that protects the
+// workspace's storage, hydrated by id through the customer-managed key's init.
+func (r *mqlDatabricksWorkspace) storageCustomerManagedKey() (*mqlDatabricksCustomerManagedKey, error) {
+	return r.resolveCustomerManagedKey(r.cacheStorageCustomerKeyId, &r.StorageCustomerManagedKey.State)
+}
+
+func (r *mqlDatabricksWorkspace) resolveCustomerManagedKey(keyId string, state *plugin.State) (*mqlDatabricksCustomerManagedKey, error) {
+	if keyId == "" {
+		*state = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	key, err := NewResource(r.MqlRuntime, "databricks.customerManagedKey", map[string]*llx.RawData{
+		"id": llx.StringData(keyId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return key.(*mqlDatabricksCustomerManagedKey), nil
 }
 
 func (r *mqlDatabricksWorkspace) network() (*mqlDatabricksNetwork, error) {

--- a/providers/databricks/resources/catalog.go
+++ b/providers/databricks/resources/catalog.go
@@ -26,23 +26,63 @@ func (r *mqlDatabricks) catalogs() ([]any, error) {
 
 	out := []any{}
 	for i := range catalogs {
-		c := catalogs[i]
-		res, err := CreateResource(r.MqlRuntime, "databricks.catalog", map[string]*llx.RawData{
-			"__id":          llx.StringData("databricks.catalog/" + c.FullName),
-			"name":          llx.StringData(c.Name),
-			"fullName":      llx.StringData(c.FullName),
-			"owner":         llx.StringData(c.Owner),
-			"metastoreId":   llx.StringData(c.MetastoreId),
-			"isolationMode": llx.StringData(string(c.IsolationMode)),
-			"comment":       llx.StringData(c.Comment),
-			"catalogType":   llx.StringData(string(c.CatalogType)),
-		})
+		res, err := newMqlDatabricksCatalog(r.MqlRuntime, catalogs[i])
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// newMqlDatabricksCatalog maps a Unity Catalog catalog to its resource. Shared
+// by the list path and the init lookup so a catalog hydrated by name carries
+// the same fields as a listed one.
+func newMqlDatabricksCatalog(runtime *plugin.Runtime, c catalog.CatalogInfo) (*mqlDatabricksCatalog, error) {
+	res, err := CreateResource(runtime, "databricks.catalog", map[string]*llx.RawData{
+		"__id":          llx.StringData("databricks.catalog/" + c.FullName),
+		"name":          llx.StringData(c.Name),
+		"fullName":      llx.StringData(c.FullName),
+		"owner":         llx.StringData(c.Owner),
+		"metastoreId":   llx.StringData(c.MetastoreId),
+		"isolationMode": llx.StringData(string(c.IsolationMode)),
+		"comment":       llx.StringData(c.Comment),
+		"catalogType":   llx.StringData(string(c.CatalogType)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDatabricksCatalog), nil
+}
+
+// initDatabricksCatalog resolves a single catalog by name so typed references
+// (such as databricks.schema.catalog) can hydrate a full catalog from its name.
+func initDatabricksCatalog(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	nameRaw, ok := args["name"]
+	if !ok {
+		return args, nil, nil
+	}
+	name, _ := nameRaw.Value.(string)
+	if name == "" {
+		return args, nil, nil
+	}
+
+	ws, err := workspaceClient(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	c, err := ws.Catalogs.GetByName(context.Background(), name)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlDatabricksCatalog(runtime, *c)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
 }
 
 func (r *mqlDatabricksCatalog) schemas() ([]any, error) {
@@ -58,22 +98,117 @@ func (r *mqlDatabricksCatalog) schemas() ([]any, error) {
 
 	out := []any{}
 	for i := range schemas {
-		s := schemas[i]
-		res, err := CreateResource(r.MqlRuntime, "databricks.schema", map[string]*llx.RawData{
-			"__id":        llx.StringData("databricks.schema/" + s.FullName),
-			"id":          llx.StringData(s.SchemaId),
-			"name":        llx.StringData(s.Name),
-			"fullName":    llx.StringData(s.FullName),
-			"catalogName": llx.StringData(s.CatalogName),
-			"owner":       llx.StringData(s.Owner),
-			"comment":     llx.StringData(s.Comment),
-		})
+		res, err := newMqlDatabricksSchema(r.MqlRuntime, schemas[i])
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// newMqlDatabricksSchema maps a Unity Catalog schema to its resource. Shared by
+// the list path and the init lookup so a schema hydrated by full name carries
+// the same fields as a listed one.
+func newMqlDatabricksSchema(runtime *plugin.Runtime, s catalog.SchemaInfo) (*mqlDatabricksSchema, error) {
+	res, err := CreateResource(runtime, "databricks.schema", map[string]*llx.RawData{
+		"__id":        llx.StringData("databricks.schema/" + s.FullName),
+		"id":          llx.StringData(s.SchemaId),
+		"name":        llx.StringData(s.Name),
+		"fullName":    llx.StringData(s.FullName),
+		"catalogName": llx.StringData(s.CatalogName),
+		"owner":       llx.StringData(s.Owner),
+		"comment":     llx.StringData(s.Comment),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDatabricksSchema), nil
+}
+
+// initDatabricksSchema resolves a single schema by its catalog and schema name
+// so typed references (such as databricks.volume.schema) can hydrate a full
+// schema from the catalog and schema names the caller already carries.
+func initDatabricksSchema(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	catalogNameRaw, ok := args["catalogName"]
+	if !ok {
+		return args, nil, nil
+	}
+	nameRaw, ok := args["name"]
+	if !ok {
+		return args, nil, nil
+	}
+	catalogName, _ := catalogNameRaw.Value.(string)
+	name, _ := nameRaw.Value.(string)
+	if catalogName == "" || name == "" {
+		return args, nil, nil
+	}
+
+	ws, err := workspaceClient(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	s, err := ws.Schemas.GetByFullName(context.Background(), catalogName+"."+name)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlDatabricksSchema(runtime, *s)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
+// catalog resolves the parent catalog this schema belongs to, hydrated by name
+// through the catalog's init.
+func (r *mqlDatabricksSchema) catalog() (*mqlDatabricksCatalog, error) {
+	if r.CatalogName.Data == "" {
+		r.Catalog.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	c, err := NewResource(r.MqlRuntime, "databricks.catalog", map[string]*llx.RawData{
+		"name": llx.StringData(r.CatalogName.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c.(*mqlDatabricksCatalog), nil
+}
+
+// catalog resolves the parent catalog this volume belongs to, hydrated by name
+// through the catalog's init.
+func (r *mqlDatabricksVolume) catalog() (*mqlDatabricksCatalog, error) {
+	if r.CatalogName.Data == "" {
+		r.Catalog.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	c, err := NewResource(r.MqlRuntime, "databricks.catalog", map[string]*llx.RawData{
+		"name": llx.StringData(r.CatalogName.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c.(*mqlDatabricksCatalog), nil
+}
+
+// schema resolves the parent schema this volume belongs to, hydrated by its
+// catalog and schema names through the schema's init.
+func (r *mqlDatabricksVolume) schema() (*mqlDatabricksSchema, error) {
+	if r.CatalogName.Data == "" || r.SchemaName.Data == "" {
+		r.Schema.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	s, err := NewResource(r.MqlRuntime, "databricks.schema", map[string]*llx.RawData{
+		"catalogName": llx.StringData(r.CatalogName.Data),
+		"name":        llx.StringData(r.SchemaName.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.(*mqlDatabricksSchema), nil
 }
 
 func (r *mqlDatabricksCatalog) grants() ([]any, error) {

--- a/providers/databricks/resources/catalog.go
+++ b/providers/databricks/resources/catalog.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	databricks "github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
@@ -67,7 +68,7 @@ func initDatabricksCatalog(runtime *plugin.Runtime, args map[string]*llx.RawData
 	}
 	name, _ := nameRaw.Value.(string)
 	if name == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("databricks.catalog requires a non-empty name")
 	}
 
 	ws, err := workspaceClient(runtime)
@@ -144,7 +145,7 @@ func initDatabricksSchema(runtime *plugin.Runtime, args map[string]*llx.RawData)
 	catalogName, _ := catalogNameRaw.Value.(string)
 	name, _ := nameRaw.Value.(string)
 	if catalogName == "" || name == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("databricks.schema requires a non-empty catalogName and name")
 	}
 
 	ws, err := workspaceClient(runtime)

--- a/providers/databricks/resources/databricks.lr
+++ b/providers/databricks/resources/databricks.lr
@@ -96,10 +96,6 @@ databricks.workspace @defaults("name workspaceId cloud") {
   awsRegion string
   // GCP or Azure location hosting the workspace
   location string
-  // Key id protecting control-plane managed services, empty when using Databricks-managed keys
-  managedServicesCustomerManagedKeyId string
-  // Key id protecting workspace storage, empty when using Databricks-managed keys
-  storageCustomerManagedKeyId string
   // Custom tags applied to the workspace
   customTags map[string]string
   // Time the workspace was created
@@ -108,6 +104,10 @@ databricks.workspace @defaults("name workspaceId cloud") {
   network() databricks.network
   // Private access settings applied to the workspace
   privateAccessSettings() databricks.privateAccessSetting
+  // Customer-managed key protecting control-plane managed services, null when using Databricks-managed keys
+  managedServicesCustomerManagedKey() databricks.customerManagedKey
+  // Customer-managed key protecting workspace storage, null when using Databricks-managed keys
+  storageCustomerManagedKey() databricks.customerManagedKey
 }
 
 // Databricks account user
@@ -135,7 +135,7 @@ databricks.user @defaults("userName active") {
   // Cloud roles (such as AWS instance profile ARNs) granted to the user
   roles []string
   // Groups the user belongs to
-  groups []string
+  groups() []databricks.group
 }
 
 // Databricks account group
@@ -183,7 +183,7 @@ databricks.servicePrincipal @defaults("displayName applicationId active") {
   // Cloud roles granted to the service principal
   roles []string
   // Groups the service principal belongs to
-  groups []string
+  groups() []databricks.group
 }
 
 // Unity Catalog metastore
@@ -510,6 +510,8 @@ databricks.schema @defaults("fullName owner") {
   fullName string
   // Name of the parent catalog
   catalogName string
+  // Parent catalog
+  catalog() databricks.catalog
   // Principal that owns the schema
   owner string
   // Schema comment
@@ -657,8 +659,12 @@ databricks.volume @defaults("fullName volumeType owner") {
   fullName string
   // Name of the parent catalog
   catalogName string
+  // Parent catalog
+  catalog() databricks.catalog
   // Name of the parent schema
   schemaName string
+  // Parent schema
+  schema() databricks.schema
   // Principal that owns the volume
   owner string
   // Volume comment

--- a/providers/databricks/resources/databricks.lr.go
+++ b/providers/databricks/resources/databricks.lr.go
@@ -61,7 +61,7 @@ func init() {
 			Create: createDatabricksUser,
 		},
 		"databricks.group": {
-			// to override args, implement: initDatabricksGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDatabricksGroup,
 			Create: createDatabricksGroup,
 		},
 		"databricks.servicePrincipal": {
@@ -109,11 +109,11 @@ func init() {
 			Create: createDatabricksWarehouse,
 		},
 		"databricks.catalog": {
-			// to override args, implement: initDatabricksCatalog(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDatabricksCatalog,
 			Create: createDatabricksCatalog,
 		},
 		"databricks.schema": {
-			// to override args, implement: initDatabricksSchema(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDatabricksSchema,
 			Create: createDatabricksSchema,
 		},
 		"databricks.grant": {
@@ -149,7 +149,7 @@ func init() {
 			Create: createDatabricksInstanceProfile,
 		},
 		"databricks.customerManagedKey": {
-			// to override args, implement: initDatabricksCustomerManagedKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initDatabricksCustomerManagedKey,
 			Create: createDatabricksCustomerManagedKey,
 		},
 	}
@@ -316,12 +316,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"databricks.workspace.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksWorkspace).GetLocation()).ToDataRes(types.String)
 	},
-	"databricks.workspace.managedServicesCustomerManagedKeyId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDatabricksWorkspace).GetManagedServicesCustomerManagedKeyId()).ToDataRes(types.String)
-	},
-	"databricks.workspace.storageCustomerManagedKeyId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDatabricksWorkspace).GetStorageCustomerManagedKeyId()).ToDataRes(types.String)
-	},
 	"databricks.workspace.customTags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksWorkspace).GetCustomTags()).ToDataRes(types.Map(types.String, types.String))
 	},
@@ -333,6 +327,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"databricks.workspace.privateAccessSettings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksWorkspace).GetPrivateAccessSettings()).ToDataRes(types.Resource("databricks.privateAccessSetting"))
+	},
+	"databricks.workspace.managedServicesCustomerManagedKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksWorkspace).GetManagedServicesCustomerManagedKey()).ToDataRes(types.Resource("databricks.customerManagedKey"))
+	},
+	"databricks.workspace.storageCustomerManagedKey": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksWorkspace).GetStorageCustomerManagedKey()).ToDataRes(types.Resource("databricks.customerManagedKey"))
 	},
 	"databricks.user.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksUser).GetId()).ToDataRes(types.String)
@@ -359,7 +359,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlDatabricksUser).GetRoles()).ToDataRes(types.Array(types.String))
 	},
 	"databricks.user.groups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDatabricksUser).GetGroups()).ToDataRes(types.Array(types.String))
+		return (r.(*mqlDatabricksUser).GetGroups()).ToDataRes(types.Array(types.Resource("databricks.group")))
 	},
 	"databricks.group.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksGroup).GetId()).ToDataRes(types.String)
@@ -401,7 +401,7 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 		return (r.(*mqlDatabricksServicePrincipal).GetRoles()).ToDataRes(types.Array(types.String))
 	},
 	"databricks.servicePrincipal.groups": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlDatabricksServicePrincipal).GetGroups()).ToDataRes(types.Array(types.String))
+		return (r.(*mqlDatabricksServicePrincipal).GetGroups()).ToDataRes(types.Array(types.Resource("databricks.group")))
 	},
 	"databricks.metastore.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksMetastore).GetId()).ToDataRes(types.String)
@@ -688,6 +688,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"databricks.schema.catalogName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksSchema).GetCatalogName()).ToDataRes(types.String)
 	},
+	"databricks.schema.catalog": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksSchema).GetCatalog()).ToDataRes(types.Resource("databricks.catalog"))
+	},
 	"databricks.schema.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksSchema).GetOwner()).ToDataRes(types.String)
 	},
@@ -832,8 +835,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"databricks.volume.catalogName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksVolume).GetCatalogName()).ToDataRes(types.String)
 	},
+	"databricks.volume.catalog": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksVolume).GetCatalog()).ToDataRes(types.Resource("databricks.catalog"))
+	},
 	"databricks.volume.schemaName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksVolume).GetSchemaName()).ToDataRes(types.String)
+	},
+	"databricks.volume.schema": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatabricksVolume).GetSchema()).ToDataRes(types.Resource("databricks.schema"))
 	},
 	"databricks.volume.owner": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatabricksVolume).GetOwner()).ToDataRes(types.String)
@@ -1129,14 +1138,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDatabricksWorkspace).Location, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"databricks.workspace.managedServicesCustomerManagedKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDatabricksWorkspace).ManagedServicesCustomerManagedKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
-	"databricks.workspace.storageCustomerManagedKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlDatabricksWorkspace).StorageCustomerManagedKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"databricks.workspace.customTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksWorkspace).CustomTags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
@@ -1151,6 +1152,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"databricks.workspace.privateAccessSettings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksWorkspace).PrivateAccessSettings, ok = plugin.RawToTValue[*mqlDatabricksPrivateAccessSetting](v.Value, v.Error)
+		return
+	},
+	"databricks.workspace.managedServicesCustomerManagedKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksWorkspace).ManagedServicesCustomerManagedKey, ok = plugin.RawToTValue[*mqlDatabricksCustomerManagedKey](v.Value, v.Error)
+		return
+	},
+	"databricks.workspace.storageCustomerManagedKey": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksWorkspace).StorageCustomerManagedKey, ok = plugin.RawToTValue[*mqlDatabricksCustomerManagedKey](v.Value, v.Error)
 		return
 	},
 	"databricks.user.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1685,6 +1694,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDatabricksSchema).CatalogName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"databricks.schema.catalog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksSchema).Catalog, ok = plugin.RawToTValue[*mqlDatabricksCatalog](v.Value, v.Error)
+		return
+	},
 	"databricks.schema.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksSchema).Owner, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -1893,8 +1906,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDatabricksVolume).CatalogName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"databricks.volume.catalog": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksVolume).Catalog, ok = plugin.RawToTValue[*mqlDatabricksCatalog](v.Value, v.Error)
+		return
+	},
 	"databricks.volume.schemaName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatabricksVolume).SchemaName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"databricks.volume.schema": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatabricksVolume).Schema, ok = plugin.RawToTValue[*mqlDatabricksSchema](v.Value, v.Error)
 		return
 	},
 	"databricks.volume.owner": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2564,21 +2585,21 @@ type mqlDatabricksWorkspace struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDatabricksWorkspaceInternal
-	WorkspaceId                         plugin.TValue[int64]
-	Name                                plugin.TValue[string]
-	DeploymentName                      plugin.TValue[string]
-	Status                              plugin.TValue[string]
-	StatusMessage                       plugin.TValue[string]
-	PricingTier                         plugin.TValue[string]
-	Cloud                               plugin.TValue[string]
-	AwsRegion                           plugin.TValue[string]
-	Location                            plugin.TValue[string]
-	ManagedServicesCustomerManagedKeyId plugin.TValue[string]
-	StorageCustomerManagedKeyId         plugin.TValue[string]
-	CustomTags                          plugin.TValue[map[string]any]
-	CreationTime                        plugin.TValue[*time.Time]
-	Network                             plugin.TValue[*mqlDatabricksNetwork]
-	PrivateAccessSettings               plugin.TValue[*mqlDatabricksPrivateAccessSetting]
+	WorkspaceId                       plugin.TValue[int64]
+	Name                              plugin.TValue[string]
+	DeploymentName                    plugin.TValue[string]
+	Status                            plugin.TValue[string]
+	StatusMessage                     plugin.TValue[string]
+	PricingTier                       plugin.TValue[string]
+	Cloud                             plugin.TValue[string]
+	AwsRegion                         plugin.TValue[string]
+	Location                          plugin.TValue[string]
+	CustomTags                        plugin.TValue[map[string]any]
+	CreationTime                      plugin.TValue[*time.Time]
+	Network                           plugin.TValue[*mqlDatabricksNetwork]
+	PrivateAccessSettings             plugin.TValue[*mqlDatabricksPrivateAccessSetting]
+	ManagedServicesCustomerManagedKey plugin.TValue[*mqlDatabricksCustomerManagedKey]
+	StorageCustomerManagedKey         plugin.TValue[*mqlDatabricksCustomerManagedKey]
 }
 
 // createDatabricksWorkspace creates a new instance of this resource
@@ -2649,14 +2670,6 @@ func (c *mqlDatabricksWorkspace) GetLocation() *plugin.TValue[string] {
 	return &c.Location
 }
 
-func (c *mqlDatabricksWorkspace) GetManagedServicesCustomerManagedKeyId() *plugin.TValue[string] {
-	return &c.ManagedServicesCustomerManagedKeyId
-}
-
-func (c *mqlDatabricksWorkspace) GetStorageCustomerManagedKeyId() *plugin.TValue[string] {
-	return &c.StorageCustomerManagedKeyId
-}
-
 func (c *mqlDatabricksWorkspace) GetCustomTags() *plugin.TValue[map[string]any] {
 	return &c.CustomTags
 }
@@ -2697,11 +2710,43 @@ func (c *mqlDatabricksWorkspace) GetPrivateAccessSettings() *plugin.TValue[*mqlD
 	})
 }
 
+func (c *mqlDatabricksWorkspace) GetManagedServicesCustomerManagedKey() *plugin.TValue[*mqlDatabricksCustomerManagedKey] {
+	return plugin.GetOrCompute[*mqlDatabricksCustomerManagedKey](&c.ManagedServicesCustomerManagedKey, func() (*mqlDatabricksCustomerManagedKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.workspace", c.__id, "managedServicesCustomerManagedKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDatabricksCustomerManagedKey), nil
+			}
+		}
+
+		return c.managedServicesCustomerManagedKey()
+	})
+}
+
+func (c *mqlDatabricksWorkspace) GetStorageCustomerManagedKey() *plugin.TValue[*mqlDatabricksCustomerManagedKey] {
+	return plugin.GetOrCompute[*mqlDatabricksCustomerManagedKey](&c.StorageCustomerManagedKey, func() (*mqlDatabricksCustomerManagedKey, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.workspace", c.__id, "storageCustomerManagedKey")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDatabricksCustomerManagedKey), nil
+			}
+		}
+
+		return c.storageCustomerManagedKey()
+	})
+}
+
 // mqlDatabricksUser for the databricks.user resource
 type mqlDatabricksUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDatabricksUserInternal it will be used here
+	mqlDatabricksUserInternal
 	Id           plugin.TValue[string]
 	UserName     plugin.TValue[string]
 	DisplayName  plugin.TValue[string]
@@ -2778,7 +2823,19 @@ func (c *mqlDatabricksUser) GetRoles() *plugin.TValue[[]any] {
 }
 
 func (c *mqlDatabricksUser) GetGroups() *plugin.TValue[[]any] {
-	return &c.Groups
+	return plugin.GetOrCompute[[]any](&c.Groups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.user", c.__id, "groups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.groups()
+	})
 }
 
 // mqlDatabricksGroup for the databricks.group resource
@@ -2854,7 +2911,7 @@ func (c *mqlDatabricksGroup) GetRoles() *plugin.TValue[[]any] {
 type mqlDatabricksServicePrincipal struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDatabricksServicePrincipalInternal it will be used here
+	mqlDatabricksServicePrincipalInternal
 	Id            plugin.TValue[string]
 	ApplicationId plugin.TValue[string]
 	DisplayName   plugin.TValue[string]
@@ -2926,7 +2983,19 @@ func (c *mqlDatabricksServicePrincipal) GetRoles() *plugin.TValue[[]any] {
 }
 
 func (c *mqlDatabricksServicePrincipal) GetGroups() *plugin.TValue[[]any] {
-	return &c.Groups
+	return plugin.GetOrCompute[[]any](&c.Groups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.servicePrincipal", c.__id, "groups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.groups()
+	})
 }
 
 // mqlDatabricksMetastore for the databricks.metastore resource
@@ -3872,6 +3941,7 @@ type mqlDatabricksSchema struct {
 	Name        plugin.TValue[string]
 	FullName    plugin.TValue[string]
 	CatalogName plugin.TValue[string]
+	Catalog     plugin.TValue[*mqlDatabricksCatalog]
 	Owner       plugin.TValue[string]
 	Comment     plugin.TValue[string]
 	Grants      plugin.TValue[[]any]
@@ -3924,6 +3994,22 @@ func (c *mqlDatabricksSchema) GetFullName() *plugin.TValue[string] {
 
 func (c *mqlDatabricksSchema) GetCatalogName() *plugin.TValue[string] {
 	return &c.CatalogName
+}
+
+func (c *mqlDatabricksSchema) GetCatalog() *plugin.TValue[*mqlDatabricksCatalog] {
+	return plugin.GetOrCompute[*mqlDatabricksCatalog](&c.Catalog, func() (*mqlDatabricksCatalog, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.schema", c.__id, "catalog")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDatabricksCatalog), nil
+			}
+		}
+
+		return c.catalog()
+	})
 }
 
 func (c *mqlDatabricksSchema) GetOwner() *plugin.TValue[string] {
@@ -4328,7 +4414,9 @@ type mqlDatabricksVolume struct {
 	Name                   plugin.TValue[string]
 	FullName               plugin.TValue[string]
 	CatalogName            plugin.TValue[string]
+	Catalog                plugin.TValue[*mqlDatabricksCatalog]
 	SchemaName             plugin.TValue[string]
+	Schema                 plugin.TValue[*mqlDatabricksSchema]
 	Owner                  plugin.TValue[string]
 	Comment                plugin.TValue[string]
 	MetastoreId            plugin.TValue[string]
@@ -4391,8 +4479,40 @@ func (c *mqlDatabricksVolume) GetCatalogName() *plugin.TValue[string] {
 	return &c.CatalogName
 }
 
+func (c *mqlDatabricksVolume) GetCatalog() *plugin.TValue[*mqlDatabricksCatalog] {
+	return plugin.GetOrCompute[*mqlDatabricksCatalog](&c.Catalog, func() (*mqlDatabricksCatalog, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.volume", c.__id, "catalog")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDatabricksCatalog), nil
+			}
+		}
+
+		return c.catalog()
+	})
+}
+
 func (c *mqlDatabricksVolume) GetSchemaName() *plugin.TValue[string] {
 	return &c.SchemaName
+}
+
+func (c *mqlDatabricksVolume) GetSchema() *plugin.TValue[*mqlDatabricksSchema] {
+	return plugin.GetOrCompute[*mqlDatabricksSchema](&c.Schema, func() (*mqlDatabricksSchema, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("databricks.volume", c.__id, "schema")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlDatabricksSchema), nil
+			}
+		}
+
+		return c.schema()
+	})
 }
 
 func (c *mqlDatabricksVolume) GetOwner() *plugin.TValue[string] {

--- a/providers/databricks/resources/databricks.lr.go
+++ b/providers/databricks/resources/databricks.lr.go
@@ -2166,7 +2166,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlDatabricks struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlDatabricksInternal it will be used here
+	mqlDatabricksInternal
 	Workspaces             plugin.TValue[[]any]
 	Users                  plugin.TValue[[]any]
 	Groups                 plugin.TValue[[]any]

--- a/providers/databricks/resources/databricks.lr.versions
+++ b/providers/databricks/resources/databricks.lr.versions
@@ -157,6 +157,7 @@ databricks.privateAccessSetting.publicAccessEnabled 13.0.0
 databricks.privateAccessSetting.region 13.0.0
 databricks.privateAccessSettings 13.0.0
 databricks.schema 13.0.0
+databricks.schema.catalog 13.0.1
 databricks.schema.catalogName 13.0.0
 databricks.schema.comment 13.0.0
 databricks.schema.fullName 13.0.0
@@ -221,6 +222,7 @@ databricks.user.roles 13.0.0
 databricks.user.userName 13.0.0
 databricks.users 13.0.0
 databricks.volume 13.0.1
+databricks.volume.catalog 13.0.1
 databricks.volume.catalogName 13.0.1
 databricks.volume.comment 13.0.1
 databricks.volume.createdAt 13.0.1
@@ -231,6 +233,7 @@ databricks.volume.id 13.0.1
 databricks.volume.metastoreId 13.0.1
 databricks.volume.name 13.0.1
 databricks.volume.owner 13.0.1
+databricks.volume.schema 13.0.1
 databricks.volume.schemaName 13.0.1
 databricks.volume.sseEncryptionAlgorithm 13.0.1
 databricks.volume.sseKmsKeyArn 13.0.1
@@ -257,14 +260,14 @@ databricks.workspace.creationTime 13.0.0
 databricks.workspace.customTags 13.0.0
 databricks.workspace.deploymentName 13.0.0
 databricks.workspace.location 13.0.0
-databricks.workspace.managedServicesCustomerManagedKeyId 13.0.0
+databricks.workspace.managedServicesCustomerManagedKey 13.0.1
 databricks.workspace.name 13.0.0
 databricks.workspace.network 13.0.0
 databricks.workspace.pricingTier 13.0.0
 databricks.workspace.privateAccessSettings 13.0.0
 databricks.workspace.status 13.0.0
 databricks.workspace.statusMessage 13.0.0
-databricks.workspace.storageCustomerManagedKeyId 13.0.0
+databricks.workspace.storageCustomerManagedKey 13.0.1
 databricks.workspace.workspaceId 13.0.0
 databricks.workspaceConf 13.0.0
 databricks.workspaceConf.automaticClusterUpdateEnabled 13.0.1

--- a/providers/databricks/resources/encryption_keys.go
+++ b/providers/databricks/resources/encryption_keys.go
@@ -6,7 +6,9 @@ package resources
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
 
@@ -23,37 +25,77 @@ func (r *mqlDatabricks) customerManagedKeys() ([]any, error) {
 
 	out := []any{}
 	for i := range keys {
-		k := keys[i]
-
-		useCases := make([]any, 0, len(k.UseCases))
-		for _, uc := range k.UseCases {
-			useCases = append(useCases, string(uc))
-		}
-
-		var keyArn, keyAlias, keyRegion, kmsKeyId string
-		if k.AwsKeyInfo != nil {
-			keyArn = k.AwsKeyInfo.KeyArn
-			keyAlias = k.AwsKeyInfo.KeyAlias
-			keyRegion = k.AwsKeyInfo.KeyRegion
-		}
-		if k.GcpKeyInfo != nil {
-			kmsKeyId = k.GcpKeyInfo.KmsKeyId
-		}
-
-		res, err := CreateResource(r.MqlRuntime, "databricks.customerManagedKey", map[string]*llx.RawData{
-			"__id":         llx.StringData("databricks.customerManagedKey/" + k.CustomerManagedKeyId),
-			"id":           llx.StringData(k.CustomerManagedKeyId),
-			"useCases":     llx.ArrayData(useCases, types.String),
-			"creationTime": llx.TimeDataPtr(epochMsTime(k.CreationTime)),
-			"keyArn":       llx.StringData(keyArn),
-			"keyAlias":     llx.StringData(keyAlias),
-			"keyRegion":    llx.StringData(keyRegion),
-			"kmsKeyId":     llx.StringData(kmsKeyId),
-		})
+		res, err := newMqlDatabricksCustomerManagedKey(r.MqlRuntime, keys[i])
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// newMqlDatabricksCustomerManagedKey maps a customer-managed encryption key to
+// its resource. Shared by the list path and the init lookup so a key hydrated
+// by id carries the same fields as a listed one.
+func newMqlDatabricksCustomerManagedKey(runtime *plugin.Runtime, k provisioning.CustomerManagedKey) (*mqlDatabricksCustomerManagedKey, error) {
+	useCases := make([]any, 0, len(k.UseCases))
+	for _, uc := range k.UseCases {
+		useCases = append(useCases, string(uc))
+	}
+
+	var keyArn, keyAlias, keyRegion, kmsKeyId string
+	if k.AwsKeyInfo != nil {
+		keyArn = k.AwsKeyInfo.KeyArn
+		keyAlias = k.AwsKeyInfo.KeyAlias
+		keyRegion = k.AwsKeyInfo.KeyRegion
+	}
+	if k.GcpKeyInfo != nil {
+		kmsKeyId = k.GcpKeyInfo.KmsKeyId
+	}
+
+	res, err := CreateResource(runtime, "databricks.customerManagedKey", map[string]*llx.RawData{
+		"__id":         llx.StringData("databricks.customerManagedKey/" + k.CustomerManagedKeyId),
+		"id":           llx.StringData(k.CustomerManagedKeyId),
+		"useCases":     llx.ArrayData(useCases, types.String),
+		"creationTime": llx.TimeDataPtr(epochMsTime(k.CreationTime)),
+		"keyArn":       llx.StringData(keyArn),
+		"keyAlias":     llx.StringData(keyAlias),
+		"keyRegion":    llx.StringData(keyRegion),
+		"kmsKeyId":     llx.StringData(kmsKeyId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDatabricksCustomerManagedKey), nil
+}
+
+// initDatabricksCustomerManagedKey resolves a single customer-managed key by id
+// so typed references (such as databricks.workspace.storageCustomerManagedKey)
+// can hydrate a full key from just its id.
+func initDatabricksCustomerManagedKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+	id, _ := idRaw.Value.(string)
+	if id == "" {
+		return args, nil, nil
+	}
+
+	acc, err := accountClient(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	key, err := acc.EncryptionKeys.GetByCustomerManagedKeyId(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlDatabricksCustomerManagedKey(runtime, *key)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
 }

--- a/providers/databricks/resources/encryption_keys.go
+++ b/providers/databricks/resources/encryption_keys.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"go.mondoo.com/mql/v13/llx"
@@ -82,7 +83,7 @@ func initDatabricksCustomerManagedKey(runtime *plugin.Runtime, args map[string]*
 	}
 	id, _ := idRaw.Value.(string)
 	if id == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("databricks.customerManagedKey requires a non-empty id")
 	}
 
 	acc, err := accountClient(runtime)

--- a/providers/databricks/resources/identity.go
+++ b/providers/databricks/resources/identity.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -164,7 +165,7 @@ func initDatabricksGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	}
 	id, _ := idRaw.Value.(string)
 	if id == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("databricks.group requires a non-empty id")
 	}
 
 	acc, err := accountClient(runtime)

--- a/providers/databricks/resources/identity.go
+++ b/providers/databricks/resources/identity.go
@@ -6,12 +6,49 @@ package resources
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlDatabricksInternal struct {
+	groupsOnce sync.Once
+	groupsByID map[string]iam.Group
+	groupsErr  error
+}
+
+// cachedAccountGroups lists the account groups at most once per scan, caching
+// the result on the root databricks resource so repeated group-ref resolutions
+// (e.g. databricks.users { groups }) share a single ListAll rather than one per
+// user or service principal.
+func cachedAccountGroups(runtime *plugin.Runtime) (map[string]iam.Group, error) {
+	rootRes, err := NewResource(runtime, "databricks", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	root := rootRes.(*mqlDatabricks)
+	root.groupsOnce.Do(func() {
+		acc, err := accountClient(runtime)
+		if err != nil {
+			root.groupsErr = err
+			return
+		}
+		groups, err := acc.Groups.ListAll(context.Background(), iam.ListAccountGroupsRequest{})
+		if err != nil {
+			root.groupsErr = err
+			return
+		}
+		byID := make(map[string]iam.Group, len(groups))
+		for i := range groups {
+			byID[groups[i].Id] = groups[i]
+		}
+		root.groupsByID = byID
+	})
+	return root.groupsByID, root.groupsErr
+}
 
 type mqlDatabricksUserInternal struct {
 	cacheGroupIds []string
@@ -41,17 +78,9 @@ func resolveGroupRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
 	if len(ids) == 0 {
 		return []any{}, nil
 	}
-	acc, err := accountClient(runtime)
+	byID, err := cachedAccountGroups(runtime)
 	if err != nil {
 		return nil, err
-	}
-	groups, err := acc.Groups.ListAll(context.Background(), iam.ListAccountGroupsRequest{})
-	if err != nil {
-		return nil, err
-	}
-	byID := make(map[string]iam.Group, len(groups))
-	for i := range groups {
-		byID[groups[i].Id] = groups[i]
 	}
 
 	out := []any{}

--- a/providers/databricks/resources/identity.go
+++ b/providers/databricks/resources/identity.go
@@ -6,11 +6,55 @@ package resources
 import (
 	"context"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+type mqlDatabricksUserInternal struct {
+	cacheGroupIds []string
+}
+
+type mqlDatabricksServicePrincipalInternal struct {
+	cacheGroupIds []string
+}
+
+// complexValueIds extracts the referenced ids (the value field) from a SCIM
+// complex-value list such as a principal's group memberships.
+func complexValueIds(vals []iam.ComplexValue) []string {
+	out := make([]string, 0, len(vals))
+	for i := range vals {
+		if vals[i].Value != "" {
+			out = append(out, vals[i].Value)
+		}
+	}
+	return out
+}
+
+// resolveGroupRefs hydrates each account group id into a databricks.group,
+// skipping any id that no longer resolves (a group that was deleted after the
+// membership was recorded).
+func resolveGroupRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	out := []any{}
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		res, err := NewResource(runtime, "databricks.group", map[string]*llx.RawData{
+			"id": llx.StringData(id),
+		})
+		if err != nil {
+			if apierr.IsMissing(err) {
+				continue
+			}
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
 
 func (r *mqlDatabricks) users() ([]any, error) {
 	acc, err := accountClient(r.MqlRuntime)
@@ -52,12 +96,19 @@ func newMqlDatabricksUser(runtime *plugin.Runtime, user iam.User) (*mqlDatabrick
 		"emails":       llx.ArrayData(emails, types.String),
 		"entitlements": llx.ArrayData(complexValues(user.Entitlements), types.String),
 		"roles":        llx.ArrayData(complexValues(user.Roles), types.String),
-		"groups":       llx.ArrayData(complexValues(user.Groups), types.String),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlDatabricksUser), nil
+	mqlUser := res.(*mqlDatabricksUser)
+	mqlUser.cacheGroupIds = complexValueIds(user.Groups)
+	return mqlUser, nil
+}
+
+// groups resolves the account groups this user belongs to, hydrated by id
+// through the group's init.
+func (r *mqlDatabricksUser) groups() ([]any, error) {
+	return resolveGroupRefs(r.MqlRuntime, r.cacheGroupIds)
 }
 
 func (r *mqlDatabricks) groups() ([]any, error) {
@@ -73,21 +124,62 @@ func (r *mqlDatabricks) groups() ([]any, error) {
 
 	list := []any{}
 	for i := range groups {
-		res, err := CreateResource(r.MqlRuntime, "databricks.group", map[string]*llx.RawData{
-			"__id":         llx.StringData("databricks.group/" + groups[i].Id),
-			"id":           llx.StringData(groups[i].Id),
-			"displayName":  llx.StringData(groups[i].DisplayName),
-			"externalId":   llx.StringData(groups[i].ExternalId),
-			"members":      llx.ArrayData(complexValues(groups[i].Members), types.String),
-			"entitlements": llx.ArrayData(complexValues(groups[i].Entitlements), types.String),
-			"roles":        llx.ArrayData(complexValues(groups[i].Roles), types.String),
-		})
+		res, err := newMqlDatabricksGroup(r.MqlRuntime, groups[i])
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, res)
 	}
 	return list, nil
+}
+
+// newMqlDatabricksGroup maps an account group to its resource. Shared by the
+// list path and the init lookup so a group hydrated by id carries the same
+// fields as a listed one.
+func newMqlDatabricksGroup(runtime *plugin.Runtime, group iam.Group) (*mqlDatabricksGroup, error) {
+	res, err := CreateResource(runtime, "databricks.group", map[string]*llx.RawData{
+		"__id":         llx.StringData("databricks.group/" + group.Id),
+		"id":           llx.StringData(group.Id),
+		"displayName":  llx.StringData(group.DisplayName),
+		"externalId":   llx.StringData(group.ExternalId),
+		"members":      llx.ArrayData(complexValues(group.Members), types.String),
+		"entitlements": llx.ArrayData(complexValues(group.Entitlements), types.String),
+		"roles":        llx.ArrayData(complexValues(group.Roles), types.String),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlDatabricksGroup), nil
+}
+
+// initDatabricksGroup resolves a single account group by id so typed references
+// (such as databricks.user.groups) can hydrate a full group from just its id.
+func initDatabricksGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+	id, _ := idRaw.Value.(string)
+	if id == "" {
+		return args, nil, nil
+	}
+
+	acc, err := accountClient(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	group, err := acc.Groups.GetById(context.Background(), id)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlDatabricksGroup(runtime, *group)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
 }
 
 func (r *mqlDatabricks) servicePrincipals() ([]any, error) {
@@ -103,21 +195,28 @@ func (r *mqlDatabricks) servicePrincipals() ([]any, error) {
 
 	list := []any{}
 	for i := range sps {
+		sp := sps[i]
 		res, err := CreateResource(r.MqlRuntime, "databricks.servicePrincipal", map[string]*llx.RawData{
-			"__id":          llx.StringData("databricks.servicePrincipal/" + sps[i].Id),
-			"id":            llx.StringData(sps[i].Id),
-			"applicationId": llx.StringData(sps[i].ApplicationId),
-			"displayName":   llx.StringData(sps[i].DisplayName),
-			"active":        llx.BoolData(sps[i].Active),
-			"externalId":    llx.StringData(sps[i].ExternalId),
-			"entitlements":  llx.ArrayData(complexValues(sps[i].Entitlements), types.String),
-			"roles":         llx.ArrayData(complexValues(sps[i].Roles), types.String),
-			"groups":        llx.ArrayData(complexValues(sps[i].Groups), types.String),
+			"__id":          llx.StringData("databricks.servicePrincipal/" + sp.Id),
+			"id":            llx.StringData(sp.Id),
+			"applicationId": llx.StringData(sp.ApplicationId),
+			"displayName":   llx.StringData(sp.DisplayName),
+			"active":        llx.BoolData(sp.Active),
+			"externalId":    llx.StringData(sp.ExternalId),
+			"entitlements":  llx.ArrayData(complexValues(sp.Entitlements), types.String),
+			"roles":         llx.ArrayData(complexValues(sp.Roles), types.String),
 		})
 		if err != nil {
 			return nil, err
 		}
+		res.(*mqlDatabricksServicePrincipal).cacheGroupIds = complexValueIds(sp.Groups)
 		list = append(list, res)
 	}
 	return list, nil
+}
+
+// groups resolves the account groups this service principal belongs to,
+// hydrated by id through the group's init.
+func (r *mqlDatabricksServicePrincipal) groups() ([]any, error) {
+	return resolveGroupRefs(r.MqlRuntime, r.cacheGroupIds)
 }

--- a/providers/databricks/resources/identity.go
+++ b/providers/databricks/resources/identity.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -34,22 +33,35 @@ func complexValueIds(vals []iam.ComplexValue) []string {
 	return out
 }
 
-// resolveGroupRefs hydrates each account group id into a databricks.group,
-// skipping any id that no longer resolves (a group that was deleted after the
-// membership was recorded).
+// resolveGroupRefs hydrates each account group id into a databricks.group. It
+// lists the account groups once and resolves each membership from that set
+// (Pattern C) rather than one GetById per id (N+1). A membership whose group was
+// deleted after it was recorded is simply skipped.
 func resolveGroupRefs(runtime *plugin.Runtime, ids []string) ([]any, error) {
+	if len(ids) == 0 {
+		return []any{}, nil
+	}
+	acc, err := accountClient(runtime)
+	if err != nil {
+		return nil, err
+	}
+	groups, err := acc.Groups.ListAll(context.Background(), iam.ListAccountGroupsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[string]iam.Group, len(groups))
+	for i := range groups {
+		byID[groups[i].Id] = groups[i]
+	}
+
 	out := []any{}
 	for _, id := range ids {
-		if id == "" {
+		g, ok := byID[id]
+		if !ok {
 			continue
 		}
-		res, err := NewResource(runtime, "databricks.group", map[string]*llx.RawData{
-			"id": llx.StringData(id),
-		})
+		res, err := newMqlDatabricksGroup(runtime, g)
 		if err != nil {
-			if apierr.IsMissing(err) {
-				continue
-			}
 			return nil, err
 		}
 		out = append(out, res)


### PR DESCRIPTION
## Summary

Adds typed cross-resource references across the `databricks` provider so audits can traverse relationships (for example `databricks.volume.catalog.owner`) instead of joining on raw id strings. The provider is unreleased (`config.go` Version `13.0.0`), so removing/renaming raw id fields is a clean breaking change requiring no deprecation shim. All new `.lr.versions` entries land at `13.0.1` (the generator default for entries added after the base).

## The 7 conversions

**Tier 1 (workspace plane, Unity Catalog graph)**
1. `databricks.schema`: **additive** `catalog() databricks.catalog` (keeps `catalogName`, a name not a dup id). Resolved by `initDatabricksCatalog` via `WorkspaceClient.Catalogs.GetByName`.
2. `databricks.volume`: **additive** `catalog() databricks.catalog` (keeps `catalogName`). Same init.
3. `databricks.volume`: **additive** `schema() databricks.schema` (keeps `schemaName`). Resolved by `initDatabricksSchema` via `WorkspaceClient.Schemas.GetByFullName` (fed `catalogName + "." + schemaName`, both carried on the volume).

**Tier 1 (account plane, workspace encryption keys)**
4. `databricks.workspace`: **breaking rename** `managedServicesCustomerManagedKeyId string` -> `managedServicesCustomerManagedKey() databricks.customerManagedKey`.
5. `databricks.workspace`: **breaking rename** `storageCustomerManagedKeyId string` -> `storageCustomerManagedKey() databricks.customerManagedKey`.

Both resolved by `initDatabricksCustomerManagedKey` via `AccountClient.EncryptionKeys.GetByCustomerManagedKeyId`. The raw ids are cached on the workspace Internal struct; empty id -> `StateIsSet|StateIsNull`, returns nil.

**Tier 2 (account plane, group membership)**
6. `databricks.user`: **breaking rename** `groups []string` (SCIM group ids) -> `groups() []databricks.group`.
7. `databricks.servicePrincipal`: **breaking rename** `groups []string` -> `groups() []databricks.group`.

Both resolved by `initDatabricksGroup` via `AccountClient.Groups.GetById`. A membership id that no longer resolves (group deleted after membership recorded) is skipped via `apierr.IsMissing`.

## Left raw on purpose: the four `metastoreId` fields

The `metastoreId` fields on `catalog` / `schema` / `volume` / `storageCredential` / `externalLocation` name `databricks.metastore`, which is an **account-plane** resource, but those resources are **workspace-plane**. A `metastore()` accessor would have to call `accountClient` from a workspace connection and would fail at runtime (a databricks connection is either account-plane or a single-workspace plane, never both). These are intentionally left as raw strings.

## SDK method names verified against databricks-sdk-go@v0.160.0

- `WorkspaceClient.Catalogs.GetByName(ctx, name) (*catalog.CatalogInfo, error)`
- `WorkspaceClient.Schemas.GetByFullName(ctx, fullName) (*catalog.SchemaInfo, error)`
- `AccountClient.EncryptionKeys.GetByCustomerManagedKeyId(ctx, id) (*provisioning.CustomerManagedKey, error)`
- `AccountClient.Groups.GetById(ctx, id) (*iam.Group, error)` (`AccountGroupsInterface`)
- `apierr.IsMissing(err)` for the 404 skip

## Testing

`make providers/build/databricks` passes (codegen + compile). **Live verification against a real Databricks account/workspace was NOT performed.**
