### PR TITLE
✨ add provider-bug-review skill

### DIFF
--- a/.claude/skills/provider-bug-review/SKILL.md
+++ b/.claude/skills/provider-bug-review/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: provider-bug-review
+description: >-
+  Deep static code review of an mql provider for logic errors, nil-handling
+  bugs, pagination truncation, caching/__id collisions, and other defects that
+  silently give users wrong data. Use this whenever someone wants to audit,
+  review, deep-dive, bug-hunt, or "find problems in" a provider (aws, gcp,
+  azure, okta, k8s, or any provider under providers/) — whether the ask is a
+  whole provider, a recently-shipped set of resources, or a PR/commit range.
+  Trigger it for "review the okta provider for bugs", "audit gcp for nil
+  issues", "any pagination problems in the azure provider?", "deep dive the
+  new resources for logic errors", or a general "check this provider for
+  issues". This is the STATIC/logic counterpart to provider-verification
+  (which proves resources against live cloud infra) — reach for this when the
+  goal is finding bugs by reading code, not spinning up infrastructure.
+---
+
+# Provider bug review
+
+Find the bugs in an mql provider that a compiler and a passing test suite will
+not catch: pagination loops that silently return one page, pointer derefs that
+panic on a real-world null, a field that resolves differently through the
+collection path than through the single-object path, an `__id` collision that
+makes every query return the first resource's data. These are the defects that
+reach users as *wrong data with no error* — the worst kind, because the wrong
+answer looks valid.
+
+This skill is a **static** review: you find bugs by reading the Go and the SDK,
+reasoning about what the cloud API actually returns, and cross-checking against
+the codebase's own conventions. It complements two other skills:
+
+- **provider-verification** — proves resources against *live* cloud infra. When
+  a finding here needs an over-50-rules policy or a real null contact to
+  confirm, hand it off there rather than guessing.
+- **code-review** (generic PR review) — this skill is mql-provider-specific and
+  goes deeper on the provider bug classes below.
+
+## When this is the right tool
+
+Use it when the goal is *finding defects by reasoning about code* across a
+provider or a meaningful slice of one. If the user instead wants to prove a
+specific PR works against real infrastructure, that's `provider-verification`.
+If they want a quick generic review of a small diff, that's `code-review`.
+
+## The core loop
+
+The method that works is **fan out, then verify**: parallel analysis agents
+generate candidate findings against a precise bug taxonomy, then *you*
+personally confirm every candidate against the actual source before reporting
+it. Agents are good at surfacing suspects across a lot of files fast; they also
+hallucinate plausible-but-wrong bugs, so nothing reaches the report unverified.
+
+Work through these steps. Create a todo per step so none are skipped.
+
+### 1. Scope and prioritize
+
+- Identify the provider and enumerate its Go files: `providers/<name>/resources/*.go`,
+  `connection/`, `provider/`, and any hand-rolled `resources/sdk/` subpackage
+  (custom HTTP clients live here and are the single richest source of bugs —
+  they reimplement pagination and error handling by hand).
+- Pull the provider version from `providers/<name>/config/config.go` and recent
+  history: `git log --oneline -15 -- providers/<name>/` and the file mtimes.
+  **Recently-added/changed files carry the most risk** and deserve the most
+  scrutiny; long-shipped code that users rely on daily is where a found bug
+  matters most. Note both.
+- If the ask is a PR or commit range, scope to those files but still read the
+  shared infrastructure (next step) for context.
+
+### 2. Learn the house patterns FIRST (do not skip)
+
+Before judging any resource, read the shared infrastructure so you know what
+"correct" looks like here and can tell a real bug from a convention you don't
+recognize yet:
+
+- `connection/connection.go` — how the client and auth are built; what
+  `conn.Client()` returns.
+- `resources/helpers.go` (or equivalent) — the nil-safe pointer helpers
+  (`oktaStr`, `<provider>Str`, `convert.To*`), link/ID parsers, shared resolvers.
+- **The SDK's pagination mechanics.** Find how the SDK signals "more pages"
+  (`resp.HasNextPage()` reading a `Link: rel="next"` header, a `NextToken`, a
+  `marker`, a `nextPageToken`). *This is what lets you judge every pagination
+  finding* — if you don't know how the SDK paginates, you can't tell whether a
+  missing loop truncates. Read the SDK source in the module cache when unsure
+  (`$GOPATH/pkg/mod/.../<sdk>@<ver>/...`).
+- One representative resource file end-to-end, to internalize the collection →
+  `CreateResource` / init → `NewResource` pattern the provider uses.
+
+### 3. Fan out analysis agents by file-group
+
+Split the resource files into groups of ~5-7 (put the newest/riskiest together)
+and dispatch one analysis agent per group **in parallel, in a single message**.
+Give each agent the bug taxonomy and the exact reporting contract. A proven
+prompt template is in `references/agent-prompt-template.md` — read it and adapt
+the file list per group. Key requirements to put in every agent prompt:
+
+- The full bug-class checklist (from `references/bug-taxonomy.md`), so agents
+  look for the same things and label findings by class.
+- "For each finding: file:line, bug class, a **concrete failure scenario**
+  (what input/state triggers it and what the user sees), a suggested fix, and
+  the quoted code."
+- "Cross-check sibling files and the SDK's actual return types before
+  reporting, to avoid false positives" — this dramatically cuts hallucinated
+  findings.
+- "Rank by severity; report what you verified as clean too."
+
+Also run a fast mechanical sweep yourself while agents work — these grep
+patterns catch two whole classes cheaply:
+
+```bash
+# range-variable pointer capture (bug): &v inside `for _, v := range`
+grep -rn "for.*:= range" providers/<name>/resources/*.go | grep -v _test
+# then check whether the body takes &loopvar rather than &slice[i]
+
+# bare single-result type assertions on runtime data (panic risk): x := v.(T)
+grep -rnE "[a-zA-Z0-9_]+ := [a-zA-Z0-9_.]+\.\([a-zA-Z]" providers/<name>/resources/*.go \
+  | grep -v ", ok" | grep -v _test
+```
+
+### 4. Verify every candidate against source
+
+This is the step that makes the review trustworthy. For each finding an agent
+reports, open the actual file and confirm the bug is real: the line still says
+what the agent quoted, the SDK type is what the agent assumed, the failure
+scenario actually holds. Check the SDK's model struct for pointer-ness and JSON
+tags. Discard anything you can't confirm, and downgrade severity for anything
+that "could" happen but realistically won't. Agent reports are leads, not
+verdicts.
+
+When a finding hinges on runtime data you can't see statically ("does the list
+endpoint really omit this field?"), say so explicitly and route it to
+`provider-verification` for live confirmation rather than asserting it.
+
+### 5. Report
+
+Produce a single severity-ranked report. Order: **silent data loss / panic >
+correctness (wrong or inconsistent data) > robustness (error propagation) >
+performance > cosmetic.** For each finding give `file:line`, the bug class, the
+concrete failure scenario, and the fix. State plainly what you checked that was
+clean — a review that only lists problems hides its own coverage.
+
+Then stop and let the user decide what to fix. **Do not open a fix PR
+unprompted** — a review's job is to report; fixing is a separate, explicit
+step. When they ask you to fix, follow the normal worktree → change →
+`make providers/build/<name>` → gofmt → PR flow, and add regression tests for
+any pure-Go logic you touch (pagination loops, parsers, splitters — exactly the
+places bugs hide).
+
+## The bug taxonomy
+
+The heart of this skill is `references/bug-taxonomy.md` — the catalogue of
+provider bug classes, each with how to spot it, why it hurts the user, the
+correct pattern, and the fix. Read it before writing the agent prompts (the
+agents need it) and keep it open while verifying. It is the accumulated result
+of many provider audits; treat it as the checklist, not a suggestion.

