### PR TITLE
🎉 bicep-13.4.5, ansible-13.2.9, atlassian-13.4.2

### DIFF
--- a/providers/ansible/config/config.go
+++ b/providers/ansible/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ansible",
 	ID:              "go.mondoo.com/mql/v13/providers/ansible",
-	Version:         "13.2.8",
+	Version:         "13.2.9",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{

--- a/providers/atlassian/config/config.go
+++ b/providers/atlassian/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "atlassian",
 	ID:        "go.mondoo.com/cnquery/v9/providers/atlassian",
-	Version:   "13.4.1",
+	Version:   "13.4.2",
 	Platforms: connection.Platforms,
 	ConnectionTypes: []string{
 		provider.DefaultConnectionType,

--- a/providers/bicep/config/config.go
+++ b/providers/bicep/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "bicep",
 	ID:              "go.mondoo.com/mql/v13/providers/bicep",
-	Version:         "13.4.4",
+	Version:         "13.4.5",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

Patch-bumps the following providers to release recently merged bugfixes:

| Provider | Version | Change |
|---|---|---|
| bicep | 13.4.4 → **13.4.5** | #9291 fix multi-line param default truncation and index-key quote stripping |
| ansible | 13.2.8 → **13.2.9** | #9290 fix `ansible.role` nil-deref panic and YAML inventory misclassification |
| atlassian | 13.4.1 → **13.4.2** | #9289 fix jira nil-deref panics and scim pagination truncation |

You can find the versioning bot under: `providers-sdk/v1/util/version`.