### PR TITLE
🐛 os: report .NET Framework 3.5 (CLR 2.0) runtime build, and detect .NET over SSH

### DIFF
--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -26,8 +26,6 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/cpe"
 	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
 	"go.mondoo.com/mql/v13/providers/os/resources/purl"
-	"go.mondoo.com/ranger-rpc/codes"
-	"go.mondoo.com/ranger-rpc/status"
 )
 
 // ProcessorArchitecture Enum
@@ -309,6 +307,9 @@ func (w *WinPkgManager) getLocalInstalledApps() ([]Package, error) {
 // .NET Framework 3.5 (CLR 2.0) and 4.x (CLR 4.0) install side-by-side, so we
 // probe both registry keys independently and emit a package for each runtime
 // that is present, rather than letting the highest version hide the other.
+//
+// Registry and version probes run over the active connection via PowerShell, so
+// this works for remote connections (e.g. SSH) as well as a local Windows host.
 func (w *WinPkgManager) getDotNetFramework() ([]Package, error) {
 	packages := []Package{}
 
@@ -336,11 +337,8 @@ func (w *WinPkgManager) getDotNetFramework4x() (*Package, error) {
 	// https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#net-framework-45-and-later-versions
 	const dotNet45plus = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full"
 
-	items, err := registry.GetNativeRegistryKeyItems(dotNet45plus)
+	items, err := w.readRegistryItems(dotNet45plus)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -374,11 +372,8 @@ func (w *WinPkgManager) getDotNetFramework35() (*Package, error) {
 	// https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#use-registry-editor-older-framework-versions
 	const dotNet35 = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.5"
 
-	items, err := registry.GetNativeRegistryKeyItems(dotNet35)
+	items, err := w.readRegistryItems(dotNet35)
 	if err != nil {
-		if status.Code(err) == codes.NotFound {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -438,6 +433,29 @@ func (w *WinPkgManager) runPwshVersion(script string) (string, error) {
 	return version, nil
 }
 
+// readRegistryItems reads the values of a single registry key over the active
+// connection. It probes via PowerShell (rather than the Windows-only native
+// registry API) so it works for remote connections such as SSH as well as a
+// local Windows host. A missing key makes the probe exit non-zero, which is
+// reported as an empty result rather than an error.
+func (w *WinPkgManager) readRegistryItems(path string) ([]registry.RegistryKeyItem, error) {
+	cmd, err := w.conn.RunCommand(powershell.Encode(registry.GetRegistryKeyItemScript(path)))
+	if err != nil {
+		return nil, err
+	}
+	if cmd.ExitStatus != 0 {
+		return nil, nil
+	}
+	data, err := io.ReadAll(cmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, nil
+	}
+	return registry.ParsePowershellRegistryKeyItems(strings.NewReader(string(data)))
+}
+
 func (w *WinPkgManager) getInstalledApps() ([]Package, error) {
 	if w.conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
 		return w.getLocalInstalledApps()
@@ -460,7 +478,22 @@ func (w *WinPkgManager) getInstalledApps() ([]Package, error) {
 		return nil, errors.New("failed to retrieve installed apps: " + string(stderr))
 	}
 
-	return ParseWindowsAppPackages(w.platform, cmd.Stdout)
+	packages, err := ParseWindowsAppPackages(w.platform, cmd.Stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	// The .NET Framework runtimes don't appear in the Uninstall registry keys,
+	// so we discover them separately here as well (the local path does the same
+	// in getLocalInstalledApps).
+	dotNetFramework, err := w.getDotNetFramework()
+	if err != nil {
+		log.Debug().Err(err).Msg("could not get .NET Framework packages from registry")
+	} else {
+		packages = append(packages, dotNetFramework...)
+	}
+
+	return packages, nil
 }
 
 func (w *WinPkgManager) getAppxPackages() ([]Package, error) {

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -114,6 +114,33 @@ const dotNetClrVersionScript = `
 ((Get-Item "%sclr.dll").VersionInfo).ProductVersion
 `
 
+// dotNetClr2VersionScript resolves the servicing build of the CLR 2.0 runtime
+// that backs .NET Framework 3.5. CLR 2.0 has no clr.dll; its assemblies live
+// under %WINDIR%\Microsoft.NET\Framework[64]\v2.0.50727. Some files there stay
+// pinned to older builds for side-by-side compatibility, so we take the highest
+// 2.0.50727.<build> across every assembly in that directory to reflect the
+// actual patch level.
+const dotNetClr2VersionScript = `
+$paths = @(
+  "$env:WINDIR\Microsoft.NET\Framework64\v2.0.50727",
+  "$env:WINDIR\Microsoft.NET\Framework\v2.0.50727"
+)
+$best = ''
+$bestBuild = -1
+foreach ($p in $paths) {
+  if (Test-Path $p) {
+    Get-ChildItem -Path $p -Filter *.dll -ErrorAction SilentlyContinue | ForEach-Object {
+      $pv = $_.VersionInfo.ProductVersion
+      if ($pv -match '^2\.0\.50727\.(\d+)') {
+        $b = [int]$Matches[1]
+        if ($b -gt $bestBuild) { $bestBuild = $b; $best = ($pv -split '\s+')[0] }
+      }
+    }
+  }
+}
+$best
+`
+
 var (
 	WINDOWS_QUERY_HOTFIXES      = `Get-HotFix | Select-Object -Property Status, Description, HotFixId, Caption, InstalledOn, InstalledBy | ConvertTo-Json`
 	WINDOWS_QUERY_APPX_PACKAGES = `Get-AppxPackage -AllUsers | Select Name, PackageFullName, Architecture, Version, Publisher, InstallLocation | ConvertTo-Json`
@@ -277,70 +304,138 @@ func (w *WinPkgManager) getLocalInstalledApps() ([]Package, error) {
 	return packages, nil
 }
 
-// getDotNetFramework returns the .NET Framework package
+// getDotNetFramework returns the installed .NET Framework runtime packages.
+//
+// .NET Framework 3.5 (CLR 2.0) and 4.x (CLR 4.0) install side-by-side, so we
+// probe both registry keys independently and emit a package for each runtime
+// that is present, rather than letting the highest version hide the other.
 func (w *WinPkgManager) getDotNetFramework() ([]Package, error) {
+	packages := []Package{}
+
+	if pkg, err := w.getDotNetFramework4x(); err != nil {
+		log.Debug().Err(err).Msg("could not get .NET Framework 4.x runtime")
+	} else if pkg != nil {
+		packages = append(packages, *pkg)
+	}
+
+	if pkg, err := w.getDotNetFramework35(); err != nil {
+		log.Debug().Err(err).Msg("could not get .NET Framework 3.5 runtime")
+	} else if pkg != nil {
+		packages = append(packages, *pkg)
+	}
+
+	if len(packages) == 0 {
+		return nil, nil
+	}
+	return packages, nil
+}
+
+// getDotNetFramework4x reports the installed .NET Framework 4.x runtime, sourcing
+// its build from clr.dll (the CLR 4.x runtime) under the registered install path.
+func (w *WinPkgManager) getDotNetFramework4x() (*Package, error) {
 	// https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#net-framework-45-and-later-versions
-	dotNet45plus := "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full"
-	// https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#use-registry-editor-older-framework-versions
-	dotNet35 := "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.5"
+	const dotNet45plus = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full"
 
 	items, err := registry.GetNativeRegistryKeyItems(dotNet45plus)
-	if err != nil && status.Code(err) != codes.NotFound {
-		return nil, err
-	}
-
-	if len(items) == 0 {
-		items, err = registry.GetNativeRegistryKeyItems(dotNet35)
-		if err != nil && status.Code(err) != codes.NotFound {
-			return nil, err
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, nil
 		}
-	}
-
-	if len(items) == 0 {
-		return nil, nil
+		return nil, err
 	}
 
 	installLocation := ""
 	for _, i := range items {
-		switch i.Key {
-		case "InstallPath":
+		if i.Key == "InstallPath" {
 			installLocation = i.Value.String
 		}
 	}
-
 	if installLocation == "" {
 		return nil, nil
 	}
 
 	dotNetRuntimeScript := fmt.Sprintf(dotNetClrVersionScript, installLocation)
-	cmd, err := w.conn.RunCommand(powershell.Encode(dotNetRuntimeScript))
+	version, err := w.runPwshVersion(dotNetRuntimeScript)
 	if err != nil {
-		return nil, fmt.Errorf("could not read app package list")
+		return nil, err
+	}
+	if version == "" {
+		return nil, nil
+	}
+
+	return createPackage("Microsoft .NET Framework", version, "windows/app", w.platform.Arch, "Microsoft", installLocation, w.platform), nil
+}
+
+// getDotNetFramework35 reports the installed .NET Framework 3.5 runtime. It is
+// detected independently of 4.x (they run side-by-side) via the NDP\v3.5 key,
+// and its build is sourced from the CLR 2.0 assemblies rather than clr.dll,
+// which does not exist for CLR 2.0.
+func (w *WinPkgManager) getDotNetFramework35() (*Package, error) {
+	// https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed#use-registry-editor-older-framework-versions
+	const dotNet35 = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.5"
+
+	items, err := registry.GetNativeRegistryKeyItems(dotNet35)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	installed := false
+	installLocation := ""
+	for _, i := range items {
+		switch i.Key {
+		case "Install":
+			installed = i.Value.Number == 1
+		case "InstallPath":
+			installLocation = i.Value.String
+		}
+	}
+	if !installed {
+		return nil, nil
+	}
+
+	version, err := w.runPwshVersion(dotNetClr2VersionScript)
+	if err != nil {
+		return nil, err
+	}
+	if version == "" {
+		return nil, nil
+	}
+
+	return createPackage("Microsoft .NET Framework", version, "windows/app", w.platform.Arch, "Microsoft", installLocation, w.platform), nil
+}
+
+// runPwshVersion runs a PowerShell script that emits a single version string and
+// returns its trimmed, single-line result.
+func (w *WinPkgManager) runPwshVersion(script string) (string, error) {
+	cmd, err := w.conn.RunCommand(powershell.Encode(script))
+	if err != nil {
+		return "", fmt.Errorf("could not run powershell command")
 	}
 
 	if cmd.ExitStatus != 0 {
 		stderr, err := io.ReadAll(cmd.Stderr)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
-		return nil, errors.New("failed to retrieve installed apps: " + string(stderr))
+		return "", errors.New("failed to retrieve .NET Framework version: " + string(stderr))
 	}
 
 	data, err := io.ReadAll(cmd.Stdout)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// for empty result set do not get the '{}', therefore lets abort here
 	if len(data) == 0 {
-		return nil, nil
+		return "", nil
 	}
 	version := strings.TrimSpace(string(data))
 	version = strings.ReplaceAll(version, "\n", "")
-
-	pkg := createPackage("Microsoft .NET Framework", version, "windows/app", w.platform.Arch, "Microsoft", installLocation, w.platform)
-
-	return []Package{*pkg}, nil
+	version = strings.ReplaceAll(version, "\r", "")
+	return version, nil
 }
 
 func (w *WinPkgManager) getInstalledApps() ([]Package, error) {

--- a/providers/os/resources/packages/windows_packages.go
+++ b/providers/os/resources/packages/windows_packages.go
@@ -310,6 +310,10 @@ func (w *WinPkgManager) getLocalInstalledApps() ([]Package, error) {
 //
 // Registry and version probes run over the active connection via PowerShell, so
 // this works for remote connections (e.g. SSH) as well as a local Windows host.
+//
+// This is called from exactly one enumeration path per connection type
+// (getLocalInstalledApps for a local Windows host, getInstalledApps for remote
+// connections), so the returned packages are not duplicated.
 func (w *WinPkgManager) getDotNetFramework() ([]Package, error) {
 	packages := []Package{}
 
@@ -339,7 +343,7 @@ func (w *WinPkgManager) getDotNetFramework4x() (*Package, error) {
 
 	items, err := w.readRegistryItems(dotNet45plus)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read registry key %q: %w", dotNet45plus, err)
 	}
 
 	installLocation := ""
@@ -374,7 +378,7 @@ func (w *WinPkgManager) getDotNetFramework35() (*Package, error) {
 
 	items, err := w.readRegistryItems(dotNet35)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read registry key %q: %w", dotNet35, err)
 	}
 
 	installed := false

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -5,6 +5,7 @@ package packages
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -1139,4 +1140,146 @@ func TestWindowsAppPackagesParserInstallDate(t *testing.T) {
 	withoutDate := findPkg(pkgs, "App Without Date")
 	require.NotNil(t, withoutDate)
 	assert.True(t, withoutDate.InstallDate.IsZero(), "missing InstallDate registry value yields zero time")
+}
+
+// regWireValue / regWireItem mirror the JSON shape emitted by the PowerShell
+// registry probe (registry.GetRegistryKeyItemScript), so tests can feed
+// getDotNetFramework's readRegistryItems realistic payloads.
+type regWireValue struct {
+	Kind int `json:"kind"`
+	Data any `json:"data"`
+}
+
+type regWireItem struct {
+	Key   string       `json:"key"`
+	Value regWireValue `json:"value"`
+}
+
+func regItemsJSON(t *testing.T, items ...regWireItem) string {
+	t.Helper()
+	b, err := json.Marshal(items)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func szItem(key, value string) regWireItem {
+	return regWireItem{Key: key, Value: regWireValue{Kind: registry.SZ, Data: value}}
+}
+
+func dwordItem(key string, value int) regWireItem {
+	return regWireItem{Key: key, Value: regWireValue{Kind: registry.DWORD, Data: value}}
+}
+
+func TestGetDotNetFramework(t *testing.T) {
+	const (
+		v4Key   = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full"
+		v35Key  = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v3.5"
+		v4Path  = "C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\"
+		v35Path = "C:\\Windows\\Microsoft.NET\\Framework64\\v3.5\\"
+	)
+
+	// Command keys exactly as getDotNetFramework issues them over the connection.
+	v4RegCmd := powershell.Encode(registry.GetRegistryKeyItemScript(v4Key))
+	v35RegCmd := powershell.Encode(registry.GetRegistryKeyItemScript(v35Key))
+	v4VerCmd := powershell.Encode(fmt.Sprintf(dotNetClrVersionScript, v4Path))
+	v35VerCmd := powershell.Encode(dotNetClr2VersionScript)
+
+	v4RegItems := regItemsJSON(t, szItem("InstallPath", v4Path), dwordItem("Release", 528449))
+	v4RegNoPath := regItemsJSON(t, dwordItem("Release", 528449))
+	v35Installed := regItemsJSON(t, dwordItem("Install", 1), szItem("InstallPath", v35Path))
+	v35NotInstalled := regItemsJSON(t, dwordItem("Install", 0), szItem("InstallPath", v35Path))
+
+	// Trailing CRLF verifies runPwshVersion trims the raw stdout.
+	v4Ver := snapCommandResult{stdout: "4.8.4795.0\r\n"}
+	v35Ver := snapCommandResult{stdout: "2.0.50727.9182\r\n"}
+
+	type want struct {
+		name    string
+		version string
+	}
+	tests := []struct {
+		name     string
+		commands map[string]snapCommandResult
+		want     []want
+	}{
+		{
+			name: "both 3.5 and 4.x present, reported side by side",
+			commands: map[string]snapCommandResult{
+				v4RegCmd:  {stdout: v4RegItems},
+				v4VerCmd:  v4Ver,
+				v35RegCmd: {stdout: v35Installed},
+				v35VerCmd: v35Ver,
+			},
+			want: []want{
+				{"Microsoft .NET Framework", "4.8.4795.0"},
+				{"Microsoft .NET Framework", "2.0.50727.9182"},
+			},
+		},
+		{
+			name: "only 4.x present (v3.5 key missing)",
+			commands: map[string]snapCommandResult{
+				v4RegCmd: {stdout: v4RegItems},
+				v4VerCmd: v4Ver,
+			},
+			want: []want{{"Microsoft .NET Framework", "4.8.4795.0"}},
+		},
+		{
+			name: "only 3.5 present (v4 key missing), sourced from CLR 2.0 build",
+			commands: map[string]snapCommandResult{
+				v35RegCmd: {stdout: v35Installed},
+				v35VerCmd: v35Ver,
+			},
+			want: []want{{"Microsoft .NET Framework", "2.0.50727.9182"}},
+		},
+		{
+			name: "3.5 key present but Install=0 is not reported",
+			commands: map[string]snapCommandResult{
+				v4RegCmd:  {stdout: v4RegItems},
+				v4VerCmd:  v4Ver,
+				v35RegCmd: {stdout: v35NotInstalled},
+				v35VerCmd: v35Ver,
+			},
+			want: []want{{"Microsoft .NET Framework", "4.8.4795.0"}},
+		},
+		{
+			name: "4.x key present without InstallPath is skipped",
+			commands: map[string]snapCommandResult{
+				v4RegCmd: {stdout: v4RegNoPath},
+				v4VerCmd: v4Ver,
+			},
+			want: nil,
+		},
+		{
+			name: "4.x present but clr.dll version blank is skipped",
+			commands: map[string]snapCommandResult{
+				v4RegCmd: {stdout: v4RegItems},
+				v4VerCmd: {stdout: "\r\n"},
+			},
+			want: nil,
+		},
+		{
+			name:     "neither runtime present",
+			commands: map[string]snapCommandResult{},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &WinPkgManager{
+				conn:     &snapTestConnection{commands: tt.commands},
+				platform: &inventory.Platform{Name: "windows", Arch: "amd64", Family: []string{"windows"}},
+			}
+
+			pkgs, err := w.getDotNetFramework()
+			require.NoError(t, err)
+			require.Len(t, pkgs, len(tt.want))
+			for i, wnt := range tt.want {
+				assert.Equal(t, wnt.name, pkgs[i].Name, "package %d name", i)
+				assert.Equal(t, wnt.version, pkgs[i].Version, "package %d version", i)
+				assert.Equal(t, "windows/app", pkgs[i].Format, "package %d format", i)
+				assert.Equal(t, "amd64", pkgs[i].Arch, "package %d arch", i)
+			}
+		})
+	}
 }

--- a/providers/os/resources/packages/windows_packages_test.go
+++ b/providers/os/resources/packages/windows_packages_test.go
@@ -1193,14 +1193,14 @@ func TestGetDotNetFramework(t *testing.T) {
 	v4Ver := snapCommandResult{stdout: "4.8.4795.0\r\n"}
 	v35Ver := snapCommandResult{stdout: "2.0.50727.9182\r\n"}
 
-	type want struct {
+	type wantPkg struct {
 		name    string
 		version string
 	}
 	tests := []struct {
 		name     string
 		commands map[string]snapCommandResult
-		want     []want
+		want     []wantPkg
 	}{
 		{
 			name: "both 3.5 and 4.x present, reported side by side",
@@ -1210,7 +1210,7 @@ func TestGetDotNetFramework(t *testing.T) {
 				v35RegCmd: {stdout: v35Installed},
 				v35VerCmd: v35Ver,
 			},
-			want: []want{
+			want: []wantPkg{
 				{"Microsoft .NET Framework", "4.8.4795.0"},
 				{"Microsoft .NET Framework", "2.0.50727.9182"},
 			},
@@ -1221,7 +1221,7 @@ func TestGetDotNetFramework(t *testing.T) {
 				v4RegCmd: {stdout: v4RegItems},
 				v4VerCmd: v4Ver,
 			},
-			want: []want{{"Microsoft .NET Framework", "4.8.4795.0"}},
+			want: []wantPkg{{"Microsoft .NET Framework", "4.8.4795.0"}},
 		},
 		{
 			name: "only 3.5 present (v4 key missing), sourced from CLR 2.0 build",
@@ -1229,7 +1229,7 @@ func TestGetDotNetFramework(t *testing.T) {
 				v35RegCmd: {stdout: v35Installed},
 				v35VerCmd: v35Ver,
 			},
-			want: []want{{"Microsoft .NET Framework", "2.0.50727.9182"}},
+			want: []wantPkg{{"Microsoft .NET Framework", "2.0.50727.9182"}},
 		},
 		{
 			name: "3.5 key present but Install=0 is not reported",
@@ -1239,7 +1239,7 @@ func TestGetDotNetFramework(t *testing.T) {
 				v35RegCmd: {stdout: v35NotInstalled},
 				v35VerCmd: v35Ver,
 			},
-			want: []want{{"Microsoft .NET Framework", "4.8.4795.0"}},
+			want: []wantPkg{{"Microsoft .NET Framework", "4.8.4795.0"}},
 		},
 		{
 			name: "4.x key present without InstallPath is skipped",
@@ -1274,9 +1274,9 @@ func TestGetDotNetFramework(t *testing.T) {
 			pkgs, err := w.getDotNetFramework()
 			require.NoError(t, err)
 			require.Len(t, pkgs, len(tt.want))
-			for i, wnt := range tt.want {
-				assert.Equal(t, wnt.name, pkgs[i].Name, "package %d name", i)
-				assert.Equal(t, wnt.version, pkgs[i].Version, "package %d version", i)
+			for i, exp := range tt.want {
+				assert.Equal(t, exp.name, pkgs[i].Name, "package %d name", i)
+				assert.Equal(t, exp.version, pkgs[i].Version, "package %d version", i)
 				assert.Equal(t, "windows/app", pkgs[i].Format, "package %d format", i)
 				assert.Equal(t, "amd64", pkgs[i].Arch, "package %d arch", i)
 			}


### PR DESCRIPTION
## Summary

Fixes #9268. Windows package enumeration reported only a single `Microsoft .NET Framework` entry (a `4.x` build sourced from `clr.dll`), and only when mql ran locally on the host. This PR fixes two gaps:

1. **.NET Framework 3.5 (CLR 2.0) was never reported.** `getDotNetFramework` read `NDP\v4\Full` first and only fell back to `NDP\v3.5` when v4 was empty, so on the common side-by-side install the 4.x runtime hid 3.5. Even the fallback read `clr.dll`, which does not exist for CLR 2.0.
2. **.NET Framework was not reported at all over remote connections (SSH).** `getDotNetFramework` was only wired into `getLocalInstalledApps` (`Type_Local && GOOS==windows`). Over SSH the enumeration took the `RunCommand` path, which never called it, so neither 3.5 nor 4.x showed up.

## Changes

- Detect 3.5 independently of 4.x via the `NDP\v3.5` key (`Install = 1`) and emit it as its own package **alongside** the 4.x entry (they install side-by-side).
- Source the 3.5 build from the `v2.0.50727` assemblies rather than `clr.dll` — taking the highest `2.0.50727.<build>` across the directory, since some files there stay pinned to older builds for side-by-side compatibility (matches [Microsoft's guidance](https://learn.microsoft.com/en-us/dotnet/framework/install/how-to-determine-which-versions-are-installed)).
- Read the `NDP` registry keys over the active connection via a PowerShell probe (`registry.GetRegistryKeyItemScript`) instead of the Windows-only native registry API, and call `getDotNetFramework` from the remote `RunCommand` path too. Both runtimes now surface over SSH as well as local.

No schema (`.lr`) change — pure Go behavior, so no `.lr.versions` entries.

## Verification

Tested end-to-end against an Azure Windows Server 2022 VM with .NET Framework 3.5 + 4.8 installed side-by-side, in **both** code paths:

| Path | How | Result |
|---|---|---|
| Remote (SSH) | `mql run ssh …` | reports `4.8.4795.0` **and** `2.0.50727.9182` |
| Local | `mql.exe run local` on the VM (windows/amd64 build) | reports `4.8.4795.0` **and** `2.0.50727.9182` |

Before: a single `4.8.4795.0` entry locally, and an empty list over SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)