### PR TITLE
🧹 mongodbatlas: unit-test isAccessDenied helper

### DIFF
--- a/providers/mongodbatlas/resources/converters_test.go
+++ b/providers/mongodbatlas/resources/converters_test.go
@@ -4,12 +4,34 @@
 package resources
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+		want bool
+	}{
+		{"nil response", nil, false},
+		{"200 OK", &http.Response{StatusCode: http.StatusOK}, false},
+		{"401 Unauthorized", &http.Response{StatusCode: http.StatusUnauthorized}, true},
+		{"403 Forbidden", &http.Response{StatusCode: http.StatusForbidden}, true},
+		// NOTE: 404 is not treated as access-denied; only 401/403 degrade to null.
+		{"404 Not Found", &http.Response{StatusCode: http.StatusNotFound}, false},
+		{"500 Internal Server Error", &http.Response{StatusCode: http.StatusInternalServerError}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAccessDenied(tt.resp))
+		})
+	}
+}
 
 func TestStrSlice(t *testing.T) {
 	assert.Equal(t, []any{}, strSlice(nil))


### PR DESCRIPTION
## What

Adds unit test coverage for `isAccessDenied` (`resources/settings.go`), the pure-Go helper that decides whether an Atlas API `*http.Response` represents an authorization failure. This guards the provider's degrade-to-null behavior: feature-gated or elevated-privilege endpoints return null instead of failing the whole scan.

## Test

`TestIsAccessDenied` — table-driven, asserting real behavior:

- nil response → `false`
- 200 OK → `false`
- 401 Unauthorized → `true`
- 403 Forbidden → `true`
- 404 Not Found → `false` (NOTE: only 401/403 degrade to null)
- 500 Internal Server Error → `false`

The other pure helpers called out for coverage (`strSlice`, `timePtr`, `dictTime`) were already tested in `converters_test.go`, so this PR adds only the one missing function. Tests only, no production changes.

```
cd providers/mongodbatlas && go test ./resources/ -run TestIsAccessDenied -v
```
