### PR TITLE
🐛 aws: degrade personalize region-scan and bedrock resource policy gracefully

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -107,6 +107,18 @@ func isResourceNotFoundError(err error) bool {
 	return false
 }
 
+// isOperationNotSupportedError reports whether err is an AWS ValidationException
+// meaning the operation is not valid for the target resource - e.g. Bedrock
+// GetResourcePolicy on a system-defined inference profile returns "The requested
+// operation is not recognized by the service". Such a resource has no
+// resource-based policy to report, so callers degrade to an empty policy.
+func isOperationNotSupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "not recognized by the service")
+}
+
 // isBadRequestError checks if the error is a 400 Bad Request error
 // This is used to handle cases where a feature is not enabled for an AWS account
 func isBadRequestError(err error) bool {

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -113,10 +113,12 @@ func isResourceNotFoundError(err error) bool {
 // operation is not recognized by the service". Such a resource has no
 // resource-based policy to report, so callers degrade to an empty policy.
 func isOperationNotSupportedError(err error) bool {
-	if err == nil {
-		return false
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		return ae.ErrorCode() == "ValidationException" &&
+			strings.Contains(ae.ErrorMessage(), "not recognized by the service")
 	}
-	return strings.Contains(err.Error(), "not recognized by the service")
+	return false
 }
 
 // isBadRequestError checks if the error is a 400 Bad Request error

--- a/providers/aws/resources/aws_bedrock.go
+++ b/providers/aws/resources/aws_bedrock.go
@@ -1845,7 +1845,12 @@ func bedrockResourcePolicyJSON(runtime *plugin.Runtime, region, arn string) (str
 	svc := conn.Bedrock(region)
 	resp, err := svc.GetResourcePolicy(context.Background(), &bedrock.GetResourcePolicyInput{ResourceArn: &arn})
 	if err != nil {
-		if Is400AccessDeniedError(err) {
+		// A resource with no attached policy, or a resource type that does not
+		// support resource-based policies at all (system-defined inference
+		// profiles return ValidationException "operation is not recognized"),
+		// simply has no policy to report - degrade to empty rather than failing
+		// the whole collection.
+		if Is400AccessDeniedError(err) || isResourceNotFoundError(err) || isOperationNotSupportedError(err) {
 			return "", nil
 		}
 		return "", err

--- a/providers/aws/resources/aws_personalize.go
+++ b/providers/aws/resources/aws_personalize.go
@@ -74,6 +74,10 @@ func (a *mqlAwsPersonalize) getDatasetGroups(conn *connection.AwsConnection) []*
 						log.Warn().Str("region", region).Msg("error accessing region for AWS Personalize API")
 						return res, nil
 					}
+					if IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("Personalize is not available in region")
+						return res, nil
+					}
 					return nil, err
 				}
 				for _, dg := range page.DatasetGroups {
@@ -491,6 +495,10 @@ func (a *mqlAwsPersonalize) getSchemas(conn *connection.AwsConnection) []*jobpoo
 				if err != nil {
 					if Is400AccessDeniedError(err) {
 						log.Warn().Str("region", region).Msg("error accessing region for AWS Personalize API")
+						return res, nil
+					}
+					if IsServiceNotAvailableInRegionError(err) {
+						log.Debug().Str("region", region).Msg("Personalize is not available in region")
 						return res, nil
 					}
 					return nil, err


### PR DESCRIPTION
## What

Two AWS accessors surfaced **hard errors for conditions that are normal in real accounts**. Both were found and fixed during live provider verification of the recent AWS provider changes, and re-verified against provisioned infrastructure.

### 1. Personalize region scan fails on unsupported regions

`aws.personalize.datasetGroups()` and `schemas()` iterate every enabled region. Amazon Personalize is only available in a subset of regions, so for any account with an unsupported region enabled (e.g. `eu-north-1`, `us-west-1`, `sa-east-1`), the SDK call fails with a DNS `no such host` error. The paginator only tolerated `Is400AccessDeniedError`, so that error propagated through the jobpool and **failed the entire accessor** — the query returned `no data available` and silently dropped the real dataset groups from supported regions.

Fix: skip service-unavailable regions using the existing `IsServiceNotAvailableInRegionError` helper (the same pattern `aws_batch.go` and `aws_bedrock_enrichment.go` already use).

### 2. Bedrock `resourcePolicy()` fails on system inference profiles

`aws.bedrock.inferenceProfile.resourcePolicy()` calls `GetResourcePolicy`, but system-defined inference profiles (every account has ~59) do not support resource-based policies — Bedrock returns `ValidationException: The requested operation is not recognized by the service`. `bedrockResourcePolicyJSON` only degraded on access-denied, so the accessor **hard-failed with dozens of errors** for a normal account.

Fix: degrade to an empty policy on that ValidationException and on a not-found (resource with no policy attached), via a new `isOperationNotSupportedError` helper. Applies to all four shareable resources (`customModel`, `importedModel`, `evaluationJob`, `inferenceProfile`).

## Verification (live)

Provisioned real infra (SageMaker domain/model, Personalize dataset group + dataset + event tracker, Bedrock) in `us-west-2` and re-ran the failing queries after the fix:

- `aws.personalize.datasetGroups` (no region filter) → returns the `us-west-2` dataset group `ACTIVE` with its dataset + event tracker (was `no data available`).
- `aws.bedrock.inferenceProfiles { resourcePolicy isPublic }` → returns all 59 profiles with `resourcePolicy: ""`, `isPublic: false` (was 59 `ValidationException` errors).

## Notes

- No `.lr` schema change; no new API calls, so `aws.permissions.json` is unchanged.
- No `.lr.versions` change.
