### PR TITLE
🐛 cloudformation: tolerate scalar section values, null param constraints, YAML bool spellings

### DIFF
--- a/providers/cloudformation/resources/cloudformation.go
+++ b/providers/cloudformation/resources/cloudformation.go
@@ -72,25 +72,26 @@ func nodeToDict(parent *yaml.Node, key string) (any, error) {
 	return convertYamlNodeToValue(val)
 }
 
-// nodeToInt extracts a YAML integer scalar at `key`, defaulting to 0 when
-// absent. Non-integer scalars return an error so callers see malformed input
-// rather than silently defaulting.
-func nodeToInt(parent *yaml.Node, key string) (int64, error) {
+// nodeToInt extracts a YAML integer scalar at `key`, returning nil when the key
+// is absent so callers can distinguish "no constraint" from an explicit 0 (a
+// legitimate CloudFormation MinValue). Non-integer scalars return an error so
+// callers see malformed input rather than silently defaulting.
+func nodeToInt(parent *yaml.Node, key string) (*int64, error) {
 	_, val, err := gatherMapValue(parent, key)
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return 0, nil
+			return nil, nil
 		}
-		return 0, err
+		return nil, err
 	}
 	if val.Kind != yaml.ScalarNode {
-		return 0, fmt.Errorf("expected scalar for %s, got kind %v", key, val.Kind)
+		return nil, fmt.Errorf("expected scalar for %s, got kind %v", key, val.Kind)
 	}
 	n, err := strconv.ParseInt(val.Value, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("invalid integer for %s: %w", key, err)
+		return nil, fmt.Errorf("invalid integer for %s: %w", key, err)
 	}
-	return n, nil
+	return &n, nil
 }
 
 // nodeToDictList walks the sequence at `key` and returns each entry as a

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -15,6 +15,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/cloudformation/connection"
+	"go.mondoo.com/mql/v13/types"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
 
@@ -101,6 +102,15 @@ func TestParameterConstraintsNullable(t *testing.T) {
 	withoutMin := byName["WithoutMin"]
 	require.NotNil(t, withoutMin)
 	assert.NotZero(t, withoutMin.MinValue.State&plugin.StateIsNull, "absent MinValue must be null")
+
+	// A null int field must serialize as a typed nil primitive (types.Nil),
+	// NOT an untyped one — otherwise MQL surfaces "primitive with no type
+	// information" when the field is queried. This is the full getter path a
+	// `cloudformation.template.parameterList { minValue }` query exercises.
+	dr := withoutMin.MinValue.ToDataRes(types.Int)
+	require.Empty(t, dr.Error)
+	require.NotNil(t, dr.Data)
+	assert.Equal(t, string(types.Nil), dr.Data.Type, "null int must carry the nil type, not an empty type")
 }
 
 func TestNoEchoBooleanSpellings(t *testing.T) {

--- a/providers/cloudformation/resources/cloudformation_test.go
+++ b/providers/cloudformation/resources/cloudformation_test.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,110 @@ import (
 	"go.mondoo.com/mql/v13/providers/cloudformation/connection"
 	"go.mondoo.com/mql/v13/utils/syncx"
 )
+
+// loadTemplateFromString writes content to a temp .yaml file and loads it as a
+// cloudformation.template, so tests can exercise the parse paths without a
+// committed fixture per case.
+func loadTemplateFromString(t *testing.T, content string) *mqlCloudformationTemplate {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "template.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	tpl, err := loadTemplate(path)
+	require.NoError(t, err)
+	return tpl
+}
+
+func TestParseCfnBool(t *testing.T) {
+	for _, s := range []string{"true", "True", "TRUE", "yes", "Yes", "on", "1", " true "} {
+		assert.True(t, parseCfnBool(s), "%q should parse true", s)
+	}
+	for _, s := range []string{"false", "False", "no", "off", "0", "", "maybe"} {
+		assert.False(t, parseCfnBool(s), "%q should parse false", s)
+	}
+}
+
+// A scalar top-level Metadata member (Metadata is free-form) must not make the
+// whole metadata() call error out and drop every member.
+func TestMetadataScalarMemberDoesNotFail(t *testing.T) {
+	tpl := loadTemplateFromString(t, `AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  License: Apache-2.0
+  Interface:
+    ParameterGroups: []
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+`)
+	md := tpl.GetMetadata()
+	require.NoError(t, md.Error)
+	assert.Equal(t, "Apache-2.0", md.Data["License"])
+	assert.Contains(t, md.Data, "Interface")
+}
+
+// A resource with a malformed (scalar) Properties body must not sink the other
+// valid resources in the template.
+func TestResourcesMalformedPropertiesDegrades(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Resources:
+  GoodBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-bucket
+  BadBucket:
+    Type: AWS::S3::Bucket
+    Properties: "oops-this-is-a-string"
+`)
+	res := tpl.GetResources()
+	require.NoError(t, res.Error)
+	assert.Equal(t, 2, len(res.Data), "a malformed Properties must not drop sibling resources")
+}
+
+// An absent numeric constraint must resolve to null, distinct from an explicit
+// MinValue: 0 (a legitimate CloudFormation value).
+func TestParameterConstraintsNullable(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  WithMin:
+    Type: Number
+    MinValue: 0
+  WithoutMin:
+    Type: Number
+`)
+	params := tpl.GetParameterList()
+	require.NoError(t, params.Error)
+
+	byName := map[string]*mqlCloudformationParameter{}
+	for _, p := range params.Data {
+		mp := p.(*mqlCloudformationParameter)
+		byName[mp.Name.Data] = mp
+	}
+
+	withMin := byName["WithMin"]
+	require.NotNil(t, withMin)
+	assert.Equal(t, int64(0), withMin.MinValue.Data)
+	assert.Zero(t, withMin.MinValue.State&plugin.StateIsNull, "explicit MinValue: 0 must not be null")
+
+	withoutMin := byName["WithoutMin"]
+	require.NotNil(t, withoutMin)
+	assert.NotZero(t, withoutMin.MinValue.State&plugin.StateIsNull, "absent MinValue must be null")
+}
+
+func TestNoEchoBooleanSpellings(t *testing.T) {
+	tpl := loadTemplateFromString(t, `Parameters:
+  Secret:
+    Type: String
+    NoEcho: yes
+  Plain:
+    Type: String
+`)
+	params := tpl.GetParameterList()
+	require.NoError(t, params.Error)
+	byName := map[string]*mqlCloudformationParameter{}
+	for _, p := range params.Data {
+		mp := p.(*mqlCloudformationParameter)
+		byName[mp.Name.Data] = mp
+	}
+	assert.True(t, byName["Secret"].NoEcho.Data, "NoEcho: yes must parse true")
+	assert.False(t, byName["Plain"].NoEcho.Data)
+}
 
 func loadTemplate(path string) (*mqlCloudformationTemplate, error) {
 	_, err := os.Stat(path)

--- a/providers/cloudformation/resources/template.go
+++ b/providers/cloudformation/resources/template.go
@@ -5,8 +5,10 @@ package resources
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/aws-cloudformation/rain/cft"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -16,6 +18,18 @@ import (
 	"go.mondoo.com/ranger-rpc/status"
 	"gopkg.in/yaml.v3"
 )
