### PR TITLE
🐛 cloudflare: scope account-level services under account, deprecate zone copies

### DIFF
--- a/providers/cloudflare/resources/cloudflare.lr
+++ b/providers/cloudflare/resources/cloudflare.lr
@@ -75,27 +75,55 @@ private cloudflare.zone @defaults("name account.name") {
 	// DNS records associated with the zone
 	dns() cloudflare.dns
 
-	// Live inputs
-	liveInputs() []cloudflare.streams.liveInput
+	// Stream live inputs
+	//
+	// Deprecated in favor of cloudflare.account.liveInputs. Stream is
+	// account-scoped, so a zone returned the same account-wide live inputs
+	// regardless of which zone it was read from.
+	liveInputs() @maturity("deprecated") []cloudflare.streams.liveInput
 
-	// Stream video assets uploaded or streamed through Cloudflare
-	videos() []cloudflare.streams.video
+	// Stream video assets
+	//
+	// Deprecated in favor of cloudflare.account.videos. Stream is
+	// account-scoped, so a zone returned the same account-wide videos
+	// regardless of which zone it was read from.
+	videos() @maturity("deprecated") []cloudflare.streams.video
 
-	// Cloudflare R2 storage (account-scoped, exposed on zone for consistency)
-	r2() cloudflare.r2
+	// Cloudflare R2 storage
+	//
+	// Deprecated in favor of cloudflare.account.r2. R2 is account-scoped,
+	// so a zone returned the same account-wide buckets regardless of which
+	// zone it was read from.
+	r2() @maturity("deprecated") cloudflare.r2
 
-  // Cloudflare Workers configuration and deployments
-	workers() cloudflare.workers
+	// Cloudflare Workers configuration and deployments
+	//
+	// Deprecated in favor of cloudflare.account.workers. Workers are
+	// account-scoped, so a zone returned the same account-wide scripts
+	// regardless of which zone it was read from.
+	workers() @maturity("deprecated") cloudflare.workers
 
 	// Cloudflare One (Zero Trust)
-	one() cloudflare.one
+	//
+	// Deprecated in favor of cloudflare.account.one. Zero Trust is
+	// account-scoped, so a zone returned the same account-wide
+	// configuration regardless of which zone it was read from.
+	one() @maturity("deprecated") cloudflare.one
 
-	// Cloudflare tunnels (account-scoped, exposed on zone for consistency with workers/r2)
-	tunnels() []cloudflare.tunnel
-	// Tunnel routes (account-scoped)
-	tunnelRoutes() []cloudflare.tunnel.route
-	// Tunnel virtual networks (account-scoped)
-	tunnelVirtualNetworks() []cloudflare.tunnel.virtualNetwork
+	// Cloudflare tunnels
+	//
+	// Deprecated in favor of cloudflare.account.tunnels. Tunnels are
+	// account-scoped, so a zone returned the same account-wide tunnels
+	// regardless of which zone it was read from.
+	tunnels() @maturity("deprecated") []cloudflare.tunnel
+	// Tunnel routes
+	//
+	// Deprecated in favor of cloudflare.account.tunnelRoutes.
+	tunnelRoutes() @maturity("deprecated") []cloudflare.tunnel.route
+	// Tunnel virtual networks
+	//
+	// Deprecated in favor of cloudflare.account.tunnelVirtualNetworks.
+	tunnelVirtualNetworks() @maturity("deprecated") []cloudflare.tunnel.virtualNetwork
 
 	// Firewall rules (legacy)
 	firewallRules() []cloudflare.zone.firewallRule
@@ -317,36 +345,63 @@ private cloudflare.dns.record @defaults("type content name") {
 
 // Cloudflare Account
 //
-// Cloudflare account and its sub-resources. Query `settings` for
-// account-level preferences such as two-factor enforcement, `roles` for the
-// set of named roles defined in the account, and `liveInputs` and `videos`
-// for Stream assets scoped to the account.
+// Cloudflare account and its account-scoped services. Query `settings` for
+// account-level preferences such as two-factor enforcement, `roles` and
+// `members` for the account's access model, `one` for Zero Trust, `r2` for
+// object storage, `workers` for deployed scripts, `tunnels` for Cloudflare
+// Tunnel connectivity, and `liveInputs` and `videos` for Stream assets.
 private cloudflare.account @defaults("name") {
-	// Cloudflare account identifier
+	// Account identifier
+	//
+	// The 32-character account ID (the account "tag") that scopes every
+	// account-level API call. It selects an account from the `accounts`
+	// list and correlates a discovered asset with its owning account.
 	id string
 
 	// Account name
 	name string
 
 	// Account type
+	//
+	// The account's plan class, for example `standard` or `enterprise`.
 	type string
 
 	// Account-level configuration and preferences
+	//
+	// Account-wide settings, including whether membership requires
+	// two-factor authentication (`enforceTwoFactor`).
 	settings cloudflare.account.settings
 
 	// Time the account was created
 	createdOn time
 
-	// Live inputs
+	// Stream live inputs
+	//
+	// Live streaming ingest endpoints defined for the account. Each entry
+	// carries its `uid`, recording retention (`deleteRecordingAfterDays`),
+	// and name, covering the account's live-video ingestion surface.
 	liveInputs() []cloudflare.streams.liveInput
 
-	// Stream video assets uploaded or streamed through Cloudflare
+	// Stream video assets
+	//
+	// On-demand videos uploaded to or recorded through Cloudflare Stream.
+	// Query `requireSignedUrls` to audit token-gated playback, alongside
+	// duration, size, playback URLs, and readiness for each asset.
 	videos() []cloudflare.streams.video
 
 	// Account roles
+	//
+	// The catalog of named roles the account can assign to members, each
+	// with an `id`, `name`, and `description`. Cross-reference with
+	// `members` to review which privileges a user holds.
 	roles() []cloudflare.account.role
 
-	// Members (users) of the account, with their assigned roles and 2FA status
+	// Account members
+	//
+	// Users belonging to the account, with their invitation `status`,
+	// assigned `roles`, and whether each has two-factor authentication
+	// enabled (`twoFactorAuthenticationEnabled`), for access and MFA
+	// reviews.
 	members() []cloudflare.account.member
 
 	// Recent audit log entries for the account (most recent first; first page only)
@@ -354,8 +409,55 @@ private cloudflare.account @defaults("name") {
 	// Returns the first page of account audit log entries. The Cloudflare API caps a page at 100 entries; for older history, narrow with a `.where(when > ...)` filter or paginate at the API level outside MQL. Use this to verify a change actor, spot unauthorized configuration changes, or feed an access review.
 	auditLogs() []cloudflare.account.auditLog
 
-	// Notification policies (alert subscriptions) configured for the account
+	// Notification policies configured for the account
+	//
+	// Alert subscriptions that route Cloudflare notifications to email,
+	// PagerDuty, or webhooks. Each policy exposes its `alertType`, whether
+	// it is `enabled`, and its delivery `mechanisms`.
 	notificationPolicies() []cloudflare.notificationPolicy
+
+	// Cloudflare Zero Trust (Cloudflare One)
+	//
+	// Account-wide Zero Trust configuration: Access applications and their
+	// policies, Access groups, service tokens, identity providers, the
+	// Access organization, Gateway rules, enrolled devices, device-posture
+	// rules and integrations, DLP profiles, and network lists and locations.
+	one() cloudflare.one
+
+	// Cloudflare R2 object storage
+	//
+	// The account's R2 storage, whose `buckets` list each bucket with its
+	// name, location, creation time, and public-access exposure. Requires
+	// R2 to be enabled on the account.
+	r2() cloudflare.r2
+
+	// Cloudflare Workers
+	//
+	// The account's Workers platform: deployed `workers` (scripts) with
+	// their size, deployment metadata, and logpush setting, plus Pages
+	// projects. Covers the serverless code running on the account.
+	workers() cloudflare.workers
+
+	// Cloudflare Tunnels
+	//
+	// Cloudflared tunnels defined for the account, each with its status,
+	// tunnel type, and active `connections`, for auditing outbound
+	// connectivity into private networks.
+	tunnels() []cloudflare.tunnel
+
+	// Tunnel routes
+	//
+	// Private-network routes (CIDRs) advertised through the account's
+	// tunnels, each naming its target `tunnelId` and optional virtual
+	// network.
+	tunnelRoutes() []cloudflare.tunnel.route
+
+	// Tunnel virtual networks
+	//
+	// Virtual networks that segment overlapping private IP ranges across
+	// the account's tunnel routes, each with its name and whether it is the
+	// default network.
+	tunnelVirtualNetworks() []cloudflare.tunnel.virtualNetwork
 }
 
 // Cloudflare API Token

--- a/providers/cloudflare/resources/cloudflare.lr.go
+++ b/providers/cloudflare/resources/cloudflare.lr.go
@@ -747,6 +747,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"cloudflare.account.notificationPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareAccount).GetNotificationPolicies()).ToDataRes(types.Array(types.Resource("cloudflare.notificationPolicy")))
 	},
+	"cloudflare.account.one": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetOne()).ToDataRes(types.Resource("cloudflare.one"))
+	},
+	"cloudflare.account.r2": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetR2()).ToDataRes(types.Resource("cloudflare.r2"))
+	},
+	"cloudflare.account.workers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetWorkers()).ToDataRes(types.Resource("cloudflare.workers"))
+	},
+	"cloudflare.account.tunnels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetTunnels()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel")))
+	},
+	"cloudflare.account.tunnelRoutes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetTunnelRoutes()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel.route")))
+	},
+	"cloudflare.account.tunnelVirtualNetworks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCloudflareAccount).GetTunnelVirtualNetworks()).ToDataRes(types.Array(types.Resource("cloudflare.tunnel.virtualNetwork")))
+	},
 	"cloudflare.apiToken.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCloudflareApiToken).GetId()).ToDataRes(types.String)
 	},
