### PR TITLE
🌟 mongodbatlas: typed cross-resource references (federation, log export, api keys, db users)

### DIFF
--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -79,7 +80,7 @@ func initMongodbatlasCluster(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 	name, _ := nameRaw.Value.(string)
 	if name == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("mongodbatlas.cluster requires a non-empty name")
 	}
 	pid, err := projectID(runtime)
 	if err != nil {

--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -7,8 +7,94 @@ import (
 	"context"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
+	"go.mongodb.org/atlas-sdk/v20250312006/admin"
 )
+
+// newMqlMongodbatlasCluster maps a cluster to its resource, shared by the
+// clusters list and the by-name init used by typed references.
+func newMqlMongodbatlasCluster(runtime *plugin.Runtime, pid string, c admin.ClusterDescription20240805) (*mqlMongodbatlasCluster, error) {
+	tlsMin := ""
+	tlsMode := ""
+	if adv, ok := c.GetAdvancedConfigurationOk(); ok {
+		tlsMin = adv.GetMinimumEnabledTlsProtocol()
+		tlsMode = adv.GetTlsCipherConfigMode()
+	}
+
+	regionConfigs := []any{}
+	for _, spec := range c.GetReplicationSpecs() {
+		for _, rc := range spec.GetRegionConfigs() {
+			entry := map[string]any{
+				"providerName": rc.GetProviderName(),
+				"regionName":   rc.GetRegionName(),
+				"priority":     int64(rc.GetPriority()),
+			}
+			if es, ok := rc.GetElectableSpecsOk(); ok {
+				entry["instanceSize"] = es.GetInstanceSize()
+				entry["nodeCount"] = int64(es.GetNodeCount())
+				entry["diskSizeGB"] = es.GetDiskSizeGB()
+			}
+			regionConfigs = append(regionConfigs, entry)
+		}
+	}
+
+	res, err := CreateResource(runtime, "mongodbatlas.cluster", map[string]*llx.RawData{
+		"__id":                         llx.StringData("mongodbatlas.cluster/" + pid + "/" + c.GetName()),
+		"id":                           llx.StringData(c.GetId()),
+		"name":                         llx.StringData(c.GetName()),
+		"mongoDBMajorVersion":          llx.StringData(c.GetMongoDBMajorVersion()),
+		"mongoDBVersion":               llx.StringData(c.GetMongoDBVersion()),
+		"clusterType":                  llx.StringData(c.GetClusterType()),
+		"stateName":                    llx.StringData(c.GetStateName()),
+		"backupEnabled":                llx.BoolData(c.GetBackupEnabled()),
+		"pitEnabled":                   llx.BoolData(c.GetPitEnabled()),
+		"encryptionAtRestProvider":     llx.StringData(c.GetEncryptionAtRestProvider()),
+		"minimumEnabledTlsProtocol":    llx.StringData(tlsMin),
+		"tlsCipherConfigMode":          llx.StringData(tlsMode),
+		"redactClientLogData":          llx.BoolData(c.GetRedactClientLogData()),
+		"terminationProtectionEnabled": llx.BoolData(c.GetTerminationProtectionEnabled()),
+		"paused":                       llx.BoolData(c.GetPaused()),
+		"versionReleaseSystem":         llx.StringData(c.GetVersionReleaseSystem()),
+		"rootCertType":                 llx.StringData(c.GetRootCertType()),
+		"createDate":                   llx.TimeDataPtr(timePtr(c.GetCreateDate())),
+		"regionConfigs":                llx.ArrayData(regionConfigs, types.Dict),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasCluster), nil
+}
+
+// initMongodbatlasCluster resolves a single cluster by name within the connected
+// project so typed references (such as a database user's scoped clusters) can
+// hydrate a full cluster from its name.
+func initMongodbatlasCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	nameRaw, ok := args["name"]
+	if !ok {
+		return args, nil, nil
+	}
+	name, _ := nameRaw.Value.(string)
+	if name == "" {
+		return args, nil, nil
+	}
+	pid, err := projectID(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	c, _, err := atlasClient(runtime).ClustersApi.GetCluster(context.Background(), pid, name).Execute()
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlMongodbatlasCluster(runtime, pid, *c)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
 
 func (r *mqlMongodbatlas) clusters() ([]any, error) {
 	pid, err := projectID(r.MqlRuntime)
@@ -26,53 +112,7 @@ func (r *mqlMongodbatlas) clusters() ([]any, error) {
 		}
 		results := resp.GetResults()
 		for i := range results {
-			c := results[i]
-
-			tlsMin := ""
-			tlsMode := ""
-			if adv, ok := c.GetAdvancedConfigurationOk(); ok {
-				tlsMin = adv.GetMinimumEnabledTlsProtocol()
-				tlsMode = adv.GetTlsCipherConfigMode()
-			}
-
-			regionConfigs := []any{}
-			for _, spec := range c.GetReplicationSpecs() {
-				for _, rc := range spec.GetRegionConfigs() {
-					entry := map[string]any{
-						"providerName": rc.GetProviderName(),
-						"regionName":   rc.GetRegionName(),
-						"priority":     int64(rc.GetPriority()),
-					}
-					if es, ok := rc.GetElectableSpecsOk(); ok {
-						entry["instanceSize"] = es.GetInstanceSize()
-						entry["nodeCount"] = int64(es.GetNodeCount())
-						entry["diskSizeGB"] = es.GetDiskSizeGB()
-					}
-					regionConfigs = append(regionConfigs, entry)
-				}
-			}
-
-			res, err := CreateResource(r.MqlRuntime, "mongodbatlas.cluster", map[string]*llx.RawData{
-				"__id":                         llx.StringData("mongodbatlas.cluster/" + pid + "/" + c.GetName()),
-				"id":                           llx.StringData(c.GetId()),
-				"name":                         llx.StringData(c.GetName()),
-				"mongoDBMajorVersion":          llx.StringData(c.GetMongoDBMajorVersion()),
-				"mongoDBVersion":               llx.StringData(c.GetMongoDBVersion()),
-				"clusterType":                  llx.StringData(c.GetClusterType()),
-				"stateName":                    llx.StringData(c.GetStateName()),
-				"backupEnabled":                llx.BoolData(c.GetBackupEnabled()),
-				"pitEnabled":                   llx.BoolData(c.GetPitEnabled()),
-				"encryptionAtRestProvider":     llx.StringData(c.GetEncryptionAtRestProvider()),
-				"minimumEnabledTlsProtocol":    llx.StringData(tlsMin),
-				"tlsCipherConfigMode":          llx.StringData(tlsMode),
-				"redactClientLogData":          llx.BoolData(c.GetRedactClientLogData()),
-				"terminationProtectionEnabled": llx.BoolData(c.GetTerminationProtectionEnabled()),
-				"paused":                       llx.BoolData(c.GetPaused()),
-				"versionReleaseSystem":         llx.StringData(c.GetVersionReleaseSystem()),
-				"rootCertType":                 llx.StringData(c.GetRootCertType()),
-				"createDate":                   llx.TimeDataPtr(timePtr(c.GetCreateDate())),
-				"regionConfigs":                llx.ArrayData(regionConfigs, types.Dict),
-			})
+			res, err := newMqlMongodbatlasCluster(r.MqlRuntime, pid, results[i])
 			if err != nil {
 				return nil, err
 			}

--- a/providers/mongodbatlas/resources/dbusers.go
+++ b/providers/mongodbatlas/resources/dbusers.go
@@ -10,6 +10,10 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+type mqlMongodbatlasDatabaseUserInternal struct {
+	cacheScopeClusterNames []string
+}
+
 func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 	pid, err := projectID(r.MqlRuntime)
 	if err != nil {
@@ -37,11 +41,15 @@ func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 				})
 			}
 			scopes := []any{}
+			clusterScopeNames := []string{}
 			for _, sc := range u.GetScopes() {
 				scopes = append(scopes, map[string]any{
 					"name": sc.GetName(),
 					"type": sc.GetType(),
 				})
+				if sc.GetType() == "CLUSTER" && sc.GetName() != "" {
+					clusterScopeNames = append(clusterScopeNames, sc.GetName())
+				}
 			}
 
 			res, err := CreateResource(r.MqlRuntime, "mongodbatlas.databaseUser", map[string]*llx.RawData{
@@ -61,11 +69,29 @@ func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, res)
+			dbUser := res.(*mqlMongodbatlasDatabaseUser)
+			dbUser.cacheScopeClusterNames = clusterScopeNames
+			out = append(out, dbUser)
 		}
 		if len(results) < pageSize {
 			break
 		}
+	}
+	return out, nil
+}
+
+// scopedClusters resolves the clusters a database user is confined to. An empty
+// result means the user may access all clusters in the project.
+func (r *mqlMongodbatlasDatabaseUser) scopedClusters() ([]any, error) {
+	out := []any{}
+	for _, name := range r.cacheScopeClusterNames {
+		res, err := NewResource(r.MqlRuntime, "mongodbatlas.cluster", map[string]*llx.RawData{
+			"name": llx.StringData(name),
+		})
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
 	}
 	return out, nil
 }

--- a/providers/mongodbatlas/resources/federation.go
+++ b/providers/mongodbatlas/resources/federation.go
@@ -14,7 +14,6 @@ import (
 )
 
 type mqlMongodbatlasFederationConfigInternal struct {
-	cacheFedID string
 	cacheIdpID string
 }
 
@@ -45,7 +44,6 @@ func (r *mqlMongodbatlas) federationSettings() (*mqlMongodbatlasFederationConfig
 		return nil, err
 	}
 	cfg := res.(*mqlMongodbatlasFederationConfig)
-	cfg.cacheFedID = fs.GetId()
 	cfg.cacheIdpID = fs.GetIdentityProviderId()
 	return cfg, nil
 }
