### PR TITLE
🎉 Patch-bump 48 providers, minor-bump digitalocean

### DIFF
--- a/providers/activedirectory/config/config.go
+++ b/providers/activedirectory/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "activedirectory",
 	ID:              "go.mondoo.com/mql/v13/providers/activedirectory",
-	Version:         "13.1.6",
+	Version:         "13.1.7",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{{

--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.7",
+	Version:         "13.2.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/arista/config/config.go
+++ b/providers/arista/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "arista",
 	ID:              "go.mondoo.com/cnquery/v9/providers/arista",
-	Version:         "13.3.9",
+	Version:         "13.3.10",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.4.0",
+	Version:   "13.4.1",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.3",
+	Version:         "13.4.4",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "claude",
 	ID:              "go.mondoo.com/mql/providers/claude",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudflare",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudflare",
-	Version:         "13.6.2",
+	Version:         "13.6.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/cloudformation/config/config.go
+++ b/providers/cloudformation/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "cloudformation",
 	ID:              "go.mondoo.com/mql/v13/providers/cloudformation",
-	Version:         "13.2.2",
+	Version:         "13.2.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/datadog/config/config.go
+++ b/providers/datadog/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "datadog",
 	ID:              "go.mondoo.com/mql/providers/datadog",
-	Version:         "13.0.15",
+	Version:         "13.0.16",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/depsdev/config/config.go
+++ b/providers/depsdev/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "depsdev",
 	ID:              "go.mondoo.com/mql/v13/providers/depsdev",
-	Version:         "13.1.2",
+	Version:         "13.1.3",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/digitalocean/config/config.go
+++ b/providers/digitalocean/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "digitalocean",
 	ID:              "go.mondoo.com/mql/providers/digitalocean",
-	Version:         "13.13.1",
+	Version:         "13.14.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/equinix/config/config.go
+++ b/providers/equinix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "equinix",
 	ID:              "go.mondoo.com/cnquery/v9/providers/equinix",
-	Version:         "13.0.22",
+	Version:         "13.0.23",
 	Maturity:        resources.MaturityDeprecated,
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "github",
 	ID:              "go.mondoo.com/cnquery/v9/providers/github",
-	Version:         "13.7.1",
+	Version:         "13.7.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/gitlab/config/config.go
+++ b/providers/gitlab/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gitlab",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gitlab",
-	Version: "13.5.1",
+	Version: "13.5.2",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		provider.GitlabGroupConnection,

--- a/providers/google-workspace/config/config.go
+++ b/providers/google-workspace/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "google-workspace",
 	ID:              "go.mondoo.com/cnquery/v9/providers/google-workspace",
-	Version:         "13.2.5",
+	Version:         "13.2.6",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/grafana/config/config.go
+++ b/providers/grafana/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "grafana",
 	ID:              "go.mondoo.com/mql/v13/providers/grafana",
-	Version:         "13.1.14",
+	Version:         "13.1.15",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/helm/config/config.go
+++ b/providers/helm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "helm",
 	ID:              "go.mondoo.com/mql/v13/providers/helm",
-	Version:         "13.3.5",
+	Version:         "13.3.6",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/hetzner/config/config.go
+++ b/providers/hetzner/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "hetzner",
 	ID:              "go.mondoo.com/mql/providers/hetzner",
-	Version:         "13.7.0",
+	Version:         "13.7.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "huggingface",
 	ID:              "go.mondoo.com/mql/providers/huggingface",
-	Version:         "13.1.8",
+	Version:         "13.1.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipinfo",
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
-	Version:         "13.0.21",
+	Version:         "13.0.22",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ipmi/config/config.go
+++ b/providers/ipmi/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipmi",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ipmi",
-	Version:         "13.0.21",
+	Version:         "13.0.22",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/jamf/config/config.go
+++ b/providers/jamf/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "jamf",
 	ID:              "go.mondoo.com/mql/v13/providers/jamf",
-	Version:         "13.1.8",
+	Version:         "13.1.9",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/k8s/config/config.go
+++ b/providers/k8s/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "k8s",
 	ID:              "go.mondoo.com/cnquery/v9/providers/k8s",
-	Version:         "13.8.0",
+	Version:         "13.8.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/kustomize/config/config.go
+++ b/providers/kustomize/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "kustomize",
 	ID:              "go.mondoo.com/mql/v13/providers/kustomize",
-	Version:         "13.1.7",
+	Version:         "13.1.8",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,

--- a/providers/mikrotik/config/config.go
+++ b/providers/mikrotik/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mikrotik",
 	ID:              "go.mondoo.com/mql/providers/mikrotik",
-	Version:         "13.0.4",
+	Version:         "13.0.5",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mistral/config/config.go
+++ b/providers/mistral/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mistral",
 	ID:              "go.mondoo.com/mql/providers/mistral",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/mondoo/config/config.go
+++ b/providers/mondoo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "mondoo",
 	ID:              "go.mondoo.com/mql/v13/providers/mondoo",
-	Version:         "13.1.11",
+	Version:         "13.1.12",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.8.4",
+	Version:         "13.8.5",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/network/config/config.go
+++ b/providers/network/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "network",
 	ID:              "go.mondoo.com/cnquery/v9/providers/network",
-	Version:         "13.2.4",
+	Version:         "13.2.5",
 	ConnectionTypes: []string{provider.HostConnectionType},
 	Platforms:       provider.Platforms,
 	CrossProviderTypes: []string{

--- a/providers/nextdns/config/config.go
+++ b/providers/nextdns/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nextdns",
 	ID:              "go.mondoo.com/mql/providers/nextdns",
-	Version:         "13.0.6",
+	Version:         "13.0.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nmap",
 	ID:              "go.mondoo.com/mql/v13/providers/nmap",
-	Version:         "13.0.20",
+	Version:         "13.0.21",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/nutanix/config/config.go
+++ b/providers/nutanix/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "nutanix",
 	ID:              "go.mondoo.com/mql/v13/providers/nutanix",
-	Version:         "13.2.3",
+	Version:         "13.2.4",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/oci/config/config.go
+++ b/providers/oci/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "oci",
 	ID:              "go.mondoo.com/cnquery/v9/providers/oci",
-	Version:         "13.16.0",
+	Version:         "13.16.1",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       resources.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ollama",
 	ID:              "go.mondoo.com/mql/providers/ollama",
-	Version:         "13.0.8",
+	Version:         "13.0.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openai",
 	ID:              "go.mondoo.com/mql/providers/openai",
-	Version:         "13.0.7",
+	Version:         "13.0.8",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "openstack",
 	ID:              "go.mondoo.com/mql/providers/openstack",
-	Version:         "13.7.1",
+	Version:         "13.7.2",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "portainer",
 	ID:              "go.mondoo.com/mql/providers/portainer",
-	Version:         "13.1.2",
+	Version:         "13.1.3",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/proxmox/config/config.go
+++ b/providers/proxmox/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "proxmox",
 	ID:              "go.mondoo.com/mql/v13/providers/proxmox",
-	Version:         "0.3.1",
+	Version:         "0.3.2",
 	Platforms:       connection.Platforms,
 	ConnectionTypes: []string{"proxmox"},
 	Connectors: []plugin.Connector{

--- a/providers/redfish/config/config.go
+++ b/providers/redfish/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "redfish",
 	ID:              "go.mondoo.com/mql/providers/redfish",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "shodan",
 	ID:              "go.mondoo.com/mql/v13/providers/shodan",
-	Version:         "13.2.5",
+	Version:         "13.2.6",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/slack/config/config.go
+++ b/providers/slack/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "slack",
 	ID:              "go.mondoo.com/cnquery/v9/providers/slack",
-	Version:         "13.1.15",
+	Version:         "13.1.16",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/snowflake/config/config.go
+++ b/providers/snowflake/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "snowflake",
 	ID:              "go.mondoo.com/mql/v13/providers/snowflake",
-	Version:         "13.4.0",
+	Version:         "13.4.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/tailscale/config/config.go
+++ b/providers/tailscale/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "tailscale",
 	ID:              "go.mondoo.com/mql/v13/providers/tailscale",
-	Version:         "13.3.6",
+	Version:         "13.3.7",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/terraform/config/config.go
+++ b/providers/terraform/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "terraform",
 	ID:        "go.mondoo.com/cnquery/v9/providers/terraform",
-	Version:   "13.3.5",
+	Version:   "13.3.6",
 	Platforms: provider.Platforms,
 	ConnectionTypes: []string{
 		provider.StateConnectionType,

--- a/providers/together/config/config.go
+++ b/providers/together/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "together",
 	ID:              "go.mondoo.com/mql/providers/together",
-	Version:         "13.0.7",
+	Version:         "13.0.8",
 	Platforms:       provider.Platforms,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{

--- a/providers/vcd/config/config.go
+++ b/providers/vcd/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vcd",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vcd",
-	Version:         "13.0.20",
+	Version:         "13.0.21",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vercel/config/config.go
+++ b/providers/vercel/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vercel",
 	ID:              "go.mondoo.com/mql/providers/vercel",
-	Version:         "13.1.0",
+	Version:         "13.1.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vllm/config/config.go
+++ b/providers/vllm/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vllm",
 	ID:              "go.mondoo.com/mql/providers/vllm",
-	Version:         "13.0.14",
+	Version:         "13.0.15",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/vsphere/config/config.go
+++ b/providers/vsphere/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "vsphere",
 	ID:              "go.mondoo.com/cnquery/v9/providers/vsphere",
-	Version:         "13.7.1",
+	Version:         "13.7.2",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Routine provider version bumps to release accumulated changes since each provider's last release.

### Minor bump
- `digitalocean` 13.13.1 → 13.14.0

### Patch bumps (48 providers)
`activedirectory`, `ansible`, `arista`, `atlassian`, `bicep`, `claude`, `cloudflare`, `cloudformation`, `datadog`, `depsdev`, `equinix`, `github`, `gitlab`, `google-workspace`, `grafana`, `helm`, `hetzner`, `huggingface`, `ipinfo`, `ipmi`, `jamf`, `k8s`, `kustomize`, `mikrotik`, `mistral`, `mondoo`, `ms365`, `network`, `nextdns`, `nmap`, `nutanix`, `oci`, `ollama`, `openai`, `openstack`, `portainer`, `proxmox`, `redfish`, `shodan`, `slack`, `snowflake`, `tailscale`, `terraform`, `together`, `vcd`, `vercel`, `vllm`, `vsphere`

Each change is a single-line `Version` bump in the provider's `config/config.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
