### PR TITLE
🎉 snowflake-13.4.0, databricks-13.1.0, vercel-13.1.0, mongodbatlas-13.1.0

### DIFF
--- a/providers/databricks/config/config.go
+++ b/providers/databricks/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "databricks",
 	ID:        "go.mondoo.com/mql/providers/databricks",
-	Version:   "13.0.0",
+	Version:   "13.1.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/mongodbatlas/config/config.go
+++ b/providers/mongodbatlas/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "mongodbatlas",
 	ID:        "go.mondoo.com/mql/providers/mongodbatlas",
-	Version:   "13.0.0",
+	Version:   "13.1.0",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.3.6",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vercel/config/config.go
+++ b/providers/vercel/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vercel",
 	ID:              "go.mondoo.com/mql/providers/vercel",
-	Version:         "13.0.0",
+	Version:         "13.1.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for four providers. Changelogs below cover everything merged since each provider's last released version.

## snowflake `13.3.6` → `13.4.0`

- ✨ add Cortex Search services and cross-region inference governance field (#9266)
- 🐛 fix 3 live-test scan crashes (function/procedure ID panic, owner/warehouse null-degrade) (#9264)
- 🧹 unit tests for external-access-integration parsing helpers (#9260)
- 🐛 fix parameter cache collision, init husks, and eager DESC (#9259)
- ✨ typed cross-resource accessors (owner, defaults, integrations, task graph) (#9252)
- 🌟 add tasks, functions, native apps, and external access integrations (#9250)
- 🐛 fix 6 resource/field bugs found in live validation (#9246)
- ✨ expose user identity-hardening fields (type, MFA, owner) (#9241)
- ✨ support programmatic access token (PAT) auth (#9238)
- ✨ discover databases as assets (account + per-database) (#9236)
- ✨ add 7 Tier-1 security & governance resources (#9227)
- 📄 enrich resource and field documentation across services (#9178)

## databricks `13.0.0` → `13.1.0`

- ✨ add model serving endpoints and Unity Catalog registered models (#9265)
- 🧹 unit tests for epoch-ms and SCIM/encryption helpers (#9262)
- ⚡ eliminate N+1 cross-reference lookups and batch workspace conf (#9258)
- 🌟 typed cross-resource references (#9254)
- 🌟 add Delta Sharing, init scripts, instance profiles, CMKs, and workspace hardening (#9251)
- 🌟 add Unity Catalog storage credentials, external locations, and volumes (#9243)

## vercel `13.0.0` → `13.1.0`

- 🧹 unit tests for flexTime, target, and store-connection helpers (#9263)
- 🐛 fix access-group cursor pagination, N+1 project fetch, per-project store re-list (#9257)
- 🌟 typed cross-resource references for webhooks, integrations, and project domains (#9253)
- ✨ DNS records, TLS certificates, project members, access-group grants (#9249)
- ✨ add storage stores (Blob and marketplace databases) (#9247)

## mongodbatlas `13.0.0` → `13.1.0`

- ✨ add Atlas Search and Vector Search index resource (#9267)
- 🧹 unit-test isAccessDenied helper (#9261)
- 🐛 degrade org-privilege endpoints and fix N+1 lookups (#9256)
- 🌟 typed cross-resource references (federation, log export, api keys, db users) (#9255)
- 🌟 add backup compliance, push-based log export, and resource policies (#9248)
- 🌟 add custom database roles and identity federation settings (#9244)
