### PR TITLE
🐛 okta: fix attackProtection, behaviorRules, and riskProviders (live-verified)

### DIFF
--- a/providers/okta/resources/okta.lr
+++ b/providers/okta/resources/okta.lr
@@ -48,8 +48,6 @@ okta {
   logStreams() []okta.logStream
   // API service integrations granted OAuth 2.0 access to the org
   apiServiceIntegrations() []okta.apiServiceIntegration
-  // Organization brute-force and account-lockout protection settings
-  attackProtection() okta.attackProtection
   // Behavior detection rules evaluated during sign-on
   behaviorRules() []okta.behaviorRule
   // Third-party risk signal providers integrated with the org
@@ -1539,7 +1537,10 @@ private okta.behaviorRule @defaults("name type status") {
   name string
   // Behavior rule type
   //
-  // One of ANOMALOUS_DEVICE, ANOMALOUS_IP, ANOMALOUS_LOCATION, or VELOCITY.
+  // The behavior evaluated, such as ANOMALOUS_DEVICE, ANOMALOUS_IP,
+  // ANOMALOUS_LOCATION, VELOCITY, or a new-factor rule like NEW_ASN,
+  // NEW_DEVICE, NEW_IP, NEW_CITY, NEW_STATE, NEW_COUNTRY, or
+  // NEW_GEO_LOCATION.
   type string
   // Status of the rule: ACTIVE or INACTIVE
   status string

--- a/providers/okta/resources/okta.lr.go
+++ b/providers/okta/resources/okta.lr.go
@@ -219,7 +219,7 @@ func init() {
 			Create: createOktaApiServiceIntegration,
 		},
 		"okta.attackProtection": {
-			// to override args, implement: initOktaAttackProtection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOktaAttackProtection,
 			Create: createOktaAttackProtection,
 		},
 		"okta.behaviorRule": {
@@ -366,9 +366,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"okta.apiServiceIntegrations": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOkta).GetApiServiceIntegrations()).ToDataRes(types.Array(types.Resource("okta.apiServiceIntegration")))
-	},
-	"okta.attackProtection": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlOkta).GetAttackProtection()).ToDataRes(types.Resource("okta.attackProtection"))
 	},
 	"okta.behaviorRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOkta).GetBehaviorRules()).ToDataRes(types.Array(types.Resource("okta.behaviorRule")))
@@ -1713,10 +1710,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"okta.apiServiceIntegrations": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOkta).ApiServiceIntegrations, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
-		return
-	},
-	"okta.attackProtection": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlOkta).AttackProtection, ok = plugin.RawToTValue[*mqlOktaAttackProtection](v.Value, v.Error)
 		return
 	},
 	"okta.behaviorRules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3614,7 +3607,6 @@ type mqlOkta struct {
 	HookKeys                plugin.TValue[[]any]
 	LogStreams              plugin.TValue[[]any]
 	ApiServiceIntegrations  plugin.TValue[[]any]
-	AttackProtection        plugin.TValue[*mqlOktaAttackProtection]
 	BehaviorRules           plugin.TValue[[]any]
 	RiskProviders           plugin.TValue[[]any]
 	Devices                 plugin.TValue[[]any]
@@ -3944,22 +3936,6 @@ func (c *mqlOkta) GetApiServiceIntegrations() *plugin.TValue[[]any] {
 		}
 
 		return c.apiServiceIntegrations()
-	})
-}
-
-func (c *mqlOkta) GetAttackProtection() *plugin.TValue[*mqlOktaAttackProtection] {
-	return plugin.GetOrCompute[*mqlOktaAttackProtection](&c.AttackProtection, func() (*mqlOktaAttackProtection, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("okta", c.__id, "attackProtection")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.(*mqlOktaAttackProtection), nil
-			}
-		}
-
-		return c.attackProtection()
 	})
 }
 

