### PR TITLE
🐛 ms365: decode Exchange domain lists that serialize as objects

### DIFF
--- a/providers/ms365/resources/ms365_exchange_policies.go
+++ b/providers/ms365/resources/ms365_exchange_policies.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"encoding/json"
+	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/types"
@@ -27,6 +28,68 @@ func decodeExchangeList[T any](raw any) ([]*T, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// exchangeDomainList decodes Exchange domain collections whose elements are
+// MultiValuedProperty<...> values (e.g. SmtpDomainWithSubdomains on hosted
+// content filter policies, SharingPolicyDomain on sharing policies).
+//
+// Depending on the cmdlet and PowerShell's ConvertTo-Json serialization, each
+// element is rendered either as a bare domain string ("contoso.com") or as an
+// object carrying a "Domain" field ({"Domain":"contoso.com",...}); a
+// single-element collection may additionally be emitted as a scalar instead of
+// an array. Decoding such objects into a plain []string fails with
+// "cannot unmarshal object into Go struct field ... of type string", which
+// aborts the whole resource. Normalizing every shape to a []string of domains
+// keeps decoding resilient for tenants that have any of these domains set.
+type exchangeDomainList []string
+
+func (d *exchangeDomainList) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*d = flattenExchangeDomains(raw)
+	return nil
+}
+
+func flattenExchangeDomains(v any) []string {
+	switch t := v.(type) {
+	case string:
+		if t == "" {
+			return nil
+		}
+		return []string{t}
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			out = append(out, flattenExchangeDomains(e)...)
+		}
+		return out
+	case map[string]any:
+		if domain := exchangeDomainFromObject(t); domain != "" {
+			return []string{domain}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func exchangeDomainFromObject(obj map[string]any) string {
+	// Preferred, explicitly-named keys first.
+	for _, key := range []string{"Domain", "SmtpDomain", "DomainName", "Name", "Address"} {
+		if s, ok := obj[key].(string); ok && s != "" {
+			return s
+		}
+	}
+	// Fallback: any string-valued key that looks like a domain.
+	for key, val := range obj {
+		if s, ok := val.(string); ok && s != "" && strings.Contains(strings.ToLower(key), "domain") {
+			return s
+		}
+	}
+	return ""
 }
 
 // --- Transport rules ---
@@ -293,17 +356,17 @@ func convertMalwareFilterPolicies(r *mqlMs365Exchangeonline, raw any) ([]any, er
 // --- Hosted content (spam) filter policies ---
 
 type ExchangeHostedContentFilterPolicy struct {
-	Identity                       string   `json:"Identity"`
-	Name                           string   `json:"Name"`
-	SpamAction                     string   `json:"SpamAction"`
-	HighConfidenceSpamAction       string   `json:"HighConfidenceSpamAction"`
-	PhishSpamAction                string   `json:"PhishSpamAction"`
-	HighConfidencePhishAction      string   `json:"HighConfidencePhishAction"`
-	BulkSpamAction                 string   `json:"BulkSpamAction"`
-	BulkThreshold                  int64    `json:"BulkThreshold"`
-	EnableEndUserSpamNotifications bool     `json:"EnableEndUserSpamNotifications"`
-	AllowedSenderDomains           []string `json:"AllowedSenderDomains"`
-	BlockedSenderDomains           []string `json:"BlockedSenderDomains"`
+	Identity                       string             `json:"Identity"`
+	Name                           string             `json:"Name"`
+	SpamAction                     string             `json:"SpamAction"`
+	HighConfidenceSpamAction       string             `json:"HighConfidenceSpamAction"`
+	PhishSpamAction                string             `json:"PhishSpamAction"`
+	HighConfidencePhishAction      string             `json:"HighConfidencePhishAction"`
+	BulkSpamAction                 string             `json:"BulkSpamAction"`
+	BulkThreshold                  int64              `json:"BulkThreshold"`
+	EnableEndUserSpamNotifications bool               `json:"EnableEndUserSpamNotifications"`
+	AllowedSenderDomains           exchangeDomainList `json:"AllowedSenderDomains"`
+	BlockedSenderDomains           exchangeDomainList `json:"BlockedSenderDomains"`
 }
 
 func convertHostedContentFilterPolicies(r *mqlMs365Exchangeonline, raw any) ([]any, error) {
@@ -328,8 +391,8 @@ func convertHostedContentFilterPolicies(r *mqlMs365Exchangeonline, raw any) ([]a
 				"bulkSpamAction":                 llx.StringData(p.BulkSpamAction),
 				"bulkThreshold":                  llx.IntData(p.BulkThreshold),
 				"enableEndUserSpamNotifications": llx.BoolData(p.EnableEndUserSpamNotifications),
-				"allowedSenderDomains":           llx.ArrayData(llx.TArr2Raw(p.AllowedSenderDomains), types.String),
-				"blockedSenderDomains":           llx.ArrayData(llx.TArr2Raw(p.BlockedSenderDomains), types.String),
+				"allowedSenderDomains":           llx.ArrayData(llx.TArr2Raw([]string(p.AllowedSenderDomains)), types.String),
+				"blockedSenderDomains":           llx.ArrayData(llx.TArr2Raw([]string(p.BlockedSenderDomains)), types.String),
 			})
 		if err != nil {
 			return nil, err
@@ -708,11 +771,11 @@ func convertAtpPoliciesForO365(r *mqlMs365Exchangeonline, raw any) ([]any, error
 // --- Sharing policies ---
 
 type ExchangeSharingPolicy struct {
-	Identity string   `json:"Identity"`
-	Name     string   `json:"Name"`
-	Enabled  bool     `json:"Enabled"`
-	Default  bool     `json:"Default"`
-	Domains  []string `json:"Domains"`
+	Identity string             `json:"Identity"`
+	Name     string             `json:"Name"`
+	Enabled  bool               `json:"Enabled"`
+	Default  bool               `json:"Default"`
+	Domains  exchangeDomainList `json:"Domains"`
 }
 
 func convertSharingPolicies(r *mqlMs365Exchangeonline, raw any) ([]any, error) {
@@ -732,7 +795,7 @@ func convertSharingPolicies(r *mqlMs365Exchangeonline, raw any) ([]any, error) {
 				"name":      llx.StringData(p.Name),
 				"enabled":   llx.BoolData(p.Enabled),
 				"isDefault": llx.BoolData(p.Default),
-				"domains":   llx.ArrayData(llx.TArr2Raw(p.Domains), types.String),
+				"domains":   llx.ArrayData(llx.TArr2Raw([]string(p.Domains)), types.String),
 			})
 		if err != nil {
 			return nil, err

--- a/providers/ms365/resources/ms365_exchange_policies_test.go
+++ b/providers/ms365/resources/ms365_exchange_policies_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Exchange domain collections (e.g. AllowedSenderDomains on hosted content
+// filter policies, Domains on sharing policies) are MultiValuedProperty<...>
+// values. Depending on the cmdlet and ConvertTo-Json serialization each entry
+// is emitted as a bare string or as an object with a "Domain" field, and a
+// single-element collection may be a scalar rather than an array. Decoding any
+// of these into exchangeDomainList must succeed and normalize to []string.
+func TestExchangeDomainList_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"null", `null`, nil},
+		{"empty array", `[]`, []string{}},
+		{"string array", `["contoso.com","fabrikam.com"]`, []string{"contoso.com", "fabrikam.com"}},
+		{"single string", `"contoso.com"`, []string{"contoso.com"}},
+		{
+			"object array",
+			`[{"Domain":"contoso.com","IncludeSubDomains":false},{"Domain":"fabrikam.com"}]`,
+			[]string{"contoso.com", "fabrikam.com"},
+		},
+		{"single object", `{"Domain":"contoso.com","IncludeSubDomains":true}`, []string{"contoso.com"}},
+		{"object without domain", `[{"Foo":"bar"}]`, []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got exchangeDomainList
+			require.NoError(t, json.Unmarshal([]byte(tc.in), &got))
+			assert.Equal(t, tc.want, []string(got))
+		})
+	}
+}
+
+// Regression: a hosted content filter policy whose AllowedSenderDomains is an
+// array of SmtpDomainWithSubdomains objects previously aborted the whole
+// resource with "cannot unmarshal object ... of type string".
+func TestExchangeHostedContentFilterPolicy_ObjectAllowedSenderDomains(t *testing.T) {
+	raw := `{
+		"Identity": "Default",
+		"Name": "Default",
+		"AllowedSenderDomains": [{"Domain":"contoso.com","IncludeSubDomains":false}],
+		"BlockedSenderDomains": []
+	}`
+	var p ExchangeHostedContentFilterPolicy
+	require.NoError(t, json.Unmarshal([]byte(raw), &p))
+	assert.Equal(t, []string{"contoso.com"}, []string(p.AllowedSenderDomains))
+	assert.Empty(t, []string(p.BlockedSenderDomains))
+}
+
+// Regression: sharing policy Domains are SharingPolicyDomain objects and must
+// decode without aborting the resource.
+func TestExchangeSharingPolicy_ObjectDomains(t *testing.T) {
+	raw := `{
+		"Identity": "Default Sharing Policy",
+		"Name": "Default Sharing Policy",
+		"Enabled": true,
+		"Default": true,
+		"Domains": [{"Domain":"contoso.com","DomainType":"CalendarSharingFreeBusySimple"}]
+	}`
+	var p ExchangeSharingPolicy
+	require.NoError(t, json.Unmarshal([]byte(raw), &p))
+	assert.Equal(t, []string{"contoso.com"}, []string(p.Domains))
+}


### PR DESCRIPTION
## Summary

`ms365.exchangeonline` decodes several PowerShell cmdlet payloads into typed Go structs. Three domain-list fields are declared `[]string` but the underlying Exchange values are `MultiValuedProperty<...>`:

- `Get-HostedContentFilterPolicy` → `AllowedSenderDomains`, `BlockedSenderDomains` (`SmtpDomainWithSubdomains`)
- `Get-SharingPolicy` → `Domains` (`SharingPolicyDomain`)

Depending on the cmdlet and `ConvertTo-Json` serialization, each entry is emitted either as a bare domain string (`"contoso.com"`) or as an **object** carrying a `Domain` field (`{"Domain":"contoso.com","IncludeSubDomains":false}`); a single-element collection may also be a scalar rather than an array.

When any of these domains is configured, the object shape fails to decode into `[]string`:

```
json: cannot unmarshal object into Go struct field ExchangeHostedContentFilterPolicy.AllowedSenderDomains of type string
```

Because `decodeExchangeList` returns that error, the **entire** `hostedContentFilterPolicies` (or `sharingPolicies`) resource fails, so checks over it error out instead of evaluating.

## Change

Adds `exchangeDomainList`, a small tolerant type with a custom `UnmarshalJSON` that normalizes every shape — string, string array, object, object array, or single scalar — to a `[]string` of domain names, and uses it for the three affected fields. Backward compatible: plain-string payloads decode exactly as before.

Includes `ms365_exchange_policies_test.go` covering: null, empty array, string array, single string, object array, single object, and object-without-domain, plus regression tests that decode a hosted content filter policy and a sharing policy carrying object-shaped domains.

## Validation

```
go test ./resources/ -run 'TestExchangeDomainList|TestExchangeHostedContentFilterPolicy_ObjectAllowedSenderDomains|TestExchangeSharingPolicy_ObjectDomains'
ok  go.mondoo.com/mql/v13/providers/ms365/resources
```

`gofmt` clean.
