### PR TITLE
🐛 bicep: fix multi-line param default truncation and index-key quote stripping

### DIFF
--- a/providers/bicep/resources/expression.go
+++ b/providers/bicep/resources/expression.go
@@ -522,14 +522,34 @@ func (p *exprParser) readIndex() (string, bool) {
 
 // normalizeIndex strips surrounding quotes from a string key so
 // foo['bar'] and foo.bar produce the same path segment "bar". Numeric and
-// expression indices are returned as-is.
+// expression indices are returned as-is — including a concatenation that
+// merely starts and ends with a quote (e.g. `'a' + suffix + 'b'`), which is
+// NOT a single literal and must not be unquoted.
 func normalizeIndex(s string) string {
-	if len(s) >= 2 {
-		if (s[0] == '\'' && s[len(s)-1] == '\'') || (s[0] == '"' && s[len(s)-1] == '"') {
-			return s[1 : len(s)-1]
-		}
+	if isSingleQuotedLiteral(s) {
+		return s[1 : len(s)-1]
 	}
 	return s
+}
+
+// isSingleQuotedLiteral reports whether s is exactly one quoted string literal
+// (e.g. "'key'"), as opposed to an expression that only happens to start and
+// end with a quote (e.g. "'a' + x + 'b'"). It walks s string-aware so a
+// concatenation whose first literal closes before the end is rejected.
+func isSingleQuotedLiteral(s string) bool {
+	if len(s) < 2 || (s[0] != '\'' && s[0] != '"') || s[len(s)-1] != s[0] {
+		return false
+	}
+	st := scanState{}
+	i := st.stepAt(s, 0) // consume the opening quote -> inStr set
+	for i < len(s) {
+		// The string closing before the final byte means s is not a lone literal.
+		if st.inStr == 0 && !st.inMulti && i < len(s)-1 {
+			return false
+		}
+		i = st.stepAt(s, i)
+	}
+	return st.inStr == 0 && !st.inMulti
 }
 
 func (p *exprParser) readIdentifier() string {

--- a/providers/bicep/resources/expression_test.go
+++ b/providers/bicep/resources/expression_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeIndex(t *testing.T) {
+	// A single quoted literal is unquoted so foo['bar'] == foo.bar.
+	assert.Equal(t, "bar", normalizeIndex("'bar'"))
+	assert.Equal(t, "bar", normalizeIndex(`"bar"`))
+	assert.Equal(t, "", normalizeIndex("''"))
+	// Numeric and bare indices pass through.
+	assert.Equal(t, "0", normalizeIndex("0"))
+	assert.Equal(t, "foo", normalizeIndex("foo"))
+	// A concatenation that merely starts and ends with a quote is NOT a single
+	// literal and must be left intact (the regression this guards).
+	assert.Equal(t, "'a' + suffix + 'b'", normalizeIndex("'a' + suffix + 'b'"))
+	// Two adjacent literals are likewise not a single literal.
+	assert.Equal(t, "'a''b'", normalizeIndex("'a''b'"))
+}
+
 func TestParseExpressionLiteral(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/bicep/resources/parser.go
+++ b/providers/bicep/resources/parser.go
@@ -267,7 +267,12 @@ func parseBicep(content string) *parsedBicepFile {
 
 		switch stmt.keyword {
 		case "param":
-			p := parseParameter(firstLine, stmt.decorators)
+			// Reassemble multi-line param statements (an object/array default
+			// spans lines) into a single line so paramRe's `(.*)$` sees the
+			// whole default instead of just the opening `{`/`[`. Inline
+			// comments are stripped string-aware so a trailing `// ...` doesn't
+			// leak into the default value.
+			p := parseParameter(reassembleParamStatement(stmtLines), stmt.decorators)
 			p.startLine, p.endLine = startLine, endLine
 			result.parameters = append(result.parameters, p)
 		case "var":
@@ -322,6 +327,37 @@ func parseBicep(content string) *parsedBicepFile {
 	}
 
 	return result
+}
+
+// reassembleParamStatement collapses a (possibly multi-line) param statement
+// into the single line parseParameter expects. Each source line has its inline
+// `// ...` comment stripped string-aware (so a `//` inside a quoted value such
+// as a URL is preserved) and is then joined with a single space. Lines are not
+// whitespace-collapsed internally, so a string default like 'hello  world'
+// keeps its spacing. A shared scanState is carried across lines so a comment
+// marker inside a multi-line triple-quoted string is not stripped.
+func reassembleParamStatement(lines []string) string {
+	st := scanState{}
+	parts := make([]string, 0, len(lines))
+	for _, l := range lines {
+		parts = append(parts, strings.TrimSpace(stripInlineComment(l, &st)))
+	}
+	return strings.Join(parts, " ")
+}
+
+// stripInlineComment returns s truncated at a trailing `// ...` line comment,
+// honoring string literals via the shared scanState so a `//` inside a string
+// (e.g. 'http://example.com') is left intact. st is advanced through s so the
+// caller can carry string/multi-line state across successive lines.
+func stripInlineComment(s string, st *scanState) string {
+	i := 0
+	for i < len(s) {
+		if st.inStr == 0 && !st.inMulti && s[i] == '/' && i+1 < len(s) && s[i+1] == '/' {
+			return s[:i]
+		}
+		i = st.stepAt(s, i)
+	}
+	return s
 }
 
 func parseParameter(line string, decorators []string) parsedParameter {

--- a/providers/bicep/resources/parser_test.go
+++ b/providers/bicep/resources/parser_test.go
@@ -115,6 +115,62 @@ func TestParseParameterDefaultValues(t *testing.T) {
 	}
 }
 
+func TestParseParameterMultilineAndCommentDefaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantDef string
+	}{
+		{
+			name: "multi-line array default preserved",
+			input: `param locations array = [
+  'eastus'
+  'westus'
+]`,
+			wantDef: "[ 'eastus' 'westus' ]",
+		},
+		{
+			name: "multi-line object default preserved",
+			input: `param config object = {
+  environment: 'prod'
+  count: 3
+}`,
+			wantDef: "{ environment: 'prod' count: 3 }",
+		},
+		{
+			name:    "trailing line comment stripped",
+			input:   "param sku string = 'Standard_LRS' // default sku",
+			wantDef: "Standard_LRS",
+		},
+		{
+			name:    "double-slash inside string is not a comment",
+			input:   "param endpoint string = 'https://example.com'",
+			wantDef: "https://example.com",
+		},
+		{
+			name:    "internal string whitespace preserved",
+			input:   "param greeting string = 'hello   world'",
+			wantDef: "hello   world",
+		},
+		{
+			name: "comment on a continuation line stripped",
+			input: `param locations array = [
+  'eastus' // primary
+  'westus'
+]`,
+			wantDef: "[ 'eastus' 'westus' ]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseBicep(tt.input)
+			require.Len(t, result.parameters, 1)
+			assert.Equal(t, tt.wantDef, result.parameters[0].defaultValue)
+		})
+	}
+}
+
 func TestParseParameterDecorators(t *testing.T) {
 	input := `@description('Teradici Registration Key')
 @secure()


### PR DESCRIPTION
## Summary

Static review of the bicep provider (a hand-rolled parser for the Bicep IaC language — no cloud API, no pagination) surfaced three correctness defects. The provider is otherwise very well-defended (the panic/hang classes are structurally closed by a string-aware `scanState` that always advances, plus a depth cap with an adversarial regression test), so these are all "wrong data on a queryable field," no panics.

### 🟠 Multi-line `param` default truncated to `"{"` / `"["`

The `param` dispatch passed only the statement's **first line** to `parseParameter`, while the sibling `output`/`var` cases reassemble multi-line statements. So a common Bicep pattern:

```bicep
param locations array = [
  'eastus'
  'westus'
]
```

parsed `bicep.parameter.defaultValue` as `"["` (and `"{"` for object defaults) — silently wrong, no error. Added `reassembleParamStatement` to collapse the statement into the single line `paramRe`'s `(.*)$` needs.

### 🟡 Trailing line comment leaked into single-line param defaults

`param sku string = 'Standard_LRS' // note` yielded `defaultValue == "'Standard_LRS' // note"`. The new `stripInlineComment` removes a trailing `// ...` **string-aware**, so a `//` inside a quoted value — e.g. a URL like `'https://example.com'` — is preserved, and internal string whitespace (`'hello   world'`) is not collapsed.

### 🟡 `normalizeIndex` corrupted a concatenated index key

`normalizeIndex` unquoted any string whose first and last bytes were matching quotes, so a concatenated index `obj['a' + suffix + 'b']` had its `bicep.expression.path` segment mangled to `a' + suffix + 'b`. Replaced the first/last-byte heuristic with a string-aware `isSingleQuotedLiteral` that only unquotes a genuine single literal.

## Tests

- `TestParseParameterMultilineAndCommentDefaults` — multi-line array and object defaults preserved, trailing comment stripped, `//` inside a string kept, internal string whitespace kept, comment on a continuation line stripped. (The existing param tests were all single-line, which is why the truncation slipped through.)
- `TestNormalizeIndex` — single literal unquoted; numeric/bare passthrough; concatenation and adjacent-literal cases left intact.

`go test ./resources/` passes; `go build ./...` clean.

## Not included

Two very-low/cosmetic observations from the review, left as-is: `bicep.resource.tags` renders null (not empty map) when absent (a doc-comment mismatch), and a pathological duplicate-object-key Bicep input could alias two property-expression `__id`s (Bicep disallows duplicate keys, so unreachable on valid input).