@@ -2527,6 +2545,30 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cloudflare.account.notificationPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCloudflareAccount).NotificationPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.one": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).One, ok = plugin.RawToTValue[*mqlCloudflareOne](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.r2": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).R2, ok = plugin.RawToTValue[*mqlCloudflareR2](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.workers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).Workers, ok = plugin.RawToTValue[*mqlCloudflareWorkers](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.tunnels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).Tunnels, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.tunnelRoutes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).TunnelRoutes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"cloudflare.account.tunnelVirtualNetworks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCloudflareAccount).TunnelVirtualNetworks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"cloudflare.apiToken.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5739,17 +5781,23 @@ type mqlCloudflareAccount struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlCloudflareAccountInternal it will be used here
-	Id                   plugin.TValue[string]
-	Name                 plugin.TValue[string]
-	Type                 plugin.TValue[string]
-	Settings             plugin.TValue[*mqlCloudflareAccountSettings]
-	CreatedOn            plugin.TValue[*time.Time]
-	LiveInputs           plugin.TValue[[]any]
-	Videos               plugin.TValue[[]any]
-	Roles                plugin.TValue[[]any]
-	Members              plugin.TValue[[]any]
-	AuditLogs            plugin.TValue[[]any]
-	NotificationPolicies plugin.TValue[[]any]
+	Id                    plugin.TValue[string]
+	Name                  plugin.TValue[string]
+	Type                  plugin.TValue[string]
+	Settings              plugin.TValue[*mqlCloudflareAccountSettings]
+	CreatedOn             plugin.TValue[*time.Time]
+	LiveInputs            plugin.TValue[[]any]
+	Videos                plugin.TValue[[]any]
+	Roles                 plugin.TValue[[]any]
+	Members               plugin.TValue[[]any]
+	AuditLogs             plugin.TValue[[]any]
+	NotificationPolicies  plugin.TValue[[]any]
+	One                   plugin.TValue[*mqlCloudflareOne]
+	R2                    plugin.TValue[*mqlCloudflareR2]
+	Workers               plugin.TValue[*mqlCloudflareWorkers]
+	Tunnels               plugin.TValue[[]any]
+	TunnelRoutes          plugin.TValue[[]any]
+	TunnelVirtualNetworks plugin.TValue[[]any]
 }
 
 // createCloudflareAccount creates a new instance of this resource
