### PR TITLE
🐛 okta: fix policy-rule/policy pagination and custom-role permissions

### DIFF
--- a/providers/okta/resources/customRoles.go
+++ b/providers/okta/resources/customRoles.go
@@ -9,10 +9,8 @@ import (
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
-	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
 	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
-	"go.mondoo.com/mql/v13/types"
 )
 
 func (o *mqlOkta) customRoles() ([]any, error) {
@@ -76,22 +74,9 @@ func initOktaCustomRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return nil, nil, err
 	}
 
-	// Permissions are a separate sub-resource on custom roles.
-	permissions := []any{}
-	perms, _, err := client.RoleAPI.ListRolePermissions(ctx, id).Execute()
-	if err != nil {
-		return nil, nil, err
-	}
-	if perms != nil {
-		for i := range perms.Permissions {
-			permissions = append(permissions, oktaStr(perms.Permissions[i].Label))
-		}
-	}
-
 	args["id"] = llx.StringData(oktaStr(role.Id))
 	args["label"] = llx.StringData(role.Label)
 	args["description"] = llx.StringData(role.Description)
-	args["permissions"] = llx.ArrayData(permissions, types.String)
 	return args, nil, nil
 }
 
@@ -100,8 +85,35 @@ func newMqlOktaCustomRole(runtime *plugin.Runtime, entry *sdk.CustomRole) (any, 
 		"id":          llx.StringData(entry.Id),
 		"label":       llx.StringData(entry.Label),
 		"description": llx.StringData(entry.Description),
-		"permissions": llx.ArrayData(convert.SliceAnyToInterface(entry.Permissions), types.String),
 	})
+}
+
+// permissions lists the fine-grained Okta permission identifiers this custom
+// role confers. Permissions are a sub-resource (GET /api/v1/iam/roles/{id}/
+// permissions), not embedded in the role listing, so we resolve them per role
+// on demand. This keeps the collection path (okta.customRoles) and the
+// single-role path (okta.customRole) returning the same permission set.
+func (o *mqlOktaCustomRole) permissions() ([]any, error) {
+	if o.Id.Error != nil {
+		return nil, o.Id.Error
+	}
+
+	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
+	client := conn.Client()
+	ctx := context.Background()
+
+	perms, _, err := client.RoleAPI.ListRolePermissions(ctx, o.Id.Data).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	permissions := []any{}
+	if perms != nil {
+		for i := range perms.Permissions {
+			permissions = append(permissions, oktaStr(perms.Permissions[i].Label))
+		}
+	}
+	return permissions, nil
 }
 
 func (o *mqlOktaRole) id() (string, error) {

--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -923,8 +923,9 @@ private okta.customRole @defaults("label") {
   //
   // List of Okta permission identifiers this role confers, for example
   // `okta.users.read`, `okta.users.manage`, `okta.apps.manage`, or
-  // `okta.groups.manage`.
-  permissions []string
+  // `okta.groups.manage`. Permissions are a sub-resource of the role, fetched
+  // per role rather than returned with the role listing.
+  permissions() []string
 }
 
 // Okta Resource Set

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -6396,7 +6396,9 @@ func (c *mqlOktaCustomRole) GetDescription() *plugin.TValue[string] {
 }
 
 func (c *mqlOktaCustomRole) GetPermissions() *plugin.TValue[[]any] {
-	return &c.Permissions
+	return plugin.GetOrCompute[[]any](&c.Permissions, func() ([]any, error) {
+		return c.permissions()
+	})
 }
 
 // mqlOktaResourceSet for the okta.resourceSet resource

--- a/providers/okta/resources/policies.go
+++ b/providers/okta/resources/policies.go
@@ -6,11 +6,7 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -260,30 +256,19 @@ func (o *mqlOktaPolicyRule) id() (string, error) {
 // see https://github.com/okta/okta-sdk-golang/issues/286 for context. okta's sdk doesn't let you fetch
 // type-specific rules which differ between the different policies. as such, we fetch those manually.
 func fetchAccessPolicyRules(ctx context.Context, policyid, host, token string) ([]oktaPolicyRuleRaw, error) {
-	urlPath := fmt.Sprintf("https://%s/api/v1/policies/%s/rules?limit=50", host, url.PathEscape(policyid))
-	client := http.Client{}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, nil)
+	apiSupplement := &sdk.ApiExtension{Host: host, Token: token}
+	raws, err := apiSupplement.ListPolicyRules(ctx, policyid, queryLimit)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("SSWS %s", token))
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New("failed to fetch access policy rules from " + urlPath + ": " + resp.Status)
 	}
 
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	result := make([]oktaPolicyRuleRaw, 0, len(raws))
+	for _, raw := range raws {
+		var entry oktaPolicyRuleRaw
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return nil, err
+		}
+		result = append(result, entry)
 	}
