### PR TITLE
🐛 mongodbatlas: degrade org-privilege endpoints and fix N+1 lookups

### DIFF
--- a/providers/mongodbatlas/resources/cluster.go
+++ b/providers/mongodbatlas/resources/cluster.go
@@ -97,6 +97,26 @@ func initMongodbatlasCluster(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	return nil, res, nil
 }
 
+// projectClustersByName lists the project's clusters once and caches them by
+// name on the root resource, so scoped-cluster resolution for database users is
+// a map lookup rather than a GetCluster call per scope entry.
+func (r *mqlMongodbatlas) projectClustersByName() (map[string]*mqlMongodbatlasCluster, error) {
+	r.clustersOnce.Do(func() {
+		clusters, err := r.clusters()
+		if err != nil {
+			r.clustersErr = err
+			return
+		}
+		m := make(map[string]*mqlMongodbatlasCluster, len(clusters))
+		for _, c := range clusters {
+			cl := c.(*mqlMongodbatlasCluster)
+			m[cl.Name.Data] = cl
+		}
+		r.clustersByName = m
+	})
+	return r.clustersByName, r.clustersErr
+}
+
 func (r *mqlMongodbatlas) clusters() ([]any, error) {
 	pid, err := projectID(r.MqlRuntime)
 	if err != nil {

--- a/providers/mongodbatlas/resources/dbusers.go
+++ b/providers/mongodbatlas/resources/dbusers.go
@@ -83,15 +83,22 @@ func (r *mqlMongodbatlas) databaseUsers() ([]any, error) {
 // scopedClusters resolves the clusters a database user is confined to. An empty
 // result means the user may access all clusters in the project.
 func (r *mqlMongodbatlasDatabaseUser) scopedClusters() ([]any, error) {
+	root, err := rootMongodbatlas(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	clustersByName, err := root.projectClustersByName()
+	if err != nil {
+		return nil, err
+	}
+
 	out := []any{}
 	for _, name := range r.cacheScopeClusterNames {
-		res, err := NewResource(r.MqlRuntime, "mongodbatlas.cluster", map[string]*llx.RawData{
-			"name": llx.StringData(name),
-		})
-		if err != nil {
-			return nil, err
+		cl, ok := clustersByName[name]
+		if !ok {
+			continue
 		}
-		out = append(out, res)
+		out = append(out, cl)
 	}
 	return out, nil
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -6,18 +6,40 @@ package resources
 import (
 	"context"
 	"errors"
+	"net/http"
 	"sync"
 	"time"
 
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/mongodbatlas/connection"
 	"go.mongodb.org/atlas-sdk/v20250312006/admin"
 )
 
 type mqlMongodbatlasInternal struct {
-	orgSettingsLock sync.Mutex
-	orgSettingsDone bool
-	orgSettings     *admin.OrganizationSettings
+	orgSettingsLock   sync.Mutex
+	orgSettingsDone   bool
+	orgSettingsDenied bool
+	orgSettings       *admin.OrganizationSettings
+
+	teamsOnce sync.Once
+	teamsByID map[string]admin.TeamResponse
+	teamsErr  error
+
+	clustersOnce   sync.Once
+	clustersByName map[string]*mqlMongodbatlasCluster
+	clustersErr    error
+}
+
+// rootMongodbatlas returns the cached root resource singleton so sub-resources
+// can share the org-wide caches (teams, clusters) that hang off its Internal
+// struct.
+func rootMongodbatlas(runtime *plugin.Runtime) (*mqlMongodbatlas, error) {
+	res, err := CreateResource(runtime, "mongodbatlas", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlas), nil
 }
 
 func (r *mqlMongodbatlas) id() (string, error) {
@@ -50,7 +72,10 @@ func projectID(runtime *plugin.Runtime) (string, error) {
 }
 
 // fetchOrgSettings loads the organization settings once and caches them for the
-// several settings fields on the root resource.
+// several settings fields on the root resource. The endpoint requires
+// organization-level privilege, so a project-scoped credential gets 401/403 (or
+// 404); rather than failing the whole scan it degrades: the cached settings stay
+// nil and each dependent field renders null.
 func (r *mqlMongodbatlas) fetchOrgSettings() (*admin.OrganizationSettings, error) {
 	r.orgSettingsLock.Lock()
 	defer r.orgSettingsLock.Unlock()
@@ -61,8 +86,13 @@ func (r *mqlMongodbatlas) fetchOrgSettings() (*admin.OrganizationSettings, error
 	if err != nil {
 		return nil, err
 	}
-	settings, _, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganizationSettings(context.Background(), oid).Execute()
+	settings, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganizationSettings(context.Background(), oid).Execute()
 	if err != nil {
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+			r.orgSettingsDenied = true
+			r.orgSettingsDone = true
+			return nil, nil
+		}
 		return nil, err
 	}
 	r.orgSettings = settings
@@ -79,8 +109,12 @@ func (r *mqlMongodbatlas) organizationName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	org, _, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganization(context.Background(), oid).Execute()
+	org, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganization(context.Background(), oid).Execute()
 	if err != nil {
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+			r.OrganizationName.State = plugin.StateIsSet | plugin.StateIsNull
+			return "", nil
+		}
 		return "", err
 	}
 	return org.GetName(), nil
@@ -91,6 +125,10 @@ func (r *mqlMongodbatlas) multiFactorAuthRequired() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if s == nil {
+		r.MultiFactorAuthRequired.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
 	return s.GetMultiFactorAuthRequired(), nil
 }
 
@@ -98,6 +136,10 @@ func (r *mqlMongodbatlas) apiAccessListRequired() (bool, error) {
 	s, err := r.fetchOrgSettings()
 	if err != nil {
 		return false, err
+	}
+	if s == nil {
+		r.ApiAccessListRequired.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
 	}
 	return s.GetApiAccessListRequired(), nil
 }
@@ -107,6 +149,10 @@ func (r *mqlMongodbatlas) restrictEmployeeAccess() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if s == nil {
+		r.RestrictEmployeeAccess.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
 	return s.GetRestrictEmployeeAccess(), nil
 }
 
@@ -114,6 +160,10 @@ func (r *mqlMongodbatlas) genAiFeaturesEnabled() (bool, error) {
 	s, err := r.fetchOrgSettings()
 	if err != nil {
 		return false, err
+	}
+	if s == nil {
+		r.GenAiFeaturesEnabled.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
 	}
 	return s.GetGenAIFeaturesEnabled(), nil
 }
@@ -123,6 +173,10 @@ func (r *mqlMongodbatlas) maxServiceAccountSecretValidityInHours() (int64, error
 	if err != nil {
 		return 0, err
 	}
+	if s == nil {
+		r.MaxServiceAccountSecretValidityInHours.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
 	return int64(s.GetMaxServiceAccountSecretValidityInHours()), nil
 }
 
@@ -130,6 +184,10 @@ func (r *mqlMongodbatlas) securityContact() (string, error) {
 	s, err := r.fetchOrgSettings()
 	if err != nil {
 		return "", err
+	}
+	if s == nil {
+		r.SecurityContact.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
 	}
 	return s.GetSecurityContact(), nil
 }

--- a/providers/mongodbatlas/resources/mongodbatlas.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.go
@@ -17,10 +17,9 @@ import (
 )
 
 type mqlMongodbatlasInternal struct {
-	orgSettingsLock   sync.Mutex
-	orgSettingsDone   bool
-	orgSettingsDenied bool
-	orgSettings       *admin.OrganizationSettings
+	orgSettingsLock sync.Mutex
+	orgSettingsDone bool
+	orgSettings     *admin.OrganizationSettings
 
 	teamsOnce sync.Once
 	teamsByID map[string]admin.TeamResponse
@@ -89,7 +88,8 @@ func (r *mqlMongodbatlas) fetchOrgSettings() (*admin.OrganizationSettings, error
 	settings, httpResp, err := atlasClient(r.MqlRuntime).OrganizationsApi.GetOrganizationSettings(context.Background(), oid).Execute()
 	if err != nil {
 		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
-			r.orgSettingsDenied = true
+			// Degrade: leave orgSettings nil and mark done. Each dependent
+			// accessor checks `s == nil` and renders its field null.
 			r.orgSettingsDone = true
 			return nil, nil
 		}

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -145,25 +145,57 @@ func newMqlMongodbatlasOrgUser(runtime *plugin.Runtime, u admin.OrgUserResponse)
 	return orgUser, nil
 }
 
+// orgTeamsByID lists every team in the organization once and caches them by id
+// on the root resource, so per-user team resolution is a map lookup rather than
+// a GetTeamById call per membership.
+func (r *mqlMongodbatlas) orgTeamsByID() (map[string]admin.TeamResponse, error) {
+	r.teamsOnce.Do(func() {
+		oid, err := orgID(r.MqlRuntime)
+		if err != nil {
+			r.teamsErr = err
+			return
+		}
+		client := atlasClient(r.MqlRuntime)
+		ctx := context.Background()
+
+		m := map[string]admin.TeamResponse{}
+		for page := 1; ; page++ {
+			resp, _, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+			if err != nil {
+				r.teamsErr = err
+				return
+			}
+			results := resp.GetResults()
+			for i := range results {
+				m[results[i].GetId()] = results[i]
+			}
+			if len(results) < pageSize {
+				break
+			}
+		}
+		r.teamsByID = m
+	})
+	return r.teamsByID, r.teamsErr
+}
+
 // teams resolves the member's team ids to the teams they belong to.
 func (r *mqlMongodbatlasOrgUser) teams() ([]any, error) {
-	oid, err := orgID(r.MqlRuntime)
+	root, err := rootMongodbatlas(r.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	client := atlasClient(r.MqlRuntime)
-	ctx := context.Background()
+	teamsByID, err := root.orgTeamsByID()
+	if err != nil {
+		return nil, err
+	}
 
 	out := []any{}
 	for _, teamID := range r.cacheTeamIds {
-		if teamID == "" {
+		t, ok := teamsByID[teamID]
+		if !ok {
 			continue
 		}
-		t, _, err := client.TeamsApi.GetTeamById(ctx, oid, teamID).Execute()
-		if err != nil {
-			return nil, err
-		}
-		res, err := newMqlMongodbatlasTeam(r.MqlRuntime, *t)
+		res, err := newMqlMongodbatlasTeam(r.MqlRuntime, t)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/mongodbatlas/resources/org.go
+++ b/providers/mongodbatlas/resources/org.go
@@ -160,8 +160,15 @@ func (r *mqlMongodbatlas) orgTeamsByID() (map[string]admin.TeamResponse, error) 
 
 		m := map[string]admin.TeamResponse{}
 		for page := 1; ; page++ {
-			resp, _, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
+			resp, httpResp, err := client.TeamsApi.ListOrganizationTeams(ctx, oid).ItemsPerPage(pageSize).PageNum(page).Execute()
 			if err != nil {
+				// A project-scoped credential without org privilege cannot list
+				// teams; degrade to no resolvable teams rather than failing every
+				// user's teams() through the cached error.
+				if isAccessDenied(httpResp) {
+					r.teamsByID = map[string]admin.TeamResponse{}
+					return
+				}
 				r.teamsErr = err
 				return
 			}

--- a/providers/mongodbatlas/resources/settings.go
+++ b/providers/mongodbatlas/resources/settings.go
@@ -50,7 +50,7 @@ func (r *mqlMongodbatlas) auditing() (*mqlMongodbatlasAuditConfig, error) {
 	}
 	a, httpResp, err := atlasClient(r.MqlRuntime).AuditingApi.GetAuditingConfiguration(context.Background(), pid).Execute()
 	if err != nil {
-		if isAccessDenied(httpResp) {
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.Auditing.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}
@@ -76,7 +76,7 @@ func (r *mqlMongodbatlas) encryptionAtRest() (*mqlMongodbatlasEncryptionConfig, 
 	}
 	e, httpResp, err := atlasClient(r.MqlRuntime).EncryptionAtRestUsingCustomerKeyManagementApi.GetEncryptionAtRest(context.Background(), pid).Execute()
 	if err != nil {
-		if isAccessDenied(httpResp) {
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
 			r.EncryptionAtRest.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil
 		}


### PR DESCRIPTION
Fixes the High + Medium findings from a code audit of the `mongodbatlas` provider. Go-only, no schema/codegen changes.

## HIGH — org-privilege endpoints hard-failed the whole scan
`GetOrganizationSettings` and `GetOrganization` require organization-level privilege. On a project-scoped credential they return 401/403 and the raw error was propagating, aborting the entire scan. They now degrade to null like the other elevated singletons (`federation`, `backupCompliance`, `logExport`).

- `fetchOrgSettings` captures the HTTP response and, on `isAccessDenied` (401/403) or 404, caches a denied state and returns `(nil, nil)`. Each dependent scalar accessor then sets its own field `StateIsSet|StateIsNull` and returns the zero value: `multiFactorAuthRequired`, `apiAccessListRequired`, `restrictEmployeeAccess`, `genAiFeaturesEnabled`, `maxServiceAccountSecretValidityInHours`, `securityContact`.
- `organizationName` degrades the same way (sets `OrganizationName` null, returns `"", nil`).

## MEDIUM — missing 404 degrade arm
`auditing` and `encryptionAtRest` degraded on 401/403 but not 404. Added `|| (httpResp != nil && httpResp.StatusCode == http.StatusNotFound)` to both, matching the sibling singletons.

## MEDIUM — `orgUser.teams()` N+1 (`GetTeamById` per team id)
Replaced the per-membership `GetTeamById` (N users × M teams) with a single `ListOrganizationTeams` pagination cached by id on the root resource (`orgTeamsByID`, guarded by `sync.Once`). Each user's team ids are resolved from the map; ids with no matching team are skipped.

## MEDIUM — `databaseUser.scopedClusters()` per-name `GetCluster`
For a cold query this fetched each scoped cluster one-by-one via the cluster `init`. Now resolves from a once-cached project cluster map (`projectClustersByName`, `sync.Once`) built from a single `ListClusters` pass. Missing names are skipped. `apiKey.roleAssignment.project()` was left as-is (deduped by `__id`).

Sub-resources reach the shared caches through a `rootMongodbatlas` helper that returns the cached root singleton (`CreateResource(runtime, "mongodbatlas", {})`).

SDK types verified against `go.mongodb.org/atlas-sdk/v20250312006/admin`: `PaginatedTeam.GetResults()` returns `[]TeamResponse`; generated root field names (`OrganizationName`, `MultiFactorAuthRequired`, `ApiAccessListRequired`, `RestrictEmployeeAccess`, `GenAiFeaturesEnabled`, `MaxServiceAccountSecretValidityInHours`, `SecurityContact`) confirmed against `mongodbatlas.lr.go`.

Build: `make providers/build/mongodbatlas` passes. Live verification was NOT performed.
