### PR TITLE
🐛 alicloud: fix pagination truncation, error-swallow, __id collisions; test time conv

### DIFF
--- a/providers/alicloud/resources/antiddos.go
+++ b/providers/alicloud/resources/antiddos.go
@@ -36,7 +36,7 @@ func (r *mqlAlicloudAntiddos) instances() ([]any, error) {
 		}
 
 		pageNumber := 1
-		pageSize := 100
+		pageSize := 50
 		centerOk := false
 		for {
 			resp, err := client.DescribeInstances(&ddoscooclient.DescribeInstancesRequest{
@@ -131,7 +131,7 @@ func (r *mqlAlicloudAntiddosInstance) webRules() ([]any, error) {
 
 	res := []any{}
 	pageNumber := int32(1)
-	pageSize := int32(100)
+	pageSize := int32(10)
 	for {
 		resp, err := client.DescribeWebRules(&ddoscooclient.DescribeWebRulesRequest{
 			InstanceIds: []*string{tea.String(r.instanceId)},
@@ -218,7 +218,7 @@ func (r *mqlAlicloudAntiddosInstance) networkRules() ([]any, error) {
 
 	res := []any{}
 	pageNumber := int32(1)
-	pageSize := int32(100)
+	pageSize := int32(10)
 	for {
 		resp, err := client.DescribeNetworkRules(&ddoscooclient.DescribeNetworkRulesRequest{
 			InstanceId: tea.String(r.instanceId),

--- a/providers/alicloud/resources/cloudfw.go
+++ b/providers/alicloud/resources/cloudfw.go
@@ -102,11 +102,16 @@ func (r *mqlAlicloudCloudFirewall) controlPolicies() ([]any, error) {
 	res := []any{}
 	for _, direction := range []string{"in", "out"} {
 		currentPage := 1
+		collected := 0
 		for {
 			resp, err := client.DescribeControlPolicy(&cloudfwclient.DescribeControlPolicyRequest{
 				Direction:   tea.String(direction),
 				CurrentPage: tea.String(strconv.Itoa(currentPage)),
-				PageSize:    tea.String("100"),
+				// The API caps PageSize server-side (documented example is 10),
+				// so use a conservative page and terminate on the accumulated
+				// count vs TotalCount below — robust to whatever the server caps
+				// the page at, rather than assuming a full page means "more".
+				PageSize: tea.String("50"),
 			})
 			if err != nil {
 				return nil, err
@@ -141,7 +146,9 @@ func (r *mqlAlicloudCloudFirewall) controlPolicies() ([]any, error) {
 				}
 				res = append(res, resource)
 			}
-			if len(items) < 100 {
+			collected += len(items)
+			total, _ := strconv.Atoi(tea.StringValue(resp.Body.TotalCount))
+			if len(items) == 0 || collected >= total {
 				break
 			}
 			currentPage++

--- a/providers/alicloud/resources/cs.go
+++ b/providers/alicloud/resources/cs.go
@@ -255,7 +255,10 @@ func initAlicloudCsCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 }
 
 func (r *mqlAlicloudCsCluster) id() (string, error) {
-	return r.region + "/" + r.clusterId, nil
+	// Read the public fields (populated by SetAllData on every path) rather
+	// than the Internal cache fields, which are unset when the resource is
+	// built from args on the init fast-path — leaving __id "/" and colliding.
+	return r.RegionId.Data + "/" + r.ClusterId.Data, nil
 }
 
 // clusterDetail lazily fetches and caches DescribeClusterDetail, which carries

--- a/providers/alicloud/resources/ecs.go
+++ b/providers/alicloud/resources/ecs.go
@@ -481,7 +481,7 @@ func (r *mqlAlicloudEcs) images() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &ecsclient.DescribeImagesRequest{
 				RegionId:   &region,
@@ -593,7 +593,7 @@ func (r *mqlAlicloudEcs) keyPairs() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &ecsclient.DescribeKeyPairsRequest{
 				RegionId:   &region,

--- a/providers/alicloud/resources/fc.go
+++ b/providers/alicloud/resources/fc.go
@@ -213,7 +213,10 @@ func initAlicloudFcFunction(runtime *plugin.Runtime, args map[string]*llx.RawDat
 }
 
 func (r *mqlAlicloudFcFunction) id() (string, error) {
-	return r.region + "/" + r.functionName, nil
+	// Read the public fields (always set by SetAllData) rather than the
+	// Internal cache fields, which are empty on the init fast-path — otherwise
+	// __id is "/" and every such function collides in the cache.
+	return r.RegionId.Data + "/" + r.FunctionName.Data, nil
 }
 
 func (r *mqlAlicloudFcFunction) executionRole() (*mqlAlicloudRamRole, error) {

--- a/providers/alicloud/resources/gaps_test.go
+++ b/providers/alicloud/resources/gaps_test.go
@@ -97,6 +97,31 @@ func TestAlicloudParseTime(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, 2026, got.Year())
 	assert.Equal(t, 5, got.Second())
+
+	// A timezone offset must parse and normalize (12:00+08:00 == 04:00 UTC),
+	// not just Z-suffixed UTC.
+	off := alicloudParseTime(strp("2026-07-20T12:00:00+08:00"))
+	require.NotNil(t, off)
+	assert.Equal(t, 4, off.UTC().Hour())
+}
+
+// TestSlsParseTime covers slsParseTime — the RFC3339 string parser used by SLS
+// and the untested twin of alicloudParseTime — including nil/empty/garbage and
+// a timezone-offset form (a regression to a Z-only layout would silently drop
+// offset-stamped times).
+func TestSlsParseTime(t *testing.T) {
+	assert.Nil(t, slsParseTime(nil))
+	assert.Nil(t, slsParseTime(strp("")))
+	assert.Nil(t, slsParseTime(strp("not-a-time")))
+
+	got := slsParseTime(strp("2026-01-02T15:04:05Z"))
+	require.NotNil(t, got)
+	assert.Equal(t, 2026, got.Year())
+	assert.Equal(t, 5, got.Second())
+
+	off := slsParseTime(strp("2026-07-20T12:00:00+08:00"))
+	require.NotNil(t, off)
+	assert.Equal(t, 4, off.UTC().Hour())
 }
 
 // TestRmParseTime covers the Resource Management parser, which must accept the

--- a/providers/alicloud/resources/kms.go
+++ b/providers/alicloud/resources/kms.go
@@ -67,16 +67,23 @@ func (r *mqlAlicloudKms) keys() ([]any, error) {
 
 		pageNumber := int32(1)
 		pageSize := int32(100)
+		firstPage := true
 		for {
 			resp, err := client.ListKeys(&kmsclient.ListKeysRequest{
 				PageNumber: tea.Int32(pageNumber),
 				PageSize:   tea.Int32(pageSize),
 			})
 			if err != nil {
-				// a region may not have KMS enabled or the credential may lack
-				// access there; skip it rather than failing the whole scan
-				break
+				// A first-page error means the region has no KMS or the
+				// credential lacks access there; skip it. A later-page error is
+				// real (region reachable) — surface it rather than silently
+				// truncating the key list.
+				if firstPage {
+					break
+				}
+				return nil, err
 			}
+			firstPage = false
 			if resp == nil || resp.Body == nil || resp.Body.Keys == nil {
 				break
 			}
@@ -281,14 +288,21 @@ func (r *mqlAlicloudKms) secrets() ([]any, error) {
 
 		pageNumber := int32(1)
 		pageSize := int32(100)
+		firstPage := true
 		for {
 			resp, err := client.ListSecrets(&kmsclient.ListSecretsRequest{
 				PageNumber: tea.Int32(pageNumber),
 				PageSize:   tea.Int32(pageSize),
 			})
 			if err != nil {
-				break
+				// First-page error = region has no KMS / no access (skip);
+				// later-page error is real — surface rather than truncate.
+				if firstPage {
+					break
+				}
+				return nil, err
 			}
+			firstPage = false
 			if resp == nil || resp.Body == nil || resp.Body.SecretList == nil {
 				break
 			}

--- a/providers/alicloud/resources/oss.go
+++ b/providers/alicloud/resources/oss.go
@@ -94,10 +94,7 @@ func newOssBucket(runtime *plugin.Runtime, conn *connection.AlicloudConnection, 
 	if err != nil {
 		return nil, err
 	}
-	mqlBucket := bucket.(*mqlAlicloudOssBucket)
-	mqlBucket.name = name
-	mqlBucket.region = region
-	return mqlBucket, nil
+	return bucket.(*mqlAlicloudOssBucket), nil
 }
 
 // resolveOssBucket returns the typed bucket for a name, or (nil, nil) when name
@@ -171,9 +168,6 @@ func initAlicloudOssBucket(runtime *plugin.Runtime, args map[string]*llx.RawData
 // OSS client and memoizes the two detail calls (GetBucketInfo and
 // GetBucketEncryption) that back more than one accessor.
 type mqlAlicloudOssBucketInternal struct {
-	name   string
-	region string
-
 	infoLock   sync.Mutex
 	infoLoaded atomic.Bool
 	info       *oss.BucketInfo
@@ -191,7 +185,7 @@ func (a *mqlAlicloudOssBucket) id() (string, error) {
 // per-bucket detail APIs address the correct endpoint.
 func (a *mqlAlicloudOssBucket) ossClient() (*oss.Client, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AlicloudConnection)
-	return conn.OssClient(a.region)
+	return conn.OssClient(a.Region.Data)
 }
 
 func (a *mqlAlicloudOssBucket) acl() (string, error) {
@@ -199,7 +193,7 @@ func (a *mqlAlicloudOssBucket) acl() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.GetBucketAcl(context.Background(), &oss.GetBucketAclRequest{Bucket: &a.name})
+	resp, err := client.GetBucketAcl(context.Background(), &oss.GetBucketAclRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		// tolerate access-denied / transient errors on this optional detail call
 		return "", nil
@@ -215,7 +209,7 @@ func (a *mqlAlicloudOssBucket) versioning() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.GetBucketVersioning(context.Background(), &oss.GetBucketVersioningRequest{Bucket: &a.name})
+	resp, err := client.GetBucketVersioning(context.Background(), &oss.GetBucketVersioningRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		return "", nil
 	}
@@ -242,7 +236,7 @@ func (a *mqlAlicloudOssBucket) fetchEncryption() (*oss.ApplyServerSideEncryption
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetBucketEncryption(context.Background(), &oss.GetBucketEncryptionRequest{Bucket: &a.name})
+	resp, err := client.GetBucketEncryption(context.Background(), &oss.GetBucketEncryptionRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		// no encryption rule configured, or access denied
 		a.encRule = nil
@@ -290,7 +284,7 @@ func (a *mqlAlicloudOssBucket) kmsKey() (*mqlAlicloudKmsKey, error) {
 		a.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	key, err := resolveKmsKey(a.MqlRuntime, a.region, *rule.KMSMasterKeyID)
+	key, err := resolveKmsKey(a.MqlRuntime, a.Region.Data, *rule.KMSMasterKeyID)
 	if err != nil || key == nil {
 		a.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
@@ -303,7 +297,7 @@ func (a *mqlAlicloudOssBucket) logging() (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetBucketLogging(context.Background(), &oss.GetBucketLoggingRequest{Bucket: &a.name})
+	resp, err := client.GetBucketLogging(context.Background(), &oss.GetBucketLoggingRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		return nil, nil
 	}
@@ -318,7 +312,7 @@ func (a *mqlAlicloudOssBucket) policy() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.GetBucketPolicy(context.Background(), &oss.GetBucketPolicyRequest{Bucket: &a.name})
+	resp, err := client.GetBucketPolicy(context.Background(), &oss.GetBucketPolicyRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		// most buckets have no policy (NoSuchBucketPolicy)
 		return "", nil
@@ -334,7 +328,7 @@ func (a *mqlAlicloudOssBucket) tags() (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetBucketTags(context.Background(), &oss.GetBucketTagsRequest{Bucket: &a.name})
+	resp, err := client.GetBucketTags(context.Background(), &oss.GetBucketTagsRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		return nil, nil
 	}
@@ -355,7 +349,7 @@ func (a *mqlAlicloudOssBucket) publicAccessBlock() (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetBucketPublicAccessBlock(context.Background(), &oss.GetBucketPublicAccessBlockRequest{Bucket: &a.name})
+	resp, err := client.GetBucketPublicAccessBlock(context.Background(), &oss.GetBucketPublicAccessBlockRequest{Bucket: &a.Name.Data})
 	if err != nil {
 		return nil, nil
 	}
@@ -382,7 +376,7 @@ func (a *mqlAlicloudOssBucket) fetchInfo() (*oss.BucketInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetBucketInfo(context.Background(), &oss.GetBucketInfoRequest{Bucket: &a.name})
+	resp, err := client.GetBucketInfo(context.Background(), &oss.GetBucketInfoRequest{Bucket: &a.Name.Data})
 	if err != nil || resp == nil {
 		a.info = nil
 		a.infoLoaded.Store(true)

--- a/providers/alicloud/resources/rds.go
+++ b/providers/alicloud/resources/rds.go
@@ -362,12 +362,19 @@ func (r *mqlAlicloudRdsInstance) securityIPList() ([]any, error) {
 	conn := r.MqlRuntime.Connection.(*connection.AlicloudConnection)
 	client, err := conn.RdsClient(r.region)
 	if err != nil {
-		return []any{}, nil
+		return nil, err
 	}
 	resp, err := client.DescribeDBInstanceIPArrayList(&rdsclient.DescribeDBInstanceIPArrayListRequest{
 		DBInstanceId: tea.String(r.instanceId),
 	})
-	if err != nil || resp == nil || resp.Body == nil || resp.Body.Items == nil {
+	// Propagate a real fetch error rather than returning an empty list: a
+	// swallowed error here reads as a locked-down (empty) whitelist and lets an
+	// actually-open instance pass an exposure check. A genuinely empty response
+	// (no error, no items) is still a legitimate empty whitelist.
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Body == nil || resp.Body.Items == nil {
 		return []any{}, nil
 	}
 	res := []any{}

--- a/providers/alicloud/resources/redis.go
+++ b/providers/alicloud/resources/redis.go
@@ -75,7 +75,7 @@ func (r *mqlAlicloudRedis) instances() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			resp, err := client.DescribeInstances(&rkvclient.DescribeInstancesRequest{
 				RegionId:   tea.String(region),

--- a/providers/alicloud/resources/slb.go
+++ b/providers/alicloud/resources/slb.go
@@ -101,6 +101,7 @@ func (r *mqlAlicloudSlb) loadBalancers() ([]any, error) {
 
 		pageNumber := int32(1)
 		pageSize := int32(100)
+		firstPage := true
 		for {
 			resp, err := client.DescribeLoadBalancers(&slbclient.DescribeLoadBalancersRequest{
 				RegionId:   tea.String(region),
@@ -108,10 +109,16 @@ func (r *mqlAlicloudSlb) loadBalancers() ([]any, error) {
 				PageSize:   tea.Int32(pageSize),
 			})
 			if err != nil {
-				// A region may not have SLB enabled or the credential may lack
-				// access there. Skip it rather than failing the whole list.
-				break
+				// A first-page error means the region has no SLB or the
+				// credential lacks access there — skip it. A later-page error
+				// means the region is reachable and the failure is real; surface
+				// it rather than silently truncating the list (matches ALB/NLB).
+				if firstPage {
+					break
+				}
+				return nil, err
 			}
+			firstPage = false
 			if resp == nil || resp.Body == nil || resp.Body.LoadBalancers == nil {
 				break
 			}

--- a/providers/alicloud/resources/sls.go
+++ b/providers/alicloud/resources/sls.go
@@ -61,16 +61,23 @@ func (r *mqlAlicloudLog) projects() ([]any, error) {
 
 		offset := int32(0)
 		size := int32(100)
+		firstPage := true
 		for {
 			resp, err := client.ListProject(&slsclient.ListProjectRequest{
 				Offset: tea.Int32(offset),
 				Size:   tea.Int32(size),
 			})
 			if err != nil {
-				// a region may not have SLS enabled or the credential may lack
-				// access there; skip it rather than failing the whole scan
-				break
+				// A first-page error means the region has no SLS or the
+				// credential lacks access there; skip it. A later-page error is
+				// real — surface it rather than silently truncating the project
+				// list.
+				if firstPage {
+					break
+				}
+				return nil, err
 			}
+			firstPage = false
 			if resp == nil || resp.Body == nil {
 				break
 			}
@@ -202,12 +209,22 @@ func (r *mqlAlicloudLogProject) logstores() ([]any, error) {
 	res := []any{}
 	offset := int32(0)
 	size := int32(200)
+	firstPage := true
 	for {
 		resp, err := client.ListLogStores(tea.String(projectName), &slsclient.ListLogStoresRequest{
 			Offset: tea.Int32(offset),
 			Size:   tea.Int32(size),
 		})
-		if err != nil || resp == nil || resp.Body == nil {
+		if err != nil {
+			// First-page error = can't read this project's stores (skip);
+			// later-page error is real — surface rather than truncate.
+			if firstPage {
+				break
+			}
+			return nil, err
+		}
+		firstPage = false
+		if resp == nil || resp.Body == nil {
 			break
 		}
 		items := resp.Body.Logstores

--- a/providers/alicloud/resources/vpc.go
+++ b/providers/alicloud/resources/vpc.go
@@ -124,7 +124,7 @@ func (r *mqlAlicloudVpc) networks() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeVpcsRequest{
 				RegionId:   &region,
@@ -256,7 +256,7 @@ func (r *mqlAlicloudVpcNetwork) vswitches() ([]any, error) {
 
 	res := []any{}
 	pageNumber := int32(1)
-	pageSize := int32(100)
+	pageSize := int32(50)
 	for {
 		resp, err := client.DescribeVSwitches(&vpcclient.DescribeVSwitchesRequest{
 			RegionId:   &r.cacheRegion,
@@ -304,7 +304,7 @@ func (r *mqlAlicloudVpcNetwork) natGateways() ([]any, error) {
 
 	res := []any{}
 	pageNumber := int32(1)
-	pageSize := int32(100)
+	pageSize := int32(50)
 	for {
 		resp, err := client.DescribeNatGateways(&vpcclient.DescribeNatGatewaysRequest{
 			RegionId:   &r.cacheRegion,
@@ -352,7 +352,7 @@ func (r *mqlAlicloudVpcNetwork) routeTables() ([]any, error) {
 
 	res := []any{}
 	pageNumber := int32(1)
-	pageSize := int32(100)
+	pageSize := int32(50)
 	for {
 		resp, err := client.DescribeRouteTableList(&vpcclient.DescribeRouteTableListRequest{
 			RegionId:   &r.cacheRegion,
@@ -401,7 +401,7 @@ func (r *mqlAlicloudVpc) vswitches() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeVSwitchesRequest{
 				RegionId:   &region,
@@ -541,7 +541,7 @@ func (r *mqlAlicloudVpc) routeTables() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeRouteTableListRequest{
 				RegionId:   &region,
@@ -758,7 +758,7 @@ func (r *mqlAlicloudVpc) natGateways() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeNatGatewaysRequest{
 				RegionId:   &region,
@@ -937,7 +937,7 @@ func (r *mqlAlicloudVpc) eipAddresses() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeEipAddressesRequest{
 				RegionId:   &region,
@@ -1065,7 +1065,7 @@ func (r *mqlAlicloudVpc) networkAcls() ([]any, error) {
 		}
 
 		pageNumber := int32(1)
-		pageSize := int32(100)
+		pageSize := int32(50)
 		for {
 			req := &vpcclient.DescribeNetworkAclsRequest{
 				RegionId:   &region,


### PR DESCRIPTION
## Summary

Fixes from a static review of the alicloud provider (28 files, ~31.6k LOC). The headline is a **systemic pagination truncation** verified against the SDK; plus error-swallow and `__id` fixes, and extended time-conversion tests.

### 🔴 Pagination truncation (silent data loss)
Several list loops requested `PageSize=100` against APIs that cap the page below 100, terminating on the *requested* size (`pageNumber*100 >= TotalCount`) or `len < 100`. Any account exceeding the cap silently lost rows — no error. Caps **verified against the SDK doc-comments in the module cache**; reduced each `PageSize` to the documented max:

| File | Endpoint(s) | SDK max |
|------|-------------|---------|
| `vpc.go` | DescribeVpcs / VSwitches / NatGateways / RouteTableList / NetworkAcls | 50 |
| `ecs.go` | DescribeKeyPairs | 50 |
| `redis.go` | DescribeInstances | 50 |
| `antiddos.go` | DescribeInstances (50), DescribeWebRules (10), DescribeNetworkRules (10, sibling) | 10–50 |

`cloudfw.go` `DescribeControlPolicy`'s cap is **unstated** in the SDK, so instead of guessing I made it **cap-agnostic**: a conservative page size plus accumulate-vs-`TotalCount` termination that's correct for whatever the server caps the page at. (Endpoints already within their caps — ecs images, rds/mongodb/polardb, kms/sls, ALB/NLB NextToken, OSS IsTruncated — were left as-is.)

### 🟠 Error handling that read as "safe"
- **`rds.go` `securityIPList`** returned an empty (locked-down-looking) whitelist on *any* fetch error — an open `0.0.0.0/0` instance could pass an exposure check via a transient throttle. Now propagates the error (a genuinely empty response is still empty).
- **`oss.go`** bucket accessors read the *private* `name`/`region` Internal fields, empty on the init fast-path, so a directly-constructed bucket ran its detail calls against `""` and (via the accessors' error-swallow) reported **private/unencrypted**. Now read the public `Name`/`Region` fields (set on every path); dead private fields removed.
- **`slb.go` / `kms.go` / `sls.go`** list loops broke on *any* page error, silently truncating on a transient mid-pagination failure. Adopted the first-page pattern (skip a region on a first-page error; surface a later-page error) that ALB/NLB/FC already use.

### 🟡 `__id` collisions
`cs.go` / `fc.go` `id()` derived `__id` from Internal fields that are unset on the init fast-path, yielding `"/"` collisions. Now read the public `RegionId`/`ClusterId` and `RegionId`/`FunctionName` fields.

### Tests
Extended the time-conversion coverage in `gaps_test.go` (which already covered the epoch converters + `alicloudParseTime`/`rmParseTime`): added **`slsParseTime`** (the previously-untested twin of `alicloudParseTime`) and a **timezone-offset** case for both RFC3339 parsers (a regression to a Z-only layout would silently drop offset-stamped times).

`go test ./resources/` passes; `go build ./...` clean.

## Intentionally not changed (noted from the review)
- Safe-direction degrade judgment calls (`ram` mfaDevice/loginProfile, `config` deliveryChannels, `resourcemanager` folders) — they degrade in the safe direction and each empty is a legitimate state.
- `nas` init fast-path husk (atypical 3-arg direct query; would need an init that re-fetches).
- The `cloudfw`/`antiddos` `DescribeNetworkRules` page caps are unconfirmed in the SDK; the fixes are conservative/cap-agnostic, but worth a live confirmation with >cap rules.