-	result := []oktaPolicyRuleRaw{}
-	err = json.Unmarshal(raw, &result)
-	return result, err
+	return result, nil
 }

--- a/providers/okta/resources/sdk/policies.go
+++ b/providers/okta/resources/sdk/policies.go
@@ -31,21 +31,64 @@ type PolicyWrapper struct {
 	Settings    json.RawMessage `json:"settings,omitempty"`
 }
 
-// ListPolicies retrieves all policies of the given type. It returns the raw
-// http.Response so callers can branch on the status code (e.g. treat 404 or an
-// "invalid policy type" 400 as an empty result).
+// ListPolicies retrieves all policies of the given type, following Okta's
+// `Link: <url>; rel="next"` pagination until no `next` link remains. It returns
+// the first page's http.Response so callers can branch on the status code (e.g.
+// treat 404 or an "invalid policy type" 400 as an empty result).
 func (m *ApiExtension) ListPolicies(ctx context.Context, policyType string, limit int) ([]*PolicyWrapper, *http.Response, error) {
 	params := url.Values{}
 	params.Set("type", policyType)
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
 	}
-	requestURL := m.url("/api/v1/policies") + "?" + params.Encode()
+	nextURL := m.url("/api/v1/policies") + "?" + params.Encode()
 
-	var policies []*PolicyWrapper
-	resp, err := m.get(ctx, requestURL, &policies)
-	if err != nil {
-		return nil, resp, err
+	policies := []*PolicyWrapper{}
+	var firstResp *http.Response
+	for nextURL != "" {
+		var page []*PolicyWrapper
+		resp, err := m.get(ctx, nextURL, &page)
+		if firstResp == nil {
+			firstResp = resp
+		}
+		if err != nil {
+			return nil, resp, err
+		}
+		policies = append(policies, page...)
+		if resp == nil {
+			break
+		}
+		nextURL = nextLinkURL(resp.Header.Values("Link"))
 	}
-	return policies, resp, nil
+
+	return policies, firstResp, nil
+}
+
+// ListPolicyRules fetches all rules for a policy, following Okta's
+// `Link: <url>; rel="next"` pagination until no `next` link remains. Rules are
+// returned as raw JSON objects because the rule shape is a per-policy-type
+// discriminated union that the caller decodes into its own struct. This backs
+// the ACCESS_POLICY rule listing, which the generated SDK does not expose.
+func (m *ApiExtension) ListPolicyRules(ctx context.Context, policyId string, limit int) ([]json.RawMessage, error) {
+	params := url.Values{}
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(limit))
+	}
+	nextURL := m.url("/api/v1/policies/"+url.PathEscape(policyId)+"/rules") + "?" + params.Encode()
+
+	rules := []json.RawMessage{}
+	for nextURL != "" {
+		page := []json.RawMessage{}
+		resp, err := m.get(ctx, nextURL, &page)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, page...)
+		if resp == nil {
+			break
+		}
+		nextURL = nextLinkURL(resp.Header.Values("Link"))
+	}
+
+	return rules, nil
 }