@@ -5902,6 +5950,102 @@ func (c *mqlCloudflareAccount) GetNotificationPolicies() *plugin.TValue[[]any] {
 		}
 
 		return c.notificationPolicies()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetOne() *plugin.TValue[*mqlCloudflareOne] {
+	return plugin.GetOrCompute[*mqlCloudflareOne](&c.One, func() (*mqlCloudflareOne, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "one")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudflareOne), nil
+			}
+		}
+
+		return c.one()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetR2() *plugin.TValue[*mqlCloudflareR2] {
+	return plugin.GetOrCompute[*mqlCloudflareR2](&c.R2, func() (*mqlCloudflareR2, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "r2")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudflareR2), nil
+			}
+		}
+
+		return c.r2()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetWorkers() *plugin.TValue[*mqlCloudflareWorkers] {
+	return plugin.GetOrCompute[*mqlCloudflareWorkers](&c.Workers, func() (*mqlCloudflareWorkers, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "workers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlCloudflareWorkers), nil
+			}
+		}
+
+		return c.workers()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetTunnels() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Tunnels, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "tunnels")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tunnels()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetTunnelRoutes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TunnelRoutes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "tunnelRoutes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tunnelRoutes()
+	})
+}
+
+func (c *mqlCloudflareAccount) GetTunnelVirtualNetworks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TunnelVirtualNetworks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("cloudflare.account", c.__id, "tunnelVirtualNetworks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.tunnelVirtualNetworks()
 	})
 }
 

