### PR TITLE
✨ azure/stackit: snapshot immutability policy + SKE audit logging

### DIFF
--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/batch/armbatch/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v3 v3.0.0
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2 v2.4.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.3.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -80,8 +80,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v3 v3.0.0 h1:ZA
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cdn/armcdn/v3 v3.0.0/go.mod h1:AVyu4xpFf0evzrgtF7+UDfZGYuARd0+HnblCNn0gPTY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v3 v3.0.0 h1:bYrZmRrdh61p92AMzz3tdI9e6SDidq4hUPUS/dFRg/8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices/v3 v3.0.0/go.mod h1:zf/MfKPM8qICo/InKfzHaFYsBp3MzWYL7/rjnrkbySM=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.1.0 h1:NOptf7OJveKQlKX4meGgb7L6xDIK+94MD6qnlmBOW2Y=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.1.0/go.mod h1:E+lMyo/54sqYcxG3b2DJP+aUp2xP3VVDcYdyNYKdu74=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.2.0 h1:WazERlTJNPkU74ZSp8vT77bHSCh3HSn8hu2iPqaEyt4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.2.0/go.mod h1:E+lMyo/54sqYcxG3b2DJP+aUp2xP3VVDcYdyNYKdu74=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2 v2.4.0 h1:+dIXMjlifRbG3d01DF8dwckUSXADuW5dgBNt1fbkpv0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerinstance/armcontainerinstance/v2 v2.4.0/go.mod h1:FN0UJ15tJ7kV7JYrYAleEq44Ew1cUiyLcJrfrTxHGd0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerregistry/armcontainerregistry/v3 v3.0.0 h1:07oYAINVqsub90MrYYdlTSwNSwqOM4OAAg5+35OMqn0=

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -838,8 +838,9 @@ azure.subscription.computeService.diskAccess @defaults("name location") {
 // `incremental` flag (incremental vs full), encryption settings
 // (platform-managed, customer-managed via diskEncryptionSet, or
 // confidential-VM encryption), the network access policy, public
-// network access, and any active SAS export for downloading the
-// underlying VHD.
+// network access, the immutability policy protecting it from
+// modification or deletion, and any active SAS export for downloading
+// the underlying VHD.
 azure.subscription.computeService.snapshot @defaults("name location diskSizeBytes diskState incremental") {
   // Snapshot ID
   id string
@@ -891,6 +892,21 @@ azure.subscription.computeService.snapshot @defaults("name location diskSizeByte
   snapshotAccessState string
   // For snapshots of Premium SSD v2 or Ultra disks, time in minutes the snapshot is retained for instant access
   instantAccessDurationMinutes int
+  // Immutability policy type protecting the snapshot from modification or deletion
+  //
+  // One of Locked (the immutability duration cannot be reduced, only
+  // extended, and the policy cannot be removed until it expires) or
+  // Unlocked (privileged users can still modify or remove the policy).
+  // Null when no immutability policy is applied to the snapshot.
+  immutabilityPolicyType string
+  // Number of days the snapshot is protected for by the immutability policy
+  immutabilityPolicyDurationDays int
+  // Whether the immutability policy on the snapshot has expired
+  immutabilityPolicyExpired bool
+  // When the immutability policy was applied to the snapshot
+  immutabilityPolicyStartTime time
+  // When the immutability policy expires on the snapshot
+  immutabilityPolicyExpirationTime time
   // Azure Resource Manager system metadata
   //
   // Deprecated in favor of systemMetadata, which exposes createdBy,

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -3339,6 +3339,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.computeService.snapshot.instantAccessDurationMinutes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetInstantAccessDurationMinutes()).ToDataRes(types.Int)
 	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyType()).ToDataRes(types.String)
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyDurationDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyDurationDays()).ToDataRes(types.Int)
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyExpired": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyExpired()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyStartTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyStartTime()).ToDataRes(types.Time)
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyExpirationTime": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetImmutabilityPolicyExpirationTime()).ToDataRes(types.Time)
+	},
 	"azure.subscription.computeService.snapshot.systemData": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionComputeServiceSnapshot).GetSystemData()).ToDataRes(types.Dict)
 	},
