### PR TITLE
📄 provider-bug-review: add stub-data class and pure-Go test-gap reporting

### DIFF
--- a/.claude/skills/provider-bug-review/SKILL.md
+++ b/.claude/skills/provider-bug-review/SKILL.md
@@ -104,7 +104,7 @@ the file list per group. Key requirements to put in every agent prompt:
 - "Rank by severity; report what you verified as clean too."
 
 Also run a fast mechanical sweep yourself while agents work — these grep
-patterns catch two whole classes cheaply:
+patterns catch whole classes cheaply:
 
 ```bash
 # range-variable pointer capture (bug): &v inside `for _, v := range`
@@ -114,6 +114,13 @@ grep -rn "for.*:= range" providers/<name>/resources/*.go | grep -v _test
 # bare single-result type assertions on runtime data (panic risk): x := v.(T)
 grep -rnE "[a-zA-Z0-9_]+ := [a-zA-Z0-9_.]+\.\([a-zA-Z]" providers/<name>/resources/*.go \
   | grep -v ", ok" | grep -v _test
+
+# STUB DATA (taxonomy class 0, top severity): accessors that return empty/zero
+# with no real fetch, and "not implemented" markers. Open each hit and confirm
+# the body actually calls the client / parses source — a `.lr`-declared field
+# that returns a stubbed zero value is silent data loss.
+grep -rnE "return nil, nil|return \[\]any\{\}, nil|return \"\", nil" providers/<name>/resources/*.go | grep -v _test
+grep -rniE "TODO|not implemented|placeholder|stub|for now" providers/<name>/resources/*.go | grep -v _test
 ```
 
 ### 4. Verify every candidate against source
@@ -137,6 +144,16 @@ correctness (wrong or inconsistent data) > robustness (error propagation) >
 performance > cosmetic.** For each finding give `file:line`, the bug class, the
 concrete failure scenario, and the fix. State plainly what you checked that was
 clean — a review that only lists problems hides its own coverage.
+
+**Always include a test-coverage section.** A review isn't complete until it
+calls out gaps in unit-test coverage of the provider's **pure-Go logic** — the
+pagination loops, parsers, splitters, id/cache-key builders, null/zero
+converters, and degrade/error-classification helpers where wrong-data bugs
+actually live and where a compiler + passing integration suite won't catch a
+regression. Name that logic, say which parts have direct unit tests and which
+don't, and treat a missing test on non-trivial pure-Go logic as a reportable
+gap (roughly robustness-tier). When you go on to fix findings, add unit tests
+for the pure-Go logic you touch.
 
 Then stop and let the user decide what to fix. **Do not open a fix PR
 unprompted** — a review's job is to report; fixing is a separate, explicit

--- a/.claude/skills/provider-bug-review/references/agent-prompt-template.md
+++ b/.claude/skills/provider-bug-review/references/agent-prompt-template.md
@@ -25,6 +25,12 @@ Read <REPO>/.claude/skills/provider-bug-review/references/bug-taxonomy.md first
 inline if the agent can't read it.]
 
 Focus on these classes (see the taxonomy for fingerprints and correct patterns):
+0. STUB / FABRICATED DATA (top severity) — an accessor or field that returns
+   empty/hardcoded/zero data with no real API call or parse: a body that is just
+   `return nil, nil` / `return []any{}, nil` / `return "", nil`, a field pinned
+   to a literal ""/false/0/{} the API actually populates, or a `.lr`-declared
+   field with no real Go population. Confirm every declared field/accessor
+   actually fetches or parses real data. All data must be real.
 1. Pagination truncation — a List over a paginated endpoint that doesn't loop
    the next-page signal (silent data loss); hand-rolled HTTP fetches that skip
    the Link:next header; hardcoded small limits.

--- a/.claude/skills/provider-bug-review/references/bug-taxonomy.md
+++ b/.claude/skills/provider-bug-review/references/bug-taxonomy.md
@@ -7,8 +7,52 @@ analysis agents work from and the reference you verify against.
 
 A theme runs through the worst of these: the bug produces *wrong data with no
 error*. A panic at least announces itself. A pagination loop that returns one
