### PR TITLE
✨ mongodbatlas: add Atlas Search and Vector Search index resource

### DIFF
--- a/providers/mongodbatlas/resources/mongodbatlas.lr
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr
@@ -227,6 +227,55 @@ mongodbatlas.cluster @defaults("name mongoDBMajorVersion encryptionAtRestProvide
   createDate time
   // Per-region configuration, each with providerName, regionName, instanceSize, nodeCount, diskSizeGB, and priority
   regionConfigs []dict
+  // Atlas Search and Atlas Vector Search indexes on the cluster
+  searchIndexes() []mongodbatlas.searchIndex
+}
+
+// MongoDB Atlas search or vector search index
+//
+// A single Atlas Search or Atlas Vector Search index defined on a cluster,
+// covering both index kinds through the type discriminator: "search" for a
+// full-text Atlas Search index and "vectorSearch" for an Atlas Vector Search
+// index. Reports the database and collection the index is built on, its build
+// status and whether it is currently queryable, and the full index definition.
+// The latestDefinition field carries the index configuration: for vector
+// search the vector and filter fields with their numDimensions, similarity
+// function, and path, plus numPartitions; for full-text search the analyzer,
+// analyzers, mappings, searchAnalyzer, synonyms, and the storedSource clause
+// that governs which document fields are copied into the index.
+mongodbatlas.searchIndex @defaults("name type database collectionName status") {
+  // Index id
+  id string
+  // Index name
+  name string
+  // Index kind
+  //
+  // The discriminator between the two index families: "search" for a full-text
+  // Atlas Search index and "vectorSearch" for an Atlas Vector Search index.
+  type string
+  // Database the index is built on
+  database string
+  // Collection the index is built on
+  collectionName string
+  // Build status
+  //
+  // One of READY, BUILDING, FAILED, STALE, PENDING, or DELETING.
+  status string
+  // Whether the index is currently queryable
+  queryable bool
+  // Version metadata for the most recent index definition, with version and createdAt
+  latestDefinitionVersion dict
+  // Most recent index definition
+  //
+  // The full index configuration. For a vector search index this holds the
+  // fields (each with a type of vector or filter, numDimensions, similarity,
+  // and path) and numPartitions. For a full-text search index it holds the
+  // analyzer, analyzers, mappings, searchAnalyzer, synonyms, and the
+  // storedSource clause that governs which document fields are copied into the
+  // index.
+  latestDefinition dict
+  // Per-host build status detail
+  statusDetail []dict
 }
 
 // MongoDB Atlas database user

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.go
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.go
@@ -24,6 +24,7 @@ const (
 	ResourceMongodbatlasApiKeyRoleAssignment    string = "mongodbatlas.apiKey.roleAssignment"
 	ResourceMongodbatlasServiceAccount          string = "mongodbatlas.serviceAccount"
 	ResourceMongodbatlasCluster                 string = "mongodbatlas.cluster"
+	ResourceMongodbatlasSearchIndex             string = "mongodbatlas.searchIndex"
 	ResourceMongodbatlasDatabaseUser            string = "mongodbatlas.databaseUser"
 	ResourceMongodbatlasNetworkAccessEntry      string = "mongodbatlas.networkAccessEntry"
 	ResourceMongodbatlasProjectConfig           string = "mongodbatlas.projectConfig"
@@ -75,6 +76,10 @@ func init() {
 		"mongodbatlas.cluster": {
 			Init:   initMongodbatlasCluster,
 			Create: createMongodbatlasCluster,
+		},
+		"mongodbatlas.searchIndex": {
+			// to override args, implement: initMongodbatlasSearchIndex(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createMongodbatlasSearchIndex,
 		},
 		"mongodbatlas.databaseUser": {
 			// to override args, implement: initMongodbatlasDatabaseUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -421,6 +426,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"mongodbatlas.cluster.regionConfigs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasCluster).GetRegionConfigs()).ToDataRes(types.Array(types.Dict))
+	},
+	"mongodbatlas.cluster.searchIndexes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasCluster).GetSearchIndexes()).ToDataRes(types.Array(types.Resource("mongodbatlas.searchIndex")))
+	},
+	"mongodbatlas.searchIndex.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetId()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetName()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetType()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.database": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetDatabase()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.collectionName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetCollectionName()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.status": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetStatus()).ToDataRes(types.String)
+	},
+	"mongodbatlas.searchIndex.queryable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetQueryable()).ToDataRes(types.Bool)
+	},
+	"mongodbatlas.searchIndex.latestDefinitionVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetLatestDefinitionVersion()).ToDataRes(types.Dict)
+	},
+	"mongodbatlas.searchIndex.latestDefinition": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetLatestDefinition()).ToDataRes(types.Dict)
+	},
+	"mongodbatlas.searchIndex.statusDetail": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMongodbatlasSearchIndex).GetStatusDetail()).ToDataRes(types.Array(types.Dict))
 	},
 	"mongodbatlas.databaseUser.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMongodbatlasDatabaseUser).GetId()).ToDataRes(types.String)
