### PR TITLE
🎉 os-13.35.4

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.35.3",
+	Version: "13.35.4",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.35.4)
- 🐛 os: report .NET Framework 3.5 (CLR 2.0) runtime build, and detect .NET over SSH (#9271)
- 📄 os: enrich resource and field documentation across services (#9217)
- ⚡ os: cache ps output in UnixProcessManager to avoid per-lookup re-runs (#9125)
- ⚡ os: skip redundant /proc stat for pids already enumerated (#9124)
- 🐛 os: fix lsof IPv6 established-connection host/port parsing (#9122)
- 🐛 os: fix sshd relative Include glob dropping first path segment (#9117)
- 🐎 os: fix windows.rdp load() data race reporting insecure config as secure (#9119)
- 🐛 os: fix binary version scanner dropping/truncating versions on short reads (#9126)
- 🐛 os: fix rsyslog != severity selectors and mid-path include globs (#9127)
- 🐛 os: skip malformed PAM lines instead of aborting the whole parse (#9128)