-page, or a field that resolves differently through two code paths, hands the
-user a confident wrong answer. Weight those highest.
+page, a field that resolves differently through two code paths, or a **stub that
+invents an authoritative-looking absence** hands the user a confident wrong
+answer. Weight those highest.
+
+---
+
+## 0. Stub / placeholder / fabricated data (silent data loss — RANK AT THE TOP)
+
+**What:** an accessor or field that returns fabricated, hardcoded, or empty data
+instead of the real value — code that never actually fetches or parses what it
+claims to expose. **All data a resource surfaces must be real.** This is the
+single worst class: other bugs mangle data that's at least present, but a stub
+invents an authoritative-looking *absence* ("this account has zero Pages
+projects"), so a security audit over it passes *vacuously* — nothing to fail on.
+
+**Fingerprints:**
+- An accessor whose whole body is `return nil, nil` / `return []any{}, nil` /
+  `return "", nil` with **no API call or parse** — a not-yet-implemented stub
+  shipping empty. Real Cloudflare example: `workers.pages()` was `return nil, nil`,
+  so every account looked like it had no Pages projects.
+- A field hardcoded to a literal `""`, `false`, `0`, or `{}` in `CreateResource`
+  where the SDK/API actually returns a value (distinct from a value the API
+  genuinely omits — see the caveat).
+- `// TODO`, `// not implemented`, `// placeholder`, `// stub`, `// for now`
+  comments near a resource method or field.
+- A `.lr`-declared field or accessor with no corresponding real population in Go.
+
+**Why it matters:** it compiles, returns no error, and looks valid. A user or
+policy concludes "there's nothing here" when there is — the most dangerous
+possible answer in a security-inventory tool.
+
+**Correct pattern:** every declared field/accessor is populated from real
+fetched/parsed data. If it can't be implemented yet, **remove the field** rather
+than ship a stub that returns empty. When you find one, rank it with
+silent-data-loss/panic at the top of the report; when fixing, implement it
+against the real endpoint (or delete it), never leave the empty stub.
+
+**Verify by:** reading the accessor body — does it actually call the client /
+parse the source, or just return a zero value? Cross-check every `.lr` field has
+a real Go population path. Route to `provider-verification` to confirm the real
+endpoint returns data if you can't tell statically.
+
+**Caveat:** a genuinely absent value the API doesn't return (a deprecated SDK
+field, a field the list endpoint omits) is *not* a stub — that's correct
+null/empty handling. The stub bug is claiming to expose data and then not
+fetching it.
 
 ---
 


### PR DESCRIPTION
## Summary

Two improvements to the `provider-bug-review` skill, distilled from recent provider reviews (atlassian, ansible, bicep, cloudformation, cloudflare):

### Stub / fabricated data → taxonomy class 0 (top severity)

A resource accessor or field that returns empty/hardcoded/zero data with **no real fetch or parse** — e.g. a `return nil, nil` body for a `.lr`-declared field (the cloudflare `workers.pages()` bug), or a field pinned to a literal `""`/`false`/`0` the API actually populates. It invents an authoritative-looking *absence*, so a security audit over it passes **vacuously** — the worst kind of wrong data. Now covered in:
- `bug-taxonomy.md` — new class 0 with fingerprints, why it matters, correct pattern, and the "genuinely-absent ≠ stub" caveat.
- `agent-prompt-template.md` — added to the fan-out agent checklist.
- `SKILL.md` — added grep patterns to the mechanical sweep (`return nil, nil` / `return []any{}, nil` / `return "", nil` and `TODO`/`not implemented`/`placeholder`/`stub` markers).

**Principle: all data a resource exposes must be real.**

### Report must call out pure-Go test-coverage gaps

The Report step now requires a **test-coverage section**: name the provider's pure-Go logic (pagination loops, parsers, splitters, id/cache-key builders, null/degrade converters) and state which parts have direct unit tests and which don't. That's exactly where wrong-data bugs live and where a compiler + passing integration suite won't catch a regression; an untested one is a reportable gap (robustness-tier), and fixes should add unit tests for the pure-Go logic they touch.

No behavior change to code — skill/reference docs only.