@@ -19778,6 +19793,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.computeService.snapshot.instantAccessDurationMinutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionComputeServiceSnapshot).InstantAccessDurationMinutes, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyDurationDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyDurationDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyExpired": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyExpired, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyStartTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyStartTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.computeService.snapshot.immutabilityPolicyExpirationTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionComputeServiceSnapshot).ImmutabilityPolicyExpirationTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.computeService.snapshot.systemData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44793,35 +44828,40 @@ type mqlAzureSubscriptionComputeServiceSnapshot struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionComputeServiceSnapshotInternal
-	Id                           plugin.TValue[string]
-	Name                         plugin.TValue[string]
-	Location                     plugin.TValue[string]
-	Tags                         plugin.TValue[map[string]any]
-	Type                         plugin.TValue[string]
-	Sku                          plugin.TValue[any]
-	Properties                   plugin.TValue[any]
-	CreationData                 plugin.TValue[any]
-	ProvisioningState            plugin.TValue[string]
-	TimeCreated                  plugin.TValue[*time.Time]
-	UniqueId                     plugin.TValue[string]
-	DiskSizeBytes                plugin.TValue[int64]
-	HyperVGeneration             plugin.TValue[string]
-	OsType                       plugin.TValue[string]
-	DiskState                    plugin.TValue[string]
-	Incremental                  plugin.TValue[bool]
-	IncrementalSnapshotFamilyId  plugin.TValue[string]
-	SupportsHibernation          plugin.TValue[bool]
-	NetworkAccessPolicy          plugin.TValue[string]
-	PublicNetworkAccess          plugin.TValue[string]
-	EncryptionType               plugin.TValue[string]
-	DataAccessAuthMode           plugin.TValue[string]
-	DiskAccessId                 plugin.TValue[string]
-	SnapshotAccessState          plugin.TValue[string]
-	InstantAccessDurationMinutes plugin.TValue[int64]
-	SystemData                   plugin.TValue[any]
-	SystemMetadata               plugin.TValue[*mqlAzureSubscriptionSystemData]
-	SourceDisk                   plugin.TValue[*mqlAzureSubscriptionComputeServiceDisk]
-	DiskEncryptionSet            plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
+	Id                               plugin.TValue[string]
+	Name                             plugin.TValue[string]
+	Location                         plugin.TValue[string]
+	Tags                             plugin.TValue[map[string]any]
+	Type                             plugin.TValue[string]
+	Sku                              plugin.TValue[any]
+	Properties                       plugin.TValue[any]
+	CreationData                     plugin.TValue[any]
+	ProvisioningState                plugin.TValue[string]
+	TimeCreated                      plugin.TValue[*time.Time]
+	UniqueId                         plugin.TValue[string]
+	DiskSizeBytes                    plugin.TValue[int64]
+	HyperVGeneration                 plugin.TValue[string]
+	OsType                           plugin.TValue[string]
+	DiskState                        plugin.TValue[string]
+	Incremental                      plugin.TValue[bool]
+	IncrementalSnapshotFamilyId      plugin.TValue[string]
+	SupportsHibernation              plugin.TValue[bool]
+	NetworkAccessPolicy              plugin.TValue[string]
+	PublicNetworkAccess              plugin.TValue[string]
+	EncryptionType                   plugin.TValue[string]
+	DataAccessAuthMode               plugin.TValue[string]
+	DiskAccessId                     plugin.TValue[string]
+	SnapshotAccessState              plugin.TValue[string]
+	InstantAccessDurationMinutes     plugin.TValue[int64]
+	ImmutabilityPolicyType           plugin.TValue[string]
+	ImmutabilityPolicyDurationDays   plugin.TValue[int64]
+	ImmutabilityPolicyExpired        plugin.TValue[bool]
+	ImmutabilityPolicyStartTime      plugin.TValue[*time.Time]
+	ImmutabilityPolicyExpirationTime plugin.TValue[*time.Time]
+	SystemData                       plugin.TValue[any]
+	SystemMetadata                   plugin.TValue[*mqlAzureSubscriptionSystemData]
+	SourceDisk                       plugin.TValue[*mqlAzureSubscriptionComputeServiceDisk]
+	DiskEncryptionSet                plugin.TValue[*mqlAzureSubscriptionComputeServiceDiskEncryptionSet]
 }
 
 // createAzureSubscriptionComputeServiceSnapshot creates a new instance of this resource