--- a/providers/okta/resources/sdk/attackProtection.go
+++ b/providers/okta/resources/sdk/attackProtection.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"net/http"
+)
+
+// AttackProtectionSettings holds the org-level brute-force protection flags.
+type AttackProtectionSettings struct {
+	PreventBruteForceLockoutFromUnknownDevices bool
+	VerifyKnowledgeSecondWhen2faRequired       bool
+}
+
+// GetAttackProtectionSettings fetches the org's attack-protection settings.
+//
+// The v5 SDK's AttackProtectionAPI.GetUserLockoutSettings and
+// GetAuthenticatorSettings type their responses as slices, but both endpoints
+// return a single JSON object (for example
+// `{"preventBruteForceLockoutFromUnknownDevices":false}`), so the SDK's
+// Execute() fails to unmarshal. We issue the two GETs ourselves and decode each
+// into its object shape. The returned http.Response is the first call's
+// response so callers can branch on its status code.
+func (m *ApiExtension) GetAttackProtectionSettings(ctx context.Context) (*AttackProtectionSettings, *http.Response, error) {
+	var lockout struct {
+		PreventBruteForceLockoutFromUnknownDevices bool `json:"preventBruteForceLockoutFromUnknownDevices"`
+	}
+	resp, err := m.get(ctx, m.url("/attack-protection/api/v1/user-lockout-settings"), &lockout)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	var authenticator struct {
+		VerifyKnowledgeSecondWhen2faRequired bool `json:"verifyKnowledgeSecondWhen2faRequired"`
+	}
+	if _, err := m.get(ctx, m.url("/attack-protection/api/v1/authenticator-settings"), &authenticator); err != nil {
+		return nil, resp, err
+	}
+
+	return &AttackProtectionSettings{
+		PreventBruteForceLockoutFromUnknownDevices: lockout.PreventBruteForceLockoutFromUnknownDevices,
+		VerifyKnowledgeSecondWhen2faRequired:       authenticator.VerifyKnowledgeSecondWhen2faRequired,
+	}, resp, nil
+}

--- a/providers/okta/resources/sdk/behaviorRules.go
+++ b/providers/okta/resources/sdk/behaviorRules.go
@@ -1,0 +1,45 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package sdk
+
+import (
+	"context"
+	"net/http"
+)
+
+// ListBehaviorRules fetches behavior detection rules from `/api/v1/behaviors`.
+//
+// The v5 SDK's BehaviorAPI.ListBehaviorDetectionRules cannot be used here: the
+// generated BehaviorRule type declares created/lastUpdated as time.Time with
+// strict RFC3339 unmarshaling, but this legacy endpoint returns timestamps in
+// Okta's space-separated form (for example "2026-07-20 17:34:59.0"), so the
+// SDK's own Execute() fails to unmarshal the response before any mapping runs.
+// Decoding into untyped maps sidesteps the SDK's time parsing; the caller
+// parses the timestamps leniently.
+//
+// The returned http.Response is the first page's response so callers can treat
+// a 404 as an empty result.
+func (m *ApiExtension) ListBehaviorRules(ctx context.Context) ([]map[string]any, *http.Response, error) {
+	rules := []map[string]any{}
+	nextURL := m.url("/api/v1/behaviors")
+	var firstResp *http.Response
+
+	for nextURL != "" {
+		var page []map[string]any
+		resp, err := m.get(ctx, nextURL, &page)
+		if firstResp == nil {
+			firstResp = resp
+		}
+		if err != nil {
+			return nil, resp, err
+		}
+		rules = append(rules, page...)
+		if resp == nil {
+			break
+		}
+		nextURL = nextLinkURL(resp.Header.Values("Link"))
+	}
+
+	return rules, firstResp, nil
+}

--- a/providers/okta/resources/threatPosture.go
+++ b/providers/okta/resources/threatPosture.go
@@ -5,7 +5,7 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/okta/okta-sdk-golang/v5/okta"
@@ -13,124 +13,122 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/okta/connection"
+	"go.mondoo.com/mql/v13/providers/okta/resources/sdk"
 )
 
 // --- attack protection (org-level singleton) ---
 