--- a/providers/cloudflare/resources/cloudflare.lr.versions
+++ b/providers/cloudflare/resources/cloudflare.lr.versions
@@ -33,6 +33,8 @@ cloudflare.account.member.userId 13.4.1
 cloudflare.account.members 13.4.1
 cloudflare.account.name 11.0.0
 cloudflare.account.notificationPolicies 13.4.1
+cloudflare.account.one 13.6.5
+cloudflare.account.r2 13.6.5
 cloudflare.account.role 13.1.0
 cloudflare.account.role.description 13.1.0
 cloudflare.account.role.id 13.1.0
@@ -40,8 +42,12 @@ cloudflare.account.role.name 13.1.0
 cloudflare.account.roles 13.1.0
 cloudflare.account.settings 11.0.0
 cloudflare.account.settings.enforceTwoFactor 11.0.0
+cloudflare.account.tunnelRoutes 13.6.5
+cloudflare.account.tunnelVirtualNetworks 13.6.5
+cloudflare.account.tunnels 13.6.5
 cloudflare.account.type 11.0.0
 cloudflare.account.videos 11.0.0
+cloudflare.account.workers 13.6.5
 cloudflare.accounts 11.0.0
 cloudflare.apiToken 13.1.1
 cloudflare.apiToken.expiresOn 13.1.1

--- a/providers/cloudflare/resources/one.go
+++ b/providers/cloudflare/resources/one.go
@@ -135,24 +135,51 @@ func isSAMLIdpType(t string) bool {
 	return false
 }
 