@@ -44959,6 +44999,26 @@ func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetSnapshotAccessState() *p
 
 func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetInstantAccessDurationMinutes() *plugin.TValue[int64] {
 	return &c.InstantAccessDurationMinutes
+}
+
+func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyType() *plugin.TValue[string] {
+	return &c.ImmutabilityPolicyType
+}
+
+func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyDurationDays() *plugin.TValue[int64] {
+	return &c.ImmutabilityPolicyDurationDays
+}
+
+func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyExpired() *plugin.TValue[bool] {
+	return &c.ImmutabilityPolicyExpired
+}
+
+func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyStartTime() *plugin.TValue[*time.Time] {
+	return &c.ImmutabilityPolicyStartTime
+}
+
+func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetImmutabilityPolicyExpirationTime() *plugin.TValue[*time.Time] {
+	return &c.ImmutabilityPolicyExpirationTime
 }
 
 func (c *mqlAzureSubscriptionComputeServiceSnapshot) GetSystemData() *plugin.TValue[any] {

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -1232,6 +1232,11 @@ azure.subscription.computeService.snapshot.diskState 13.7.1
 azure.subscription.computeService.snapshot.encryptionType 13.7.1
 azure.subscription.computeService.snapshot.hyperVGeneration 13.7.1
 azure.subscription.computeService.snapshot.id 13.7.1
+azure.subscription.computeService.snapshot.immutabilityPolicyDurationDays 13.31.1
+azure.subscription.computeService.snapshot.immutabilityPolicyExpirationTime 13.31.1
+azure.subscription.computeService.snapshot.immutabilityPolicyExpired 13.31.1
+azure.subscription.computeService.snapshot.immutabilityPolicyStartTime 13.31.1
+azure.subscription.computeService.snapshot.immutabilityPolicyType 13.31.1
 azure.subscription.computeService.snapshot.incremental 13.7.1
 azure.subscription.computeService.snapshot.incrementalSnapshotFamilyId 13.7.1
 azure.subscription.computeService.snapshot.instantAccessDurationMinutes 13.8.2

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -1511,13 +1511,27 @@ func snapshotToMql(runtime *plugin.Runtime, snap compute.Snapshot) (*mqlAzureSub
 			args["instantAccessDurationMinutes"] = llx.IntDataPtr(props.CreationData.InstantAccessDurationMinutes)
 		}
 
+		// Always set the immutability policy fields so they resolve to null
+		// (not their Go zero value) when no policy is applied. Leaving them
+		// absent from args would make immutabilityPolicyExpired default to
+		// false, wrongly passing audits like `!immutabilityPolicyExpired`
+		// for snapshots that have no immutability protection at all.
+		var ipType *compute.ImmutabilityPolicyType
+		var ipDurationDays *int32
+		var ipExpired *bool
+		var ipStartTime, ipExpirationTime *time.Time
 		if ip := props.ImmutabilityPolicy; ip != nil {
-			args["immutabilityPolicyType"] = llx.StringDataPtr(stringEnumPtr(ip.Type))
-			args["immutabilityPolicyDurationDays"] = llx.IntDataPtr(ip.ImmutabilityDurationDays)
-			args["immutabilityPolicyExpired"] = llx.BoolDataPtr(ip.IsPolicyExpired)
-			args["immutabilityPolicyStartTime"] = llx.TimeDataPtr(ip.PolicyStartTime)
-			args["immutabilityPolicyExpirationTime"] = llx.TimeDataPtr(ip.PolicyExpirationTime)
+			ipType = ip.Type
+			ipDurationDays = ip.ImmutabilityDurationDays
+			ipExpired = ip.IsPolicyExpired
+			ipStartTime = ip.PolicyStartTime
+			ipExpirationTime = ip.PolicyExpirationTime
 		}
+		args["immutabilityPolicyType"] = llx.StringDataPtr(stringEnumPtr(ipType))
+		args["immutabilityPolicyDurationDays"] = llx.IntDataPtr(ipDurationDays)
+		args["immutabilityPolicyExpired"] = llx.BoolDataPtr(ipExpired)
+		args["immutabilityPolicyStartTime"] = llx.TimeDataPtr(ipStartTime)
+		args["immutabilityPolicyExpirationTime"] = llx.TimeDataPtr(ipExpirationTime)
 	}
 
 	res, err := CreateResource(runtime, "azure.subscription.computeService.snapshot", args)