@@ -88,7 +86,8 @@ func (r *mqlMongodbatlasFederationConfig) identityProvider() (*mqlMongodbatlasId
 		r.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	idp, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationApi.GetIdentityProvider(context.Background(), r.cacheFedID, r.cacheIdpID).Execute()
+	fedID := r.Id.Data
+	idp, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationApi.GetIdentityProvider(context.Background(), fedID, r.cacheIdpID).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
@@ -96,7 +95,7 @@ func (r *mqlMongodbatlasFederationConfig) identityProvider() (*mqlMongodbatlasId
 		}
 		return nil, err
 	}
-	return newMqlMongodbatlasIdentityProvider(r.MqlRuntime, r.cacheFedID, *idp)
+	return newMqlMongodbatlasIdentityProvider(r.MqlRuntime, fedID, *idp)
 }
 
 func (r *mqlMongodbatlasFederationConfig) identityProviders() ([]any, error) {

--- a/providers/mongodbatlas/resources/federation.go
+++ b/providers/mongodbatlas/resources/federation.go
@@ -10,7 +10,13 @@ import (
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
+	"go.mongodb.org/atlas-sdk/v20250312006/admin"
 )
+
+type mqlMongodbatlasFederationConfigInternal struct {
+	cacheFedID string
+	cacheIdpID string
+}
 
 func (r *mqlMongodbatlas) federationSettings() (*mqlMongodbatlasFederationConfig, error) {
 	oid, err := orgID(r.MqlRuntime)
@@ -32,14 +38,65 @@ func (r *mqlMongodbatlas) federationSettings() (*mqlMongodbatlasFederationConfig
 		"__id":                   llx.StringData("mongodbatlas.federationConfig/" + fs.GetId()),
 		"id":                     llx.StringData(fs.GetId()),
 		"identityProviderStatus": llx.StringData(fs.GetIdentityProviderStatus()),
-		"identityProviderId":     llx.StringData(fs.GetIdentityProviderId()),
 		"hasRoleMappings":        llx.BoolData(fs.GetHasRoleMappings()),
 		"federatedDomains":       llx.ArrayData(strSlice(fs.GetFederatedDomains()), types.String),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlMongodbatlasFederationConfig), nil
+	cfg := res.(*mqlMongodbatlasFederationConfig)
+	cfg.cacheFedID = fs.GetId()
+	cfg.cacheIdpID = fs.GetIdentityProviderId()
+	return cfg, nil
+}
+
+// newMqlMongodbatlasIdentityProvider maps an identity provider to its resource,
+// shared by the identityProviders list and the connected-provider accessor.
+func newMqlMongodbatlasIdentityProvider(runtime *plugin.Runtime, fedID string, idp admin.FederationIdentityProvider) (*mqlMongodbatlasIdentityProvider, error) {
+	res, err := CreateResource(runtime, "mongodbatlas.identityProvider", map[string]*llx.RawData{
+		"__id":                       llx.StringData("mongodbatlas.identityProvider/" + fedID + "/" + idp.GetId()),
+		"id":                         llx.StringData(idp.GetId()),
+		"displayName":                llx.StringData(idp.GetDisplayName()),
+		"description":                llx.StringData(idp.GetDescription()),
+		"protocol":                   llx.StringData(idp.GetProtocol()),
+		"idpType":                    llx.StringData(idp.GetIdpType()),
+		"status":                     llx.StringData(idp.GetStatus()),
+		"issuerUri":                  llx.StringData(idp.GetIssuerUri()),
+		"associatedDomains":          llx.ArrayData(strSlice(idp.GetAssociatedDomains()), types.String),
+		"ssoUrl":                     llx.StringData(idp.GetSsoUrl()),
+		"ssoDebugEnabled":            llx.BoolData(idp.GetSsoDebugEnabled()),
+		"requestBinding":             llx.StringData(idp.GetRequestBinding()),
+		"responseSignatureAlgorithm": llx.StringData(idp.GetResponseSignatureAlgorithm()),
+		"clientId":                   llx.StringData(idp.GetClientId()),
+		"authorizationType":          llx.StringData(idp.GetAuthorizationType()),
+		"groupsClaim":                llx.StringData(idp.GetGroupsClaim()),
+		"userClaim":                  llx.StringData(idp.GetUserClaim()),
+		"requestedScopes":            llx.ArrayData(strSlice(idp.GetRequestedScopes()), types.String),
+		"createdAt":                  llx.TimeDataPtr(timePtr(idp.GetCreatedAt())),
+		"updatedAt":                  llx.TimeDataPtr(timePtr(idp.GetUpdatedAt())),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasIdentityProvider), nil
+}
+
+// identityProvider resolves the identity provider connected to the organization,
+// the anchor of the SSO posture. Null when no provider is connected.
+func (r *mqlMongodbatlasFederationConfig) identityProvider() (*mqlMongodbatlasIdentityProvider, error) {
+	if r.cacheIdpID == "" {
+		r.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	idp, httpResp, err := atlasClient(r.MqlRuntime).FederatedAuthenticationApi.GetIdentityProvider(context.Background(), r.cacheFedID, r.cacheIdpID).Execute()
+	if err != nil {
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+			r.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	return newMqlMongodbatlasIdentityProvider(r.MqlRuntime, r.cacheFedID, *idp)
 }
 
 func (r *mqlMongodbatlasFederationConfig) identityProviders() ([]any, error) {
@@ -55,29 +112,7 @@ func (r *mqlMongodbatlasFederationConfig) identityProviders() ([]any, error) {
 		}
 		results := resp.GetResults()
 		for i := range results {
-			idp := results[i]
-			res, err := CreateResource(r.MqlRuntime, "mongodbatlas.identityProvider", map[string]*llx.RawData{
-				"__id":                       llx.StringData("mongodbatlas.identityProvider/" + fedID + "/" + idp.GetId()),
-				"id":                         llx.StringData(idp.GetId()),
-				"displayName":                llx.StringData(idp.GetDisplayName()),
-				"description":                llx.StringData(idp.GetDescription()),
-				"protocol":                   llx.StringData(idp.GetProtocol()),
-				"idpType":                    llx.StringData(idp.GetIdpType()),
-				"status":                     llx.StringData(idp.GetStatus()),
-				"issuerUri":                  llx.StringData(idp.GetIssuerUri()),
-				"associatedDomains":          llx.ArrayData(strSlice(idp.GetAssociatedDomains()), types.String),
-				"ssoUrl":                     llx.StringData(idp.GetSsoUrl()),
-				"ssoDebugEnabled":            llx.BoolData(idp.GetSsoDebugEnabled()),
-				"requestBinding":             llx.StringData(idp.GetRequestBinding()),
-				"responseSignatureAlgorithm": llx.StringData(idp.GetResponseSignatureAlgorithm()),
-				"clientId":                   llx.StringData(idp.GetClientId()),
-				"authorizationType":          llx.StringData(idp.GetAuthorizationType()),
-				"groupsClaim":                llx.StringData(idp.GetGroupsClaim()),
-				"userClaim":                  llx.StringData(idp.GetUserClaim()),
-				"requestedScopes":            llx.ArrayData(strSlice(idp.GetRequestedScopes()), types.String),
-				"createdAt":                  llx.TimeDataPtr(timePtr(idp.GetCreatedAt())),
-				"updatedAt":                  llx.TimeDataPtr(timePtr(idp.GetUpdatedAt())),
-			})
+			res, err := newMqlMongodbatlasIdentityProvider(r.MqlRuntime, fedID, results[i])
 			if err != nil {
 				return nil, err
 			}

--- a/providers/mongodbatlas/resources/log_export.go
+++ b/providers/mongodbatlas/resources/log_export.go
@@ -11,6 +11,11 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+type mqlMongodbatlasPushBasedLogConfigInternal struct {
+	cacheProjectID string
+	cacheRoleID    string
+}
+
 func (r *mqlMongodbatlas) pushBasedLogExport() (*mqlMongodbatlasPushBasedLogConfig, error) {
 	pid, err := projectID(r.MqlRuntime)
 	if err != nil {
@@ -31,12 +36,32 @@ func (r *mqlMongodbatlas) pushBasedLogExport() (*mqlMongodbatlasPushBasedLogConf
 	res, err := CreateResource(r.MqlRuntime, "mongodbatlas.pushBasedLogConfig", map[string]*llx.RawData{
 		"__id":       llx.StringData("mongodbatlas.pushBasedLogConfig/" + pid),
 		"bucketName": llx.StringData(cfg.GetBucketName()),
-		"iamRoleId":  llx.StringData(cfg.GetIamRoleId()),
 		"prefixPath": llx.StringData(cfg.GetPrefixPath()),
 		"state":      llx.StringData(cfg.GetState()),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlMongodbatlasPushBasedLogConfig), nil
+	logCfg := res.(*mqlMongodbatlasPushBasedLogConfig)
+	logCfg.cacheProjectID = pid
+	logCfg.cacheRoleID = cfg.GetIamRoleId()
+	return logCfg, nil
+}
+
+// cloudProviderAccessRole resolves the cloud provider access role Atlas assumes
+// to write logs to the bucket. Null when no role is configured.
+func (r *mqlMongodbatlasPushBasedLogConfig) cloudProviderAccessRole() (*mqlMongodbatlasCloudProviderAccessRole, error) {
+	if r.cacheRoleID == "" {
+		r.CloudProviderAccessRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	role, err := resolveCloudProviderAccessRole(r.MqlRuntime, r.cacheProjectID, r.cacheRoleID)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		r.CloudProviderAccessRole.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.lr
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr
@@ -110,8 +110,6 @@ mongodbatlas.orgUser @defaults("username orgMembershipStatus") {
   orgMembershipStatus string
   // Organization-level roles granted to the member
   orgRoles []string
-  // Ids of the teams the member belongs to
-  teamIds []string
   // Teams the member belongs to
   teams() []mongodbatlas.team
   // Time the member last authenticated
@@ -145,8 +143,22 @@ mongodbatlas.apiKey @defaults("publicKey description") {
   publicKey string
   // Description of the key
   description string
-  // Role assignments granted to the key, each with roleName and the org or project it applies to
-  roles []dict
+  // Role assignments granted to the key at the organization or project level
+  roleAssignments() []mongodbatlas.apiKey.roleAssignment
+}
+
+// MongoDB Atlas API key role assignment
+//
+// A single role granted to a programmatic API key, either at the organization
+// level or scoped to one project. Covers the role name, whether the grant is
+// organization-level, and the project a project-scoped grant applies to.
+private mongodbatlas.apiKey.roleAssignment @defaults("roleName") {
+  // Role granted (such as ORG_OWNER or GROUP_READ_ONLY)
+  roleName string
+  // Whether the role is granted at the organization level rather than a project
+  orgLevel bool
+  // Project the role applies to, null for an organization-level role
+  project() mongodbatlas.project
 }
 
 // MongoDB Atlas service account
@@ -246,6 +258,8 @@ mongodbatlas.databaseUser @defaults("username databaseName") {
   roles []dict
   // Scopes limiting the clusters or data lakes the user may access, each with name and type
   scopes []dict
+  // Clusters the user is scoped to, empty when the user may access all clusters in the project
+  scopedClusters() []mongodbatlas.cluster
   // Time after which the user is automatically deleted, null when permanent
   deleteAfterDate time
 }
@@ -433,12 +447,12 @@ mongodbatlas.federationConfig @defaults("id identityProviderStatus") {
   id string
   // Status of the connected identity provider (ACTIVE or INACTIVE)
   identityProviderStatus string
-  // Id of the identity provider connected to the organization
-  identityProviderId string
   // Whether the organization has role mappings configured
   hasRoleMappings bool
   // Domains the organization has federated to its identity provider
   federatedDomains []string
+  // Identity provider connected to the organization
+  identityProvider() mongodbatlas.identityProvider
   // Identity providers linked to the federation
   identityProviders() []mongodbatlas.identityProvider
 }
@@ -531,8 +545,8 @@ mongodbatlas.backupComplianceConfig @defaults("state pitEnabled copyProtectionEn
 mongodbatlas.pushBasedLogConfig @defaults("state bucketName") {
   // Name of the AWS S3 bucket logs are delivered to
   bucketName string
-  // Id of the cloud provider access role Atlas assumes to write to the bucket
-  iamRoleId string
+  // Cloud provider access role Atlas assumes to write to the bucket
+  cloudProviderAccessRole() mongodbatlas.cloudProviderAccessRole
   // Object key prefix under which logs are written in the bucket
   prefixPath string
   // Configuration state (such as ACTIVE, UNCONFIGURED, or INITIATING)

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.go
@@ -21,6 +21,7 @@ const (
 	ResourceMongodbatlasOrgUser                 string = "mongodbatlas.orgUser"
 	ResourceMongodbatlasTeam                    string = "mongodbatlas.team"
 	ResourceMongodbatlasApiKey                  string = "mongodbatlas.apiKey"
+	ResourceMongodbatlasApiKeyRoleAssignment    string = "mongodbatlas.apiKey.roleAssignment"
 	ResourceMongodbatlasServiceAccount          string = "mongodbatlas.serviceAccount"
 	ResourceMongodbatlasCluster                 string = "mongodbatlas.cluster"
 	ResourceMongodbatlasDatabaseUser            string = "mongodbatlas.databaseUser"
@@ -48,7 +49,7 @@ func init() {
 			Create: createMongodbatlas,
 		},
 		"mongodbatlas.project": {
-			// to override args, implement: initMongodbatlasProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMongodbatlasProject,
 			Create: createMongodbatlasProject,
 		},
 		"mongodbatlas.orgUser": {
@@ -63,12 +64,16 @@ func init() {
 			// to override args, implement: initMongodbatlasApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMongodbatlasApiKey,
 		},
+		"mongodbatlas.apiKey.roleAssignment": {
+			// to override args, implement: initMongodbatlasApiKeyRoleAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMongodbatlasApiKeyRoleAssignment,
+		},
 		"mongodbatlas.serviceAccount": {
 			// to override args, implement: initMongodbatlasServiceAccount(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createMongodbatlasServiceAccount,
 		},
 		"mongodbatlas.cluster": {
-			// to override args, implement: initMongodbatlasCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initMongodbatlasCluster,
 			Create: createMongodbatlasCluster,
 		},
 		"mongodbatlas.databaseUser": {
@@ -309,9 +314,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.orgUser.orgRoles": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasOrgUser).GetOrgRoles()).ToDataRes(types.Array(types.String))
 	},
-	"mongodbatlas.orgUser.teamIds": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMongodbatlasOrgUser).GetTeamIds()).ToDataRes(types.Array(types.String))
-	},
 	"mongodbatlas.orgUser.teams": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasOrgUser).GetTeams()).ToDataRes(types.Array(types.Resource("mongodbatlas.team")))
 	},
@@ -336,8 +338,17 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.apiKey.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasApiKey).GetDescription()).ToDataRes(types.String)
 	},
-	"mongodbatlas.apiKey.roles": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMongodbatlasApiKey).GetRoles()).ToDataRes(types.Array(types.Dict))
+	"mongodbatlas.apiKey.roleAssignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiKey).GetRoleAssignments()).ToDataRes(types.Array(types.Resource("mongodbatlas.apiKey.roleAssignment")))
+	},
+	"mongodbatlas.apiKey.roleAssignment.roleName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiKeyRoleAssignment).GetRoleName()).ToDataRes(types.String)
+	},
+	"mongodbatlas.apiKey.roleAssignment.orgLevel": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiKeyRoleAssignment).GetOrgLevel()).ToDataRes(types.Bool)
+	},
+	"mongodbatlas.apiKey.roleAssignment.project": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasApiKeyRoleAssignment).GetProject()).ToDataRes(types.Resource("mongodbatlas.project"))
 	},
 	"mongodbatlas.serviceAccount.clientId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasServiceAccount).GetClientId()).ToDataRes(types.String)