-func (c *mqlCloudflareZone) one() (*mqlCloudflareOne, error) {
-	res, err := CreateResource(c.MqlRuntime, "cloudflare.one", map[string]*llx.RawData{
-		"__id": llx.StringData("cloudflare.one@" + c.Id.Data),
+func newOne(runtime *plugin.Runtime, accountID, zoneID string) (*mqlCloudflareOne, error) {
+	// Cloudflare One is account-scoped; the __id keys on the account. A
+	// zone-scoped access is retained for backward compatibility and keys on
+	// the zone so its zone-pathed apps/identityProviders stay distinct.
+	key := "account@" + accountID
+	if zoneID != "" {
+		key = "zone@" + zoneID
+	}
+	res, err := CreateResource(runtime, "cloudflare.one", map[string]*llx.RawData{
+		"__id": llx.StringData("cloudflare.one@" + key),
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	one := res.(*mqlCloudflareOne)
-	one.ZoneID = c.Id.Data
-
-	acc := c.GetAccount()
-	if acc.Error != nil {
-		return nil, acc.Error
-	}
-	one.AccountID = acc.Data.GetId().Data
+	one.AccountID = accountID
+	one.ZoneID = zoneID
 
 	return one, nil
+}
+
+// accessScope returns the API path prefix for Access endpoints that exist at
+// both account and zone scope (apps, identity providers). A zone-scoped One
+// keeps querying the zone; an account-scoped One queries the account.
+func (c *mqlCloudflareOne) accessScope() string {
+	if c.ZoneID != "" {
+		return "zones/" + c.ZoneID
+	}
+	return "accounts/" + c.AccountID
+}
+
+func (c *mqlCloudflareAccount) one() (*mqlCloudflareOne, error) {
+	return newOne(c.MqlRuntime, c.Id.Data, "")
+}
+
+// Deprecated: Zero Trust is account-scoped. Use cloudflare.account.one.
+// Retained so existing queries keep working; resolves the parent account and
+// delegates, keeping the zone id so apps/identityProviders stay zone-scoped.
+func (c *mqlCloudflareZone) one() (*mqlCloudflareOne, error) {
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
+	return newOne(c.MqlRuntime, accountID, c.Id.Data)
 }
 
 type mqlCloudflareOneAppInternal struct {
@@ -227,7 +254,7 @@ func (c *mqlCloudflareOneApp) policies() ([]any, error) {
 func (c *mqlCloudflareOne) apps() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, err := cfGetPaged[accessApp](conn, fmt.Sprintf("zones/%s/access/apps", c.ZoneID))
+	records, err := cfGetPaged[accessApp](conn, fmt.Sprintf("%s/access/apps", c.accessScope()))
 	if err != nil {
 		return degradedList(err)
 	}
@@ -446,7 +473,7 @@ func (c *mqlCloudflareOneIdp) id() (string, error) {
 func (c *mqlCloudflareOne) identityProviders() ([]any, error) {
 	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
 
-	records, err := cfGetPaged[accessIdp](conn, fmt.Sprintf("zones/%s/access/identity_providers", c.ZoneID))
+	records, err := cfGetPaged[accessIdp](conn, fmt.Sprintf("%s/access/identity_providers", c.accessScope()))
 	if err != nil {
 		return degradedList(err)
 	}

--- a/providers/cloudflare/resources/r2.go
+++ b/providers/cloudflare/resources/r2.go
@@ -37,12 +37,8 @@ type mqlCloudflareR2Internal struct {
 	AccountID string
 }
 
-func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	res, err := CreateResource(c.MqlRuntime, "cloudflare.r2", map[string]*llx.RawData{
+func newR2(runtime *plugin.Runtime, accountID string) (*mqlCloudflareR2, error) {
+	res, err := CreateResource(runtime, "cloudflare.r2", map[string]*llx.RawData{
 		"__id": llx.StringData("cloudflare.r2@" + accountID),
 	})
 	if err != nil {
@@ -53,6 +49,20 @@ func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
 	r2.AccountID = accountID
 
 	return r2, nil
+}
+
+func (c *mqlCloudflareAccount) r2() (*mqlCloudflareR2, error) {
+	return newR2(c.MqlRuntime, c.Id.Data)
+}
+
+// Deprecated: R2 is account-scoped. Use cloudflare.account.r2. Retained so
+// existing queries keep working; resolves the parent account and delegates.
+func (c *mqlCloudflareZone) r2() (*mqlCloudflareR2, error) {
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
+	return newR2(c.MqlRuntime, accountID)
 }
 
 type mqlCloudflareR2BucketInternal struct {
@@ -105,7 +115,10 @@ func (c *mqlCloudflareR2) buckets() ([]any, error) {
 			} `json:"result_info"`
 		}
 		if err := conn.Cf.Get(context.TODO(), uri, nil, &env); err != nil {
-			return nil, err
+			// R2 is a gated add-on; an account without it returns 403
+			// ("Please enable R2 through the Cloudflare Dashboard"). Degrade
+			// to empty like the other add-on-gated list accessors.
+			return degradedList(err)
 		}
 
 		for i := range env.Result.Buckets {

--- a/providers/cloudflare/resources/tunnels.go
+++ b/providers/cloudflare/resources/tunnels.go
@@ -28,13 +28,23 @@ func (c *mqlCloudflareTunnelConnection) id() (string, error) {
 	return c.Id.Data, nil
 }
 
+func (c *mqlCloudflareAccount) tunnels() ([]any, error) {
+	return fetchTunnels(c.MqlRuntime, c.Id.Data)
+}
+
+// Deprecated: tunnels are account-scoped. Use cloudflare.account.tunnels.
+// Retained so existing queries keep working; resolves the parent account and
+// delegates.
 func (c *mqlCloudflareZone) tunnels() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-	acc := c.GetAccount()
-	if acc.Error != nil {
-		return nil, acc.Error
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
 	}
-	accountID := acc.Data.GetId().Data
+	return fetchTunnels(c.MqlRuntime, accountID)
+}
+
+func fetchTunnels(runtime *plugin.Runtime, accountID string) ([]any, error) {
+	conn := runtime.Connection.(*connection.CloudflareConnection)
 
 	var result []any
 	iter := conn.Cf.ZeroTrust.Tunnels.Cloudflared.ListAutoPaging(context.TODO(), zero_trust.TunnelCloudflaredListParams{
@@ -46,12 +56,12 @@ func (c *mqlCloudflareZone) tunnels() ([]any, error) {
 		// The inline connections field on the list response is deprecated in
 		// cloudflare-go v6 in favor of the dedicated per-tunnel connections
 		// endpoint, so fetch connection details from there instead.
-		connections, err := c.tunnelConnections(conn, accountID, rec.ID, string(rec.TunType))
+		connections, err := tunnelConnections(runtime, conn, accountID, rec.ID, string(rec.TunType))
 		if err != nil {
 			return nil, err
 		}
 
-		res, err := NewResource(c.MqlRuntime, "cloudflare.tunnel", map[string]*llx.RawData{
+		res, err := NewResource(runtime, "cloudflare.tunnel", map[string]*llx.RawData{
 			"id":         llx.StringData(rec.ID),
 			"name":       llx.StringData(rec.Name),
 			"tunnelType": llx.StringData(string(rec.TunType)),
@@ -81,7 +91,7 @@ func (c *mqlCloudflareZone) tunnels() ([]any, error) {
 // dedicated connections endpoint. This endpoint only serves cloudflared
 // ("cfd_tunnel") tunnels; other tunnel types (e.g. warp_connector) have no
 // connections here, so we return an empty list for them.
-func (c *mqlCloudflareZone) tunnelConnections(conn *connection.CloudflareConnection, accountID, tunnelID, tunType string) ([]any, error) {
+func tunnelConnections(runtime *plugin.Runtime, conn *connection.CloudflareConnection, accountID, tunnelID, tunType string) ([]any, error) {
 	connections := []any{}
 	if tunType != "cfd_tunnel" {
 		return connections, nil
@@ -95,7 +105,7 @@ func (c *mqlCloudflareZone) tunnelConnections(conn *connection.CloudflareConnect
 		for j := range client.Conns {
 			tc := client.Conns[j]
 
-			connRes, err := NewResource(c.MqlRuntime, "cloudflare.tunnel.connection", map[string]*llx.RawData{
+			connRes, err := NewResource(runtime, "cloudflare.tunnel.connection", map[string]*llx.RawData{
 				"__id":               llx.StringData(fmt.Sprintf("tunnelConn@%s@%s", tunnelID, tc.ID)),
 				"id":                 llx.StringData(tc.ID),
 				"coloName":           llx.StringData(tc.ColoName),
@@ -163,13 +173,22 @@ type tunnelRouteRecord struct {
 	DeletedAt        time.Time `json:"deleted_at"`
 }
 
+func (c *mqlCloudflareAccount) tunnelRoutes() ([]any, error) {
+	return fetchTunnelRoutes(c.MqlRuntime, c.Id.Data)
+}
+
+// Deprecated: tunnel routes are account-scoped. Use
+// cloudflare.account.tunnelRoutes. Retained so existing queries keep working.
 func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-	acc := c.GetAccount()
-	if acc.Error != nil {
-		return nil, acc.Error
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
 	}
-	accountID := acc.Data.GetId().Data
+	return fetchTunnelRoutes(c.MqlRuntime, accountID)
+}
+
+func fetchTunnelRoutes(runtime *plugin.Runtime, accountID string) ([]any, error) {
+	conn := runtime.Connection.(*connection.CloudflareConnection)
 
 	const perPage = 50
 	var result []any
@@ -186,7 +205,7 @@ func (c *mqlCloudflareZone) tunnelRoutes() ([]any, error) {
 		for i := range env.Result {
 			rec := env.Result[i]
 
-			res, err := CreateResource(c.MqlRuntime, "cloudflare.tunnel.route", map[string]*llx.RawData{
+			res, err := CreateResource(runtime, "cloudflare.tunnel.route", map[string]*llx.RawData{
 				"__id":       llx.StringData(tunnelRouteID(rec.Network, rec.TunnelID, rec.VirtualNetworkID)),
 				"network":    llx.StringData(rec.Network),
 				"tunnelId":   llx.StringData(rec.TunnelID),
@@ -219,13 +238,22 @@ func (c *mqlCloudflareTunnelVirtualNetwork) id() (string, error) {
 	return c.Id.Data, nil
 }
 
+func (c *mqlCloudflareAccount) tunnelVirtualNetworks() ([]any, error) {
+	return fetchTunnelVirtualNetworks(c.MqlRuntime, c.Id.Data)
+}
+
+// Deprecated: tunnel virtual networks are account-scoped. Use
+// cloudflare.account.tunnelVirtualNetworks. Retained for existing queries.
 func (c *mqlCloudflareZone) tunnelVirtualNetworks() ([]any, error) {
-	conn := c.MqlRuntime.Connection.(*connection.CloudflareConnection)
-	acc := c.GetAccount()
-	if acc.Error != nil {
-		return nil, acc.Error
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
 	}
-	accountID := acc.Data.GetId().Data
+	return fetchTunnelVirtualNetworks(c.MqlRuntime, accountID)
+}
+
+func fetchTunnelVirtualNetworks(runtime *plugin.Runtime, accountID string) ([]any, error) {
+	conn := runtime.Connection.(*connection.CloudflareConnection)
 
 	var result []any
 	iter := conn.Cf.ZeroTrust.Networks.VirtualNetworks.ListAutoPaging(context.TODO(), zero_trust.NetworkVirtualNetworkListParams{
@@ -234,7 +262,7 @@ func (c *mqlCloudflareZone) tunnelVirtualNetworks() ([]any, error) {
 	for iter.Next() {
 		rec := iter.Current()
 
-		res, err := NewResource(c.MqlRuntime, "cloudflare.tunnel.virtualNetwork", map[string]*llx.RawData{
+		res, err := NewResource(runtime, "cloudflare.tunnel.virtualNetwork", map[string]*llx.RawData{
 			"id":               llx.StringData(rec.ID),
 			"name":             llx.StringData(rec.Name),
 			"comment":          llx.StringData(rec.Comment),

--- a/providers/cloudflare/resources/workers.go
+++ b/providers/cloudflare/resources/workers.go
@@ -9,17 +9,14 @@ import (
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/cloudflare/connection"
 	"go.mondoo.com/mql/v13/types"
 )
 
-func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
-	accountID, err := c.zoneAccountID()
-	if err != nil {
-		return nil, err
-	}
-	res, err := CreateResource(c.MqlRuntime, "cloudflare.workers", map[string]*llx.RawData{
+func newWorkers(runtime *plugin.Runtime, accountID string) (*mqlCloudflareWorkers, error) {
+	res, err := CreateResource(runtime, "cloudflare.workers", map[string]*llx.RawData{
 		"__id": llx.StringData("cloudflare.workers@" + accountID),
 	})
 	if err != nil {
@@ -30,6 +27,21 @@ func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
 	workers.AccountID = accountID
 
 	return workers, nil
+}
+
+func (c *mqlCloudflareAccount) workers() (*mqlCloudflareWorkers, error) {
+	return newWorkers(c.MqlRuntime, c.Id.Data)
+}
+
+// Deprecated: Workers are account-scoped. Use cloudflare.account.workers.
+// Retained so existing queries keep working; resolves the parent account and
+// delegates.
+func (c *mqlCloudflareZone) workers() (*mqlCloudflareWorkers, error) {
+	accountID, err := c.zoneAccountID()
+	if err != nil {
+		return nil, err
+	}
+	return newWorkers(c.MqlRuntime, accountID)
 }
 
 // workerScript mirrors the account workers-scripts list entry. We decode it via


### PR DESCRIPTION
## Problem

Cloudflare One (Zero Trust), R2, Workers, tunnels/routes/virtual-networks, and Stream are **account-scoped**, but the schema only exposed them on `cloudflare.zone`. Two consequences:

- An account with **no DNS zones** (common for Zero-Trust-only, Workers-only, or R2-only orgs) could not reach any of them at all — `cloudflare.zones` is empty, so there was no path.
- Reaching them from a zone was misleading: every zone under an account returned the same account-wide data.

Found during a live test of the provider against a zoneless account.

## Change

**Expose account-scoped services on `cloudflare.account`:** `one`, `r2`, `workers`, `tunnels`, `tunnelRoutes`, `tunnelVirtualNetworks` (`liveInputs`/`videos` already existed there).

**Deprecate the zone-level copies** via `@maturity("deprecated")`, each pointing at the account equivalent. The zone accessors are **retained and still work** — they resolve the parent account and delegate to shared helpers (`newR2`, `newWorkers`, `newOne`, `fetchTunnels`, `fetchTunnelRoutes`, `fetchTunnelVirtualNetworks`), so no existing query breaks.

**`cloudflare.one` is mixed-scope:** Access apps and identity providers exist at both account and zone scope. A new `accessScope()` helper routes a zone-reached `one` to the zone endpoints (unchanged behavior) and an account-reached `one` to the account endpoints.

**Preexisting bug fix exposed by this change:** `r2.buckets()` propagated the `403 "Please enable R2"` error instead of degrading to empty like every other gated accessor. Routed through `degradedList`.

**Docs:** enriched the doc-comment for every `cloudflare.account` field.

## Verification (live)

Against an account with these add-ons disabled and no zones:

- `cloudflare.accounts { one { apps identityProviders accessGroups } r2 { buckets } workers { workers } tunnels tunnelRoutes tunnelVirtualNetworks }` → all resolve to empty, **no errors** (previously unreachable; R2 previously hard-errored).
- Deprecated zone paths still compile and resolve.
- `go test ./resources/...` passes.

## Notes

- New `.lr.versions` entries at **13.6.5** (next patch after shipped 13.6.4); `config.go` `Version` unchanged per the release-flow convention.
- No `.permissions.json` for cloudflare (not auto-extracted).