--- a/providers/azure/resources/compute.go
+++ b/providers/azure/resources/compute.go
@@ -1510,6 +1510,14 @@ func snapshotToMql(runtime *plugin.Runtime, snap compute.Snapshot) (*mqlAzureSub
 			cacheSourceDiskId = props.CreationData.SourceResourceID
 			args["instantAccessDurationMinutes"] = llx.IntDataPtr(props.CreationData.InstantAccessDurationMinutes)
 		}
+
+		if ip := props.ImmutabilityPolicy; ip != nil {
+			args["immutabilityPolicyType"] = llx.StringDataPtr(stringEnumPtr(ip.Type))
+			args["immutabilityPolicyDurationDays"] = llx.IntDataPtr(ip.ImmutabilityDurationDays)
+			args["immutabilityPolicyExpired"] = llx.BoolDataPtr(ip.IsPolicyExpired)
+			args["immutabilityPolicyStartTime"] = llx.TimeDataPtr(ip.PolicyStartTime)
+			args["immutabilityPolicyExpirationTime"] = llx.TimeDataPtr(ip.PolicyExpirationTime)
+		}
 	}
 
 	res, err := CreateResource(runtime, "azure.subscription.computeService.snapshot", args)

--- a/providers/stackit/resources/ske.go
+++ b/providers/stackit/resources/ske.go
@@ -113,6 +113,11 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 		}
 	}
 
+	var auditEnabled bool
+	if audit, ok := cluster.GetAuditOk(); ok {
+		auditEnabled = audit.GetEnabled()
+	}
+
 	var idpEnabled bool
 	var idpType string
 	if access, ok := cluster.GetAccessOk(); ok {
@@ -145,6 +150,7 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 		"egressAddressRanges":              strSliceData(egressRanges),
 		"podAddressRanges":                 strSliceData(podRanges),
 		"serviceAccountIssuer":             llx.StringData(saIssuer),
+		"auditEnabled":                     llx.BoolData(auditEnabled),
 		"idpEnabled":                       llx.BoolData(idpEnabled),
 		"idpType":                          llx.StringData(idpType),
 		"observabilityEnabled":             llx.BoolData(obsEnabled),

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -875,8 +875,8 @@ stackit.ske {
 // the project and region). Exposes the `status` (aggregated lifecycle),
 // the Kubernetes version, the node pools (with their flavor, OS, taints,
 // autoscaling, labels), the hibernation and maintenance windows, network
-// and DNS overrides, extensions (ACL, observability), and the creation
-// and update timestamps.
+// and DNS overrides, extensions (ACL, observability), whether API server
+// audit logging is enabled, and the creation and update timestamps.
 private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   init(name? string)
   // Cluster name
@@ -924,6 +924,8 @@ private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   podAddressRanges []string
   // OIDC service-account token issuer URL
   serviceAccountIssuer string
+  // Whether Kubernetes API server audit logging is enabled for the cluster
+  auditEnabled bool
   // Whether an identity provider is enabled for cluster access
   idpEnabled bool
   // Identity-provider type configured for cluster access

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -1390,6 +1390,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.ske.cluster.serviceAccountIssuer": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSkeCluster).GetServiceAccountIssuer()).ToDataRes(types.String)
 	},
+	"stackit.ske.cluster.auditEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSkeCluster).GetAuditEnabled()).ToDataRes(types.Bool)
+	},
 	"stackit.ske.cluster.idpEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSkeCluster).GetIdpEnabled()).ToDataRes(types.Bool)
 	},
