### PR TITLE
🐛 ansible: fix ansible.role nil-deref panic and YAML inventory misclassification

### DIFF
--- a/providers/ansible/project/galaxy.go
+++ b/providers/ansible/project/galaxy.go
@@ -72,7 +72,9 @@ func loadRequirements(root string) (*Requirements, error) {
 	// Old style: a bare list of roles.
 	var list []any
 	if err := yaml.Unmarshal(data, &list); err != nil {
-		return nil, err
+		// An unparseable requirements file should not abort the whole project
+		// load; treat it as absent, matching loadPlaybooks' skip behavior.
+		return nil, nil
 	}
 	for _, r := range list {
 		req.Roles = append(req.Roles, parseGalaxyRole(r))

--- a/providers/ansible/project/inventory.go
+++ b/providers/ansible/project/inventory.go
@@ -121,7 +121,10 @@ func loadInventory(root string) (*Inventory, error) {
 		if isINIInventory(data) {
 			parseINIInventory(b, data)
 		} else if err := parseYAMLInventory(b, data); err != nil {
-			return nil, err
+			// A single unparseable inventory file (e.g. YAML that yaml.v3
+			// rejects but Ansible tolerates) should not abort the whole
+			// project load; skip it, matching loadPlaybooks.
+			continue
 		}
 		found = true
 	}
@@ -183,6 +186,13 @@ func isINIInventory(data []byte) bool {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
 			continue
+		}
+		// A YAML document marker (--- / ...) can only start a YAML inventory;
+		// INI has no such construct. Skip it so classification keys off the
+		// first real content line (e.g. an `all:` mapping) rather than
+		// mistaking `---` for a bare INI host line.
+		if line == "---" || line == "..." {
+			return false
 		}
 		if strings.HasPrefix(line, "[") {
 			return true

--- a/providers/ansible/project/project_test.go
+++ b/providers/ansible/project/project_test.go
@@ -67,6 +67,62 @@ func TestSymlinkVarsEscapeSkipped(t *testing.T) {
 	}
 }
 
+// isINIInventory must not mistake a YAML inventory that opens with a `---`
+// document marker for an INI file — doing so parsed the whole inventory as
+// garbage INI host lines.
+func TestIsINIInventoryClassification(t *testing.T) {
+	assert.True(t, isINIInventory([]byte("[web]\nhost1\n")), "bracket section is INI")
+	assert.True(t, isINIInventory([]byte("host1\nhost2\n")), "bare host lines are INI")
+	assert.False(t, isINIInventory([]byte("all:\n  hosts:\n    web1:\n")), "key mapping is YAML")
+	assert.False(t, isINIInventory([]byte("---\nall:\n  hosts:\n    web1:\n")), "leading --- is YAML")
+	assert.False(t, isINIInventory([]byte("# comment\n---\nall:\n")), "comment then --- is YAML")
+}
+
+// A YAML inventory that opens with a `---` document marker must be parsed as
+// YAML, not misclassified as INI (which produced bogus "---"/"all:" hosts).
+func TestInventoryYAMLWithDocumentMarker(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "inventory.yml"),
+		[]byte("---\nweb:\n  hosts:\n    web1:\n    web2:\n"),
+		0o600,
+	))
+
+	inv, err := loadInventory(root)
+	require.NoError(t, err)
+	require.NotNil(t, inv)
+
+	groups := map[string]*InventoryGroup{}
+	for _, g := range inv.Groups {
+		groups[g.Name] = g
+	}
+	require.Contains(t, groups, "web")
+	assert.ElementsMatch(t, []string{"web1", "web2"}, groups["web"].Hosts)
+	assert.NotContains(t, groups, "---", "the document marker must not become a group")
+}
+
+// A role whose file fails to decode (e.g. duplicate mapping keys, which yaml.v3
+// rejects but Ansible tolerates) must be skipped rather than aborting the whole
+// project load, matching loadPlaybooks.
+func TestLoadRolesSkipsUnparseableRole(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "roles", "good"), 0o755))
+	badDefaults := filepath.Join(root, "roles", "bad", "defaults")
+	require.NoError(t, os.MkdirAll(badDefaults, 0o755))
+	// Duplicate mapping key -> yaml.v3 returns a decode error.
+	require.NoError(t, os.WriteFile(filepath.Join(badDefaults, "main.yml"), []byte("foo: 1\nfoo: 2\n"), 0o600))
+
+	roles, err := loadRoles(filepath.Join(root, "roles"))
+	require.NoError(t, err, "one unparseable role must not fail the whole load")
+
+	names := make([]string, 0, len(roles))
+	for _, r := range roles {
+		names = append(names, r.Name)
+	}
+	assert.Contains(t, names, "good")
+	assert.NotContains(t, names, "bad")
+}
+
 // A YAML inventory written with `hosts:` as a list (each element a bare
 // hostname, which Ansible accepts) must be honored, not silently dropped by a
 // map-only type assertion.