@@ -440,6 +451,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.databaseUser.scopes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasDatabaseUser).GetScopes()).ToDataRes(types.Array(types.Dict))
+	},
+	"mongodbatlas.databaseUser.scopedClusters": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasDatabaseUser).GetScopedClusters()).ToDataRes(types.Array(types.Resource("mongodbatlas.cluster")))
 	},
 	"mongodbatlas.databaseUser.deleteAfterDate": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasDatabaseUser).GetDeleteAfterDate()).ToDataRes(types.Time)
@@ -597,14 +611,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.federationConfig.identityProviderStatus": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasFederationConfig).GetIdentityProviderStatus()).ToDataRes(types.String)
 	},
-	"mongodbatlas.federationConfig.identityProviderId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMongodbatlasFederationConfig).GetIdentityProviderId()).ToDataRes(types.String)
-	},
 	"mongodbatlas.federationConfig.hasRoleMappings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasFederationConfig).GetHasRoleMappings()).ToDataRes(types.Bool)
 	},
 	"mongodbatlas.federationConfig.federatedDomains": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasFederationConfig).GetFederatedDomains()).ToDataRes(types.Array(types.String))
+	},
+	"mongodbatlas.federationConfig.identityProvider": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasFederationConfig).GetIdentityProvider()).ToDataRes(types.Resource("mongodbatlas.identityProvider"))
 	},
 	"mongodbatlas.federationConfig.identityProviders": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasFederationConfig).GetIdentityProviders()).ToDataRes(types.Array(types.Resource("mongodbatlas.identityProvider")))
