### PR TITLE
🐛 vercel: fix access-group cursor pagination, N+1 project fetch, per-project store re-list

### DIFF
--- a/providers/vercel/resources/access.go
+++ b/providers/vercel/resources/access.go
@@ -18,10 +18,12 @@ type mqlVercelAccessGroupInternal struct {
 }
 
 // mqlVercelAccessGroupProjectInternal caches the scope needed to resolve the
-// typed project reference on a grant.
+// typed project reference on a grant, plus the project object the grants
+// endpoint embeds, so project() can avoid a per-grant project-by-id fetch.
 type mqlVercelAccessGroupProjectInternal struct {
-	teamID    string
-	projectID string
+	teamID       string
+	projectID    string
+	cacheProject *projectRecord
 }
 
 // --- project members ------------------------------------------------------
@@ -112,10 +114,11 @@ func (g *mqlVercelAccessGroup) members() ([]any, error) {
 // --- access group project grants ------------------------------------------
 
 type accessGroupProjectRecord struct {
-	ProjectID string   `json:"projectId"`
-	Role      string   `json:"role"`
-	CreatedAt flexTime `json:"createdAt"`
-	UpdatedAt flexTime `json:"updatedAt"`
+	ProjectID string         `json:"projectId"`
+	Role      string         `json:"role"`
+	CreatedAt flexTime       `json:"createdAt"`
+	UpdatedAt flexTime       `json:"updatedAt"`
+	Project   *projectRecord `json:"project"`
 }
 
 func (g *mqlVercelAccessGroup) projects() ([]any, error) {
@@ -145,6 +148,7 @@ func (g *mqlVercelAccessGroup) projects() ([]any, error) {
 		grant := resource.(*mqlVercelAccessGroupProject)
 		grant.teamID = g.teamID
 		grant.projectID = rec.ProjectID
+		grant.cacheProject = rec.Project
 		res = append(res, grant)
 	}
 	return res, nil
@@ -154,6 +158,16 @@ func (p *mqlVercelAccessGroupProject) project() (*mqlVercelProject, error) {
 	if p.projectID == "" {
 		p.Project.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
+	}
+
+	// The access-group projects endpoint embeds the full project object in each
+	// grant; build the typed reference from it and skip the per-grant fetch.
+	if p.cacheProject != nil && (p.cacheProject.ID != "" || p.cacheProject.Name != "") {
+		rec := *p.cacheProject
+		if rec.ID == "" {
+			rec.ID = p.projectID
+		}
+		return newVercelProject(p.MqlRuntime, p.teamID, &rec)
 	}
 
 	conn := p.MqlRuntime.Connection.(*connection.VercelConnection)

--- a/providers/vercel/resources/stores.go
+++ b/providers/vercel/resources/stores.go
@@ -5,12 +5,55 @@ package resources
 
 import (
 	"context"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/vercel/connection"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// mqlVercelInternal caches per-team store listings on the root resource so a
+// scan that reads stores across many projects (for example team.projects {
+// stores }) fetches each team's store list once and shares it, rather than
+// re-listing the whole team store list per project.
+type mqlVercelInternal struct {
+	storesMu     sync.Mutex
+	storesByTeam map[string][]storeRecord
+}
+
+// rootVercel returns the cached root vercel resource, creating it if a scan
+// reaches a store accessor before the root has been materialized. Both paths
+// resolve to the same singleton (cache key "vercel"), so the store cache is
+// shared regardless of entry point.
+func rootVercel(runtime *plugin.Runtime) (*mqlVercel, error) {
+	res, err := CreateResource(runtime, "vercel", nil)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlVercel), nil
+}
+
+// teamStores returns the team's store list, fetching it once per team and
+// caching the result. Errors are not cached, so a transient failure or a
+// forbidden response is re-evaluated by the caller on the next access.
+func (v *mqlVercel) teamStores(teamID string) ([]storeRecord, error) {
+	v.storesMu.Lock()
+	defer v.storesMu.Unlock()
+	if v.storesByTeam == nil {
+		v.storesByTeam = map[string][]storeRecord{}
+	}
+	if recs, ok := v.storesByTeam[teamID]; ok {
+		return recs, nil
+	}
+	conn := v.MqlRuntime.Connection.(*connection.VercelConnection)
+	recs, err := listStores(context.Background(), conn, teamID)
+	if err != nil {
+		return nil, err
+	}
+	v.storesByTeam[teamID] = recs
+	return recs, nil
+}
 
 // mqlVercelStoreInternal caches the team a store belongs to and the ids of the
 // projects connected to it, so connectedProjects can resolve typed project
@@ -132,8 +175,11 @@ func (c *mqlVercelStore) id() (string, error) {
 }
 
 func (c *mqlVercelTeam) stores() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
-	records, err := listStores(context.Background(), conn, c.Id.Data)
+	root, err := rootVercel(c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	records, err := root.teamStores(c.Id.Data)
 	if err != nil {
 		if connection.IsForbidden(err) {
 			return []any{}, nil
@@ -159,8 +205,11 @@ func (c *mqlVercelTeam) stores() ([]any, error) {
 }
 
 func (c *mqlVercelProject) stores() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
-	records, err := listStores(context.Background(), conn, c.teamID)
+	root, err := rootVercel(c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	records, err := root.teamStores(c.teamID)
 	if err != nil {
 		if connection.IsForbidden(err) {
 			return []any{}, nil

--- a/providers/vercel/resources/teams.go
+++ b/providers/vercel/resources/teams.go
@@ -456,7 +456,9 @@ type accessGroupRecord struct {
 
 func (c *mqlVercelTeam) accessGroups() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.VercelConnection)
-	records, err := connection.GetPaged[accessGroupRecord](context.Background(), conn, "/v1/access-groups", connection.TeamQuery(c.Id.Data), "accessGroups")
+	query := connection.TeamQuery(c.Id.Data)
+	query.Set("limit", "100")
+	records, err := connection.GetPagedCursor[accessGroupRecord](context.Background(), conn, "/v1/access-groups", query, "accessGroups")
 	if err != nil {
 		// Access groups are an Enterprise feature; degrade to empty on plans
 		// that do not expose the endpoint.

--- a/providers/vercel/resources/vercel.lr.go
+++ b/providers/vercel/resources/vercel.lr.go
@@ -1847,7 +1847,7 @@ func SetAllData(resource plugin.Resource, args map[string]*llx.RawData) error {
 type mqlVercel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlVercelInternal it will be used here
+	mqlVercelInternal
 	Teams        plugin.TValue[[]any]
 	Projects     plugin.TValue[[]any]
 	CurrentUser  plugin.TValue[*mqlVercelUser]


### PR DESCRIPTION
Fixes three findings from a code audit of the `vercel` provider. Go-only, no schema changes.

## 1. HIGH — `accessGroups()` used the wrong pagination cursor type

`team.accessGroups()` called `GetPaged[accessGroupRecord]` against `GET /v1/access-groups`, but that endpoint returns `pagination.next` as a **string** cursor (the same shape the sibling `accessGroup.members`/`accessGroup.projects` accessors correctly handle with `GetPagedCursor`). `GetPaged` decodes `pagination.next` into `*int64`, so on a multi-page team the follow-up page's decode fails with `cannot unmarshal string into int64`. That error is **not** an `*APIError`, so the `IsForbidden`/`IsNotFound` degrade-to-empty guard doesn't catch it and the field hard-errors — this only bites enterprise teams large enough to paginate (access groups are Enterprise-only). It would also send `until=` instead of `next=`, truncating results even without a decode error.

Fix: switched to `GetPagedCursor[accessGroupRecord]` and set `limit=100`, matching the sibling calls exactly.

## 2. MEDIUM — `accessGroupProject.project()` re-fetched an already-embedded object (N+1)

`GET /v1/access-groups/{id}/projects` embeds the full `project` object in every grant item, but `accessGroupProjectRecord` only decoded `projectId/role/createdAt/updatedAt` and dropped it. `project()` then issued a separate `GET /v9/projects/{projectId}` per grant.

Fix: decode the embedded `project` object, cache it on the grant's Internal struct, and build the typed `vercel.project` from it via the existing `newVercelProject` mapper. Falls back to the per-id GET only when the embedded object is absent/empty. The `StateIsSet|StateIsNull` null-guard behavior is preserved.

## 3. MEDIUM — `project.stores()` re-listed ALL team stores per project

`project.stores()` called `listStores(teamID)` (paging the whole team store list) then filtered in memory, so `team.projects { stores }` re-fetched the entire team store list once per project.

Fix: added a `mqlVercelInternal` on the root `vercel` singleton that caches each team's store list (mutex-guarded, keyed by team id, errors not cached) and routed both `team.stores()` and `project.stores()` through it, so a scan fetches each team's store list once and shares it. Both entry points resolve to the same root singleton (cache key `vercel`), and a store accessor reached before the root is materialized simply creates and caches it.

## Verification

`make providers/build/vercel` passes; provider unit tests pass. Live verification against a real Vercel account was **not** performed.
