### PR TITLE
🎉 okta-13.4.0

### DIFF
--- a/providers/okta/config/config.go
+++ b/providers/okta/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "okta",
 	ID:              "go.mondoo.com/cnquery/v9/providers/okta",
-	Version:         "13.3.1",
+	Version:         "13.4.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### okta (13.4.0)
- 🐛 okta: fix attackProtection, behaviorRules, and riskProviders (#9286)
- 🐛 okta: fix policy-rule/policy pagination and custom-role permissions (#9285)
- ✨ okta: expose device trust and threat-posture resources (#9284)
- ✨ okta: expose hooks, log streams, and API service integrations (#9283)
- ✨ okta: expose application entitlements and client admin roles (#9282)
- ✨ okta: expose resource sets and the admin-privilege graph (#9281)
- 🧹 Update deps for mql and providers 20260719 (#9242)
- 🧹 Update deps for mql and providers 20260719 (#9232)
- 📄 okta: enrich resource and field documentation across services (#9187)
- bump: ranger-rpc v0.8.1 (#9061)
- 🧹 Update deps for mql and providers 20260713 (#9060)
- 🧹 Update deps for mql and providers 20260707 (#8998)
- 🧹 Update deps for mql and providers 20260706 (#8962)
- 🧹 Update deps for mql and providers 20260701 (#8862)
- 🧹 Update mondoo.com/docs URLs to their current canonical targets (#8791)
- ⭐ Update deps and expose new Azure/OpenStack resources unlocked by the bump 20260628 (#8779)
- 🧹 Provide static platform support information across all providers (#8722)
- 🧹 Update deps for mql and providers 20260625 (#8733)
- 🧹 Update deps for mql and providers 20260624 (#8706)
- 🧹 Update deps for mql and providers 20260623 (#8690)
- 🧹 Update deps for mql and providers 20260623 (#8645)
- 🧹 Update deps for mql and providers 20260622 (#8595)
- 🧹 Update deps for mql and providers 20260615 (#8443)
- 🧹 okta: migrate provider from okta-sdk-golang v2 to v5 (#8353)