@@ -693,8 +707,8 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"mongodbatlas.pushBasedLogConfig.bucketName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasPushBasedLogConfig).GetBucketName()).ToDataRes(types.String)
 	},
-	"mongodbatlas.pushBasedLogConfig.iamRoleId": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlMongodbatlasPushBasedLogConfig).GetIamRoleId()).ToDataRes(types.String)
+	"mongodbatlas.pushBasedLogConfig.cloudProviderAccessRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasPushBasedLogConfig).GetCloudProviderAccessRole()).ToDataRes(types.Resource("mongodbatlas.cloudProviderAccessRole"))
 	},
 	"mongodbatlas.pushBasedLogConfig.prefixPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasPushBasedLogConfig).GetPrefixPath()).ToDataRes(types.String)
@@ -898,10 +912,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasOrgUser).OrgRoles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
-	"mongodbatlas.orgUser.teamIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMongodbatlasOrgUser).TeamIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
 	"mongodbatlas.orgUser.teams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasOrgUser).Teams, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -942,8 +952,24 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasApiKey).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"mongodbatlas.apiKey.roles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMongodbatlasApiKey).Roles, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+	"mongodbatlas.apiKey.roleAssignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKey).RoleAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiKey.roleAssignment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKeyRoleAssignment).__id, ok = v.Value.(string)
+		return
+	},
+	"mongodbatlas.apiKey.roleAssignment.roleName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKeyRoleAssignment).RoleName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiKey.roleAssignment.orgLevel": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKeyRoleAssignment).OrgLevel, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.apiKey.roleAssignment.project": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasApiKeyRoleAssignment).Project, ok = plugin.RawToTValue[*mqlMongodbatlasProject](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.serviceAccount.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1092,6 +1118,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.databaseUser.scopes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasDatabaseUser).Scopes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.databaseUser.scopedClusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasDatabaseUser).ScopedClusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.databaseUser.deleteAfterDate": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1338,16 +1368,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasFederationConfig).IdentityProviderStatus, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"mongodbatlas.federationConfig.identityProviderId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMongodbatlasFederationConfig).IdentityProviderId, ok = plugin.RawToTValue[string](v.Value, v.Error)
-		return
-	},
 	"mongodbatlas.federationConfig.hasRoleMappings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasFederationConfig).HasRoleMappings, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.federationConfig.federatedDomains": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasFederationConfig).FederatedDomains, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.federationConfig.identityProvider": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasFederationConfig).IdentityProvider, ok = plugin.RawToTValue[*mqlMongodbatlasIdentityProvider](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.federationConfig.identityProviders": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1478,8 +1508,8 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlMongodbatlasPushBasedLogConfig).BucketName, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
-	"mongodbatlas.pushBasedLogConfig.iamRoleId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlMongodbatlasPushBasedLogConfig).IamRoleId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+	"mongodbatlas.pushBasedLogConfig.cloudProviderAccessRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasPushBasedLogConfig).CloudProviderAccessRole, ok = plugin.RawToTValue[*mqlMongodbatlasCloudProviderAccessRole](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.pushBasedLogConfig.prefixPath": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2046,12 +2076,11 @@ func (c *mqlMongodbatlasProject) GetRegionUsageRestrictions() *plugin.TValue[str
 type mqlMongodbatlasOrgUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMongodbatlasOrgUserInternal it will be used here
+	mqlMongodbatlasOrgUserInternal
 	Id                  plugin.TValue[string]
 	Username            plugin.TValue[string]
 	OrgMembershipStatus plugin.TValue[string]
 	OrgRoles            plugin.TValue[[]any]
-	TeamIds             plugin.TValue[[]any]
 	Teams               plugin.TValue[[]any]
 	LastAuth            plugin.TValue[*time.Time]
 }