--- a/.claude/skills/provider-bug-review/references/agent-prompt-template.md
+++ b/.claude/skills/provider-bug-review/references/agent-prompt-template.md
@@ -1,0 +1,82 @@
+# Analysis-agent prompt template
+
+Dispatch one agent per file-group, **all in a single message** so they run
+concurrently. Use `general-purpose` (or `Explore` if read-only). Fill in the
+`<...>` slots. Paste the full bug-class list from `bug-taxonomy.md` into each
+prompt (agents don't share your context) — or, if the skill files are on the
+agent's filesystem, tell it to read `bug-taxonomy.md` first.
+
+Keep groups to ~5-7 files and put the newest/riskiest files together so their
+findings come back from one focused agent.
+
+---
+
+```
+You are auditing Go source files in the <PROVIDER> provider of the `mql`
+codebase (a cloud-inventory tool) for USER-IMPACTING BUGS. Working dir: <REPO>
+
+Audit ONLY these files (read each fully):
+- <file 1>
+- <file 2>
+- ...
+
+Read <REPO>/.claude/skills/provider-bug-review/references/bug-taxonomy.md first
+— it is the exact catalogue of bug classes to look for. [OR: paste the taxonomy
+inline if the agent can't read it.]
+
+Focus on these classes (see the taxonomy for fingerprints and correct patterns):
+1. Pagination truncation — a List over a paginated endpoint that doesn't loop
+   the next-page signal (silent data loss); hand-rolled HTTP fetches that skip
+   the Link:next header; hardcoded small limits.
+2. Nil deref / panic — SDK pointer derefs without the nil-safe helper; BARE
+   type assertions on runtime/JSON data (v.(T) not x,ok:=v.(T)); response bodies
+   used without a nil check.
+3. Singular resource accessor returning nil,nil without setting
+   `a.Field.State = plugin.StateIsSet | plugin.StateIsNull` first.
+4. Init fall-through husk — `return args, nil, nil` after a lookup found NOTHING
+   (should be a not-found error); NOT the legit "args complete"/"no id" fast-path.
+5. Caching/__id — CreateResource where NewResource/init-built identity is needed
+   (cache collision); empty/duplicate __id; non-unique id().
+6. null && null — degraded/stub resources that leave booleans as StateIsNull
+   instead of explicit false (they spuriously pass `{a && b}` assertions).
+7. Typed-reference misses — raw *Id/*Arn/*Url strings that should be typed
+   accessors (breaking to fix after ship).
+8. Cross-path inconsistency — a field populated from the list API on the
+   collection path but from a separate detail call on the single-object path,
+   where the list API doesn't return it (collection yields empty).
+8b. `.lr` type vs llx.*Data mismatch — a `[]dict` field populated with
+   `llx.DictData(x)` instead of `llx.ArrayData(x, types.Dict)` (or any helper
+   that doesn't match the field's declared .lr type). Cross-check every
+   CreateResource arg's llx.*Data helper against the field type in the .lr.
+9. Error propagation — a 403/permission gap or "not configured" that fails the
+   whole query instead of degrading to null/empty.
+10. Range-variable pointer capture — `&v` inside `for _, v := range` (should be
+    `&slice[i]`).
+
+For EACH finding report:
+- file path + line number
+- the bug class
+- a CONCRETE failure scenario: what input/state triggers it and what the user
+  sees (wrong data? panic? empty list?)
+- a suggested fix
+- the quoted code
+
+Rank findings by severity (silent data loss / panic > wrong-or-inconsistent
+data > error-propagation > perf > cosmetic). CROSS-CHECK sibling files and the
+SDK's actual return types / model structs before reporting, to avoid false
+positives — verify the pointer-ness and JSON tags of SDK fields, and confirm
+paginated response types really expose a next-page signal. Also list what you
+checked that came back CLEAN, so coverage is visible.
+
+This structured list is your final output (it is not shown directly to a human,
+so include full detail).
+```
+
+---
+
+## After the agents return
+
+Do **not** relay agent output verbatim. For every candidate finding, open the
+file and confirm it against source and the SDK model (see SKILL.md step 4).
+Only verified findings go in the report; route anything that needs live runtime
+data to `provider-verification`.

--- a/.claude/skills/provider-bug-review/references/bug-taxonomy.md
+++ b/.claude/skills/provider-bug-review/references/bug-taxonomy.md
@@ -1,0 +1,338 @@
+# Provider bug taxonomy
+
+The catalogue of bug classes that recur in mql providers, ordered roughly by how
+badly they hurt users. Each entry: **what it is**, **fingerprint** (how to spot
+it), **why it matters**, and the **correct pattern**. This is the checklist the
+analysis agents work from and the reference you verify against.
+
+A theme runs through the worst of these: the bug produces *wrong data with no
+error*. A panic at least announces itself. A pagination loop that returns one
+page, or a field that resolves differently through two code paths, hands the
+user a confident wrong answer. Weight those highest.
+
+---
+
+## 1. Pagination truncation (silent data loss)
+
+**What:** a list endpoint returns only the first page of results, silently
+dropping the rest.
+
+**Fingerprints:**
+- A `List...` call whose SDK response supports paging but the code never loops.
+  For the header-cursor SDKs (okta): initial `.Execute()` returns `(slice, resp, err)`
+  but there's no `for resp.HasNextPage() { resp, err = resp.Next(&slice); ... }`.
+  For token SDKs (aws/gcp/azure): a response with `NextToken`/`nextPageToken`/
+  `marker`/a pager `.More()` that's read once, not looped.
+- A **hand-rolled HTTP client** (in `resources/sdk/`) that does one `GET` and
+  never follows the `Link: rel="next"` header. These are the highest-risk spot —
+  the SDK's automatic paging is bypassed, so the loop must be written by hand and
+  is easy to forget.
+- A **hardcoded small limit** like `?limit=50` on a raw fetch, especially with no
+  next-page follow — a double bug (small page *and* truncated).
+- Missing `.Limit(queryLimit)` / max page size. This one is usually **perf-only,
+  not data loss** — if the `HasNextPage` loop is present, results are complete,
+  just fetched in more round-trips. Flag it, but rank it low.
+
+**Why it matters:** an audit that counts or inspects a collection (policy rules,
+role bindings, users in a group) is silently wrong past the first page. No error
+surfaces. Real Okta example: `fetchAccessPolicyRules` did `GET .../rules?limit=50`
+with no `Link` follow while the sibling path paginated correctly — any policy
+with >50 rules lost the rest.
+
+**Correct pattern:** every paginated list loops until the SDK says there are no
+more pages; hand-rolled fetches follow the `Link: rel="next"` header (or the
+token) in a loop, ideally bounded by a `maxPages` guard so a malformed/cycling
+cursor can't hang the whole scan.
+
+**Verify by:** confirming the SDK response type actually exposes a next-page
+signal (read the SDK source), and that the loop consumes it.
+
+---
+
+## 2. Nil dereference / panic on real-world data
+
+**What:** dereferencing an SDK pointer or asserting a type without a guard, on a
+value that is legitimately null/absent in some accounts.
+
+**Fingerprints:**
+- `*entry.Field` or `entry.Field.Sub` where `Field` is a `*string`/`*bool`/
+  `*time.Time` or a nested pointer, without going through the nil-safe helper
+  (`<provider>Str()`, `oktaBool()`, `llx.*DataPtr()`) or a `== nil` check.
+- **Bare type assertions on runtime/JSON data**: `x := v.(T)` instead of
+  `x, ok := v.(T)`. A panic here is not local — the executor runs blocks in
+  goroutines, so a panic **crashes the entire scan**, not just one query. Guard
+  every assertion on `arg.Value` / `map[string]any` values / `AdditionalProperties`
+  with comma-ok or a `== nil` check.
+- A response object dereferenced right after the error check on the assumption
+  it's non-nil (`resp, _, err := Get(...); if err != nil {...}; x := resp.Field`)
+  — if the API can return `(nil, nil)`, that's a panic. Sibling inits usually
+  guard `if resp == nil`; a missing guard where siblings have one is a tell.
+
+**Why it matters:** panics crash scans; and OpenAPI-generated SDKs model almost
+every scalar as a pointer precisely because "absent" is common.
+
+**Correct pattern:** pointers go through nil-safe helpers; assertions use
+comma-ok; response bodies are nil-checked before use.
+
+---
+
+## 3. Singular resource accessor returns nil without StateIsNull
+
+**What:** a computed accessor returning a single resource pointer (`(*mqlXxx, error)`)
+does `return nil, nil` for the legit-null case without first marking the field
+set-and-null.
+
+**Fingerprint:**
+```go
+func (a *mqlFoo) bar() (*mqlBar, error) {
+    if id == "" {
+        return nil, nil   // BUG: runtime doesn't know the field resolved
+    }
+```
+Correct:
+```go
+    if id == "" {
+        a.Bar.State = plugin.StateIsSet | plugin.StateIsNull
+        return nil, nil
+    }
+```
+
+**Why it matters:** without the state flag the runtime doesn't know the field was
+resolved to null and may panic or re-fetch indefinitely. Applies to **every**
+`return nil, nil` path in such an accessor: empty id, access-denied fallback, nil
+API response, unset optional. Does **not** apply to functions returning slices,
+maps, or scalars — only singular resource pointers.
+
+---
+
+## 4. Init fall-through husk
+
+**What:** a singular resource's `init` returns `args, nil, nil` after a lookup
+that found nothing, instead of a not-found error.
+
+**Fingerprint:** an init loop that searches for a match and ends with
+`return args, nil, nil` when no match was found (as opposed to the legitimate
+early "args already complete" fast-path like `if len(args) > 2 { return args, nil, nil }`).
+
+**Why it matters:** returning no resource *and* no error tells the runtime to
+build the resource from whatever partial `args` exist (often just an id/arn),
+leaving every other field **unset** (not null — unset). Any query touching those
+fields surfaces client-side as `llx: encountered a primitive with no type
+information, coercing to null`, with no attribution. Return a not-found error
+instead. Same for intermediate failures inside the init (an ARN that won't parse).
+
+**Note the nuance:** a *bare resource with no id* is a valid empty state and
+should return `args, nil, nil`. The bug is specifically the *lookup-miss*
+fall-through.
+
+---
+
+## 5. Caching / `__id` bugs
+
+**What:** wrong or colliding cache keys, so resources overwrite each other or
+never cache.
+
+**Fingerprints:**
+- **`CreateResource` where `NewResource` is required.** Only `NewResource` runs a
+  resource's `init`. If a resource's identity (`__id`) is computed *in* its init,
+  or it's a parameterized resource (an access-review / who-can lookup keyed on
+  args), `CreateResource` skips init → the `__id` stays empty and every instance
+  collides in the cache → every query returns the first one's result.
+- **Empty or duplicated `__id`.** A new resource created without a stable unique
+  `__id` (and without an `id()` method) collides. Review caught exactly this: a
+  sub-resource missing `__id` used an empty cache key and every row aliased.
+- **Non-unique `id()`.** An `id()` that returns a value shared across instances.
+- **Typo'd `__id` prefix.** Cosmetic if still unique (e.g. `okta.trustedOriogin/`),
+  but a real defect — flag it low.
+
+**Correct pattern:** every resource has a stable, unique `__id` — an ARN, a
+GCP resource name, a composite `<parent>/<leaf>`. Hide synthetic composite ids
+(pass `"__id"` directly, no public `id` field); expose `id` only when it carries
+user-meaningful, queryable information.
+
+---
+
+## 6. `null && null == true` — unset booleans pass assertions
+
+**What:** an init-miss stub or degraded resource leaves boolean fields as
+`StateIsNull` instead of explicit `false`.
+
+**Fingerprint:** a not-found / access-denied path that creates a resource but
+doesn't set its bool fields; or a stub returning without explicit `false` values.
+
+**Why it matters:** MQL uses three-valued logic where `null && null` evaluates to
+`true`. A `{ a && b }` assertion over such a stub passes even though nothing was
+actually verified — a false sense of security in a security scan. Misses and typos
+must **fail**, so degraded/stub resources need explicit `false`, not null.
+
+---
+
+## 7. Typed-reference gate misses (data-model bug, expensive to fix later)
+
+**What:** a field that identifies or points at another modeled resource is shipped
+as a raw `*Id` / `*Arn` / `*Url` string instead of a typed accessor.
+
+**Fingerprints:** `projectId string`, `vpcId string`, `roleArn string`,
+`networkUrl string` (GCP self-links), `subnetIds []string`, etc. — where the value
+names something the provider models as a resource.
+
+**Why it matters:** it blocks MQL traversal (`aws.rds.proxy.vpc.cidrBlock`), and
+replacing a shipped `projectId string` with `project() <provider>.project` later
+is a **breaking change** (version bump + consumer migration). So it's worth
+catching in review of *unreleased* resources especially. The fix: store the raw
+id in a `cache*` field on the Internal struct and resolve via `NewResource` in a
+typed accessor named for the domain (`project()`, `vpc()`), not `<thing>Typed`.
+Deprecate the raw `*Id` when a typed ref carries the same value.
+
+**Caveat:** a raw string is correct when it's the resource's own `id`, or a
+genuinely opaque/scalar value (a hash, a free-form name, a discriminator). Don't
+flag those.
+
+---
+
+## 8. Cross-path data inconsistency
+
+**What:** the same field resolves to different values depending on whether you
+reach the resource through the collection or through a single-object lookup.
+
+**Fingerprint:** the collection creator (`newMqlXxx` / list loop) populates a
+field from the *list* API response, while the init/single-fetch path populates
+the same field from a *separate detail* call. If the list API doesn't actually
+return that field, the collection path yields empty/zero while the single path
+yields the real value.
+
+**Why it matters:** `provider.things { field }` disagrees with
+`provider.thing(id: "...") { field }`, and the empty answer looks valid. Real
+Okta example: `okta.customRole.permissions` decoded inline from the list roles
+endpoint (which doesn't include permissions) but the single-role init made a
+separate `ListRolePermissions` call — so the collection returned `[]` for every
+role. Fix: make the field a lazy computed method backed by the detail call, so
+both paths resolve identically (and queries not selecting it skip the call).
+
+**Verify by:** checking whether the list API response actually carries the field
+(SDK model + docs), or route to live verification.
+
+---
+
+## 8b. `.lr` type vs `llx.*Data` constructor mismatch
+
+**What:** a field's declared `.lr` type doesn't match the `llx.*Data` helper used to
+populate it, so the runtime stamps the value with the wrong type.
+
+**Fingerprint:** the classic one is a **`[]dict` field populated with
+`llx.DictData(x)`** (scalar dict) instead of `llx.ArrayData(x, types.Dict)` —
+`convert.JsonToDictSlice` returns a `[]interface{}`, and `DictData` stamps it as
+a single `types.Dict` rather than an array of dicts. Look for any `llx.DictData(`,
+`llx.StringData(`, `llx.IntData(` whose target `.lr` field is a list or a
+different scalar type. Cross-check each `CreateResource` arg's helper against the
+field's declared type in the `.lr`, and against how sibling `[]dict` fields in the
+same provider do it (they're the reference — e.g. `scopes []dict` using
+`ArrayData(scopes, types.Dict)`).
+
+**Why it matters:** `provider.things { listDictField }` hits a type/coercion
+error, or silently returns a mistyped value that downstream MQL can't iterate. It
+compiles and the field "exists," so tests and codegen don't catch it — only a
+query that touches the field reveals it. Real Okta example: `okta.domain.dnsRecords`
+(declared `[]dict`) was set with `llx.DictData` while the sibling
+`okta.trustedOrigin.scopes` used `llx.ArrayData(..., types.Dict)` correctly.
+
+**Correct pattern:** the `llx.*Data` constructor matches the `.lr` type exactly —
+`[]dict` → `ArrayData(x, types.Dict)`, `[]string` → `ArrayData(x, types.String)`,
+`dict` → `DictData(x)`, and so on. A quick grep of every `Data(` call against the
+resource's `.lr` field list catches these fast.
+
+---
+
+## 9. Error propagation / access-denied handling
+
+**What:** a single permission gap or expected-empty condition fails a whole query
+instead of degrading.
+
+**Fingerprints:**
+- A sub-accessor that returns the raw error on a 403/permission denial, where the
+  provider's convention is to degrade (`Is400AccessDeniedError(err)` → nil result;
+  region-not-available guards; resource-policy "operation not recognized" →
+  null). New region-looping accessors especially need the not-available guard or
+  they hard-fail whole accounts.
+- A "not configured" 404 (e.g. no billing contact) propagated as an error instead
+  of a clean null via `StateIsSet | StateIsNull`.
+
+**Why it matters:** one inaccessible resource shouldn't sink an entire scan; and a
+legitimately-absent optional should read as null, not an error. **But judgment
+applies:** surfacing a real permission error so the user learns their token is
+under-scoped is sometimes correct. Flag the pattern; let the reviewer decide.
+
+---
+
+## 10. Range-variable pointer capture
+
+**What:** taking the address of a `for _, v := range xs` loop variable and storing
+it, so every stored pointer aliases the same final element (pre-Go-1.22 semantics;
+still a real bug in mapping code that appends `&v`).
+
+**Fingerprint:** `for _, v := range xs { ...&v... }` or passing `&v` into a
+`CreateResource` arg. The correct provider idiom is index-addressed:
+`for i := range xs { ...&xs[i]... }`.
+
+**Why it matters:** every created resource ends up with the last element's data.
+Fast to sweep for with grep; the whole provider usually uses `&slice[i]` — an
+`&v` stands out.
+
+---
+
+## 11. Schema-naming husks (build/compile-time fingerprints)
+
+**What:** `.lr` resource/field naming that produces an empty or mistyped resource.
+
+**Fingerprints:**
+- A resource named `<parent>.<field>` queried by that same dotted path becomes an
+  empty husk: `cannot convert primitive with NO type information`. Don't give a
+  resource the same name as the path used to reach it.
+- A list field whose path equals its element resource type compiles as a single
+  resource, not a list: `is not a list type`. Use a plural field name with a
+  singular element resource (field `policies` → resource `...policy`).
+
+**Why it matters:** these surface as broken queries, not build failures, so they
+slip through. Mostly relevant when reviewing new `.lr` schema.
+
+---
+
+## 12. Shared-runtime mutation (mostly llx/core, occasionally providers)
+
+**What:** mutating a slice/map obtained from `arg.Value` / `bind.Value` in place.
+
+**Fingerprint:** `append(x[:j], x[j+1:]...)` or index assignment on a slice/map
+taken directly from runtime data without copying first.
+
+**Why it matters:** the runtime caches resolved values and hands the same pointer
+to multiple callers; mutating it corrupts the value for every subsequent use.
+Copy before modifying. Primarily a concern in `llx/` builtins, but worth a glance
+if a provider does clever in-place list surgery.
+
+---
+
+## 13. convert.SliceStrPtr* panic on nil elements
+
+**What:** `convert.SliceStrPtrToStr` / `convert.SliceStrPtrToInterface` deref each
+pointer with no nil guard — they **panic** on a slice containing nil elements.
+
+**Fingerprint:** either helper called on an SDK `[]*string` that may hold nils.
+
+**Correct pattern:** write a nil-safe loop when the SDK slice can contain nil
+pointers. They are not drop-in "safe" replacements.
+
+---
+
+## Things that are usually NOT bugs (avoid false positives)
+
+- `runtime.Connection.(*connection.XxxConnection)` — a bare assertion, but a
+  codebase-wide invariant; always the right connection type. Not a panic risk.
+- `if len(slice) == 0 { return nil, nil }` before a pagination loop — an empty
+  first page implies no next page, so no data is dropped; it's a null-vs-empty
+  style choice, not a truncation.
+- Missing `.Limit()` on a list call whose SDK request type has **no** `.Limit`
+  builder — verify in the SDK before flagging; some endpoints genuinely don't
+  offer it.
+- Deprecated SDK fields left unmodeled — often correct (the data moved), not an
+  omission.
+- A type switch (`switch v := x.(type)`) — safe, not a bare assertion.


### PR DESCRIPTION
## What

A new `.claude/skills/provider-bug-review` skill for doing a deep **static/logic** review of an mql provider — the kind of bugs a compiler and a passing test suite miss: pagination loops that silently return one page, pointer derefs that panic on a real null, a field that resolves differently through the collection path than the single-object path, `__id` collisions.

It's the static counterpart to the existing `provider-verification` skill (which proves resources against live cloud infra) and goes deeper than generic `code-review` on provider-specific bug classes.

## Contents

- **`SKILL.md`** — the "fan out, then verify" workflow: scope & prioritize (newest files = highest risk) → learn the house patterns and the SDK's pagination mechanics first → dispatch parallel per-file-group analysis agents → **verify every candidate against source** → severity-ranked report → stop (report-first; fixing is a separate explicit step). Includes mechanical grep sweeps for range-capture and bare type assertions.
- **`references/bug-taxonomy.md`** — the catalogue of ~14 recurring provider bug classes, each with fingerprint / why-it-hurts / correct-pattern, ordered by user impact, plus a "usually NOT a bug" section to suppress false positives. Distilled from repeated aws/gcp/azure/okta audits.
- **`references/agent-prompt-template.md`** — the ready-to-adapt fan-out prompt with the reporting contract and the cross-check-siblings instruction.

## Validation

Ground-truth tested against the Okta provider **pre-fix snapshot** (the state before #9285). A with-skill review re-discovered all **3** real data-correctness bugs #9285 fixed (access-policy-rule truncation, `customRole.permissions` cross-path emptiness, `ListPolicies` single-page) plus most of the deferred backlog, with clean severity ranking and a "verified clean" coverage section.

A baseline (no-skill) run of the same prompt also found the 3 headline bugs but surfaced one real bug the skill-guided run missed — a `[]dict` field populated with `llx.DictData` instead of `llx.ArrayData(..., types.Dict)`. That class is now captured in the taxonomy (`8b`), so future runs get both the structure and that check.