--- a/providers/ansible/project/role.go
+++ b/providers/ansible/project/role.go
@@ -48,7 +48,10 @@ func loadRoles(rolesDir string) ([]*Role, error) {
 		}
 		role, err := loadRole(e.Name(), filepath.Join(rolesDir, e.Name()))
 		if err != nil {
-			return nil, err
+			// A role with an unparseable file (e.g. YAML that yaml.v3 rejects
+			// but Ansible tolerates) should not abort the whole project load;
+			// skip it, matching loadPlaybooks.
+			continue
 		}
 		roles = append(roles, role)
 	}

--- a/providers/ansible/resources/project.go
+++ b/providers/ansible/resources/project.go
@@ -270,15 +270,25 @@ func newMqlAnsibleRole(runtime *plugin.Runtime, role *project.Role) (*mqlAnsible
 }
 
 func (r *mqlAnsibleRole) tasks() ([]any, error) {
+	// role is nil when the resource was instantiated bare (e.g. a top-level
+	// `ansible.role` query, or recording replay) rather than through
+	// newMqlAnsibleRole. Guard before dereferencing, matching the sibling
+	// ansible.play / ansible.task accessors.
+	if r.role == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleTasks(r.MqlRuntime, r.MqlID(), "tasks", filepath.Join(r.role.Path, "tasks"), r.role.Tasks)
 }
 
 func (r *mqlAnsibleRole) handlers() ([]any, error) {
+	if r.role == nil {
+		return []any{}, nil
+	}
 	return newMqlAnsibleHandlers(r.MqlRuntime, r.MqlID(), r.role.Handlers)
 }
 
 func (r *mqlAnsibleRole) meta() (*mqlAnsibleRoleMeta, error) {
-	if r.role.Meta == nil {
+	if r.role == nil || r.role.Meta == nil {
 		r.Meta.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -297,7 +307,7 @@ func (r *mqlAnsibleRole) meta() (*mqlAnsibleRoleMeta, error) {
 
 func (r *mqlAnsibleRole) dependencies() ([]any, error) {
 	proj := ansibleProject(r.MqlRuntime)
-	if proj == nil {
+	if proj == nil || r.role == nil {
 		return []any{}, nil
 	}
 	return newMqlAnsibleRoleRefs(r.MqlRuntime, proj, r.role.DependencyNames)

--- a/providers/ansible/resources/project_test.go
+++ b/providers/ansible/resources/project_test.go
@@ -89,6 +89,31 @@ func TestProjectRolesAndDependencies(t *testing.T) {
 	assert.Equal(t, "common", deps[0].(*mqlAnsibleRole).Name.Data)
 }
 
+// A bare ansible.role (Internal .role unset) is what a top-level `ansible.role`
+// query or a recording replay produces. Its accessors must degrade to
+// empty/null rather than panic on the nil dereference, matching the sibling
+// ansible.play / ansible.task accessors.
+func TestRoleAccessorsNilRole(t *testing.T) {
+	rt := newProjectRuntime(t)
+	role := &mqlAnsibleRole{MqlRuntime: rt}
+
+	tasks, err := role.tasks()
+	require.NoError(t, err)
+	assert.Empty(t, tasks)
+
+	handlers, err := role.handlers()
+	require.NoError(t, err)
+	assert.Empty(t, handlers)
+
+	meta, err := role.meta()
+	require.NoError(t, err)
+	assert.Nil(t, meta)
+
+	deps, err := role.dependencies()
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
 func TestProjectPlayRoleApplications(t *testing.T) {
 	rt := newProjectRuntime(t)
 	proj := &mqlAnsibleProject{MqlRuntime: rt}


### PR DESCRIPTION
## Summary

Static review of the ansible provider (a local-file static analyzer, so the risk surface is YAML parsing and file walking, not cloud pagination) surfaced three defects. Two are HIGH, one MEDIUM. All are the "wrong data / crashed scan with no error" class.

### 🔴 `ansible.role` accessors panic on a bare instance (crashes the whole scan)

`ansible.role.tasks` / `.handlers` / `.meta` / `.dependencies` dereference the Internal `role` field with no nil guard. `ansible.role` is a **public, init-less** resource, so a top-level `ansible.role.tasks` query — or a recording replay — creates a bare instance with `role == nil` and panics. Executor blocks run in goroutines, so the panic is unrecoverable and takes down the entire scan. The sibling `ansible.play` / `ansible.task` accessors already guard `if r.play == nil` / `if r.task == nil`; the role accessors were the only ones missing it. Fixed by adding the same guard (empty slice for the list accessors, `StateIsSet | StateIsNull` for `meta()`).

### 🔴 YAML inventory with a `---` document marker parsed as INI (silent wrong data)

`isINIInventory` classified a YAML inventory whose first content line is the `---` document marker as INI: `---` isn't a `[section]`, doesn't end in `:`, and has no `": "`, so it fell through to the "bare host line → INI" branch. The file was then walked as INI, emitting bogus `"---"` / `"all:"` / hostname host entries in the `ungrouped` group and dropping the real groups and host vars — `ansible.inventory.hosts` / `.groups` returned garbage with no error. A leading `---` is a common YAML convention, so this hits real inventories. Fixed by treating a leading `---`/`...` marker as a YAML signal.

### 🟠 One unparseable file aborted the entire project load

A role/inventory/requirements file that `yaml.v3` rejects but Ansible tolerates (most notably **duplicate mapping keys**) made `Load` return the decode error, failing the whole `Connect` — while `loadPlaybooks` skips an unparseable playbook and continues. Made role/inventory/requirements loading skip-and-continue too, matching the established playbook behavior.

## Tests

- `TestIsINIInventoryClassification` — direct classifier coverage including the `---` and comment-then-`---` cases.
- `TestInventoryYAMLWithDocumentMarker` — end-to-end: a `---`-prefixed YAML inventory yields the real `web` group with `web1`/`web2`, no bogus `---` group.
- `TestRoleAccessorsNilRole` — a bare `ansible.role` returns empty/null from all four accessors instead of panicking.
- `TestLoadRolesSkipsUnparseableRole` — a role with a duplicate-key `defaults/main.yml` is skipped; the good role still loads.

`go test ./resources/ ./project/` passes; `go build ./...` clean.

## Not included

Lower-severity findings left for a separate decision: `ansible.playbook.plays()` lacks the same nil guard but does not panic (a nil playbook slice ranges empty); `walkYAMLGroup` creates spurious empty groups from non-group top-level YAML keys (dynamic-inventory config files); and the vault walkers (`detectVaultFiles` / `detectInlineVaultVars`) follow in-tree symlinks pointing outside the project root (limited to metadata/paths, no file content) — a security-hardening follow-up.