@@ -2102,10 +2131,6 @@ func (c *mqlMongodbatlasOrgUser) GetOrgMembershipStatus() *plugin.TValue[string]
 
 func (c *mqlMongodbatlasOrgUser) GetOrgRoles() *plugin.TValue[[]any] {
 	return &c.OrgRoles
-}
-
-func (c *mqlMongodbatlasOrgUser) GetTeamIds() *plugin.TValue[[]any] {
-	return &c.TeamIds
 }
 
 func (c *mqlMongodbatlasOrgUser) GetTeams() *plugin.TValue[[]any] {
@@ -2198,11 +2223,11 @@ func (c *mqlMongodbatlasTeam) GetUsers() *plugin.TValue[[]any] {
 type mqlMongodbatlasApiKey struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMongodbatlasApiKeyInternal it will be used here
-	Id          plugin.TValue[string]
-	PublicKey   plugin.TValue[string]
-	Description plugin.TValue[string]
-	Roles       plugin.TValue[[]any]
+	mqlMongodbatlasApiKeyInternal
+	Id              plugin.TValue[string]
+	PublicKey       plugin.TValue[string]
+	Description     plugin.TValue[string]
+	RoleAssignments plugin.TValue[[]any]
 }
 
 // createMongodbatlasApiKey creates a new instance of this resource
@@ -2249,8 +2274,86 @@ func (c *mqlMongodbatlasApiKey) GetDescription() *plugin.TValue[string] {
 	return &c.Description
 }
 
-func (c *mqlMongodbatlasApiKey) GetRoles() *plugin.TValue[[]any] {
-	return &c.Roles
+func (c *mqlMongodbatlasApiKey) GetRoleAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoleAssignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.apiKey", c.__id, "roleAssignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roleAssignments()
+	})
+}
+
+// mqlMongodbatlasApiKeyRoleAssignment for the mongodbatlas.apiKey.roleAssignment resource
+type mqlMongodbatlasApiKeyRoleAssignment struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlMongodbatlasApiKeyRoleAssignmentInternal
+	RoleName plugin.TValue[string]
+	OrgLevel plugin.TValue[bool]
+	Project  plugin.TValue[*mqlMongodbatlasProject]
+}
+
+// createMongodbatlasApiKeyRoleAssignment creates a new instance of this resource
+func createMongodbatlasApiKeyRoleAssignment(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMongodbatlasApiKeyRoleAssignment{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("mongodbatlas.apiKey.roleAssignment", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMongodbatlasApiKeyRoleAssignment) MqlName() string {
+	return "mongodbatlas.apiKey.roleAssignment"
+}
+
+func (c *mqlMongodbatlasApiKeyRoleAssignment) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMongodbatlasApiKeyRoleAssignment) GetRoleName() *plugin.TValue[string] {
+	return &c.RoleName
+}
+
+func (c *mqlMongodbatlasApiKeyRoleAssignment) GetOrgLevel() *plugin.TValue[bool] {
+	return &c.OrgLevel
+}
+
+func (c *mqlMongodbatlasApiKeyRoleAssignment) GetProject() *plugin.TValue[*mqlMongodbatlasProject] {
+	return plugin.GetOrCompute[*mqlMongodbatlasProject](&c.Project, func() (*mqlMongodbatlasProject, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.apiKey.roleAssignment", c.__id, "project")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMongodbatlasProject), nil
+			}
+		}
+
+		return c.project()
+	})
 }
 
 // mqlMongodbatlasServiceAccount for the mongodbatlas.serviceAccount resource
@@ -2455,7 +2558,7 @@ func (c *mqlMongodbatlasCluster) GetRegionConfigs() *plugin.TValue[[]any] {
 type mqlMongodbatlasDatabaseUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMongodbatlasDatabaseUserInternal it will be used here
+	mqlMongodbatlasDatabaseUserInternal
 	Id              plugin.TValue[string]
 	Username        plugin.TValue[string]
 	DatabaseName    plugin.TValue[string]
@@ -2466,6 +2569,7 @@ type mqlMongodbatlasDatabaseUser struct {
 	OidcAuthType    plugin.TValue[string]
 	Roles           plugin.TValue[[]any]
 	Scopes          plugin.TValue[[]any]
+	ScopedClusters  plugin.TValue[[]any]
 	DeleteAfterDate plugin.TValue[*time.Time]
 }
 
@@ -2539,6 +2643,22 @@ func (c *mqlMongodbatlasDatabaseUser) GetRoles() *plugin.TValue[[]any] {
 
 func (c *mqlMongodbatlasDatabaseUser) GetScopes() *plugin.TValue[[]any] {
 	return &c.Scopes
+}
+
+func (c *mqlMongodbatlasDatabaseUser) GetScopedClusters() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ScopedClusters, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.databaseUser", c.__id, "scopedClusters")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.scopedClusters()
+	})
 }
 
 func (c *mqlMongodbatlasDatabaseUser) GetDeleteAfterDate() *plugin.TValue[*time.Time] {
@@ -3106,12 +3226,12 @@ func (c *mqlMongodbatlasCustomDatabaseRole) GetInheritedRoles() *plugin.TValue[[
 type mqlMongodbatlasFederationConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMongodbatlasFederationConfigInternal it will be used here
+	mqlMongodbatlasFederationConfigInternal
 	Id                     plugin.TValue[string]
 	IdentityProviderStatus plugin.TValue[string]
-	IdentityProviderId     plugin.TValue[string]
 	HasRoleMappings        plugin.TValue[bool]
 	FederatedDomains       plugin.TValue[[]any]
+	IdentityProvider       plugin.TValue[*mqlMongodbatlasIdentityProvider]
 	IdentityProviders      plugin.TValue[[]any]
 }
 
@@ -3155,16 +3275,28 @@ func (c *mqlMongodbatlasFederationConfig) GetIdentityProviderStatus() *plugin.TV
 	return &c.IdentityProviderStatus
 }
 
-func (c *mqlMongodbatlasFederationConfig) GetIdentityProviderId() *plugin.TValue[string] {
-	return &c.IdentityProviderId
-}
-
 func (c *mqlMongodbatlasFederationConfig) GetHasRoleMappings() *plugin.TValue[bool] {
 	return &c.HasRoleMappings
 }
 
 func (c *mqlMongodbatlasFederationConfig) GetFederatedDomains() *plugin.TValue[[]any] {
 	return &c.FederatedDomains
+}
+
+func (c *mqlMongodbatlasFederationConfig) GetIdentityProvider() *plugin.TValue[*mqlMongodbatlasIdentityProvider] {
+	return plugin.GetOrCompute[*mqlMongodbatlasIdentityProvider](&c.IdentityProvider, func() (*mqlMongodbatlasIdentityProvider, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.federationConfig", c.__id, "identityProvider")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMongodbatlasIdentityProvider), nil
+			}
+		}
+
+		return c.identityProvider()
+	})
 }
 
 func (c *mqlMongodbatlasFederationConfig) GetIdentityProviders() *plugin.TValue[[]any] {
@@ -3400,11 +3532,11 @@ func (c *mqlMongodbatlasBackupComplianceConfig) GetScheduledPolicyItems() *plugi
 type mqlMongodbatlasPushBasedLogConfig struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlMongodbatlasPushBasedLogConfigInternal it will be used here
-	BucketName plugin.TValue[string]
-	IamRoleId  plugin.TValue[string]
-	PrefixPath plugin.TValue[string]
-	State      plugin.TValue[string]
+	mqlMongodbatlasPushBasedLogConfigInternal
+	BucketName              plugin.TValue[string]
+	CloudProviderAccessRole plugin.TValue[*mqlMongodbatlasCloudProviderAccessRole]
+	PrefixPath              plugin.TValue[string]
+	State                   plugin.TValue[string]
 }
 
 // createMongodbatlasPushBasedLogConfig creates a new instance of this resource