-func (o *mqlOkta) attackProtection() (*mqlOktaAttackProtection, error) {
-	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
-	client := conn.Client()
+// initOktaAttackProtection populates the singleton on construction. It is an
+// init rather than an okta accessor because okta.attackProtection is a
+// directly-addressable resource: a field of the same dotted name would collide
+// with the resource and leave the fields unset when queried as
+// `okta.attackProtection`.
+func initOktaAttackProtection(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 1 {
+		return args, nil, nil
+	}
+
+	conn := runtime.Connection.(*connection.OktaConnection)
 	ctx := context.Background()
-
-	var preventLockout bool
-	lockout, _, err := client.AttackProtectionAPI.GetUserLockoutSettings(ctx).Execute()
-	if err != nil {
-		return nil, err
-	}
-	if len(lockout) > 0 && lockout[0].PreventBruteForceLockoutFromUnknownDevices != nil {
-		preventLockout = *lockout[0].PreventBruteForceLockoutFromUnknownDevices
+	apiSupplement := &sdk.ApiExtension{
+		Host:  conn.OrganizationID(),
+		Token: conn.Token(),
 	}
 
-	var verifyKnowledge bool
-	authSettings, _, err := client.AttackProtectionAPI.GetAuthenticatorSettings(ctx).Execute()
+	// Fetched through the extension: the SDK types both attack-protection
+	// endpoints as slices, but each returns a single JSON object, so the SDK's
+	// Execute() fails to unmarshal.
+	settings, _, err := apiSupplement.GetAttackProtectionSettings(ctx)
 	if err != nil {
-		return nil, err
-	}
-	if len(authSettings) > 0 && authSettings[0].VerifyKnowledgeSecondWhen2faRequired != nil {
-		verifyKnowledge = *authSettings[0].VerifyKnowledgeSecondWhen2faRequired
+		return nil, nil, err
 	}
 
-	r, err := CreateResource(o.MqlRuntime, "okta.attackProtection", map[string]*llx.RawData{
-		"__id": llx.StringData("okta.attackProtection"),
-		"preventBruteForceLockoutFromUnknownDevices": llx.BoolData(preventLockout),
-		"verifyKnowledgeSecondWhen2faRequired":       llx.BoolData(verifyKnowledge),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return r.(*mqlOktaAttackProtection), nil
+	args["__id"] = llx.StringData("okta.attackProtection")
+	args["preventBruteForceLockoutFromUnknownDevices"] = llx.BoolData(settings.PreventBruteForceLockoutFromUnknownDevices)
+	args["verifyKnowledgeSecondWhen2faRequired"] = llx.BoolData(settings.VerifyKnowledgeSecondWhen2faRequired)
+	return args, nil, nil
 }
 
 // --- behavior detection rules ---
 
 func (o *mqlOkta) behaviorRules() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OktaConnection)
-	client := conn.Client()
-
 	ctx := context.Background()
-	slice, resp, err := client.BehaviorAPI.ListBehaviorDetectionRules(ctx).Execute()
+	apiSupplement := &sdk.ApiExtension{
+		Host:  conn.OrganizationID(),
+		Token: conn.Token(),
+	}
+
+	// Fetched through the extension rather than the SDK: the /api/v1/behaviors
+	// endpoint returns non-RFC3339 timestamps ("2026-07-20 17:34:59.0") that
+	// break the SDK's strict time unmarshaling.
+	rules, resp, err := apiSupplement.ListBehaviorRules(ctx)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
 
 	list := []any{}
-	appendEntry := func(datalist []okta.ListBehaviorDetectionRules200ResponseInner) error {
-		for i := range datalist {
-			r, err := newMqlOktaBehaviorRule(o.MqlRuntime, &datalist[i])
-			if err != nil {
-				return err
-			}
-			list = append(list, r)
-		}
-		return nil
-	}
-
-	if err := appendEntry(slice); err != nil {
-		return nil, err
-	}
-	for resp != nil && resp.HasNextPage() {
-		var page []okta.ListBehaviorDetectionRules200ResponseInner
-		resp, err = resp.Next(&page)
+	for i := range rules {
+		r, err := newMqlOktaBehaviorRule(o.MqlRuntime, rules[i])
 		if err != nil {
 			return nil, err
 		}
-		if err := appendEntry(page); err != nil {
-			return nil, err
-		}
+		list = append(list, r)
 	}
 	return list, nil
 }
 
-// oktaBehaviorRuleRaw flattens the polymorphic behavior rule (anomalous
-// device/IP/location or velocity). All variants share the base fields and a
-// type-specific settings object, so re-marshaling to JSON gives one code path.
-type oktaBehaviorRuleRaw struct {
-	Id          string     `json:"id"`
-	Name        string     `json:"name"`
-	Type        string     `json:"type"`
-	Status      string     `json:"status"`
-	Settings    any        `json:"settings"`
-	Created     *time.Time `json:"created"`
-	LastUpdated *time.Time `json:"lastUpdated"`
-}
-
-func newMqlOktaBehaviorRule(runtime *plugin.Runtime, entry *okta.ListBehaviorDetectionRules200ResponseInner) (any, error) {
-	raw, err := json.Marshal(entry.GetActualInstance())
-	if err != nil {
-		return nil, err
-	}
-	var rule oktaBehaviorRuleRaw
-	if err := json.Unmarshal(raw, &rule); err != nil {
-		return nil, err
-	}
-	settings, err := convert.JsonToDict(rule.Settings)
+func newMqlOktaBehaviorRule(runtime *plugin.Runtime, rule map[string]any) (any, error) {
+	settings, err := convert.JsonToDict(rule["settings"])
 	if err != nil {
 		return nil, err
 	}
 
 	return CreateResource(runtime, "okta.behaviorRule", map[string]*llx.RawData{
-		"id":          llx.StringData(rule.Id),
-		"name":        llx.StringData(rule.Name),
-		"type":        llx.StringData(rule.Type),
-		"status":      llx.StringData(rule.Status),
+		"id":          llx.StringData(oktaMapStr(rule, "id")),
+		"name":        llx.StringData(oktaMapStr(rule, "name")),
+		"type":        llx.StringData(oktaMapStr(rule, "type")),
+		"status":      llx.StringData(oktaMapStr(rule, "status")),
 		"settings":    llx.DictData(settings),
-		"created":     llx.TimeDataPtr(rule.Created),
-		"lastUpdated": llx.TimeDataPtr(rule.LastUpdated),
+		"created":     llx.TimeDataPtr(parseOktaTimestamp(oktaMapStr(rule, "created"))),
+		"lastUpdated": llx.TimeDataPtr(parseOktaTimestamp(oktaMapStr(rule, "lastUpdated"))),
 	})
 }
 
 func (o *mqlOktaBehaviorRule) id() (string, error) {
 	return "okta.behaviorRule/" + o.Id.Data, o.Id.Error
+}
+
+// oktaMapStr reads a string value from an untyped JSON map, returning "" when
+// the key is missing or not a string.
+func oktaMapStr(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// parseOktaTimestamp parses the timestamp forms Okta returns, including the
+// legacy space-separated form some endpoints (behaviors) use in addition to
+// RFC3339. Returns nil when the value is empty or unparseable so the field
+// renders as null rather than a zero time.
+func parseOktaTimestamp(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	for _, layout := range []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return &t
+		}
+	}
+	return nil
 }
 
 // --- risk providers ---
@@ -142,6 +140,12 @@ func (o *mqlOkta) riskProviders() ([]any, error) {
 	ctx := context.Background()
 	slice, resp, err := client.RiskProviderAPI.ListRiskProviders(ctx).Execute()
 	if err != nil {
+		// The risk providers endpoint is not available on every org edition
+		// and returns 410 Gone (or 404) when the feature is absent; degrade to
+		// an empty result rather than failing the query.
+		if resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/okta/resources/threatPosture_test.go
+++ b/providers/okta/resources/threatPosture_test.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOktaTimestamp(t *testing.T) {
+	// The legacy /api/v1/behaviors form that breaks the SDK's RFC3339 parsing.
+	got := parseOktaTimestamp("2026-07-20 17:34:59.0")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, 2026, got.Year())
+		assert.Equal(t, 34, got.Minute())
+	}
+
+	// RFC3339 (used by most other endpoints).
+	got = parseOktaTimestamp("2024-03-01T12:34:56Z")
+	if assert.NotNil(t, got) {
+		assert.Equal(t, 56, got.Second())
+	}
+
+	// Space form without fractional seconds.
+	assert.NotNil(t, parseOktaTimestamp("2026-07-20 17:34:59"))
+
+	// Empty and unparseable render as null.
+	assert.Nil(t, parseOktaTimestamp(""))
+	assert.Nil(t, parseOktaTimestamp("garbage"))
+}
+
+func TestOktaMapStr(t *testing.T) {
+	m := map[string]any{"id": "bhv1", "count": 5, "nilval": nil}
+	assert.Equal(t, "bhv1", oktaMapStr(m, "id"))
+	assert.Equal(t, "", oktaMapStr(m, "count"))  // non-string
+	assert.Equal(t, "", oktaMapStr(m, "nilval")) // nil
+	assert.Equal(t, "", oktaMapStr(m, "absent")) // missing
+	require.Equal(t, "", oktaMapStr(map[string]any{}, "id"))
+}


### PR DESCRIPTION
## What

Three bugs found and fixed during **live verification** of the okta service-expansion PRs (#9281–#9285) against a real Okta org. All three are now verified working against live data.

### 1. `okta.attackProtection` — null fields, empty id

Two compounding problems:
- **Name/field collision:** it was a field accessor on `okta` returning a same-named resource `okta.attackProtection`. Querying `okta.attackProtection` constructed the bare resource directly instead of routing through the accessor, so nothing populated (`field was never set` / `primitive with no type information`). Fixed by switching to the **init pattern** (like `okta.organization`), so constructing the resource fetches and populates it.
- **SDK-vs-wire mismatch:** the v5 SDK types both attack-protection endpoints (`GetUserLockoutSettings`, `GetAuthenticatorSettings`) as **slices**, but each endpoint returns a single JSON object (`{"preventBruteForceLockoutFromUnknownDevices":false}`), so the SDK's `Execute()` fails to unmarshal. Fetched via a hand-rolled `ApiExtension` call.

### 2. `okta.behaviorRules` — whole collection errored

The legacy `/api/v1/behaviors` endpoint returns **non-RFC3339 timestamps** (`"2026-07-20 17:34:59.0"` — space-separated, no `T`/offset). The SDK's `BehaviorRule.Created time.Time` uses strict RFC3339 unmarshaling, so `Execute()` failed before any mapping ran. Fetched via a hand-rolled `ApiExtension` call into untyped maps and parse the timestamps leniently (`parseOktaTimestamp` handles RFC3339 and the space-separated form).

### 3. `okta.riskProviders` — hard error on `410 Gone`

The risk-providers endpoint returns `410 Gone` on org editions where the feature is absent; the accessor surfaced that as a query failure. Degrade to an empty result on `410`/`404`, matching `customRoles`.

## Verification (live)

Confirmed against a real trial org, before → after:

| Query | Before | After |
|---|---|---|
| `okta.attackProtection` | `field was never set` error | `{ preventBruteForceLockoutFromUnknownDevices: false, verifyKnowledgeSecondWhen2faRequired: false }` |
| `okta.behaviorRules` | `cannot parse "…17:34:58.0" as "T"` | 8 rules with parsed timestamps + settings |
| `okta.riskProviders` | `410 Gone` | `0` (degraded) |

Also re-confirmed the rest of the surface on live data: `okta.resourceSets` (+ ORN parse), `okta.applications.assignedUsers`/`scopeConsentGrants` with typed refs, and `okta.devices.users` all resolve correctly.

## Also

- Broadened the `behaviorRule.type` enum doc-comment (live org surfaced `NEW_ASN`, `NEW_DEVICE`, `NEW_IP`, `NEW_CITY`, `NEW_STATE`, `NEW_COUNTRY`, `NEW_GEO_LOCATION` beyond the four originally listed).
- Unit tests for `parseOktaTimestamp` (incl. the Okta space form) and the untyped-map string reader.

## Pattern note

All three are the same class of issue as the two caught in #9283 review: **trust the wire shape, not the generated SDK type.** The v5 SDK mistypes several endpoints (array-vs-object, strict-vs-lenient time), and the fix each time is a hand-rolled `ApiExtension` fetch — the pattern the provider already uses for `ListCustomRoles`/`ListClientRoles`.

## Testing

`go build ./...`, `go test ./resources/`, `go vet`, and `make providers/build/okta` all pass; live-verified end to end.
