### PR TITLE
⚡ databricks: eliminate N+1 cross-reference lookups and batch workspace conf

### DIFF
--- a/providers/databricks/resources/account.go
+++ b/providers/databricks/resources/account.go
@@ -95,24 +95,81 @@ func (r *mqlDatabricksWorkspace) resolveCustomerManagedKey(keyId string, state *
 	return key.(*mqlDatabricksCustomerManagedKey), nil
 }
 
+// cachedNetworks lists the account networks at most once per scan, caching the
+// result on the root databricks resource keyed by network id so per-workspace
+// network resolutions (databricks.workspaces { network }) share a single List
+// rather than one Get per workspace.
+func cachedNetworks(runtime *plugin.Runtime) (map[string]provisioning.Network, error) {
+	rootRes, err := NewResource(runtime, "databricks", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	root := rootRes.(*mqlDatabricks)
+	root.networksOnce.Do(func() {
+		acc, err := accountClient(runtime)
+		if err != nil {
+			root.networksErr = err
+			return
+		}
+		networks, err := acc.Networks.List(context.Background())
+		if err != nil {
+			root.networksErr = err
+			return
+		}
+		byID := make(map[string]provisioning.Network, len(networks))
+		for i := range networks {
+			byID[networks[i].NetworkId] = networks[i]
+		}
+		root.networksByID = byID
+	})
+	return root.networksByID, root.networksErr
+}
+
+// cachedPrivateAccessSettings lists the account private access settings at most
+// once per scan, caching the result on the root databricks resource keyed by id
+// so per-workspace resolutions (databricks.workspaces { privateAccessSettings })
+// share a single List rather than one Get per workspace.
+func cachedPrivateAccessSettings(runtime *plugin.Runtime) (map[string]provisioning.PrivateAccessSettings, error) {
+	rootRes, err := NewResource(runtime, "databricks", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	root := rootRes.(*mqlDatabricks)
+	root.privateAccessOnce.Do(func() {
+		acc, err := accountClient(runtime)
+		if err != nil {
+			root.privateAccessErr = err
+			return
+		}
+		settings, err := acc.PrivateAccess.List(context.Background())
+		if err != nil {
+			root.privateAccessErr = err
+			return
+		}
+		byID := make(map[string]provisioning.PrivateAccessSettings, len(settings))
+		for i := range settings {
+			byID[settings[i].PrivateAccessSettingsId] = settings[i]
+		}
+		root.privateAccessByID = byID
+	})
+	return root.privateAccessByID, root.privateAccessErr
+}
+
 func (r *mqlDatabricksWorkspace) network() (*mqlDatabricksNetwork, error) {
 	if r.cacheNetworkId == "" {
 		r.Network.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	acc, err := accountClient(r.MqlRuntime)
+	byID, err := cachedNetworks(r.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	net, err := acc.Networks.Get(context.Background(), provisioning.GetNetworkRequest{NetworkId: r.cacheNetworkId})
-	if err != nil {
-		return nil, err
-	}
-	if net == nil {
+	net, ok := byID[r.cacheNetworkId]
+	if !ok {
 		r.Network.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newMqlDatabricksNetwork(r.MqlRuntime, *net)
+	return newMqlDatabricksNetwork(r.MqlRuntime, net)
 }
 
 func (r *mqlDatabricksWorkspace) privateAccessSettings() (*mqlDatabricksPrivateAccessSetting, error) {
@@ -120,19 +177,16 @@ func (r *mqlDatabricksWorkspace) privateAccessSettings() (*mqlDatabricksPrivateA
 		r.PrivateAccessSettings.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	acc, err := accountClient(r.MqlRuntime)
+	byID, err := cachedPrivateAccessSettings(r.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	pas, err := acc.PrivateAccess.Get(context.Background(), provisioning.GetPrivateAccesRequest{PrivateAccessSettingsId: r.cachePrivateAccessSettingsId})
-	if err != nil {
-		return nil, err
-	}
-	if pas == nil {
+	pas, ok := byID[r.cachePrivateAccessSettingsId]
+	if !ok {
 		r.PrivateAccessSettings.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newMqlDatabricksPrivateAccessSetting(r.MqlRuntime, *pas)
+	return newMqlDatabricksPrivateAccessSetting(r.MqlRuntime, pas)
 }
 
 func (r *mqlDatabricks) metastores() ([]any, error) {

--- a/providers/databricks/resources/compute.go
+++ b/providers/databricks/resources/compute.go
@@ -17,6 +17,36 @@ type mqlDatabricksClusterInternal struct {
 	cachePolicyId string
 }
 
+// cachedClusterPolicies lists the workspace cluster policies at most once per
+// scan, caching the result on the root databricks resource keyed by policy id so
+// that per-cluster policy resolutions (databricks.clusters { policy }) share a
+// single ListAll rather than one Get per cluster.
+func cachedClusterPolicies(runtime *plugin.Runtime) (map[string]compute.Policy, error) {
+	rootRes, err := NewResource(runtime, "databricks", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	root := rootRes.(*mqlDatabricks)
+	root.policiesOnce.Do(func() {
+		ws, err := workspaceClient(runtime)
+		if err != nil {
+			root.policiesErr = err
+			return
+		}
+		policies, err := ws.ClusterPolicies.ListAll(context.Background(), compute.ListClusterPoliciesRequest{})
+		if err != nil {
+			root.policiesErr = err
+			return
+		}
+		byID := make(map[string]compute.Policy, len(policies))
+		for i := range policies {
+			byID[policies[i].PolicyId] = policies[i]
+		}
+		root.policiesByID = byID
+	})
+	return root.policiesByID, root.policiesErr
+}
+
 func (r *mqlDatabricks) clusterPolicies() ([]any, error) {
 	ws, err := workspaceClient(r.MqlRuntime)
 	if err != nil {
@@ -101,19 +131,16 @@ func (r *mqlDatabricksCluster) policy() (*mqlDatabricksClusterPolicy, error) {
 		r.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	ws, err := workspaceClient(r.MqlRuntime)
+	byID, err := cachedClusterPolicies(r.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	p, err := ws.ClusterPolicies.Get(context.Background(), compute.GetClusterPolicyRequest{PolicyId: r.cachePolicyId})
-	if err != nil {
-		return nil, err
-	}
-	if p == nil {
+	p, ok := byID[r.cachePolicyId]
+	if !ok {
 		r.Policy.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return newMqlDatabricksClusterPolicy(r.MqlRuntime, *p)
+	return newMqlDatabricksClusterPolicy(r.MqlRuntime, p)
 }
 
 func (r *mqlDatabricks) warehouses() ([]any, error) {

--- a/providers/databricks/resources/identity.go
+++ b/providers/databricks/resources/identity.go
@@ -8,16 +8,34 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/provisioning"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
 
+// mqlDatabricksInternal caches account- and workspace-wide listings on the root
+// databricks resource so cross-references resolve them once per scan rather than
+// issuing one lookup per referring resource. Each cache is a list-once map keyed
+// by the referenced resource's id.
 type mqlDatabricksInternal struct {
 	groupsOnce sync.Once
 	groupsByID map[string]iam.Group
 	groupsErr  error
+
+	policiesOnce sync.Once
+	policiesByID map[string]compute.Policy
+	policiesErr  error
+
+	networksOnce sync.Once
+	networksByID map[string]provisioning.Network
+	networksErr  error
+
+	privateAccessOnce sync.Once
+	privateAccessByID map[string]provisioning.PrivateAccessSettings
+	privateAccessErr  error
 }
 
 // cachedAccountGroups lists the account groups at most once per scan, caching

--- a/providers/databricks/resources/unity_catalog_storage.go
+++ b/providers/databricks/resources/unity_catalog_storage.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"go.mondoo.com/mql/v13/llx"
@@ -84,7 +85,7 @@ func initDatabricksStorageCredential(runtime *plugin.Runtime, args map[string]*l
 	}
 	name, _ := nameRaw.Value.(string)
 	if name == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("databricks.storageCredential requires a non-empty name")
 	}
 
 	ws, err := workspaceClient(runtime)

--- a/providers/databricks/resources/workspace.go
+++ b/providers/databricks/resources/workspace.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	databricks "github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/settings"
@@ -134,14 +135,26 @@ func (r *mqlDatabricks) workspaceSettings() (*mqlDatabricksWorkspaceConf, error)
 		id = conn.Host()
 	}
 
+	// The workspace-conf GET endpoint accepts a comma-separated key list and
+	// returns every requested key in one response, so all of these settings are
+	// read with a single call rather than one request per key.
+	conf := confStatus(ctx, ws,
+		"enableTokens",
+		"maxTokenLifetimeDays",
+		"enableIpAccessLists",
+		"enableDeprecatedGlobalInitScripts",
+		"enableDeprecatedClusterNamedInitScripts",
+		"storeInteractiveNotebookResultsInCustomerAccount",
+	)
+
 	res, err := CreateResource(r.MqlRuntime, "databricks.workspaceConf", map[string]*llx.RawData{
 		"__id":                                             llx.StringData("databricks.workspaceConf/" + id),
-		"tokensEnabled":                                    llx.BoolDataPtr(confBool(ctx, ws, "enableTokens")),
-		"maxTokenLifetimeDays":                             llx.IntDataPtr(confInt(ctx, ws, "maxTokenLifetimeDays")),
-		"ipAccessListsEnabled":                             llx.BoolDataPtr(confBool(ctx, ws, "enableIpAccessLists")),
-		"deprecatedGlobalInitScriptsEnabled":               llx.BoolDataPtr(confBool(ctx, ws, "enableDeprecatedGlobalInitScripts")),
-		"deprecatedClusterNamedInitScriptsEnabled":         llx.BoolDataPtr(confBool(ctx, ws, "enableDeprecatedClusterNamedInitScripts")),
-		"storeInteractiveNotebookResultsInCustomerAccount": llx.BoolDataPtr(confBool(ctx, ws, "storeInteractiveNotebookResultsInCustomerAccount")),
+		"tokensEnabled":                                    llx.BoolDataPtr(confBoolFrom(conf, "enableTokens")),
+		"maxTokenLifetimeDays":                             llx.IntDataPtr(confIntFrom(conf, "maxTokenLifetimeDays")),
+		"ipAccessListsEnabled":                             llx.BoolDataPtr(confBoolFrom(conf, "enableIpAccessLists")),
+		"deprecatedGlobalInitScriptsEnabled":               llx.BoolDataPtr(confBoolFrom(conf, "enableDeprecatedGlobalInitScripts")),
+		"deprecatedClusterNamedInitScriptsEnabled":         llx.BoolDataPtr(confBoolFrom(conf, "enableDeprecatedClusterNamedInitScripts")),
+		"storeInteractiveNotebookResultsInCustomerAccount": llx.BoolDataPtr(confBoolFrom(conf, "storeInteractiveNotebookResultsInCustomerAccount")),
 	})
 	if err != nil {
 		return nil, err
@@ -149,13 +162,23 @@ func (r *mqlDatabricks) workspaceSettings() (*mqlDatabricksWorkspaceConf, error)
 	return res.(*mqlDatabricksWorkspaceConf), nil
 }
 
-// confBool reads a single workspace conf key and interprets it as a boolean,
-// returning nil when the key is unset or cannot be read. Each key is fetched
-// individually because WorkspaceConf.GetStatus does not accept a
-// comma-separated key list (a joined string is treated as one unknown key and
-// returns nothing).
-func confBool(ctx context.Context, ws *databricks.WorkspaceClient, key string) *bool {
-	v, ok := confValue(ctx, ws, key)
+// confStatus reads the given workspace conf keys in a single request. The
+// workspace-conf GET endpoint accepts a comma-separated key list and returns
+// each requested key that is set, so one call covers every key. An empty map is
+// returned when the settings cannot be read (for example without workspace admin
+// rights), which leaves each derived field null.
+func confStatus(ctx context.Context, ws *databricks.WorkspaceClient, keys ...string) map[string]string {
+	resp, err := ws.WorkspaceConf.GetStatus(ctx, settings.GetStatusRequest{Keys: strings.Join(keys, ",")})
+	if err != nil || resp == nil {
+		return map[string]string{}
+	}
+	return *resp
+}
+
+// confBoolFrom interprets a workspace conf value as a boolean, returning nil
+// when the key is absent from the fetched status.
+func confBoolFrom(conf map[string]string, key string) *bool {
+	v, ok := conf[key]
 	if !ok {
 		return nil
 	}
@@ -163,10 +186,10 @@ func confBool(ctx context.Context, ws *databricks.WorkspaceClient, key string) *
 	return &b
 }
 
-// confInt reads a single workspace conf key and interprets it as an integer,
-// returning nil when the key is unset or cannot be parsed.
-func confInt(ctx context.Context, ws *databricks.WorkspaceClient, key string) *int64 {
-	v, ok := confValue(ctx, ws, key)
+// confIntFrom interprets a workspace conf value as an integer, returning nil
+// when the key is absent or cannot be parsed.
+func confIntFrom(conf map[string]string, key string) *int64 {
+	v, ok := conf[key]
 	if !ok {
 		return nil
 	}
@@ -175,13 +198,4 @@ func confInt(ctx context.Context, ws *databricks.WorkspaceClient, key string) *i
 		return nil
 	}
 	return &n
-}
-
-func confValue(ctx context.Context, ws *databricks.WorkspaceClient, key string) (string, bool) {
-	resp, err := ws.WorkspaceConf.GetStatus(ctx, settings.GetStatusRequest{Keys: key})
-	if err != nil || resp == nil {
-		return "", false
-	}
-	v, ok := (*resp)[key]
-	return v, ok
 }


### PR DESCRIPTION
Fixes the Medium (plus one trivial Low) findings from a code audit of the `databricks` provider. All changes are Go-only; no `.lr` schema changes, so no new `.lr.versions` entries. Each fix reuses the existing list-once cache pattern already established by `cachedAccountGroups` in `resources/identity.go`, storing the caches on the root `databricks` resource's `mqlDatabricksInternal` (already embedded, so no second codegen pass was needed).

## Fixes

**1. `resources/compute.go` — `cluster.policy()` N+1.**
Each cluster resolved its policy with a separate `ClusterPolicies.Get(policyId)`. Added `cachedClusterPolicies()` which calls `ClusterPolicies.ListAll(...)` once and maps by `PolicyId`; `policy()` now resolves `cachePolicyId` from that map. The `cachePolicyId == ""` → `StateIsSet|StateIsNull` guard is preserved, and a cache miss also yields a null field. Added `policiesOnce`/`policiesByID`/`policiesErr` to `mqlDatabricksInternal`.

**2. `resources/account.go` — `workspace.network()` N+1.**
Each workspace resolved its network with a separate `Networks.Get(networkId)`. Added `cachedNetworks()` which calls `Networks.List(...)` once and maps by `NetworkId`. Added `networksOnce`/`networksByID`/`networksErr`.

**3. `resources/account.go` — `workspace.privateAccessSettings()` N+1.**
Each workspace resolved its private access setting with a separate `PrivateAccess.Get(id)`. Added `cachedPrivateAccessSettings()` which calls `PrivateAccess.List(...)` once and maps by `PrivateAccessSettingsId`. Added `privateAccessOnce`/`privateAccessByID`/`privateAccessErr`.

**4. `resources/workspace.go` — 6 eager `WorkspaceConf.GetStatus` calls collapsed to 1.**
`workspaceSettings()` fetched `tokensEnabled`, `maxTokenLifetimeDays`, `ipAccessListsEnabled`, and the two deprecated-init-script flags plus the notebook-results flag via 6 separate single-key `WorkspaceConf.GetStatus` calls. The `/api/2.0/workspace-conf` GET endpoint accepts a comma-separated key list and returns every requested key in one response, so these are now a single combined `GetStatus`. The old comment claiming batching was impossible was incorrect and has been removed. The fields remain stored `.lr` fields (no schema change); they are simply populated from one map instead of six calls. Fetch failures still degrade to null values.

**5. `resources/unity_catalog_storage.go` — husk on empty key (trivial Low, for consistency).**
`initDatabricksStorageCredential` returned `args, nil, nil` (a blank husk) on an empty `name`. It now returns `fmt.Errorf("databricks.storageCredential requires a non-empty name")`, matching every sibling init (`initDatabricksCatalog`, `initDatabricksSchema`, `initDatabricksGroup`, `initDatabricksCustomerManagedKey`). The `!ok` missing-key branch stays `args, nil, nil`.

## SDK verification (databricks-sdk-go@v0.160.0)
- `ClusterPolicies.ListAll(ctx, compute.ListClusterPoliciesRequest{}) ([]compute.Policy, error)`
- `Networks.List(ctx) ([]provisioning.Network, error)`
- `PrivateAccess.List(ctx) ([]provisioning.PrivateAccessSettings, error)`
- `WorkspaceConf.GetStatus(ctx, settings.GetStatusRequest{Keys: string}) (*map[string]string, error)` — the `Keys` field is forwarded as the `keys` query param; the official `terraform-provider-databricks` `SafeGetStatus` joins multiple keys with `,` in a single call, confirming the endpoint batches.

## Verification
- `make providers/build/databricks` passes.
- Live verification against a real Databricks account/workspace was **not** performed.
