### PR TITLE
🐛 cloudflare: degrade Stream to empty; fix token env var name in help + docs

### DIFF
--- a/providers/cloudflare/config/config.go
+++ b/providers/cloudflare/config/config.go
@@ -26,7 +26,7 @@ Examples:
   cnspec scan cloudflare --token <access_token>
 
 Notes:
-  If you set the CLOUDFLARE_API_TOKEN environment variable, you can omit the token flag.
+  If you set the CLOUDFLARE_TOKEN environment variable, you can omit the token flag.
 `,
 			Discovery: []string{
 				connection.DiscoveryAll,

--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -17,7 +17,13 @@ cloudflare {
 	// List available accounts
 	accounts() []cloudflare.account
 
-	// API tokens visible to the calling user (user-scoped tokens)
+	// API tokens visible to the calling user
+	//
+	// Cloudflare API tokens are user-scoped, so this reads the tokens of
+	// the user the connecting token authenticates as. It requires a
+	// token with user-level access (the User API Tokens Read permission);
+	// an account-scoped token cannot list them and this returns empty.
+	// Account-owned tokens (Enterprise) are not exposed here.
 	apiTokens() []cloudflare.apiToken
 }
 

--- a/providers/cloudflare/resources/stream.go
+++ b/providers/cloudflare/resources/stream.go
@@ -79,7 +79,10 @@ func fetchLiveInputs(runtime *plugin.Runtime, accountID string) ([]any, error) {
 	}
 	uri := fmt.Sprintf("accounts/%s/stream/live_inputs", accountID)
 	if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
-		return nil, err
+		// Stream is a gated add-on; an account without it returns 403
+		// ("Cloudflare Stream not enabled"). Degrade to empty like the
+		// other add-on-gated list accessors rather than failing the query.
+		return degradedList(err)
 	}
 
 	var res []any
@@ -122,7 +125,10 @@ func fetchVideos(runtime *plugin.Runtime, accountID string) ([]any, error) {
 	}
 	uri := fmt.Sprintf("accounts/%s/stream", accountID)
 	if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
-		return nil, err
+		// Stream is a gated add-on; an account without it returns 403
+		// ("Cloudflare Stream not enabled"). Degrade to empty like the
+		// other add-on-gated list accessors rather than failing the query.
+		return degradedList(err)
 	}
 
 	var result []any


### PR DESCRIPTION
## What

Three fixes for the cloudflare provider, all found during a live test against a real Cloudflare account.

### 1. Stream accessors fail hard when Stream isn't enabled (bug)

`cloudflare.account.videos` / `.liveInputs` (and the zone-scoped variants) propagated the raw API error, so an account **without the Stream add-on** got a hard query failure:

```
* GET ".../accounts/<id>/stream": 403 Forbidden ... "Cloudflare Stream not enabled"
```

Every other add-on-gated list accessor in the provider maps 401/403/404 to an empty list via `degradedList`; Stream was the lone exception. Routed `fetchLiveInputs`/`fetchVideos` through `degradedList`.

**Verified live** against a Stream-disabled account: both now return `[]` instead of erroring.

### 2. Wrong env var in CLI help text

The connection reads the token from **`CLOUDFLARE_TOKEN`** (`connection/connection.go`, `provider/provider.go`), but `config/config.go` help told users to set `CLOUDFLARE_API_TOKEN`, so following it left the env var ignored (`a valid Cloudflare token is required`). Fixed the help text. Companion docs PR: mondoohq/docs#1709.

### 3. `apiTokens` scope not documented

`cloudflare.apiTokens` returns empty for an account-scoped token because Cloudflare API tokens are *user*-scoped (`/user/tokens`); listing them needs user-level access. Expanded the field doc-comment so an empty result is self-explanatory.

## Notes

- No `.lr.versions` change — doc-comment-only schema edit.
- `make providers/build/cloudflare` regenerates cleanly; CLI json now emits `CLOUDFLARE_TOKEN`.