@@ -3964,6 +3967,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.ske.cluster.serviceAccountIssuer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSkeCluster).ServiceAccountIssuer, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.ske.cluster.auditEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSkeCluster).AuditEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"stackit.ske.cluster.idpEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9244,6 +9251,7 @@ type mqlStackitSkeCluster struct {
 	EgressAddressRanges              plugin.TValue[[]any]
 	PodAddressRanges                 plugin.TValue[[]any]
 	ServiceAccountIssuer             plugin.TValue[string]
+	AuditEnabled                     plugin.TValue[bool]
 	IdpEnabled                       plugin.TValue[bool]
 	IdpType                          plugin.TValue[string]
 	ObservabilityEnabled             plugin.TValue[bool]
@@ -9373,6 +9381,10 @@ func (c *mqlStackitSkeCluster) GetPodAddressRanges() *plugin.TValue[[]any] {
 
 func (c *mqlStackitSkeCluster) GetServiceAccountIssuer() *plugin.TValue[string] {
 	return &c.ServiceAccountIssuer
+}
+
+func (c *mqlStackitSkeCluster) GetAuditEnabled() *plugin.TValue[bool] {
+	return &c.AuditEnabled
 }
 
 func (c *mqlStackitSkeCluster) GetIdpEnabled() *plugin.TValue[bool] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -623,6 +623,7 @@ stackit.ske 13.0.0
 stackit.ske.cluster 13.0.0
 stackit.ske.cluster.apiServerAclAllowedCidrs 13.1.1
 stackit.ske.cluster.apiServerAclEnabled 13.1.1
+stackit.ske.cluster.auditEnabled 13.4.2
 stackit.ske.cluster.creationTime 13.0.0
 stackit.ske.cluster.credentialsRotationLastCompleted 13.1.1
 stackit.ske.cluster.credentialsRotationLastInitiated 13.1.1


### PR DESCRIPTION
## What

Surfaces two read-only fields that became reachable after recent provider SDK bumps (the API surface these fields describe is returned by calls we already make, so no new IAM permissions).

### azure — snapshot immutability policy
`armcompute` v8.1.0 → v8.2.0 added the immutability policy to `SnapshotProperties`. Immutable snapshots are a ransomware / tamper protection control, so `azure.subscription.computeService.snapshot` now exposes:

- `immutabilityPolicyType` — `Locked` or `Unlocked` (null when no policy is applied)
- `immutabilityPolicyDurationDays`
- `immutabilityPolicyExpired`
- `immutabilityPolicyStartTime`
- `immutabilityPolicyExpirationTime`

These are all read-only flat scalars with no ID or typed refs, so they're flattened onto the snapshot resource rather than modeled as a sub-resource.

```mql
azure.subscription.computeService.snapshots.where( immutabilityPolicyType == "Locked" )
```

### stackit — SKE audit logging
The `Audit` config model on the SKE `Cluster` (vendored since `ske` v1.19) exposes whether Kubernetes API server audit logging is on. `stackit.ske.cluster` now exposes:

- `auditEnabled`

```mql
stackit.ske.clusters.all( auditEnabled == true )
```

## Notes

- Only `providers/azure/go.mod` is bumped (`armcompute/v8` → v8.2.0); the matching line is also in the open weekly dep PR #9270. stackit needs no bump — `ske` v1.19 already carries the `Audit` model.
- `*.permissions.json` is unchanged for both providers.
- `.lr.versions`: azure fields at `13.31.1`, stackit field at `13.4.2` (auto-assigned next-patch).

## Testing

Codegen + build verified for both providers (`make providers/build/azure`, `make providers/build/stackit`). Live verification against a snapshot with an immutability policy and an SKE cluster with audit logging still pending (will batch via the provider-verification flow).
