### PR TITLE
🐛 cloudflare: fix worker __id collision, id/degrade/null-time issues across resources

### DIFF
--- a/providers/cloudflare/resources/audit_logs.go
+++ b/providers/cloudflare/resources/audit_logs.go
@@ -54,7 +54,7 @@ func (c *mqlCloudflareAccount) auditLogs() ([]any, error) {
 
 	entries, err := cfGetPaged[auditLogEntry](conn, fmt.Sprintf("accounts/%s/audit_logs?direction=desc", c.Id.Data))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	results := []any{}

--- a/providers/cloudflare/resources/certificates.go
+++ b/providers/cloudflare/resources/certificates.go
@@ -46,9 +46,9 @@ func (c *mqlCloudflareZone) customCertificates() ([]any, error) {
 			"signature":    llx.StringData(cert.Signature),
 			"status":       llx.StringData(string(cert.Status)),
 			"bundleMethod": llx.StringData(string(cert.BundleMethod)),
-			"expiresAt":    llx.TimeData(cert.ExpiresOn),
-			"uploadedAt":   llx.TimeData(cert.UploadedOn),
-			"modifiedAt":   llx.TimeData(cert.ModifiedOn),
+			"expiresAt":    timeOrNil(cert.ExpiresOn),
+			"uploadedAt":   timeOrNil(cert.UploadedOn),
+			"modifiedAt":   timeOrNil(cert.ModifiedOn),
 			"priority":     llx.IntData(int64(cert.Priority)),
 		})
 		if err != nil {
@@ -83,7 +83,7 @@ func (c *mqlCloudflareZone) certificatePacks() ([]any, error) {
 
 	packs, err := cfGetPaged[certificatePack](conn, fmt.Sprintf("zones/%s/ssl/certificate_packs?status=all", c.Id.Data))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any

--- a/providers/cloudflare/resources/devices.go
+++ b/providers/cloudflare/resources/devices.go
@@ -49,7 +49,7 @@ func (c *mqlCloudflareOne) devices() ([]any, error) {
 
 	records, err := cfGetPaged[teamsDevice](conn, fmt.Sprintf("accounts/%s/devices", c.AccountID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -70,10 +70,10 @@ func (c *mqlCloudflareOne) devices() ([]any, error) {
 			"osDistroRevision": llx.StringData(rec.OSDistroRevision),
 			"version":          llx.StringData(rec.Version),
 			"deleted":          llx.BoolData(rec.Deleted),
-			"created":          llx.TimeData(parseRFC3339(rec.Created)),
-			"updated":          llx.TimeData(parseRFC3339(rec.Updated)),
-			"lastSeen":         llx.TimeData(parseRFC3339(rec.LastSeen)),
-			"revokedAt":        llx.TimeData(parseRFC3339(rec.RevokedAt)),
+			"created":          timeOrNil(parseRFC3339(rec.Created)),
+			"updated":          timeOrNil(parseRFC3339(rec.Updated)),
+			"lastSeen":         timeOrNil(parseRFC3339(rec.LastSeen)),
+			"revokedAt":        timeOrNil(parseRFC3339(rec.RevokedAt)),
 		})
 		if err != nil {
 			return nil, err
@@ -117,7 +117,7 @@ func (c *mqlCloudflareOne) devicePostureRules() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil
@@ -153,7 +153,7 @@ func (c *mqlCloudflareOne) devicePostureIntegrations() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/dns.go
+++ b/providers/cloudflare/resources/dns.go
@@ -60,7 +60,7 @@ func (c *mqlCloudflareDns) records() ([]any, error) {
 
 	records, err := cfGetPaged[dnsRecord](conn, fmt.Sprintf("zones/%s/dns_records", c.ZoneID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -80,8 +80,8 @@ func (c *mqlCloudflareDns) records() ([]any, error) {
 			"ttl":      llx.IntData(rec.TTL),
 			"priority": llx.IntData(int64(rec.Priority)),
 
-			"createdOn":  llx.TimeData(rec.CreatedOn),
-			"modifiedOn": llx.TimeData(rec.ModifiedOn),
+			"createdOn":  timeOrNil(rec.CreatedOn),
+			"modifiedOn": timeOrNil(rec.ModifiedOn),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/cloudflare/resources/email_routing.go
+++ b/providers/cloudflare/resources/email_routing.go
@@ -162,6 +162,11 @@ func (c *mqlCloudflareZoneEmailRouting) dmarcConfigured() (bool, error) {
 	}
 	uri := fmt.Sprintf("zones/%s/dns_records?type=TXT&name=%s", c.zoneID, url.QueryEscape(dmarcName))
 	if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
+		// Degrade to "not configured" when the token can't read DNS records,
+		// matching the rest of this file rather than erroring the field.
+		if isUnavailable(err) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -226,6 +231,14 @@ func (c *mqlCloudflareZoneEmailRouting) fetchSuggestedDNSRecords() ([]emailRouti
 	}
 	uri := fmt.Sprintf("zones/%s/email/routing/dns", c.zoneID)
 	if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
+		// A token without DNS-record read (403/404) degrades to "no suggested
+		// records" so mxConfigured/spfConfigured read false instead of erroring;
+		// cache the empty result since the permission won't change mid-scan.
+		if isUnavailable(err) {
+			c.dnsCache = nil
+			c.dnsFetched = true
+			return nil, nil
+		}
 		// Don't cache transient errors — leave dnsFetched=false so the next
 		// call retries instead of returning the stale failure forever.
 		return nil, err

--- a/providers/cloudflare/resources/firewall.go
+++ b/providers/cloudflare/resources/firewall.go
@@ -82,7 +82,9 @@ func (c *mqlCloudflareZone) firewallRules() ([]any, error) {
 			result = append(result, res)
 		}
 
-		if env.ResultInfo.TotalPages == 0 || env.ResultInfo.Page >= env.ResultInfo.TotalPages {
+		// Terminate on the local page counter, not the server-echoed
+		// ResultInfo.Page, so a page:0 echo with total_pages>0 can't loop forever.
+		if env.ResultInfo.TotalPages == 0 || page >= env.ResultInfo.TotalPages {
 			break
 		}
 		page++

--- a/providers/cloudflare/resources/gateway.go
+++ b/providers/cloudflare/resources/gateway.go
@@ -58,7 +58,7 @@ func (c *mqlCloudflareOne) gatewayRules() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil
@@ -97,7 +97,7 @@ func (c *mqlCloudflareOne) lists() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil
@@ -130,7 +130,7 @@ func (c *mqlCloudflareOne) locations() ([]any, error) {
 
 	records, err := cfGetPaged[gatewayLocation](conn, fmt.Sprintf("accounts/%s/gateway/locations", c.AccountID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -192,7 +192,7 @@ func (c *mqlCloudflareOne) dlpProfiles() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/helpers.go
+++ b/providers/cloudflare/resources/helpers.go
@@ -54,12 +54,28 @@ func cfGetPaged[T any](conn *connection.CloudflareConnection, uriBase string) ([
 			return nil, err
 		}
 		all = append(all, env.Result...)
-		if env.ResultInfo.TotalPages == 0 || env.ResultInfo.Page >= env.ResultInfo.TotalPages {
+		// Terminate on the local page counter, not the server-echoed
+		// ResultInfo.Page: if the API ever returned page:0 with total_pages>0
+		// the echoed-page comparison would never satisfy and the loop would
+		// spin forever appending empty pages.
+		if env.ResultInfo.TotalPages == 0 || page >= env.ResultInfo.TotalPages {
 			break
 		}
 		page++
 	}
 	return all, nil
+}
+
+// degradedList maps an unavailable-resource error (401/403/404, via
+// isUnavailable) to an empty list, so a gated add-on or permission-limited
+// collection endpoint reads as "nothing here" instead of failing the whole
+// query. Other errors propagate unchanged. Callers use it as the error branch
+// of a list accessor: `if err != nil { return degradedList(err) }`.
+func degradedList(err error) ([]any, error) {
+	if isUnavailable(err) {
+		return []any{}, nil
+	}
+	return nil, err
 }
 
 // isUnavailable reports whether err is a 401, 403, or 404 from the Cloudflare

--- a/providers/cloudflare/resources/helpers_unit_test.go
+++ b/providers/cloudflare/resources/helpers_unit_test.go
@@ -1,0 +1,111 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cloudflarev6 "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestTimeOrNil(t *testing.T) {
+	// A zero time (how the v6 SDK models a JSON null timestamp) must resolve to
+	// MQL null, not the 0001-01-01 zero value — the basis of the null-time fix.
+	assert.Equal(t, llx.NilData, timeOrNil(time.Time{}))
+
+	ts := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	got := timeOrNil(ts)
+	require.NotEqual(t, llx.NilData, got)
+	gotTime, ok := got.Value.(*time.Time)
+	require.True(t, ok, "non-zero time must carry a *time.Time value")
+	assert.True(t, gotTime.Equal(ts))
+}
+
+func TestParseRFC3339(t *testing.T) {
+	assert.True(t, parseRFC3339("").IsZero(), "empty string is zero time")
+	assert.True(t, parseRFC3339("not-a-timestamp").IsZero(), "unparseable string is zero time")
+
+	got := parseRFC3339("2026-07-20T12:00:00Z")
+	require.False(t, got.IsZero())
+	assert.Equal(t, 2026, got.Year())
+	assert.Equal(t, time.July, got.Month())
+}
+
+func TestIsUnavailable(t *testing.T) {
+	for _, code := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		assert.Truef(t, isUnavailable(&cloudflarev6.Error{StatusCode: code}), "status %d should be treated as unavailable", code)
+	}
+	for _, code := range []int{http.StatusInternalServerError, http.StatusTooManyRequests, http.StatusBadRequest} {
+		assert.Falsef(t, isUnavailable(&cloudflarev6.Error{StatusCode: code}), "status %d should NOT be unavailable", code)
+	}
+	assert.False(t, isUnavailable(errors.New("plain error")))
+	assert.False(t, isUnavailable(nil))
+}
+
+func TestDegradedList(t *testing.T) {
+	// An unavailable-resource error degrades to an empty (non-nil) list.
+	got, err := degradedList(&cloudflarev6.Error{StatusCode: http.StatusForbidden})
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, got)
+
+	// A 404 likewise degrades.
+	got, err = degradedList(&cloudflarev6.Error{StatusCode: http.StatusNotFound})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// Any other error propagates unchanged (not swallowed).
+	sentinel := errors.New("rate limited")
+	got, err = degradedList(&cloudflarev6.Error{StatusCode: http.StatusTooManyRequests})
+	assert.Nil(t, got)
+	require.Error(t, err)
+
+	got, err = degradedList(sentinel)
+	assert.Nil(t, got)
+	assert.Equal(t, sentinel, err)
+}
+
+type pagedTestItem struct {
+	ID string `json:"id"`
+}
+
+// TestCfGetPagedTerminatesOnZeroEchoedPage is the regression guard for the
+// pagination-termination fix: when the API advertises total_pages>1 but echoes
+// result_info.page as 0 (or omits it), the old `ResultInfo.Page >= TotalPages`
+// check never became true and the loop spun forever. The fix compares the local
+// page counter instead, so the walk stops after total_pages requests.
+func TestCfGetPagedTerminatesOnZeroEchoedPage(t *testing.T) {
+	env := setupTestEnv(t)
+
+	const totalPages = 3
+	var calls int32
+	env.Mux.HandleFunc("/widgets", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if int(n) > totalPages+2 {
+			// Bound a regression so it fails loudly instead of hanging CI.
+			t.Errorf("cfGetPaged did not terminate: %d requests for %d pages", n, totalPages)
+			jsonResponse(w, `{"success":true,"result":[],"result_info":{"page":0,"total_pages":0}}`)
+			return
+		}
+		reqPage, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		// Echo page:0 regardless of the requested page while advertising 3 pages.
+		jsonResponse(w, fmt.Sprintf(`{"success":true,"errors":[],"messages":[],
+			"result":[{"id":"w%d"}],
+			"result_info":{"page":0,"per_page":100,"total_pages":%d}}`, reqPage, totalPages))
+	})
+
+	got, err := cfGetPaged[pagedTestItem](env.Conn, "widgets")
+	require.NoError(t, err)
+	require.Len(t, got, totalPages, "one item collected per page, then stop")
+	assert.Equal(t, int32(totalPages), atomic.LoadInt32(&calls), "exactly one request per page — no infinite loop")
+	assert.Equal(t, []string{"w1", "w2", "w3"}, []string{got[0].ID, got[1].ID, got[2].ID})
+}

--- a/providers/cloudflare/resources/logpush.go
+++ b/providers/cloudflare/resources/logpush.go
@@ -56,6 +56,11 @@ func (c *mqlCloudflareZone) logpushJobs() ([]any, error) {
 		rec := env.Result[i]
 
 		res, err := NewResource(c.MqlRuntime, "cloudflare.zone.logpushJob", map[string]*llx.RawData{
+			// Pass __id explicitly: id() derives it from zoneID, but zoneID is
+			// set on the Internal struct only AFTER NewResource returns, so
+			// relying on id() would key every job as `logpush@@<id>` (empty
+			// zone). An explicit __id is honored ahead of id().
+			"__id":            llx.StringData(fmt.Sprintf("logpush@%s@%d", c.Id.Data, rec.ID)),
 			"id":              llx.IntData(rec.ID),
 			"name":            llx.StringData(rec.Name),
 			"dataset":         llx.StringData(rec.Dataset),

--- a/providers/cloudflare/resources/logpush_test.go
+++ b/providers/cloudflare/resources/logpush_test.go
@@ -26,6 +26,11 @@ func TestLogpushJobs(t *testing.T) {
 	require.Len(t, result, 1)
 
 	job := result[0].(*mqlCloudflareZoneLogpushJob)
+	// The cache key must embed the zone: id() reads a zoneID set only after
+	// NewResource returns, so the fix passes __id explicitly. Without it the
+	// key was `logpush@@42` (empty zone) and jobs with the same numeric id in
+	// different zones would alias.
+	assert.Contains(t, job.MqlID(), testZoneID, "logpush job __id must be zone-scoped")
 	assert.Equal(t, int64(42), job.Id.Data)
 	assert.Equal(t, "HTTP Requests to S3", job.Name.Data)
 	assert.Equal(t, "http_requests", job.Dataset.Data)

--- a/providers/cloudflare/resources/members.go
+++ b/providers/cloudflare/resources/members.go
@@ -41,7 +41,7 @@ func (c *mqlCloudflareAccount) members() ([]any, error) {
 
 	members, err := cfGetPaged[accountMember](conn, fmt.Sprintf("accounts/%s/members", c.Id.Data))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	results := []any{}

--- a/providers/cloudflare/resources/mtls.go
+++ b/providers/cloudflare/resources/mtls.go
@@ -4,6 +4,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 
 	cloudflare "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/mtls_certificates"
@@ -24,6 +25,9 @@ func (c *mqlCloudflareZone) mtlsCertificates() ([]any, error) {
 	acc := c.GetAccount()
 	if acc.Error != nil {
 		return nil, acc.Error
+	}
+	if acc.Data == nil {
+		return nil, errors.New("cloudflare zone has no associated account")
 	}
 	accountID := acc.Data.GetId().Data
 

--- a/providers/cloudflare/resources/one.go
+++ b/providers/cloudflare/resources/one.go
@@ -182,8 +182,11 @@ func accessRules(in []any) []any {
 // listing and the per-application policies() accessor. fallbackKey supplies a
 // unique cache key for inline app-attached policies, which historically arrive
 // with an empty id — without it, every such policy would collide on the empty
-// __id and alias to the first one. A policy with a real id keys on that id so
-// the same reusable policy dedups across the two access paths.
+// __id and alias to the first one. A policy with a real id keys on that id, so
+// the same reusable policy dedups across the two access paths regardless of
+// which path built it. An inline policy (empty id) keys on fallbackKey and is
+// intentionally per-app: it has no id to dedup on and only ever exists inline,
+// so it never needs to match an account-level entry.
 func newAccessPolicyResource(runtime *plugin.Runtime, fallbackKey string, p accessPolicy) (plugin.Resource, error) {
 	idKey := p.ID
 	if idKey == "" {
@@ -206,8 +209,13 @@ func newAccessPolicyResource(runtime *plugin.Runtime, fallbackKey string, p acce
 func (c *mqlCloudflareOneApp) policies() ([]any, error) {
 	result := make([]any, 0, len(c.appPolicies))
 	for i := range c.appPolicies {
-		fallback := fmt.Sprintf("%s/policy/%d", c.Id.Data, i)
-		res, err := newAccessPolicyResource(c.MqlRuntime, fallback, c.appPolicies[i])
+		p := c.appPolicies[i]
+		// Content-derived fallback for inline policies without an id: name +
+		// decision + precedence is stable across list reordering (precedence is
+		// unique per app), unlike the loop index, which would shift the __id if
+		// the API returned the policies in a different order on a later scan.
+		fallback := fmt.Sprintf("%s/policy/%s/%s/%d", c.Id.Data, p.Name, p.Decision, p.Precedence)
+		res, err := newAccessPolicyResource(c.MqlRuntime, fallback, p)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/cloudflare/resources/one.go
+++ b/providers/cloudflare/resources/one.go
@@ -179,9 +179,18 @@ func accessRules(in []any) []any {
 
 // newAccessPolicyResource builds an access policy resource, including its
 // include/require/exclude condition rules. Shared by the account accessPolicies()
-// listing and the per-application policies() accessor.
-func newAccessPolicyResource(runtime *plugin.Runtime, p accessPolicy) (plugin.Resource, error) {
+// listing and the per-application policies() accessor. fallbackKey supplies a
+// unique cache key for inline app-attached policies, which historically arrive
+// with an empty id — without it, every such policy would collide on the empty
+// __id and alias to the first one. A policy with a real id keys on that id so
+// the same reusable policy dedups across the two access paths.
+func newAccessPolicyResource(runtime *plugin.Runtime, fallbackKey string, p accessPolicy) (plugin.Resource, error) {
+	idKey := p.ID
+	if idKey == "" {
+		idKey = fallbackKey
+	}
 	return NewResource(runtime, "cloudflare.one.accessPolicy", map[string]*llx.RawData{
+		"__id":       llx.StringData("cloudflare.one.accessPolicy@" + idKey),
 		"id":         llx.StringData(p.ID),
 		"name":       llx.StringData(p.Name),
 		"decision":   llx.StringData(p.Decision),
@@ -197,7 +206,8 @@ func newAccessPolicyResource(runtime *plugin.Runtime, p accessPolicy) (plugin.Re
 func (c *mqlCloudflareOneApp) policies() ([]any, error) {
 	result := make([]any, 0, len(c.appPolicies))
 	for i := range c.appPolicies {
-		res, err := newAccessPolicyResource(c.MqlRuntime, c.appPolicies[i])
+		fallback := fmt.Sprintf("%s/policy/%d", c.Id.Data, i)
+		res, err := newAccessPolicyResource(c.MqlRuntime, fallback, c.appPolicies[i])
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +221,7 @@ func (c *mqlCloudflareOne) apps() ([]any, error) {
 
 	records, err := cfGetPaged[accessApp](conn, fmt.Sprintf("zones/%s/access/apps", c.ZoneID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -292,12 +302,12 @@ func (c *mqlCloudflareOne) accessPolicies() ([]any, error) {
 
 	records, err := cfGetPaged[accessPolicy](conn, fmt.Sprintf("accounts/%s/access/policies", c.AccountID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
 	for i := range records {
-		res, err := newAccessPolicyResource(c.MqlRuntime, records[i])
+		res, err := newAccessPolicyResource(c.MqlRuntime, records[i].ID, records[i])
 		if err != nil {
 			return nil, err
 		}
@@ -320,7 +330,7 @@ func (c *mqlCloudflareOne) accessGroups() ([]any, error) {
 
 	records, err := cfGetPaged[accessGroup](conn, fmt.Sprintf("accounts/%s/access/groups", c.AccountID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -355,7 +365,7 @@ func (c *mqlCloudflareOne) serviceTokens() ([]any, error) {
 
 	records, err := cfGetPaged[accessServiceToken](conn, fmt.Sprintf("accounts/%s/access/service_tokens", c.AccountID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any
@@ -430,7 +440,7 @@ func (c *mqlCloudflareOne) identityProviders() ([]any, error) {
 
 	records, err := cfGetPaged[accessIdp](conn, fmt.Sprintf("zones/%s/access/identity_providers", c.ZoneID))
 	if err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	var result []any

--- a/providers/cloudflare/resources/rate_limits.go
+++ b/providers/cloudflare/resources/rate_limits.go
@@ -107,7 +107,9 @@ func (c *mqlCloudflareZone) rateLimitRules() ([]any, error) {
 			result = append(result, res)
 		}
 
-		if env.ResultInfo.TotalPages == 0 || env.ResultInfo.Page >= env.ResultInfo.TotalPages {
+		// Terminate on the local page counter, not the server-echoed
+		// ResultInfo.Page, so a page:0 echo with total_pages>0 can't loop forever.
+		if env.ResultInfo.TotalPages == 0 || page >= env.ResultInfo.TotalPages {
 			break
 		}
 		page++

--- a/providers/cloudflare/resources/settings.go
+++ b/providers/cloudflare/resources/settings.go
@@ -87,6 +87,13 @@ func (c *mqlCloudflareZone) settings() (*mqlCloudflareZoneSettings, error) {
 	}
 	uri := fmt.Sprintf("zones/%s/settings", c.Id.Data)
 	if err := conn.Cf.Get(context.Background(), uri, nil, &env); err != nil {
+		// A token that can read the zone but not its settings (403), or a plan
+		// without this endpoint (404), degrades to null rather than failing the
+		// whole zone traversal — matching botManagement() below.
+		if isUnavailable(err) {
+			c.Settings.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -71,7 +71,7 @@ func (c *mqlCloudflareZone) tunnels() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil
@@ -112,7 +112,7 @@ func (c *mqlCloudflareZone) tunnelConnections(conn *connection.CloudflareConnect
 		}
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return connections, nil
@@ -180,7 +180,7 @@ func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
 		}
 		uri := fmt.Sprintf("accounts/%s/teamnet/routes?per_page=%d&page=%d", accountID, perPage, page)
 		if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
-			return nil, err
+			return degradedList(err)
 		}
 
 		for i := range env.Result {
@@ -249,7 +249,7 @@ func (c *mqlCloudflareZone) tunnelVirtualNetworks() ([]any, error) {
 		result = append(result, res)
 	}
 	if err := iter.Err(); err != nil {
-		return nil, err
+		return degradedList(err)
 	}
 
 	return result, nil

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
@@ -93,6 +95,10 @@ func (c *mqlCloudflareWorkers) workers() ([]any, error) {
 		w := workerList[i]
 
 		res, err := NewResource(c.MqlRuntime, "cloudflare.workers.worker", map[string]*llx.RawData{
+			// This resource has no id() method, so without an explicit __id every
+			// worker would share the empty cache key and alias to the first
+			// script. Scope by account so cross-account scans don't collide.
+			"__id":             llx.StringData("cloudflare.workers.worker@" + c.AccountID + "/" + w.ID),
 			"id":               llx.StringData(w.ID),
 			"etag":             llx.StringData(w.ETag),
 			"size":             llx.IntData(w.Size),
@@ -113,8 +119,46 @@ func (c *mqlCloudflareWorkers) workers() ([]any, error) {
 	return result, nil
 }
 
+// pages lists Cloudflare Pages projects, surfacing each project's canonical
+// (production) deployment. The projects endpoint embeds that deployment, so a
+// single paged call covers it; preview/historical deployments are out of scope
+// here. Degrades to empty when Pages isn't available to the token.
 func (c *mqlCloudflareWorkers) pages() ([]any, error) {
-	return nil, nil
+	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
+
+	projects, err := cfGetPaged[pagesProject](conn, fmt.Sprintf("accounts/%s/pages/projects", c.AccountID))
+	if err != nil {
+		if isUnavailable(err) {
+			return []any{}, nil
+		}
+		return nil, err
+	}
+
+	var result []any
+	for i := range projects {
+		p := projects[i]
+		d := p.CanonicalDeployment
+		if d == nil {
+			// No production deployment yet — nothing to describe for this project.
+			continue
+		}
+		res, err := CreateResource(c.MqlRuntime, "cloudflare.workers.page", map[string]*llx.RawData{
+			"__id":             llx.StringData("cloudflare.workers.page@" + c.AccountID + "/" + p.Name + "/" + d.ID),
+			"id":               llx.StringData(d.ID),
+			"shortId":          llx.StringData(d.ShortID),
+			"projectId":        llx.StringData(d.ProjectID),
+			"projectName":      llx.StringData(p.Name),
+			"environment":      llx.StringData(d.Environment),
+			"url":              llx.StringData(d.URL),
+			"aliases":          llx.ArrayData(convert.SliceAnyToInterface(d.Aliases), types.String),
+			"productionBranch": llx.StringData(p.ProductionBranch),
+		})
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, res)
+	}
+	return result, nil
 }
 
 func (c *mqlCloudflareWorkersSecret) id() (string, error) {
@@ -159,7 +203,7 @@ func (c *mqlCloudflareWorkers) secrets() ([]any, error) {
 		for j := range env.Result {
 			s := env.Result[j]
 			res, err := CreateResource(c.MqlRuntime, "cloudflare.workers.secret", map[string]*llx.RawData{
-				"__id":       llx.StringData("cloudflare.workers.secret@" + w.ID + "/" + s.Name),
+				"__id":       llx.StringData("cloudflare.workers.secret@" + c.AccountID + "/" + w.ID + "/" + s.Name),
 				"scriptName": llx.StringData(w.ID),
 				"name":       llx.StringData(s.Name),
 				"secretType": llx.StringData(s.Type),
@@ -180,9 +224,24 @@ type pagesDeployConfig struct {
 	} `json:"env_vars"`
 }
 
+// pagesDeployment is the deployment object embedded in a Pages project (the
+// canonical/production deployment), decoded via the client's generic Get.
+type pagesDeployment struct {
+	ID          string   `json:"id"`
+	ShortID     string   `json:"short_id"`
+	ProjectID   string   `json:"project_id"`
+	ProjectName string   `json:"project_name"`
+	Environment string   `json:"environment"`
+	URL         string   `json:"url"`
+	Aliases     []string `json:"aliases"`
+}
+
 type pagesProject struct {
-	Name              string `json:"name"`
-	DeploymentConfigs struct {
+	ID                  string           `json:"id"`
+	Name                string           `json:"name"`
+	ProductionBranch    string           `json:"production_branch"`
+	CanonicalDeployment *pagesDeployment `json:"canonical_deployment"`
+	DeploymentConfigs   struct {
 		Preview    pagesDeployConfig `json:"preview"`
 		Production pagesDeployConfig `json:"production"`
 	} `json:"deployment_configs"`
@@ -210,7 +269,7 @@ func (c *mqlCloudflareWorkers) pageEnvVars() ([]any, error) {
 				varType = v.Type
 			}
 			res, err := CreateResource(c.MqlRuntime, "cloudflare.pages.envVar", map[string]*llx.RawData{
-				"__id":        llx.StringData("cloudflare.pages.envVar@" + projectName + "/" + env + "/" + name),
+				"__id":        llx.StringData("cloudflare.pages.envVar@" + c.AccountID + "/" + projectName + "/" + env + "/" + name),
 				"projectName": llx.StringData(projectName),
 				"environment": llx.StringData(env),
 				"name":        llx.StringData(name),

--- a/providers/cloudflare/resources/workers_test.go
+++ b/providers/cloudflare/resources/workers_test.go
@@ -1,0 +1,93 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestWorkers(env *testEnv) *mqlCloudflareWorkers {
+	w := &mqlCloudflareWorkers{MqlRuntime: env.Runtime}
+	w.AccountID = testAccountID
+	return w
+}
+
+// TestWorkersDistinctIDs is the regression guard for the __id collision: the
+// cloudflare.workers.worker resource has no id() method, so without an explicit
+// __id every worker shared the empty cache key ("cloudflare.workers.worker\x00")
+// and every row aliased the first script. Assert two scripts resolve to two
+// distinct resources with their own data.
+func TestWorkersDistinctIDs(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, `{"success":true,"errors":[],"messages":[],"result":[
+			{"id":"script-a","etag":"etag-a","size":100},
+			{"id":"script-b","etag":"etag-b","size":200}
+		]}`)
+	})
+
+	res, err := newTestWorkers(env).workers()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+
+	w0 := res[0].(*mqlCloudflareWorkersWorker)
+	w1 := res[1].(*mqlCloudflareWorkersWorker)
+
+	assert.NotEqual(t, w0.MqlID(), w1.MqlID(), "each worker must get a distinct cache key")
+	assert.Equal(t, "script-a", w0.Id.Data)
+	assert.Equal(t, "script-b", w1.Id.Data)
+	assert.Equal(t, int64(100), w0.Size.Data)
+	assert.Equal(t, int64(200), w1.Size.Data)
+}
+
+// TestWorkersListDegradesOnForbidden verifies a gated/permission-limited
+// account degrades to an empty list rather than failing the whole query.
+func TestWorkersListDegradesOnForbidden(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		jsonResponse(w, `{"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"result":null}`)
+	})
+
+	// workers() itself propagates the fetch error (the list is a core Workers
+	// call, not a gated sub-resource); pages(), a gated add-on, degrades.
+	env.Mux.HandleFunc("/accounts/"+testAccountID+"/pages/projects", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		jsonResponse(w, `{"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"result":null}`)
+	})
+
+	pages, err := newTestWorkers(env).pages()
+	require.NoError(t, err, "pages() must degrade on 403, not error")
+	assert.Empty(t, pages)
+}
+
+// TestWorkersPages verifies the pages() implementation maps a project's
+// canonical deployment (previously pages() was a stub returning empty).
+func TestWorkersPages(t *testing.T) {
+	env := setupTestEnv(t)
+	env.Mux.HandleFunc("/accounts/"+testAccountID+"/pages/projects", func(w http.ResponseWriter, r *http.Request) {
+		jsonResponse(w, `{"success":true,"errors":[],"messages":[],"result":[
+			{"id":"proj-1","name":"marketing-site","production_branch":"main",
+			 "canonical_deployment":{"id":"dep-1","short_id":"dep1","project_id":"proj-1",
+			   "project_name":"marketing-site","environment":"production",
+			   "url":"https://marketing.pages.dev","aliases":["https://www.example.com"]}},
+			{"id":"proj-2","name":"no-deploy-yet","production_branch":"main","canonical_deployment":null}
+		],"result_info":{"page":1,"total_pages":1}}`)
+	})
+
+	pages, err := newTestWorkers(env).pages()
+	require.NoError(t, err)
+	require.Len(t, pages, 1, "a project without a canonical deployment is skipped")
+
+	p := pages[0].(*mqlCloudflareWorkersPage)
+	assert.Equal(t, "dep-1", p.Id.Data)
+	assert.Equal(t, "marketing-site", p.ProjectName.Data)
+	assert.Equal(t, "production", p.Environment.Data)
+	assert.Equal(t, "https://marketing.pages.dev", p.Url.Data)
+	assert.Equal(t, "main", p.ProductionBranch.Data)
+}


### PR DESCRIPTION
## Summary

Static review of the cloudflare provider (cloudflare-go/v6) surfaced nine defects, fixed here. The headline is a silent inventory-corruption bug; the rest are id/degrade/null-time correctness issues.

### 🔴 1. Every `cloudflare.workers.worker` aliased the first script
`cloudflare.workers.worker` has no `id()` method and `workers()` passed no `__id`, so `SetAllData` left `__id` empty and every worker shared the cache key `"cloudflare.workers.worker\x00"` — `workers.workers` returned N copies of the first script (wrong size/logPush/deployment), no error. Now passes an explicit account-scoped `__id` (siblings `secrets()`/`pageEnvVars()` already did).

### 🟠 2. `logpushJob` `__id` zone-scoping was a dead no-op
`id()` builds `logpush@<zoneID>@<jobID>`, but `zoneID` is set on the Internal struct *after* `NewResource` computes `__id` — so it was always `logpush@@<jobID>`. Now passes `__id` explicitly (honored ahead of `id()`).

### 🟠 3. `workers.pages()` was a stub
It returned empty unconditionally, hiding all Pages projects. Implemented from `accounts/{id}/pages/projects` (canonical/production deployment per project).

### 🟠 4. Gated endpoints hard-failed instead of degrading
A partial-permission token (common with Cloudflare) made Zero Trust / gateway / devices / tunnels / settings / members / auditLogs / dns / certificatePacks / email-routing accessors error the whole query, while siblings degraded via `isUnavailable`. Added a shared `degradedList` helper and applied the `isUnavailable` → empty/null convention consistently.

### 🟡 5–9
- **5.** Zero-time timestamps rendered as `0001-01-01` instead of null (devices, custom certs, dns records) → routed through `timeOrNil`.
- **6.** `mtlsCertificates` dereferenced `acc.Data` without a nil guard.
- **7.** `workers.secret` / `pages.envVar` `__id`s omitted the account → cross-account collisions; now account-scoped.
- **8.** `cfGetPaged` (and inline firewall/rate-limit loops) terminated on the server-echoed `result_info.page`; switched to the local page counter so a `page:0` echo can't infinite-loop.
- **9.** Inline app-attached access policies with an empty id collided; keyed on an app-scoped fallback (real ids still dedup across the two access paths).

## Tests

New `workers_test.go` (mock-HTTP harness): distinct worker cache keys (the #1 regression), `pages()` canonical-deployment mapping, and gated-endpoint degrade. Full `go test ./resources/` passes; `go build ./...` clean.

## Live verification

Built and ran against a real Cloudflare account. The account has **no zones**, so zone-scoped resources (workers, one, dns, settings, tunnels, r2, logpush, certs) couldn't be exercised with live data — those are covered by the unit tests + mock-harness suite. Confirmed live at the account level: auth, `accounts`, `members` (correct data), `auditLogs` (multi-page pagination via the fixed `cfGetPaged`, distinct ids), and `apiTokens` (clean empty degrade) — all with no crashes, correct distinct ids, and no `no type information` errors.
