### PR TITLE
🐛 snowflake: fix 3 live-test scan crashes (function/procedure ID panic, owner/warehouse null-degrade)

### DIFF
--- a/providers/snowflake/resources/applications.go
+++ b/providers/snowflake/resources/applications.go
@@ -57,7 +57,15 @@ func (r *mqlSnowflakeApplication) owner() (*mqlSnowflakeRole, error) {
 		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	role, err := snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }
 
 func (r *mqlSnowflakeAccount) applicationPackages() ([]any, error) {
@@ -94,5 +102,13 @@ func (r *mqlSnowflakeApplicationPackage) owner() (*mqlSnowflakeRole, error) {
 		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	role, err := snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }

--- a/providers/snowflake/resources/functions.go
+++ b/providers/snowflake/resources/functions.go
@@ -40,8 +40,12 @@ func (r *mqlSnowflakeAccount) functions() ([]any, error) {
 }
 
 func newMqlSnowflakeFunction(runtime *plugin.Runtime, function sdk.Function) (*mqlSnowflakeFunction, error) {
+	// Build the cache key from the raw fields rather than function.ID(): the
+	// SDK's ID() panics (nil deref in TableDataType.ToLegacyDataTypeSql) for
+	// functions whose signature involves a TABLE type. ArgumentsRaw carries the
+	// full signature, so it disambiguates overloads.
 	r, err := CreateResource(runtime, "snowflake.function", map[string]*llx.RawData{
-		"__id":               llx.StringData(function.ID().FullyQualifiedName()),
+		"__id":               llx.StringData(function.CatalogName + "." + function.SchemaName + "." + function.Name + "/" + function.ArgumentsRaw),
 		"name":               llx.StringData(function.Name),
 		"databaseName":       llx.StringData(function.CatalogName),
 		"schemaName":         llx.StringData(function.SchemaName),

--- a/providers/snowflake/resources/procedures.go
+++ b/providers/snowflake/resources/procedures.go
@@ -36,7 +36,10 @@ func (r *mqlSnowflakeAccount) procedures() ([]any, error) {
 
 func newMqlSnowflakeProcedure(runtime *plugin.Runtime, procedure sdk.Procedure) (*mqlSnowflakeProcedure, error) {
 	r, err := CreateResource(runtime, "snowflake.procedure", map[string]*llx.RawData{
-		"__id":                 llx.StringData(procedure.ID().FullyQualifiedName()),
+		// Build __id from raw fields, not procedure.ID(): the SDK's ID() panics
+		// (nil deref in TableDataType.ToLegacyDataTypeSql) for a procedure whose
+		// signature involves a TABLE type. ArgumentsRaw disambiguates overloads.
+		"__id":                 llx.StringData(procedure.CatalogName + "." + procedure.SchemaName + "." + procedure.Name + "/" + procedure.ArgumentsRaw),
 		"name":                 llx.StringData(procedure.Name),
 		"description":          llx.StringData(procedure.Description),
 		"schemaName":           llx.StringData(procedure.SchemaName),

--- a/providers/snowflake/resources/roles.go
+++ b/providers/snowflake/resources/roles.go
@@ -52,17 +52,27 @@ func initSnowflakeRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 // snowflakeRoleByName resolves a role name to a typed snowflake.role, hydrated
 // through the role's init. It returns nil for an empty name; callers should set
 // the field's null state before calling in that case.
+// snowflakeRoleByName resolves an account role by name, returning nil (not an
+// error) when the name is not a listable account role. Object owners are not
+// always account roles: they can be an application, a database role, or a role
+// the caller cannot see. Callers treat a nil result as a null typed reference
+// rather than failing the query, so this looks the role up directly instead of
+// through NewResource (whose init returns a not-found error for direct queries).
 func snowflakeRoleByName(runtime *plugin.Runtime, name string) (*mqlSnowflakeRole, error) {
 	if name == "" {
 		return nil, nil
 	}
-	role, err := NewResource(runtime, "snowflake.role", map[string]*llx.RawData{
-		"name": llx.StringData(name),
-	})
+	conn := runtime.Connection.(*connection.SnowflakeConnection)
+	roles, err := conn.Client().Roles.Show(context.Background(), sdk.NewShowRoleRequest().WithLike(sdk.NewLikeRequest(name)))
 	if err != nil {
 		return nil, err
 	}
-	return role.(*mqlSnowflakeRole), nil
+	for i := range roles {
+		if roles[i].Name == name {
+			return newMqlSnowflakeRole(runtime, roles[i])
+		}
+	}
+	return nil, nil
 }
 
 func (r *mqlSnowflakeAccount) roles() ([]any, error) {
@@ -115,7 +125,17 @@ func resolveOwnerRole(runtime *plugin.Runtime, name string, field *plugin.TValue
 		field.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return snowflakeRoleByName(runtime, name)
+	role, err := snowflakeRoleByName(runtime, name)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		// The owner is not a listable account role (an application, database
+		// role, or one the caller cannot see); report the ref as null.
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }
 
 func (r *mqlSnowflakeRole) ownerRole() (*mqlSnowflakeRole, error) {

--- a/providers/snowflake/resources/roles.go
+++ b/providers/snowflake/resources/roles.go
@@ -49,9 +49,6 @@ func initSnowflakeRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	return nil, nil, fmt.Errorf("snowflake.role %q not found", name)
 }
 
-// snowflakeRoleByName resolves a role name to a typed snowflake.role, hydrated
-// through the role's init. It returns nil for an empty name; callers should set
-// the field's null state before calling in that case.
 // snowflakeRoleByName resolves an account role by name, returning nil (not an
 // error) when the name is not a listable account role. Object owners are not
 // always account roles: they can be an application, a database role, or a role

--- a/providers/snowflake/resources/tasks.go
+++ b/providers/snowflake/resources/tasks.go
@@ -78,7 +78,15 @@ func (r *mqlSnowflakeTask) owner() (*mqlSnowflakeRole, error) {
 		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	return snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	role, err := snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
+	if err != nil {
+		return nil, err
+	}
+	if role == nil {
+		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }
 
 func (r *mqlSnowflakeTask) warehouse() (*mqlSnowflakeWarehouse, error) {
@@ -86,13 +94,15 @@ func (r *mqlSnowflakeTask) warehouse() (*mqlSnowflakeWarehouse, error) {
 		r.Warehouse.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	wh, err := NewResource(r.MqlRuntime, "snowflake.warehouse", map[string]*llx.RawData{
-		"name": llx.StringData(r.cacheWarehouse),
-	})
+	wh, err := snowflakeWarehouseByName(r.MqlRuntime, r.cacheWarehouse)
 	if err != nil {
 		return nil, err
 	}
-	return wh.(*mqlSnowflakeWarehouse), nil
+	if wh == nil {
+		r.Warehouse.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return wh, nil
 }
 
 // initSnowflakeTask resolves a task by its database, schema, and name so typed

--- a/providers/snowflake/resources/users.go
+++ b/providers/snowflake/resources/users.go
@@ -108,13 +108,15 @@ func (r *mqlSnowflakeUser) owner() (*mqlSnowflakeRole, error) {
 		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	role, err := NewResource(r.MqlRuntime, "snowflake.role", map[string]*llx.RawData{
-		"name": llx.StringData(r.cacheOwner),
-	})
+	role, err := snowflakeRoleByName(r.MqlRuntime, r.cacheOwner)
 	if err != nil {
 		return nil, err
 	}
-	return role.(*mqlSnowflakeRole), nil
+	if role == nil {
+		r.Owner.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return role, nil
 }
 
 // daysSinceLastLogin returns whole days since the user's last successful login.

--- a/providers/snowflake/resources/warehouse.go
+++ b/providers/snowflake/resources/warehouse.go
@@ -50,6 +50,27 @@ func initSnowflakeWarehouse(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	return nil, nil, fmt.Errorf("snowflake.warehouse %q not found", name)
 }
 
+// snowflakeWarehouseByName resolves a warehouse by name, returning nil (not an
+// error) when no such warehouse is listable (dropped, or not visible to the
+// caller). Callers treat a nil result as a null typed reference rather than
+// failing the query.
+func snowflakeWarehouseByName(runtime *plugin.Runtime, name string) (*mqlSnowflakeWarehouse, error) {
+	if name == "" {
+		return nil, nil
+	}
+	conn := runtime.Connection.(*connection.SnowflakeConnection)
+	warehouses, err := conn.Client().Warehouses.Show(context.Background(), &sdk.ShowWarehouseOptions{Like: &sdk.Like{Pattern: sdk.String(name)}})
+	if err != nil {
+		return nil, err
+	}
+	for i := range warehouses {
+		if warehouses[i].Name == name {
+			return newMqlSnowflakeWarehouse(runtime, warehouses[i])
+		}
+	}
+	return nil, nil
+}
+
 func (r *mqlSnowflakeAccount) warehouses() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.SnowflakeConnection)
 	client := conn.Client()


### PR DESCRIPTION
## What

Three crashes found during **live testing** against a real Snowflake account, all of which take down the entire scan (a panic in a provider `GetData` is unrecoverable), plus two typed-reference null-degrade fixes so owner/warehouse refs don't fail queries.

### 1. `functions` panic on TABLE-typed signatures

`snowflake.account.functions` panics on any account that has a function whose signature involves a `TABLE` type (Cortex / system functions commonly do):

```
sdk/datatypes.(*TableDataType).ToLegacyDataTypeSql  ← nil deref
sdk.LegacyDataTypeFrom
sdk.NewSchemaObjectIdentifierWithArguments
sdk.(*Function).ID()
resources.newMqlSnowflakeFunction   (functions.go:44)
```

`newMqlSnowflakeFunction` used `function.ID().FullyQualifiedName()` for the `__id`, but the terraform-provider-snowflake SDK's `Function.ID()` derefs a nil `TableDataType`.

**Fix:** build the `__id` from raw fields — `CatalogName + "." + SchemaName + "." + Name + "/" + ArgumentsRaw` — instead of calling the panicky `ID()`. `ArgumentsRaw` carries the full signature, so overloaded functions still get distinct ids.

### 2. `procedures` same panic

`snowflake.account.procedures` has the identical `procedure.ID().FullyQualifiedName()` bug and panics on a TABLE-typed procedure parameter. Applied the same raw-field `__id` construction (proactively caught by the review bot).

### 3. `owner` / `warehouse` typed refs crash on non-role owners

Object owners are not always listable account roles: an owner can be an application (e.g. `SNOWFLAKE`), a database role, or a role the caller cannot see. Resolving those through `snowflake.role`'s init returned a **not-found error**, which propagated and crashed the query (found live: a task owned by the `SNOWFLAKE` application).

**Fix:** added `snowflakeRoleByName` / `snowflakeWarehouseByName` helpers that look the object up directly and return `nil` (not an error) on no-match. Every owner/warehouse accessor (`task.owner`, `task.warehouse`, `user.owner`, `application.owner`, `applicationPackage.owner`, `resolveOwnerRole`) now degrades to a **null typed reference** (`StateIsSet | StateIsNull`) instead of failing.

## Verification

All fixes found and verified via live testing against a real Snowflake account:
- `functions` — before: `panic: nil pointer dereference`; after: list resolves, overloaded `ACCEPTED_VALUES` functions get distinct ids.
- `procedures` — `procedures.length` = 60, no panic.
- `task.owner` / `task.warehouse` — return null (no crash) for an application-owned task.
- Also live-verified in the same session: the Critical `parameter.__id` cache-collision fix (account vs user `WORKSHEETS_MIGRATED` now distinct), and `user.owner` / `defaultRoleRef` / `defaultWarehouseRef` typed accessors.
