### PR TITLE
🎉 aws-13.49.0, azure-13.32.0, gcp-13.32.0, ms365-13.9.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.48.1",
+	Version:         "13.49.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.31.0",
+	Version:   "13.32.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.31.2",
+	Version: "13.32.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.8.5",
+	Version:         "13.9.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
Minor version bump for four providers.

| Provider | From | To |
|---|---|---|
| aws | 13.48.1 | **13.49.0** |
| azure | 13.31.0 | **13.32.0** |
| gcp | 13.31.2 | **13.32.0** |
| ms365 | 13.8.4 | **13.9.0** |

## What's changed

### aws (13.49.0)
- ✨ Expose resource-based policies on Bedrock + SageMaker shareable AI resources (#9166)
- ✨ Deepen SageMaker domain/model/endpointConfig posture surface (#9154)
- ✨ Discover SageMaker domains and models as assets (#9145)
- ✨ Add Amazon Personalize resources (#9137)
- 🐛 Fix three Tier-1 crashers/data corruption in resources (#9131)
- 🐛 Fix init husks, S3 wrong-region calls, and loggroup kmsKey null-state (#9132)
- 📄 Enrich resource and field documentation across services (#9151)
- 📄 Enrich S3 resource and field documentation (#9146)
- 🧹 Dependency updates (#9232, #9242)

### azure (13.32.0)
- ✨ Propagate Azure subscription tags to discovered assets (#9106)
- ✨ Snapshot immutability policy + SKE audit logging (azure/stackit) (#9274)
- ✨ Add roleAssignments() to AI Services account for Entra RBAC access posture (#9163)
- ✨ Deepen AI Services (Cognitive Services) account posture surface (#9155)
- ✨ Discover Cognitive Services (AI Services) accounts as assets (#9144)
- ✨ Adopt Cosmos DB v4 RBAC resources + bump provider deps (#9135)
- 🐛 Fix policyAssignments pagination, mysql ssl error-handling, nil-derefs, elasticPoolName (#9134)
- 🐛 Fix nil-pointer crashers in iam, advisor, and keyvault (#9133)
- 📄 Enrich resource and field documentation across services (#9153)
- 🧹 Align discovery filters (#9098) + dependency updates (#9232, #9242, #9270)

### gcp (13.32.0)
- ✨ Add iamPolicy() + public() to Vertex AI model and notebook runtime template (#9162)
- ✨ Deepen Vertex AI endpoint/pipelineJob/notebook posture surface (#9157)
- ✨ Discover Vertex AI endpoints, pipeline jobs, and notebook runtime templates (#9148)
- ✨ Add Document AI resources (#9140)
- 🐛 Fix monitoring/dataproc/pubsub/functions correctness bugs (#9130)
- 🐛 Fix scan-crash panic, subnetwork husk, and DNS zone lookup (#9129)
- 🐛 Fix doubled sqlService and vertexaiService descriptions (#9224)
- 📄 Enrich resource and field documentation across services (#9158)
- 🧹 Dependency updates (#9232, #9242)

### ms365 (13.9.0)
- 🐛 Decode Exchange domain lists that serialize as objects (#9269)
- 🐛 Recover from nil-element panic in Graph page iterator (#9035)
- 📄 Enrich resource and field documentation across services (#9167)
- 🧹 Dependency updates (ranger-rpc v0.8.1 #9061, #9060, #9232, #9242)