@@ -1074,6 +1112,54 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"mongodbatlas.cluster.regionConfigs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMongodbatlasCluster).RegionConfigs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.cluster.searchIndexes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasCluster).SearchIndexes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).__id, ok = v.Value.(string)
+		return
+	},
+	"mongodbatlas.searchIndex.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.database": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Database, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.collectionName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).CollectionName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.status": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Status, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.queryable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).Queryable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.latestDefinitionVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).LatestDefinitionVersion, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.latestDefinition": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).LatestDefinition, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"mongodbatlas.searchIndex.statusDetail": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMongodbatlasSearchIndex).StatusDetail, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"mongodbatlas.databaseUser.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2448,6 +2534,7 @@ type mqlMongodbatlasCluster struct {
 	RootCertType                 plugin.TValue[string]
 	CreateDate                   plugin.TValue[*time.Time]
 	RegionConfigs                plugin.TValue[[]any]
+	SearchIndexes                plugin.TValue[[]any]
 }
 
 // createMongodbatlasCluster creates a new instance of this resource
@@ -2552,6 +2639,111 @@ func (c *mqlMongodbatlasCluster) GetCreateDate() *plugin.TValue[*time.Time] {
 
 func (c *mqlMongodbatlasCluster) GetRegionConfigs() *plugin.TValue[[]any] {
 	return &c.RegionConfigs
+}
+
+func (c *mqlMongodbatlasCluster) GetSearchIndexes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SearchIndexes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("mongodbatlas.cluster", c.__id, "searchIndexes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.searchIndexes()
+	})
+}
+
+// mqlMongodbatlasSearchIndex for the mongodbatlas.searchIndex resource
+type mqlMongodbatlasSearchIndex struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlMongodbatlasSearchIndexInternal it will be used here
+	Id                      plugin.TValue[string]
+	Name                    plugin.TValue[string]
+	Type                    plugin.TValue[string]
+	Database                plugin.TValue[string]
+	CollectionName          plugin.TValue[string]
+	Status                  plugin.TValue[string]
+	Queryable               plugin.TValue[bool]
+	LatestDefinitionVersion plugin.TValue[any]
+	LatestDefinition        plugin.TValue[any]
+	StatusDetail            plugin.TValue[[]any]
+}
+
+// createMongodbatlasSearchIndex creates a new instance of this resource
+func createMongodbatlasSearchIndex(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlMongodbatlasSearchIndex{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("mongodbatlas.searchIndex", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlMongodbatlasSearchIndex) MqlName() string {
+	return "mongodbatlas.searchIndex"
+}
+
+func (c *mqlMongodbatlasSearchIndex) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetDatabase() *plugin.TValue[string] {
+	return &c.Database
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetCollectionName() *plugin.TValue[string] {
+	return &c.CollectionName
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetStatus() *plugin.TValue[string] {
+	return &c.Status
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetQueryable() *plugin.TValue[bool] {
+	return &c.Queryable
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetLatestDefinitionVersion() *plugin.TValue[any] {
+	return &c.LatestDefinitionVersion
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetLatestDefinition() *plugin.TValue[any] {
+	return &c.LatestDefinition
+}
+
+func (c *mqlMongodbatlasSearchIndex) GetStatusDetail() *plugin.TValue[[]any] {
+	return &c.StatusDetail
 }
 
 // mqlMongodbatlasDatabaseUser for the mongodbatlas.databaseUser resource

--- a/providers/mongodbatlas/resources/mongodbatlas.lr.versions
+++ b/providers/mongodbatlas/resources/mongodbatlas.lr.versions
@@ -54,6 +54,7 @@ mongodbatlas.cluster.pitEnabled 13.0.0
 mongodbatlas.cluster.redactClientLogData 13.0.0
 mongodbatlas.cluster.regionConfigs 13.0.0
 mongodbatlas.cluster.rootCertType 13.0.0
+mongodbatlas.cluster.searchIndexes 13.0.1
 mongodbatlas.cluster.stateName 13.0.0
 mongodbatlas.cluster.terminationProtectionEnabled 13.0.0
 mongodbatlas.cluster.tlsCipherConfigMode 13.0.0
@@ -188,6 +189,17 @@ mongodbatlas.resourcePolicy.lastUpdatedDate 13.0.1
 mongodbatlas.resourcePolicy.name 13.0.1
 mongodbatlas.resourcePolicy.policies 13.0.1
 mongodbatlas.restrictEmployeeAccess 13.0.0
+mongodbatlas.searchIndex 13.0.1
+mongodbatlas.searchIndex.collectionName 13.0.1
+mongodbatlas.searchIndex.database 13.0.1
+mongodbatlas.searchIndex.id 13.0.1
+mongodbatlas.searchIndex.latestDefinition 13.0.1
+mongodbatlas.searchIndex.latestDefinitionVersion 13.0.1
+mongodbatlas.searchIndex.name 13.0.1
+mongodbatlas.searchIndex.queryable 13.0.1
+mongodbatlas.searchIndex.status 13.0.1
+mongodbatlas.searchIndex.statusDetail 13.0.1
+mongodbatlas.searchIndex.type 13.0.1
 mongodbatlas.securityContact 13.0.0
 mongodbatlas.serviceAccount 13.0.0
 mongodbatlas.serviceAccount.clientId 13.0.0

--- a/providers/mongodbatlas/resources/search.go
+++ b/providers/mongodbatlas/resources/search.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/types"
+	"go.mongodb.org/atlas-sdk/v20250312006/admin"
+)
+
+// searchIndexes lists the Atlas Search and Atlas Vector Search indexes defined
+// on the cluster. A single cluster-wide call returns every index across all
+// databases and collections, discriminated by the type field ("search" versus
+// "vectorSearch"). Search may be unavailable on some cluster tiers or states;
+// such responses degrade to an empty list rather than failing the scan.
+func (c *mqlMongodbatlasCluster) searchIndexes() ([]any, error) {
+	pid, err := projectID(c.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	name := c.Name.Data
+
+	indexes, httpResp, err := atlasClient(c.MqlRuntime).AtlasSearchApi.
+		ListAtlasSearchIndexesCluster(context.Background(), pid, name).Execute()
+	if err != nil {
+		// Atlas Search is not available on every cluster tier or state; degrade
+		// to an empty list rather than failing the scan when it cannot be read.
+		if isAccessDenied(httpResp) || (httpResp != nil && httpResp.StatusCode == http.StatusNotFound) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	out := make([]any, 0, len(indexes))
+	for i := range indexes {
+		res, err := newMqlMongodbatlasSearchIndex(c.MqlRuntime, name, indexes[i])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+func newMqlMongodbatlasSearchIndex(runtime *plugin.Runtime, clusterName string, idx admin.SearchIndexResponse) (*mqlMongodbatlasSearchIndex, error) {
+	args := map[string]*llx.RawData{
+		"__id":           llx.StringData("mongodbatlas.searchIndex/" + clusterName + "/" + idx.GetIndexID()),
+		"id":             llx.StringData(idx.GetIndexID()),
+		"name":           llx.StringData(idx.GetName()),
+		"type":           llx.StringData(idx.GetType()),
+		"database":       llx.StringData(idx.GetDatabase()),
+		"collectionName": llx.StringData(idx.GetCollectionName()),
+		"status":         llx.StringData(idx.GetStatus()),
+		"queryable":      llx.BoolData(idx.GetQueryable()),
+	}
+
+	if def, ok := idx.GetLatestDefinitionOk(); ok {
+		dict, err := convert.JsonToDict(def)
+		if err != nil {
+			return nil, err
+		}
+		args["latestDefinition"] = llx.DictData(dict)
+	} else {
+		args["latestDefinition"] = llx.NilData
+	}
+
+	if ver, ok := idx.GetLatestDefinitionVersionOk(); ok {
+		dict, err := convert.JsonToDict(ver)
+		if err != nil {
+			return nil, err
+		}
+		args["latestDefinitionVersion"] = llx.DictData(dict)
+	} else {
+		args["latestDefinitionVersion"] = llx.NilData
+	}
+
+	if detail, ok := idx.GetStatusDetailOk(); ok {
+		list, err := convert.JsonToDictSlice(detail)
+		if err != nil {
+			return nil, err
+		}
+		args["statusDetail"] = llx.ArrayData(list, types.Dict)
+	} else {
+		args["statusDetail"] = llx.ArrayData([]any{}, types.Dict)
+	}
+
+	res, err := CreateResource(runtime, "mongodbatlas.searchIndex", args)
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlMongodbatlasSearchIndex), nil
+}


### PR DESCRIPTION
## What

Adds **Atlas Search and Atlas Vector Search index** coverage to the mongodbatlas provider. Vector search is what powers RAG/AI applications on Atlas, and the indexed fields + `storedSource` are a real data-exposure surface.

## Changes

- **`mongodbatlas.searchIndex`** via a new **`searchIndexes()`** accessor on `mongodbatlas.cluster`. One resource covers both index families through the `type` discriminator (`search` for full-text Atlas Search, `vectorSearch` for Vector Search).
- Fields: `id`, `name`, `type`, `database`, `collectionName`, `status` (READY/BUILDING/FAILED/STALE/PENDING/DELETING), `queryable`, `latestDefinition` (the full index config — for vector search the fields with `numDimensions`/`similarity`/`path` and `numPartitions`; for full-text the analyzers/mappings/synonyms and the `storedSource` clause governing which document data is copied into the index), `latestDefinitionVersion`, `statusDetail`.

## Notes

- Uses the current cluster-wide `ListAtlasSearchIndexesCluster` (one call returns every index across all databases/collections on the cluster — no per-collection fan-out), not the deprecated `ClusterSearchIndex`-based methods.
- Degrades to an empty list on access-denied/404, matching the provider's existing error-degrade pattern.

## Verification

Live-tested against a real Atlas project: `clusters { searchIndexes { ... } }` resolves and degrades cleanly to an empty list (the test cluster has no indexes provisioned, so field extraction against a live index is exercised by code review). Build + gofmt clean.
