### PR TITLE
🐛 atlassian: fix jira nil-deref panics and scim pagination truncation

### DIFF
--- a/providers/atlassian/resources/atlassian_jira.go
+++ b/providers/atlassian/resources/atlassian_jira.go
@@ -94,6 +94,12 @@ func (a *mqlAtlassianJiraUser) applicationRoles() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	// ApplicationRoles is an omitempty pointer; accounts with no application-role
+	// assignment (app/customer account types) return it nil, so guard before
+	// dereferencing Items.
+	if user == nil || user.ApplicationRoles == nil {
+		return []any{}, nil
+	}
 	roles := user.ApplicationRoles
 
 	res := []any{}
@@ -293,15 +299,23 @@ func (a *mqlAtlassianJira) issues() ([]any, error) {
 			break
 		}
 		for _, issue := range issues.Issues {
-			creator, err := mqlJiraUser(a.MqlRuntime, issue.Fields.Creator)
+			// Fields is an omitempty pointer. A malformed/permission-restricted
+			// search hit can carry no fields block at all; skip it rather than
+			// panic (and crash the whole scan) on the derefs below.
+			if issue == nil || issue.Fields == nil {
+				continue
+			}
+			f := issue.Fields
+
+			creator, err := mqlJiraUser(a.MqlRuntime, f.Creator)
 			if err != nil {
 				return nil, err
 			}
-			assignee, err := mqlJiraUser(a.MqlRuntime, issue.Fields.Assignee)
+			assignee, err := mqlJiraUser(a.MqlRuntime, f.Assignee)
 			if err != nil {
 				return nil, err
 			}
-			reporter, err := mqlJiraUser(a.MqlRuntime, issue.Fields.Reporter)
+			reporter, err := mqlJiraUser(a.MqlRuntime, f.Reporter)
 			if err != nil {
 				return nil, err
 			}
@@ -310,28 +324,28 @@ func (a *mqlAtlassianJira) issues() ([]any, error) {
 				map[string]*llx.RawData{
 					"id":            llx.StringData(issue.ID),
 					"key":           llx.StringData(issue.Key),
-					"summary":       llx.StringData(issue.Fields.Summary),
-					"project":       llx.StringData(issue.Fields.Project.Name),
-					"projectKey":    llx.StringData(issue.Fields.Project.Key),
-					"status":        llx.StringData(issue.Fields.Status.Name),
-					"description":   llx.StringData(issue.Fields.Description),
-					"priority":      llx.StringData(jiraPriorityName(issue.Fields.Priority)),
-					"resolution":    llx.StringData(jiraResolutionName(issue.Fields.Resolution)),
-					"labels":        llx.ArrayData(stringsToAny(issue.Fields.Labels), types.String),
-					"createdAt":     llx.TimeDataPtr(jiraDateTime(issue.Fields.Created)),
-					"updatedAt":     llx.TimeDataPtr(jiraDateTime(issue.Fields.Updated)),
-					"resolvedAt":    llx.TimeDataPtr(jiraDateTime(issue.Fields.ResolutionDate)),
-					"dueDate":       llx.TimeDataPtr(jiraDate(issue.Fields.DueDate)),
+					"summary":       llx.StringData(f.Summary),
+					"project":       llx.StringData(jiraProjectName(f.Project)),
+					"projectKey":    llx.StringData(jiraProjectKey(f.Project)),
+					"status":        llx.StringData(jiraStatusName(f.Status)),
+					"description":   llx.StringData(f.Description),
+					"priority":      llx.StringData(jiraPriorityName(f.Priority)),
+					"resolution":    llx.StringData(jiraResolutionName(f.Resolution)),
+					"labels":        llx.ArrayData(stringsToAny(f.Labels), types.String),
+					"createdAt":     llx.TimeDataPtr(jiraDateTime(f.Created)),
+					"updatedAt":     llx.TimeDataPtr(jiraDateTime(f.Updated)),
+					"resolvedAt":    llx.TimeDataPtr(jiraDateTime(f.ResolutionDate)),
+					"dueDate":       llx.TimeDataPtr(jiraDate(f.DueDate)),
 					"creator":       creator,
 					"assignee":      assignee,
 					"reporter":      reporter,
-					"typeName":      llx.StringData(issue.Fields.IssueType.Name),
-					"components":    llx.ArrayData(jiraIssueComponents(issue.Fields.Components), types.Dict),
-					"fixVersions":   llx.ArrayData(jiraIssueVersions(issue.Fields.FixVersions), types.Dict),
-					"securityLevel": llx.DictData(jiraIssueSecurity(issue.Fields.Security)),
-					"watcherCount":  llx.IntData(int64(jiraWatcherCount(issue.Fields.Watcher))),
-					"voteCount":     llx.IntData(int64(jiraVoteCount(issue.Fields.Votes))),
-					"comments":      llx.ArrayData(jiraIssueComments(issue.Fields.Comment), types.Dict),
+					"typeName":      llx.StringData(jiraIssueTypeName(f.IssueType)),
+					"components":    llx.ArrayData(jiraIssueComponents(f.Components), types.Dict),
+					"fixVersions":   llx.ArrayData(jiraIssueVersions(f.FixVersions), types.Dict),
+					"securityLevel": llx.DictData(jiraIssueSecurity(f.Security)),
+					"watcherCount":  llx.IntData(int64(jiraWatcherCount(f.Watcher))),
+					"voteCount":     llx.IntData(int64(jiraVoteCount(f.Votes))),
+					"comments":      llx.ArrayData(jiraIssueComments(f.Comment), types.Dict),
 				})
 			if err != nil {
 				return nil, err
@@ -386,6 +400,34 @@ func jiraResolutionName(r *models.ResolutionScheme) string {
 		return ""
 	}
 	return r.Name
+}
+
+func jiraProjectName(p *models.ProjectScheme) string {
+	if p == nil {
+		return ""
+	}
+	return p.Name
+}
+
+func jiraProjectKey(p *models.ProjectScheme) string {
+	if p == nil {
+		return ""
+	}
+	return p.Key
+}
+
+func jiraStatusName(s *models.StatusScheme) string {
+	if s == nil {
+		return ""
+	}
+	return s.Name
+}
+
+func jiraIssueTypeName(it *models.IssueTypeScheme) string {
+	if it == nil {
+		return ""
+	}
+	return it.Name
 }
 
 func jiraDate(d *models.DateScheme) *time.Time {

--- a/providers/atlassian/resources/atlassian_jira_test.go
+++ b/providers/atlassian/resources/atlassian_jira_test.go
@@ -24,6 +24,23 @@ func TestJiraResolutionName(t *testing.T) {
 	assert.Equal(t, "", jiraResolutionName(&models.ResolutionScheme{}))
 }
 
+func TestJiraFieldPointerHelpers(t *testing.T) {
+	// These guard the issues() mapping against nil Project/Status/IssueType
+	// pointers (all omitempty in the SDK), which would otherwise panic and
+	// crash the whole scan.
+	assert.Equal(t, "", jiraProjectName(nil))
+	assert.Equal(t, "Platform", jiraProjectName(&models.ProjectScheme{Name: "Platform"}))
+
+	assert.Equal(t, "", jiraProjectKey(nil))
+	assert.Equal(t, "PLAT", jiraProjectKey(&models.ProjectScheme{Key: "PLAT"}))
+
+	assert.Equal(t, "", jiraStatusName(nil))
+	assert.Equal(t, "Done", jiraStatusName(&models.StatusScheme{Name: "Done"}))
+
+	assert.Equal(t, "", jiraIssueTypeName(nil))
+	assert.Equal(t, "Bug", jiraIssueTypeName(&models.IssueTypeScheme{Name: "Bug"}))
+}
+
 func TestJiraDateTime(t *testing.T) {
 	t.Run("nil returns nil", func(t *testing.T) {
 		assert.Nil(t, jiraDateTime(nil))

--- a/providers/atlassian/resources/atlassian_scim.go
+++ b/providers/atlassian/resources/atlassian_scim.go
@@ -68,10 +68,10 @@ func (a *mqlAtlassianScim) users() ([]any, error) {
 			u.cachedGroups = true
 			res = append(res, mqlUser)
 		}
-		if len(page.Resources) < scimPageSize {
+		startIndex += len(page.Resources)
+		if scimReachedEnd(startIndex, len(page.Resources), page.TotalResults) {
 			break
 		}
-		startIndex += len(page.Resources)
 	}
 	return res, nil
 }
@@ -113,12 +113,29 @@ func (a *mqlAtlassianScim) groups() ([]any, error) {
 			g.cachedMembers = true
 			res = append(res, mqlGroup)
 		}
-		if len(page.Resources) < scimPageSize {
+		startIndex += len(page.Resources)
+		if scimReachedEnd(startIndex, len(page.Resources), page.TotalResults) {
 			break
 		}
-		startIndex += len(page.Resources)
 	}
 	return res, nil
+}
+
+// scimReachedEnd reports whether a SCIM list loop should stop. nextStartIndex is
+// the 1-based index of the next page's first resource (already advanced past the
+// page just processed), pageLen is that page's resource count, and totalResults
+// is the server-reported total.
+//
+// TotalResults is the authoritative signal: keep paging until nextStartIndex has
+// moved past it, regardless of page size. This matters because Atlassian SCIM
+// caps count server-side, so a page shorter than the requested scimPageSize does
+// NOT mean the end. Only when the server omits a total (<= 0) do we fall back to
+// the short-page heuristic.
+func scimReachedEnd(nextStartIndex, pageLen, totalResults int) bool {
+	if totalResults > 0 {
+		return nextStartIndex > totalResults
+	}
+	return pageLen < scimPageSize
 }
 
 func (a *mqlAtlassianScimUser) id() (string, error) {

--- a/providers/atlassian/resources/atlassian_scim_test.go
+++ b/providers/atlassian/resources/atlassian_scim_test.go
@@ -1,0 +1,42 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScimReachedEnd(t *testing.T) {
+	// TotalResults is authoritative: keep paging until we've moved past it,
+	// even when a page is shorter than scimPageSize (Atlassian caps count
+	// server-side, so a short page is NOT the end).
+	t.Run("short page with more remaining does not stop", func(t *testing.T) {
+		// Server capped the page at 50 though we asked for scimPageSize; 250 total.
+		// nextStartIndex = 1 + 50 = 51, still <= 250 -> keep going.
+		assert.False(t, scimReachedEnd(51, 50, 250))
+	})
+
+	t.Run("stops once past the total", func(t *testing.T) {
+		// Fetched the final chunk: nextStartIndex 251 > 250 -> stop.
+		assert.True(t, scimReachedEnd(251, 50, 250))
+	})
+
+	t.Run("full page mid-stream keeps going", func(t *testing.T) {
+		assert.False(t, scimReachedEnd(scimPageSize+1, scimPageSize, 3*scimPageSize))
+	})
+
+	t.Run("exact boundary stops", func(t *testing.T) {
+		// total == scimPageSize, one full page: nextStartIndex scimPageSize+1 > total.
+		assert.True(t, scimReachedEnd(scimPageSize+1, scimPageSize, scimPageSize))
+	})
+
+	t.Run("no total falls back to short-page heuristic", func(t *testing.T) {
+		// totalResults omitted (0): a short page means the end.
+		assert.True(t, scimReachedEnd(51, 50, 0))
+		// a full page means keep going.
+		assert.False(t, scimReachedEnd(scimPageSize+1, scimPageSize, 0))
+	})
+}


### PR DESCRIPTION
## Summary

Static review of the atlassian provider surfaced two panic paths and one silent-truncation bug. All three are the "wrong data / crashed scan with no error" class. Verified against the go-atlassian v2.12.0 SDK model structs.

### 🔴 Jira nil-deref panics (crash the whole scan)

Executor blocks run in goroutines, so an unrecovered panic takes down the entire scan, not just one query.

- **`issues()`** — `issue.Fields` (`*IssueFieldsSchemeV2`) and its `Project` / `Status` / `IssueType` (all `omitempty` pointers) were dereferenced directly (`issue.Fields.Project.Name`, `.Status.Name`, `.IssueType.Name`). A malformed or permission-restricted search hit with an absent fields block, or a missing project/status/type, panicked. The author already routed Creator/Assignee/Reporter/Priority/Resolution/Security/Votes through nil-safe helpers — these four were the gap. Now guards `issue.Fields` and routes the sub-pointers through new nil-safe helpers.
- **`applicationRoles()`** — `user.ApplicationRoles` (`*UserApplicationRolesScheme`, `omitempty`) was dereferenced via `roles.Items`. Accounts with no application-role assignment (app/customer account types — common) return it nil. Now guarded before iterating.

### 🟠 SCIM pagination truncation (silent data loss)

`scim.users()` / `groups()` terminated the page loop on `len(Resources) < scimPageSize`. Atlassian caps SCIM `count` server-side (the existing code comment notes this), so a page shorter than the requested size does **not** mean the end. A deployment that returned short pages while more results remained would silently drop every remaining user/group — a SCIM access review would then audit only a prefix of the directory with no error. Now terminates on the authoritative `TotalResults`, falling back to the short-page heuristic only when the server omits a total.

## Tests

- Nil-safe helper table tests (`jiraProjectName` / `jiraProjectKey` / `jiraStatusName` / `jiraIssueTypeName`), matching the existing helper-test style.
- `scimReachedEnd` pagination logic: short-page-with-more-remaining, past-total, mid-stream full page, exact boundary, and the no-total fallback.

`go test ./resources/` passes; `go build ./...` clean.

## Not included

The remaining review findings were lower severity and left for a separate decision: `serverInfos()` panicking on the `CreateResource` error path (low probability), the Confluence CQL user-search `len < LIMIT` heuristic (low confidence), and `properties()` missing nil guards.
