### PR TITLE
🎉 ipinfo-13.0.23

### DIFF
--- a/providers/ipinfo/config/config.go
+++ b/providers/ipinfo/config/config.go
@@ -11,7 +11,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ipinfo",
 	ID:              "go.mondoo.com/cnquery/providers/ipinfo",
-	Version:         "13.0.22",
+	Version:         "13.0.23",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### ipinfo (13.0.23)
- 🐛 ipinfo: key the resource on the requested IP; add resource unit tests (#9298)