### PR TITLE
🐛 ipinfo: key the resource on the requested IP; add resource unit tests

### DIFF
--- a/providers/ipinfo/resources/ipinfo.go
+++ b/providers/ipinfo/resources/ipinfo.go
@@ -35,28 +35,36 @@ func queryIPWithSDK(token string, queryIP net.IP) (*ipinfo.Core, error) {
 	return info, nil
 }
 
+// requestedIP extracts the optional `ip` argument. It returns (nil, nil) when
+// no ip was supplied (meaning: query the caller's own public IP), and an error
+// when the argument is present but malformed. Kept separate from initIpinfo so
+// the arg handling is unit-testable without a live API call.
+func requestedIP(args map[string]*llx.RawData) (net.IP, error) {
+	ip, ok := args["ip"]
+	if !ok {
+		return nil, nil
+	}
+	ipVal, ok := ip.Value.(llx.RawIP)
+	if !ok {
+		return nil, errors.New("ip must be of type ip")
+	}
+	if ipVal.IP == nil {
+		return nil, errors.New("ip cannot be empty")
+	}
+	return ipVal.IP, nil
+}
+
 func initIpinfo(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	log.Debug().Str("args", fmt.Sprintf("%+v", args)).Msg("initIpinfo called")
 
 	conn := runtime.Connection.(*connection.IpinfoConnection)
 	token := conn.Token()
 
-	var queryIP net.IP
-	var requestedIP net.IP
-
-	// Check if an IP was provided as input
-	if ip, ok := args["ip"]; ok {
-		ipVal, ok := ip.Value.(llx.RawIP)
-		if !ok {
-			return nil, nil, errors.New("ip must be of type ip")
-		}
-		if ipVal.IP == nil {
-			return nil, nil, errors.New("ip cannot be empty")
-		}
-		queryIP = ipVal.IP
-		requestedIP = ipVal.IP
+	// queryIP is nil when no ip arg was given → query the caller's public IP.
+	queryIP, err := requestedIP(args)
+	if err != nil {
+		return nil, nil, err
 	}
-	// If no IP provided, queryIP remains nil (query for your public IP)
 	log.Debug().
 		Str("queryIP", func() string {
 			if queryIP == nil {
@@ -85,13 +93,15 @@ func initIpinfo(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 		Msg("ipinfo response")
 
 	res := make(map[string]*llx.RawData)
-	if requestedIP != nil {
-		res["requested_ip"] = llx.IPData(llx.RawIP{IP: requestedIP})
+	if queryIP != nil {
+		res["requested_ip"] = llx.IPData(llx.RawIP{IP: queryIP})
 	} else {
 		res["requested_ip"] = llx.NilData
 	}
 
-	res["returned_ip"] = llx.IPData(llx.ParseIP(info.IP.String()))
+	// Build the returned IP directly from the SDK's net.IP rather than
+	// round-tripping through String()+ParseIP (matches requested_ip above).
+	res["returned_ip"] = llx.IPData(llx.RawIP{IP: info.IP})
 	res["hostname"] = llx.StringData(info.Hostname)
 	res["bogon"] = llx.BoolData(info.Bogon)
 	res["city"] = llx.StringData(info.City)
@@ -108,8 +118,16 @@ func initIpinfo(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[stri
 }
 
 func (c *mqlIpinfo) id() (string, error) {
-	if c.Returned_ip.Error != nil {
-		return "", c.Returned_ip.Error
+	if c.Requested_ip.Error != nil {
+		return "", c.Requested_ip.Error
 	}
-	return "ipinfo\x00" + c.Returned_ip.Data.String(), nil
+	// Identity is the *requested* IP (the query), not the returned IP. A query
+	// for the caller's own public IP (requested = null) and an explicit query
+	// for that same address return the same IP but are different queries; keying
+	// on the returned IP collided them in the cache and crossed their
+	// requested_ip values. A null requested IP means "self".
+	if c.Requested_ip.IsNull() || c.Requested_ip.Data.IP == nil {
+		return "ipinfo\x00self", nil
+	}
+	return "ipinfo\x00" + c.Requested_ip.Data.String(), nil
 }

--- a/providers/ipinfo/resources/ipinfo_test.go
+++ b/providers/ipinfo/resources/ipinfo_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func nullIP() plugin.TValue[llx.RawIP] {
+	return plugin.TValue[llx.RawIP]{State: plugin.StateIsNull | plugin.StateIsSet}
+}
+
+func setIP(ip string) plugin.TValue[llx.RawIP] {
+	return plugin.TValue[llx.RawIP]{Data: llx.RawIP{IP: net.ParseIP(ip)}, State: plugin.StateIsSet}
+}
+
+func TestIpinfoID(t *testing.T) {
+	// A public-IP query (requested = null) keys as "self".
+	public := &mqlIpinfo{Requested_ip: nullIP()}
+	publicID, err := public.id()
+	require.NoError(t, err)
+	assert.Equal(t, "ipinfo\x00self", publicID)
+
+	// An explicit query keys on the requested address.
+	explicit := &mqlIpinfo{Requested_ip: setIP("8.8.8.8")}
+	explicitID, err := explicit.id()
+	require.NoError(t, err)
+	assert.Equal(t, "ipinfo\x00"+(llx.RawIP{IP: net.ParseIP("8.8.8.8")}).String(), explicitID)
+
+	// Regression: the public query and an explicit query for that SAME address
+	// return the same IP but must be DISTINCT resources. Keying on the returned
+	// IP collided them (and crossed requested_ip); keying on the request keeps
+	// them apart.
+	assert.NotEqual(t, publicID, explicitID, "public vs explicit-same-IP must not collide")
+
+	// Different explicit IPs are distinct.
+	otherID, err := (&mqlIpinfo{Requested_ip: setIP("1.1.1.1")}).id()
+	require.NoError(t, err)
+	assert.NotEqual(t, explicitID, otherID)
+}
+
+func TestRequestedIP(t *testing.T) {
+	t.Run("absent arg -> nil, no error (query own public IP)", func(t *testing.T) {
+		got, err := requestedIP(map[string]*llx.RawData{})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("valid ip arg", func(t *testing.T) {
+		got, err := requestedIP(map[string]*llx.RawData{
+			"ip": llx.IPData(llx.RawIP{IP: net.ParseIP("8.8.8.8")}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.Equal(net.ParseIP("8.8.8.8")))
+	})
+
+	t.Run("wrong type -> error", func(t *testing.T) {
+		_, err := requestedIP(map[string]*llx.RawData{"ip": llx.StringData("8.8.8.8")})
+		require.Error(t, err)
+	})
+
+	t.Run("empty ip -> error", func(t *testing.T) {
+		_, err := requestedIP(map[string]*llx.RawData{"ip": llx.IPData(llx.RawIP{IP: nil})})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes from a static review of the ipinfo provider, plus the resources package's first unit tests.

### 🟡 1. `id()` keyed on the returned IP, not the query → cache collision
`ipinfo` is a parameterized resource (the optional `ip` arg), but `id()` derived the cache key from `returned_ip` (the API result). A query for the caller's own public IP (`requested_ip` = null) and an explicit query for that same address return the same IP, so they got the same `__id` and collided — `CreateResource` handed the second query the first's cached resource, crossing their `requested_ip` values (one would read null where it should read the address). Now `id()` keys on the **requested** IP — the query's identity — using `"self"` when null, so the public and explicit queries are distinct resources.

### 🟢 2. Direct `RawIP` instead of a String round-trip
`returned_ip` was built as `llx.IPData(llx.ParseIP(info.IP.String()))`, a lossy round-trip through the string form. `Core.IP` is a `net.IP`, so it's now `llx.IPData(llx.RawIP{IP: info.IP})`, matching how `requested_ip` is built.

### Unit tests (new)
The `resources` package had **no** tests. Added `ipinfo_test.go`:
- `id()` — the `self`/explicit cases, the **collision regression** (public vs explicit-same-IP now distinct), and distinct-IP sanity.
- `requestedIP()` — extracted the `ip`-arg parsing into a pure, testable helper (absent → nil/no-error, valid, wrong-type → error, empty → error).

`go test ./resources/` passes; `go build ./...` clean.

Not changed (called out in the review, out of scope here): the SDK exposes security-relevant fields the resource doesn't model yet (`privacy.*`, `abuse`, `asn`) — a possible follow-up feature.