+
+// parseCfnBool interprets the boolean spellings CloudFormation accepts.
+// CloudFormation parses templates as YAML 1.1, so `yes`/`on`/`1` are true in
+// addition to `true` (any case). Anything else is false. This matters for
+// NoEcho: a `NoEcho: yes` credential parameter must not read as unmasked.
+func parseCfnBool(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "yes", "on", "1":
+		return true
+	}
+	return false
+}
 
 // isEvenMappingNode reports whether n is a YAML mapping with an even number of
 // content nodes — i.e. safe to iterate two-at-a-time (key, value). A template
@@ -104,12 +118,16 @@ func (r *mqlCloudformationTemplate) extractDict(section cft.Section) (map[string
 		keyNode := parameters.Content[i]
 		valueNode := parameters.Content[i+1]
 
-		dict, err := convertYamlToDict(valueNode)
+		// A section member's value need not be a mapping — a Metadata entry
+		// like `License: Apache-2.0` is a scalar, and Metadata is free-form.
+		// convertYamlNodeToValue accepts scalars, sequences, and mappings, so
+		// one scalar member no longer fails the whole section.
+		val, err := convertYamlNodeToValue(valueNode)
 		if err != nil {
 			return nil, err
 		}
 
-		result[keyNode.Value] = dict
+		result[keyNode.Value] = val
 	}
 
 	return result, nil
@@ -185,21 +203,24 @@ func (r *mqlCloudformationTemplate) resources() ([]any, error) {
 			resourceDocumentation = val.Value
 		}
 
+		// Attributes/Properties are objects in valid CloudFormation. A
+		// malformed (scalar/sequence) body shouldn't sink every other resource
+		// in the template — leave the field empty and keep going.
 		attrs := make(map[string](any))
-		_, val, err = gatherMapValue(valueNode, "Attributes")
-		if err == nil {
-			attrs, err = convertYamlToDict(val)
-			if err != nil {
-				return nil, err
+		if _, val, gerr := gatherMapValue(valueNode, "Attributes"); gerr == nil {
+			if converted, cerr := convertYamlToDict(val); cerr == nil {
+				attrs = converted
+			} else {
+				log.Warn().Err(cerr).Str("resource", keyNode.Value).Msg("cloudformation: Attributes is not an object; leaving empty")
 			}
 		}
 
 		props := make(map[string](any))
-		_, val, err = gatherMapValue(valueNode, "Properties")
-		if err == nil {
-			props, err = convertYamlToDict(val)
-			if err != nil {
-				return nil, err
+		if _, val, gerr := gatherMapValue(valueNode, "Properties"); gerr == nil {
+			if converted, cerr := convertYamlToDict(val); cerr == nil {
+				props = converted
+			} else {
+				log.Warn().Err(cerr).Str("resource", keyNode.Value).Msg("cloudformation: Properties is not an object; leaving empty")
 			}
 		}
 
@@ -373,9 +394,13 @@ func (r *mqlCloudformationTemplate) outputs() ([]any, error) {
 		keyNode := outputs.Content[i]
 		valueNode := outputs.Content[i+1]
 
-		dict, err := convertYamlToDict(valueNode)
-		if err != nil {
-			return nil, err
+		// An output body is an object in valid CloudFormation; degrade rather
+		// than fail every output if one is malformed.
+		dict := map[string]any{}
+		if converted, cerr := convertYamlToDict(valueNode); cerr == nil {
+			dict = converted
+		} else {
+			log.Warn().Err(cerr).Str("output", keyNode.Value).Msg("cloudformation: output body is not an object; leaving empty")
 		}
 
 		value, err := nodeToDict(valueNode, "Value")
@@ -469,7 +494,7 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 
 		noEcho := false
 		if _, n, err := gatherMapValue(valueNode, "NoEcho"); err == nil {
-			noEcho = n.Value == "true" || n.Value == "True" || n.Value == "TRUE"
+			noEcho = parseCfnBool(n.Value)
 		}
 
 		minLength, err := nodeToInt(valueNode, "MinLength")
@@ -513,10 +538,10 @@ func (r *mqlCloudformationTemplate) parameterList() ([]any, error) {
 			"allowedValues":         llx.ArrayData(allowedValues, types.Dict),
 			"allowedPattern":        llx.StringData(allowedPattern),
 			"noEcho":                llx.BoolData(noEcho),
-			"minLength":             llx.IntData(minLength),
-			"maxLength":             llx.IntData(maxLength),
-			"minValue":              llx.IntData(minValue),
-			"maxValue":              llx.IntData(maxValue),
+			"minLength":             llx.IntDataPtr(minLength),
+			"maxLength":             llx.IntDataPtr(maxLength),
+			"minValue":              llx.IntDataPtr(minValue),
+			"maxValue":              llx.IntDataPtr(maxValue),
 			"constraintDescription": llx.StringData(constraintDescription),
 			"context":               llx.ResourceData(ctx, "cloudformation.context"),
 		})


### PR DESCRIPTION
## Summary

Static review of the cloudformation provider (it parses CloudFormation templates via the `aws-cloudformation/rain` SDK and walks the resulting YAML node tree) surfaced three correctness defects.

### 🟠 A scalar value node made an entire section/collection fail to load

`convertYamlToDict` unmarshals strictly into `map[string]any`, so a scalar or sequence value node returned an error that every caller propagated as `nil, err` for the **whole** collection. This bit **valid** templates: `Metadata` is free-form, so a member like

```yaml
Metadata:
  License: Apache-2.0
```

made `template.metadata()` error out and drop every member. It also dropped **all** resources when one resource had a malformed (scalar/sequence) `Properties`. Fix: `extractDict` now uses the tolerant `convertYamlNodeToValue` (scalars/sequences/mappings all accepted), and `resources()`/`outputs()` degrade a malformed `Properties`/`Attributes`/output body to an empty map (with a warning) and continue, matching the intent of the provider's newer `nodeToDict` helpers.

### 🟡 Parameter constraints reported `0` for "absent"

`minValue`/`maxValue`/`minLength`/`maxLength` defaulted to `0` when the key was absent, indistinguishable from an explicit `MinValue: 0` (a legitimate value). A policy like "every Number parameter declares a lower bound" (`minValue != null`) could never work. `nodeToInt` now returns `*int64` (nil when absent) and the four constraints are emitted via `IntDataPtr`, so an unconstrained parameter resolves to null. The `.lr` type stays `int` (MQL ints are nullable) — a behavior fix, not a breaking type change.

### 🟡 `noEcho` missed YAML 1.1 boolean spellings

CloudFormation parses templates as YAML 1.1, where `yes`/`on`/`1` are booleans. `NoEcho: yes` on a credential parameter is honored as `true` by CFN but was read as `false` here — a security false-negative. New `parseCfnBool` handles `true`/`yes`/`on`/`1` (any case).

## Tests

- `TestParseCfnBool`, `TestMetadataScalarMemberDoesNotFail`, `TestResourcesMalformedPropertiesDegrades`, `TestParameterConstraintsNullable`, `TestNoEchoBooleanSpellings`. The existing suite covered sequence-*bodied sections* but not scalar *value bodies* inside a section — the gap that let #1 through.

`go test ./resources/` passes; `go build ./...` clean.