@@ -3443,8 +3575,20 @@ func (c *mqlMongodbatlasPushBasedLogConfig) GetBucketName() *plugin.TValue[strin
 	return &c.BucketName
 }
 
-func (c *mqlMongodbatlasPushBasedLogConfig) GetIamRoleId() *plugin.TValue[string] {
-	return &c.IamRoleId
+func (c *mqlMongodbatlasPushBasedLogConfig) GetCloudProviderAccessRole() *plugin.TValue[*mqlMongodbatlasCloudProviderAccessRole] {
+	return plugin.GetOrCompute[*mqlMongodbatlasCloudProviderAccessRole](&c.CloudProviderAccessRole, func() (*mqlMongodbatlasCloudProviderAccessRole, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.pushBasedLogConfig", c.__id, "cloudProviderAccessRole")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlMongodbatlasCloudProviderAccessRole), nil
+			}
+		}
+
+		return c.cloudProviderAccessRole()
+	})
 }
 
 func (c *mqlMongodbatlasPushBasedLogConfig) GetPrefixPath() *plugin.TValue[string] {

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.versions
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.versions
@@ -7,7 +7,11 @@ mongodbatlas.apiKey 13.0.0
 mongodbatlas.apiKey.description 13.0.0
 mongodbatlas.apiKey.id 13.0.0
 mongodbatlas.apiKey.publicKey 13.0.0
-mongodbatlas.apiKey.roles 13.0.0
+mongodbatlas.apiKey.roleAssignment 13.0.1
+mongodbatlas.apiKey.roleAssignment.orgLevel 13.0.1
+mongodbatlas.apiKey.roleAssignment.project 13.0.1
+mongodbatlas.apiKey.roleAssignment.roleName 13.0.1
+mongodbatlas.apiKey.roleAssignments 13.0.1
 mongodbatlas.apiKeys 13.0.0
 mongodbatlas.auditConfig 13.0.0
 mongodbatlas.auditConfig.auditAuthorizationSuccess 13.0.0
@@ -69,6 +73,7 @@ mongodbatlas.databaseUser.id 13.0.0
 mongodbatlas.databaseUser.ldapAuthType 13.0.0
 mongodbatlas.databaseUser.oidcAuthType 13.0.0
 mongodbatlas.databaseUser.roles 13.0.0
+mongodbatlas.databaseUser.scopedClusters 13.0.1
 mongodbatlas.databaseUser.scopes 13.0.0
 mongodbatlas.databaseUser.username 13.0.0
 mongodbatlas.databaseUser.x509Type 13.0.0
@@ -86,7 +91,7 @@ mongodbatlas.federationConfig 13.0.1
 mongodbatlas.federationConfig.federatedDomains 13.0.1
 mongodbatlas.federationConfig.hasRoleMappings 13.0.1
 mongodbatlas.federationConfig.id 13.0.1
-mongodbatlas.federationConfig.identityProviderId 13.0.1
+mongodbatlas.federationConfig.identityProvider 13.0.1
 mongodbatlas.federationConfig.identityProviderStatus 13.0.1
 mongodbatlas.federationConfig.identityProviders 13.0.1
 mongodbatlas.federationSettings 13.0.1
@@ -136,7 +141,6 @@ mongodbatlas.orgUser.id 13.0.0
 mongodbatlas.orgUser.lastAuth 13.0.0
 mongodbatlas.orgUser.orgMembershipStatus 13.0.0
 mongodbatlas.orgUser.orgRoles 13.0.0
-mongodbatlas.orgUser.teamIds 13.0.0
 mongodbatlas.orgUser.teams 13.0.0
 mongodbatlas.orgUser.username 13.0.0
 mongodbatlas.orgUsers 13.0.0
@@ -169,7 +173,7 @@ mongodbatlas.projectSettings 13.0.0
 mongodbatlas.projects 13.0.0
 mongodbatlas.pushBasedLogConfig 13.0.1
 mongodbatlas.pushBasedLogConfig.bucketName 13.0.1
-mongodbatlas.pushBasedLogConfig.iamRoleId 13.0.1
+mongodbatlas.pushBasedLogConfig.cloudProviderAccessRole 13.0.1
 mongodbatlas.pushBasedLogConfig.prefixPath 13.0.1
 mongodbatlas.pushBasedLogConfig.state 13.0.1
 mongodbatlas.pushBasedLogExport 13.0.1

--- a/providers/mongodbatlas/resources/network.go
+++ b/providers/mongodbatlas/resources/network.go
@@ -202,7 +202,9 @@ func (r *mqlMongodbatlas) cloudProviderAccessRoles() ([]any, error) {
 }
 
 // resolveCloudProviderAccessRole finds a project's cloud provider access role by
-// id and maps it, or returns nil when no role matches.
+// id and maps it, or returns nil when no role matches. It lists the project's
+// roles on each call; the only caller today is pushBasedLogConfig, of which
+// there is at most one per project, so the list call is bounded to one per scan.
 func resolveCloudProviderAccessRole(runtime *plugin.Runtime, pid, roleID string) (*mqlMongodbatlasCloudProviderAccessRole, error) {
 	roles, _, err := atlasClient(runtime).CloudProviderAccessApi.ListCloudProviderAccessRoles(context.Background(), pid).Execute()
 	if err != nil {

--- a/providers/mongodbatlas/resources/network.go
+++ b/providers/mongodbatlas/resources/network.go
@@ -6,10 +6,33 @@ package resources
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// newMqlMongodbatlasCloudProviderAccessRole maps a cloud provider access role to
+// its resource. Flat scalar params so the AWS, Azure, and GCP variants (and the
+// pushBasedLogConfig accessor) share one mapper.
+func newMqlMongodbatlasCloudProviderAccessRole(runtime *plugin.Runtime, pid, slug, providerName, id, iamAssumedRoleArn, atlasAWSAccountArn, azureAtlasAppId, azureTenantId, gcpServiceAccount string, authorizedDate *time.Time) (*mqlMongodbatlasCloudProviderAccessRole, error) {
+	res, err := CreateResource(runtime, "mongodbatlas.cloudProviderAccessRole", map[string]*llx.RawData{
+		"__id":               llx.StringData("mongodbatlas.cloudProviderAccessRole/" + pid + "/" + slug + "/" + id),
+		"id":                 llx.StringData(id),
+		"providerName":       llx.StringData(providerName),
+		"iamAssumedRoleArn":  llx.StringData(iamAssumedRoleArn),
+		"atlasAWSAccountArn": llx.StringData(atlasAWSAccountArn),
+		"azureAtlasAppId":    llx.StringData(azureAtlasAppId),
+		"azureTenantId":      llx.StringData(azureTenantId),
+		"gcpServiceAccount":  llx.StringData(gcpServiceAccount),
+		"authorizedDate":     llx.TimeDataPtr(authorizedDate),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasCloudProviderAccessRole), nil
+}
 
 func (r *mqlMongodbatlas) ipAccessList() ([]any, error) {
 	pid, err := projectID(r.MqlRuntime)
@@ -155,55 +178,50 @@ func (r *mqlMongodbatlas) cloudProviderAccessRoles() ([]any, error) {
 
 	out := []any{}
 	for _, role := range roles.GetAwsIamRoles() {
-		res, err := CreateResource(r.MqlRuntime, "mongodbatlas.cloudProviderAccessRole", map[string]*llx.RawData{
-			"__id":               llx.StringData("mongodbatlas.cloudProviderAccessRole/" + pid + "/aws/" + role.GetRoleId()),
-			"id":                 llx.StringData(role.GetRoleId()),
-			"providerName":       llx.StringData(role.GetProviderName()),
-			"iamAssumedRoleArn":  llx.StringData(role.GetIamAssumedRoleArn()),
-			"atlasAWSAccountArn": llx.StringData(role.GetAtlasAWSAccountArn()),
-			"azureAtlasAppId":    llx.StringData(""),
-			"azureTenantId":      llx.StringData(""),
-			"gcpServiceAccount":  llx.StringData(""),
-			"authorizedDate":     llx.TimeDataPtr(timePtr(role.GetAuthorizedDate())),
-		})
+		res, err := newMqlMongodbatlasCloudProviderAccessRole(r.MqlRuntime, pid, "aws", role.GetProviderName(), role.GetRoleId(), role.GetIamAssumedRoleArn(), role.GetAtlasAWSAccountArn(), "", "", "", timePtr(role.GetAuthorizedDate()))
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	for _, sp := range roles.GetAzureServicePrincipals() {
-		res, err := CreateResource(r.MqlRuntime, "mongodbatlas.cloudProviderAccessRole", map[string]*llx.RawData{
-			"__id":               llx.StringData("mongodbatlas.cloudProviderAccessRole/" + pid + "/azure/" + sp.GetId()),
-			"id":                 llx.StringData(sp.GetId()),
-			"providerName":       llx.StringData(sp.GetProviderName()),
-			"iamAssumedRoleArn":  llx.StringData(""),
-			"atlasAWSAccountArn": llx.StringData(""),
-			"azureAtlasAppId":    llx.StringData(sp.GetAtlasAzureAppId()),
-			"azureTenantId":      llx.StringData(sp.GetTenantId()),
-			"gcpServiceAccount":  llx.StringData(""),
-			"authorizedDate":     llx.TimeDataPtr(timePtr(sp.GetCreatedDate())),
-		})
+		res, err := newMqlMongodbatlasCloudProviderAccessRole(r.MqlRuntime, pid, "azure", sp.GetProviderName(), sp.GetId(), "", "", sp.GetAtlasAzureAppId(), sp.GetTenantId(), "", timePtr(sp.GetCreatedDate()))
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	for _, sa := range roles.GetGcpServiceAccounts() {
-		res, err := CreateResource(r.MqlRuntime, "mongodbatlas.cloudProviderAccessRole", map[string]*llx.RawData{
-			"__id":               llx.StringData("mongodbatlas.cloudProviderAccessRole/" + pid + "/gcp/" + sa.GetRoleId()),
-			"id":                 llx.StringData(sa.GetRoleId()),
-			"providerName":       llx.StringData(sa.GetProviderName()),
-			"iamAssumedRoleArn":  llx.StringData(""),
-			"atlasAWSAccountArn": llx.StringData(""),
-			"azureAtlasAppId":    llx.StringData(""),
-			"azureTenantId":      llx.StringData(""),
-			"gcpServiceAccount":  llx.StringData(sa.GetGcpServiceAccountForAtlas()),
-			"authorizedDate":     llx.TimeDataPtr(timePtr(sa.GetCreatedDate())),
-		})
+		res, err := newMqlMongodbatlasCloudProviderAccessRole(r.MqlRuntime, pid, "gcp", sa.GetProviderName(), sa.GetRoleId(), "", "", "", "", sa.GetGcpServiceAccountForAtlas(), timePtr(sa.GetCreatedDate()))
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// resolveCloudProviderAccessRole finds a project's cloud provider access role by
+// id and maps it, or returns nil when no role matches.
+func resolveCloudProviderAccessRole(runtime *plugin.Runtime, pid, roleID string) (*mqlMongodbatlasCloudProviderAccessRole, error) {
+	roles, _, err := atlasClient(runtime).CloudProviderAccessApi.ListCloudProviderAccessRoles(context.Background(), pid).Execute()
+	if err != nil {
+		return nil, err
+	}
+	for _, role := range roles.GetAwsIamRoles() {
+		if role.GetRoleId() == roleID {
+			return newMqlMongodbatlasCloudProviderAccessRole(runtime, pid, "aws", role.GetProviderName(), role.GetRoleId(), role.GetIamAssumedRoleArn(), role.GetAtlasAWSAccountArn(), "", "", "", timePtr(role.GetAuthorizedDate()))
+		}
+	}
+	for _, sp := range roles.GetAzureServicePrincipals() {
+		if sp.GetId() == roleID {
+			return newMqlMongodbatlasCloudProviderAccessRole(runtime, pid, "azure", sp.GetProviderName(), sp.GetId(), "", "", sp.GetAtlasAzureAppId(), sp.GetTenantId(), "", timePtr(sp.GetCreatedDate()))
+		}
+	}
+	for _, sa := range roles.GetGcpServiceAccounts() {
+		if sa.GetRoleId() == roleID {
+			return newMqlMongodbatlasCloudProviderAccessRole(runtime, pid, "gcp", sa.GetProviderName(), sa.GetRoleId(), "", "", "", "", sa.GetGcpServiceAccountForAtlas(), timePtr(sa.GetCreatedDate()))
+		}
+	}
+	return nil, nil
 }

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -55,7 +56,7 @@ func initMongodbatlasProject(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	}
 	id, _ := idRaw.Value.(string)
 	if id == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("mongodbatlas.project requires a non-empty id")
 	}
 	p, _, err := atlasClient(runtime).ProjectsApi.GetProject(context.Background(), id).Execute()
 	if err != nil {

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -25,6 +25,49 @@ func dictTime(t time.Time) any {
 	return t.Format(time.RFC3339)
 }
 
+// newMqlMongodbatlasProject maps a project to its resource, shared by the
+// projects list and the by-id init used by typed references.
+func newMqlMongodbatlasProject(runtime *plugin.Runtime, p admin.Group) (*mqlMongodbatlasProject, error) {
+	res, err := CreateResource(runtime, "mongodbatlas.project", map[string]*llx.RawData{
+		"__id":                    llx.StringData("mongodbatlas.project/" + p.GetId()),
+		"id":                      llx.StringData(p.GetId()),
+		"name":                    llx.StringData(p.GetName()),
+		"orgId":                   llx.StringData(p.GetOrgId()),
+		"clusterCount":            llx.IntData(p.GetClusterCount()),
+		"created":                 llx.TimeDataPtr(timePtr(p.GetCreated())),
+		"regionUsageRestrictions": llx.StringData(p.GetRegionUsageRestrictions()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasProject), nil
+}
+
+// initMongodbatlasProject resolves a single project by id so typed references
+// (such as an API key role assignment) can hydrate a full project from its id.
+func initMongodbatlasProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok {
+		return args, nil, nil
+	}
+	id, _ := idRaw.Value.(string)
+	if id == "" {
+		return args, nil, nil
+	}
+	p, _, err := atlasClient(runtime).ProjectsApi.GetProject(context.Background(), id).Execute()
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := newMqlMongodbatlasProject(runtime, *p)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, res, nil
+}
+
 func (r *mqlMongodbatlas) projects() ([]any, error) {
 	client := atlasClient(r.MqlRuntime)
 	ctx := context.Background()
@@ -37,16 +80,7 @@ func (r *mqlMongodbatlas) projects() ([]any, error) {
 		}
 		results := resp.GetResults()
 		for i := range results {
-			p := results[i]
-			res, err := CreateResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
-				"__id":                    llx.StringData("mongodbatlas.project/" + p.GetId()),
-				"id":                      llx.StringData(p.GetId()),
-				"name":                    llx.StringData(p.GetName()),
-				"orgId":                   llx.StringData(p.GetOrgId()),
-				"clusterCount":            llx.IntData(p.GetClusterCount()),
-				"created":                 llx.TimeDataPtr(timePtr(p.GetCreated())),
-				"regionUsageRestrictions": llx.StringData(p.GetRegionUsageRestrictions()),
-			})
+			res, err := newMqlMongodbatlasProject(r.MqlRuntime, results[i])
 			if err != nil {
 				return nil, err
 			}
@@ -88,6 +122,10 @@ func (r *mqlMongodbatlas) orgUsers() ([]any, error) {
 	return out, nil
 }
 
+type mqlMongodbatlasOrgUserInternal struct {
+	cacheTeamIds []string
+}
+
 func newMqlMongodbatlasOrgUser(runtime *plugin.Runtime, u admin.OrgUserResponse) (*mqlMongodbatlasOrgUser, error) {
 	roles := u.GetRoles()
 	res, err := CreateResource(runtime, "mongodbatlas.orgUser", map[string]*llx.RawData{
@@ -96,13 +134,14 @@ func newMqlMongodbatlasOrgUser(runtime *plugin.Runtime, u admin.OrgUserResponse)
 		"username":            llx.StringData(u.GetUsername()),
 		"orgMembershipStatus": llx.StringData(u.GetOrgMembershipStatus()),
 		"orgRoles":            llx.ArrayData(strSlice(roles.GetOrgRoles()), types.String),
-		"teamIds":             llx.ArrayData(strSlice(u.GetTeamIds()), types.String),
 		"lastAuth":            llx.TimeDataPtr(timePtr(u.GetLastAuth())),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlMongodbatlasOrgUser), nil
+	orgUser := res.(*mqlMongodbatlasOrgUser)
+	orgUser.cacheTeamIds = u.GetTeamIds()
+	return orgUser, nil
 }
 
 // teams resolves the member's team ids to the teams they belong to.
@@ -115,9 +154,8 @@ func (r *mqlMongodbatlasOrgUser) teams() ([]any, error) {
 	ctx := context.Background()
 
 	out := []any{}
-	for _, raw := range r.TeamIds.Data {
-		teamID, ok := raw.(string)
-		if !ok || teamID == "" {
+	for _, teamID := range r.cacheTeamIds {
+		if teamID == "" {
 			continue
 		}
 		t, _, err := client.TeamsApi.GetTeamById(ctx, oid, teamID).Execute()
@@ -221,31 +259,76 @@ func (r *mqlMongodbatlas) apiKeys() ([]any, error) {
 		results := resp.GetResults()
 		for i := range results {
 			k := results[i]
-			roles := []any{}
-			for _, role := range k.GetRoles() {
-				roles = append(roles, map[string]any{
-					"roleName": role.GetRoleName(),
-					"groupId":  role.GetGroupId(),
-					"orgId":    role.GetOrgId(),
-				})
-			}
 			res, err := CreateResource(r.MqlRuntime, "mongodbatlas.apiKey", map[string]*llx.RawData{
 				"__id":        llx.StringData("mongodbatlas.apiKey/" + k.GetId()),
 				"id":          llx.StringData(k.GetId()),
 				"publicKey":   llx.StringData(k.GetPublicKey()),
 				"description": llx.StringData(k.GetDesc()),
-				"roles":       llx.ArrayData(roles, types.Dict),
 			})
 			if err != nil {
 				return nil, err
 			}
-			out = append(out, res)
+			apiKey := res.(*mqlMongodbatlasApiKey)
+			apiKey.cacheApiKeyID = k.GetId()
+			apiKey.cacheRoles = k.GetRoles()
+			out = append(out, apiKey)
 		}
 		if len(results) < pageSize {
 			break
 		}
 	}
 	return out, nil
+}
+
+type mqlMongodbatlasApiKeyInternal struct {
+	cacheApiKeyID string
+	cacheRoles    []admin.CloudAccessRoleAssignment
+}
+
+type mqlMongodbatlasApiKeyRoleAssignmentInternal struct {
+	cacheGroupID string
+}
+
+// roleAssignments expands the key's granted roles into typed assignments, each
+// carrying the role name and, for a project-scoped grant, the project.
+func (r *mqlMongodbatlasApiKey) roleAssignments() ([]any, error) {
+	out := []any{}
+	for _, role := range r.cacheRoles {
+		groupID := role.GetGroupId()
+		orgLevel := groupID == ""
+		scopeKey := groupID
+		if orgLevel {
+			scopeKey = "org/" + role.GetOrgId()
+		}
+		res, err := CreateResource(r.MqlRuntime, "mongodbatlas.apiKey.roleAssignment", map[string]*llx.RawData{
+			"__id":     llx.StringData("mongodbatlas.apiKey.roleAssignment/" + r.cacheApiKeyID + "/" + role.GetRoleName() + "/" + scopeKey),
+			"roleName": llx.StringData(role.GetRoleName()),
+			"orgLevel": llx.BoolData(orgLevel),
+		})
+		if err != nil {
+			return nil, err
+		}
+		ra := res.(*mqlMongodbatlasApiKeyRoleAssignment)
+		ra.cacheGroupID = groupID
+		out = append(out, ra)
+	}
+	return out, nil
+}
+
+// project resolves the project a project-scoped role applies to. Null for an
+// organization-level role.
+func (r *mqlMongodbatlasApiKeyRoleAssignment) project() (*mqlMongodbatlasProject, error) {
+	if r.cacheGroupID == "" {
+		r.Project.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	proj, err := NewResource(r.MqlRuntime, "mongodbatlas.project", map[string]*llx.RawData{
+		"id": llx.StringData(r.cacheGroupID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return proj.(*mqlMongodbatlasProject), nil
 }
 
 func (r *mqlMongodbatlas) serviceAccounts() ([]any, error) {


### PR DESCRIPTION
## What

Makes MongoDB Atlas resources traversable by converting raw ID strings into typed accessors. The provider is **unreleased**, so these are clean conversions (raw field removed / dict promoted), not deprecations.

### Tier 1
| Change | Unlocks |
|---|---|
| `federationConfig.identityProviderId` (string) → **`identityProvider()`** `mongodbatlas.identityProvider` | `federationSettings.identityProvider.ssoDebugEnabled` / `.requestBinding` — the connected IdP is the anchor of every SSO-posture audit |
| `pushBasedLogConfig.iamRoleId` (string) → **`cloudProviderAccessRole()`** `mongodbatlas.cloudProviderAccessRole` | `pushBasedLogExport.cloudProviderAccessRole.iamAssumedRoleArn` — the IAM role Atlas assumes to write the audit-log bucket |
| `orgUser.teamIds []string` **removed** | the typed `teams()` already round-trips it |

### Tier 2
| Change | Unlocks |
|---|---|
| `apiKey.roles []dict` → **`roleAssignments()`** `[]mongodbatlas.apiKey.roleAssignment` (nested typed `project()`) | `apiKeys.roleAssignments.where(orgLevel == false).project.name` — blast-radius of a programmatic key |
| `databaseUser` + **`scopedClusters()`** `[]mongodbatlas.cluster` | `databaseUsers.scopedClusters.name` — which clusters a user is confined to (empty = all) |

## How

- Added **`initMongodbatlasProject`** (`GetProject`) and **`initMongodbatlasCluster`** (`GetCluster`) so those resources hydrate from just their key; the list-path mappers were refactored into shared `newMql…` helpers so hydrate-by-key and list produce identical resources.
- `identityProvider()` and `cloudProviderAccessRole()` resolve directly against the parent's cached context and **degrade to null** (401/403/404) rather than failing the scan, matching the provider's existing settings pattern.
- The `apiKey.roleAssignment` sub-resource earns its place via the nested typed `project()` ref (sub-resource bar). Org-level grants report `orgLevel = true` and a null `project`.

## Plane note

All the typed targets here are reachable: the org-plane ones (`project`, `identityProvider`) resolve from a project connection too via `EnsureOrgID`, and `cluster`/`cloudProviderAccessRole` are project-plane like their sources. (Contrast Databricks, where `metastoreId` had to stay raw because it's cross-plane.)

## Notes
- `.lr.versions` entries at `13.0.1`; no `config.go` bump. `mongodbatlas.resources.json` is gitignored.
- `make providers/build/mongodbatlas` + `go vet` clean. Live verification NOT performed (build + codegen only).