--- a/providers/okta/resources/sdk/policies.go
+++ b/providers/okta/resources/sdk/policies.go
@@ -31,6 +31,11 @@ type PolicyWrapper struct {
 	Settings    json.RawMessage `json:"settings,omitempty"`
 }
 
+// maxPages bounds the pagination loops so a malformed or cycling
+// `Link: rel="next"` header cannot spin forever and hang a scan. At queryLimit
+// (200) per page this covers 200k records, far beyond any real org.
+const maxPages = 1000
+
 // ListPolicies retrieves all policies of the given type, following Okta's
 // `Link: <url>; rel="next"` pagination until no `next` link remains. It returns
 // the first page's http.Response so callers can branch on the status code (e.g.
@@ -45,7 +50,7 @@ func (m *ApiExtension) ListPolicies(ctx context.Context, policyType string, limi
 
 	policies := []*PolicyWrapper{}
 	var firstResp *http.Response
-	for nextURL != "" {
+	for i := 0; i < maxPages && nextURL != ""; i++ {
 		var page []*PolicyWrapper
 		resp, err := m.get(ctx, nextURL, &page)
 		if firstResp == nil {
@@ -77,7 +82,7 @@ func (m *ApiExtension) ListPolicyRules(ctx context.Context, policyId string, lim
 	nextURL := m.url("/api/v1/policies/"+url.PathEscape(policyId)+"/rules") + "?" + params.Encode()
 
 	rules := []json.RawMessage{}
-	for nextURL != "" {
+	for i := 0; i < maxPages && nextURL != ""; i++ {
 		page := []json.RawMessage{}
 		resp, err := m.get(ctx, nextURL, &page)
 		if err != nil {

--- a/providers/okta/resources/sdk/policies_pagination_test.go
+++ b/providers/okta/resources/sdk/policies_pagination_test.go
@@ -46,25 +46,24 @@ func (rt *pagedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	}, nil
 }
 
-func withFakeTransport(t *testing.T, rt http.RoundTripper) {
-	t.Helper()
-	orig := http.DefaultClient
-	http.DefaultClient = &http.Client{Transport: rt}
-	t.Cleanup(func() { http.DefaultClient = orig })
+// fakeClient returns an ApiExtension whose transport is the given round-tripper,
+// so pagination is exercised without touching any global http.Client.
+func fakeClient(rt http.RoundTripper) *ApiExtension {
+	return &ApiExtension{Host: "x.okta.com", Token: "t", HTTPClient: &http.Client{Transport: rt}}
 }
 
 // TestListPolicyRulesFollowsPagination guards the ACCESS_POLICY rule fetch
 // against the single-page truncation regression: it must follow the
 // `Link: rel="next"` header and return rules from every page.
 func TestListPolicyRulesFollowsPagination(t *testing.T) {
+	t.Parallel()
 	rt := &pagedRoundTripper{
 		page1:     `[{"id":"rule1"},{"id":"rule2"}]`,
 		page2:     `[{"id":"rule3"}]`,
 		nextQuery: "after=p2",
 	}
-	withFakeTransport(t, rt)
 
-	m := &ApiExtension{Host: "x.okta.com", Token: "t"}
+	m := fakeClient(rt)
 	rules, err := m.ListPolicyRules(context.Background(), "pol1", 200)
 	require.NoError(t, err)
 	require.Len(t, rules, 3, "expected rules from both pages, not just the first")
@@ -74,16 +73,44 @@ func TestListPolicyRulesFollowsPagination(t *testing.T) {
 // TestListPoliciesFollowsPagination guards the same behavior for the policy
 // listing itself across all policy types.
 func TestListPoliciesFollowsPagination(t *testing.T) {
+	t.Parallel()
 	rt := &pagedRoundTripper{
 		page1:     `[{"id":"p1"},{"id":"p2"}]`,
 		page2:     `[{"id":"p3"}]`,
 		nextQuery: "after=p2",
 	}
-	withFakeTransport(t, rt)
 
-	m := &ApiExtension{Host: "x.okta.com", Token: "t"}
+	m := fakeClient(rt)
 	policies, _, err := m.ListPolicies(context.Background(), "ACCESS_POLICY", 200)
 	require.NoError(t, err)
 	require.Len(t, policies, 3, "expected policies from both pages, not just the first")
 	assert.Equal(t, 2, rt.calls)
+}
+
+// cyclingRoundTripper always returns a `next` link pointing back at the same
+// path, simulating a malformed Okta response that would otherwise loop forever.
+type cyclingRoundTripper struct{ calls int }
+
+func (rt *cyclingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls++
+	header := http.Header{}
+	header.Set("Link", "<https://"+req.URL.Host+req.URL.Path+`?after=loop>; rel="next"`)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewBufferString(`[{"id":"x"}]`)),
+		Request:    req,
+	}, nil
+}
+
+// TestPaginationStopsOnCyclingLink proves the maxPages guard terminates a
+// self-referential `Link: rel="next"` cycle instead of hanging the scan.
+func TestPaginationStopsOnCyclingLink(t *testing.T) {
+	t.Parallel()
+	rt := &cyclingRoundTripper{}
+	m := fakeClient(rt)
+
+	_, err := m.ListPolicyRules(context.Background(), "pol1", 200)
+	require.NoError(t, err)
+	assert.Equal(t, maxPages, rt.calls, "loop should stop at the maxPages bound")
 }

--- a/providers/okta/resources/sdk/policies_pagination_test.go
+++ b/providers/okta/resources/sdk/policies_pagination_test.go
@@ -1,0 +1,89 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pagedRoundTripper serves two pages for any Okta collection GET: the first
+// request (no `after` cursor) returns page one plus a `Link: rel="next"`
+// header pointing at the same path with `after=p2`; the follow-up request
+// returns page two with no next link. It records how many requests it saw so a
+// test can prove the client actually followed the next link rather than
+// stopping after page one.
+type pagedRoundTripper struct {
+	page1     string
+	page2     string
+	nextQuery string // e.g. "after=p2"
+	calls     int
+}
+
+func (rt *pagedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls++
+	body := rt.page1
+	header := http.Header{}
+	if strings.Contains(req.URL.RawQuery, rt.nextQuery) {
+		body = rt.page2
+	} else {
+		next := "https://" + req.URL.Host + req.URL.Path + "?" + rt.nextQuery
+		header.Set("Link", "<"+next+`>; rel="next"`)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Request:    req,
+	}, nil
+}
+
+func withFakeTransport(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	orig := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: rt}
+	t.Cleanup(func() { http.DefaultClient = orig })
+}
+
+// TestListPolicyRulesFollowsPagination guards the ACCESS_POLICY rule fetch
+// against the single-page truncation regression: it must follow the
+// `Link: rel="next"` header and return rules from every page.
+func TestListPolicyRulesFollowsPagination(t *testing.T) {
+	rt := &pagedRoundTripper{
+		page1:     `[{"id":"rule1"},{"id":"rule2"}]`,
+		page2:     `[{"id":"rule3"}]`,
+		nextQuery: "after=p2",
+	}
+	withFakeTransport(t, rt)
+
+	m := &ApiExtension{Host: "x.okta.com", Token: "t"}
+	rules, err := m.ListPolicyRules(context.Background(), "pol1", 200)
+	require.NoError(t, err)
+	require.Len(t, rules, 3, "expected rules from both pages, not just the first")
+	assert.Equal(t, 2, rt.calls, "expected the client to follow the next-page link once")
+}
+
+// TestListPoliciesFollowsPagination guards the same behavior for the policy
+// listing itself across all policy types.
+func TestListPoliciesFollowsPagination(t *testing.T) {
+	rt := &pagedRoundTripper{
+		page1:     `[{"id":"p1"},{"id":"p2"}]`,
+		page2:     `[{"id":"p3"}]`,
+		nextQuery: "after=p2",
+	}
+	withFakeTransport(t, rt)
+
+	m := &ApiExtension{Host: "x.okta.com", Token: "t"}
+	policies, _, err := m.ListPolicies(context.Background(), "ACCESS_POLICY", 200)
+	require.NoError(t, err)
+	require.Len(t, policies, 3, "expected policies from both pages, not just the first")
+	assert.Equal(t, 2, rt.calls)
+}

--- a/providers/okta/resources/sdk/sdk.go
+++ b/providers/okta/resources/sdk/sdk.go
@@ -20,6 +20,18 @@ type ApiExtension struct {
 	Host string
 	// Token is the Okta API token used for SSWS authorization.
 	Token string
+	// HTTPClient issues the requests. When nil, http.DefaultClient is used.
+	// Tests inject a client with a custom transport so pagination can be
+	// exercised without mutating any global state.
+	HTTPClient *http.Client
+}
+
+// httpClient returns the configured client, falling back to the shared default.
+func (m *ApiExtension) httpClient() *http.Client {
+	if m.HTTPClient != nil {
+		return m.HTTPClient
+	}
+	return http.DefaultClient
 }
 
 // get issues an authenticated GET against an absolute Okta URL and decodes the
@@ -36,7 +48,7 @@ func (m *ApiExtension) get(ctx context.Context, url string, out any) (*http.Resp
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "SSWS "+m.Token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := m.httpClient().Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Three fixes to Okta collection fetches that silently returned incorrect data to users. All three were found during a deep-dive audit of the Okta provider (pagination / nil-handling / logic-error sweep).

### 1. Access-policy rules were truncated at 50 (silent data loss)
`fetchAccessPolicyRules` (`policies.go`) issued a single `GET /api/v1/policies/{id}/rules?limit=50` and **never followed the `Link: rel="next"` header** — even though the non-access-policy rule path directly above it paginated correctly. Any `ACCESS_POLICY` (app sign-on) policy with more than 50 rules silently dropped the rest, with no error. This shipped with the original provider, so it affects users today.

Fixed by routing through a new paginating `ApiExtension.ListPolicyRules`, which follows the next-page link and uses the standard `queryLimit` (200) like the rest of the provider.

### 2. `okta.customRole.permissions` was empty via the collection (data inconsistency)
The list path decoded `permissions` inline from `GET /api/v1/iam/roles`, which Okta **does not populate** — permissions are a per-role sub-resource (that is exactly why the single-role `init` path made a separate `ListRolePermissions` call). Net effect:

- `okta.customRoles { permissions }` → `[]` for every role
- `okta.customRole(id: "...") { permissions }` → the real permission set

Same field, two paths, contradictory answers — and the empty answer looked valid. `permissions` is now a lazy computed field backed by `ListRolePermissions`, so both paths resolve identically. Queries that don't select `permissions` skip the per-role call entirely.

### 3. `ApiExtension.ListPolicies` fetched only the first page
It now follows the `Link: rel="next"` header like the other hand-rolled listings (`ListCustomRoles`, `ListApiTokens`), while still returning the first page's response so callers keep branching on status codes (404 / invalid policy type). Low real-world impact (>200 policies of one type is rare) but the same bug class as #1.

## Tests
- Adds httptest-backed regression tests (`sdk/policies_pagination_test.go`) proving both `ListPolicyRules` and `ListPolicies` follow pagination past the first page.
- Full Okta resource + sdk test suites pass; `go vet` and `gofmt` clean; codegen regenerated and idempotent; no `.lr.versions` churn.

## Notes
- `permissions` changes from a static `[]string` field to a computed `permissions()` field. This is not customer-breaking: the field name and `[]string` type are unchanged, and existing MQL queries work the same.
