### PR TITLE
📄 provider-bug-review: scope fan-out by size, make SDK-read the verify spine

### DIFF
--- a/.claude/skills/provider-bug-review/SKILL.md
+++ b/.claude/skills/provider-bug-review/SKILL.md
@@ -87,8 +87,25 @@ recognize yet:
 
 ### 3. Fan out analysis agents by file-group
 
-Split the resource files into groups of ~5-7 (put the newest/riskiest together)
-and dispatch one analysis agent per group **in parallel, in a single message**.
+**First decide whether to fan out at all — match the machinery to the size.**
+The parallel fan-out earns its cost (each agent is ~100k+ tokens and minutes of
+wall time) only when the provider is too large to hold and reason about in one
+context. Gate it on the hand-written surface:
+
+- **Small (≲6–8 hand-written resource files / ≲2k LOC):** skip the fan-out. Read
+  every file yourself, run the mechanical greps below, and use **at most one**
+  verification agent (or none). A single focused agent on a 2-file provider
+  mostly re-confirms your own read — spend the tokens on the SDK verification in
+  step 4 instead. (Most non-cloud/IaC providers land here: cloudformation was 2
+  files, ansible/bicep a handful.)
+- **Large (many files, or a hand-rolled `resources/sdk/` client — aws/gcp/azure/
+  cloudflare-scale):** fan out. This is where parallel agents pay off; cloudflare
+  (28 files) is where the fan-out surfaced a HIGH `__id` bug a single pass would
+  likely have missed.
+
+When you do fan out: split the resource files into groups of ~5-7 (put the
+newest/riskiest together) and dispatch one analysis agent per group **in
+parallel, in a single message**.
 Give each agent the bug taxonomy and the exact reporting contract. A proven
 prompt template is in `references/agent-prompt-template.md` — read it and adapt
 the file list per group. Key requirements to put in every agent prompt:
@@ -128,14 +145,35 @@ grep -rniE "TODO|not implemented|placeholder|stub|for now" providers/<name>/reso
 This is the step that makes the review trustworthy. For each finding an agent
 reports, open the actual file and confirm the bug is real: the line still says
 what the agent quoted, the SDK type is what the agent assumed, the failure
-scenario actually holds. Check the SDK's model struct for pointer-ness and JSON
-tags. Discard anything you can't confirm, and downgrade severity for anything
-that "could" happen but realistically won't. Agent reports are leads, not
-verdicts.
+scenario actually holds. Agent reports are leads, not verdicts.
+
+**Reading the SDK / generated source is the spine of this step, not an
+"if unsure" fallback.** In practice nearly every confirm-vs-refute decision
+turns on a fact you can only get from source: a field's pointer-ness and JSON
+tags, whether a `List` returns a real paginator or a single-page type, how the
+generated `createXxx` computes `__id` (see the caching class in the taxonomy),
+what `IntDataPtr(nil)`/`ToDataRes` do with a null. So: **a finding whose severity
+depends on a type, pointer-ness, pagination shape, or generated-code behavior is
+NOT confirmed until you have read and can cite that source.** This is cheap (SDK
+reads are small) and it is what kills both hallucinated findings *and*
+false-clean dismissals — e.g. the same reads refuted a nullable-int "bug" and
+confirmed a real `__id` collision in the same review.
+
+**Re-rank severity, don't just confirm existence.** An agent's severity is a
+lead too. On verification, upgrade findings whose trigger is more common than the
+agent thought and downgrade ones that "could" happen but realistically won't. Two
+real examples from this skill's own use: an agent flagged a scalar-value parse
+bug as a rare malformed-input case, but verifying the caller showed it fires on a
+*valid, common* input (metadata with a scalar member) → upgraded; and an agent
+called a Stream list "truncating past one page" MEDIUM, but the SDK modeled it as
+a single-page type → downgraded to a live-verification item, not asserted.
 
 When a finding hinges on runtime data you can't see statically ("does the list
 endpoint really omit this field?"), say so explicitly and route it to
-`provider-verification` for live confirmation rather than asserting it.
+`provider-verification` for live confirmation rather than asserting it. Before
+offering or running live verification, check the target account/infra actually
+contains instances of the resources under review — proving a fix against an empty
+account verifies nothing.
 
 ### 5. Report
 

--- a/.claude/skills/provider-bug-review/references/bug-taxonomy.md
+++ b/.claude/skills/provider-bug-review/references/bug-taxonomy.md
@@ -194,6 +194,25 @@ GCP resource name, a composite `<parent>/<leaf>`. Hide synthetic composite ids
 (pass `"__id"` directly, no public `id` field); expose `id` only when it carries
 user-meaningful, queryable information.
 
+**How the `__id` is actually set (read this before judging any `__id` finding).**
+The generated `createXxx` does `SetAllData(res, args)` then, *only when the
+result is still empty*, falls back to the `id()` method:
+```go
+SetAllData(res, args)          // sets res.__id from an explicit "__id" arg, if passed
+if res.__id == "" {            // otherwise, and ONLY otherwise:
+    res.__id, err = res.id()   // ...call the id() method
+}
+```
+Consequences to reason from:
+- An explicit `"__id"` arg **wins** over `id()`. So an `id()` that depends on an
+  Internal-struct field set *after* `NewResource` returns (e.g. `zoneID` assigned
+  post-construction) is silently bypassed if you also pass `"__id"` — and is
+  *wrong* (empty field) if you rely on it. Fix by passing `"__id"` explicitly.
+- A resource with **neither** an `id()` method **nor** an `"__id"` arg gets the
+  empty key and every instance collides (the classic silent aliasing bug).
+- To confirm any `__id` finding, open the generated `createXxx` in `*.lr.go` and
+  check which of these paths the resource takes.
+
 ---
 
 ## 6. `null && null == true` — unset booleans pass assertions


### PR DESCRIPTION
## Summary

Efficiency + accuracy refinements to the `provider-bug-review` skill, distilled from running it across five providers this cycle (atlassian, ansible, bicep, cloudformation, cloudflare). Four changes, all approved:

### 1. Gate the fan-out on provider size (cheaper)
Each analysis agent costs ~100k+ tokens and minutes of wall time. That pays off on large providers (cloudflare's 28-file fan-out surfaced a HIGH `__id` bug), but on a small hand-written surface (~6–8 files / ~2k LOC) the agents mostly re-confirm your own read. The step now says: small → read it yourself + mechanical greps + ≤1 verification agent; large (many files / hand-rolled `resources/sdk` client) → fan out.

### 2. Reading the SDK / generated source is the *spine* of verification (better)
Not an "if unsure" fallback. Nearly every confirm-vs-refute decision turns on a source fact (pointer-ness, paginator-vs-single-page, `createXxx` `__id` logic, `IntDataPtr`/`ToDataRes` null handling). A finding whose severity depends on such a fact isn't confirmed until the source is cited — this kills both hallucinated findings and false-clean dismissals.

### 3. Re-rank severity, don't just confirm existence (better)
Worked examples baked in: a metadata-scalar parse bug **upgraded** on verify (fires on valid, common input, not rare malformed input); a Stream "truncation" **downgraded** (SDK models it single-page) to a live-verify item. Plus: check the target account actually has instances before offering live verification (an empty account verifies nothing).

### 4. Document the `__id` / `createXxx` precedence (faster)
Added to the caching taxonomy class: `SetAllData` sets `__id` from an explicit `"__id"` arg; `id()` runs only when `__id` is still empty; an explicit `"__id"` wins over `id()`; neither → empty-key collision. So `__id` findings are judged against the generated code instead of re-deriving it each review.

Docs/skill only — no code behavior change.
