### PR TITLE
🐛 os: don't nest PowerShell inside PowerShell on local Windows

### DIFF
--- a/providers/os/connection/local/local.go
+++ b/providers/os/connection/local/local.go
@@ -20,6 +20,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/connection/ssh/cat"
 	"go.mondoo.com/mql/v13/providers/os/registry"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
 )
 
 type LocalConnection struct {
@@ -204,7 +205,15 @@ func (c *CommandRunner) Exec(usercmd string, args []string) (*shared.Command, er
 	var cmd string
 	cmdArgs := []string{}
 
-	if len(c.Shell) > 0 {
+	// When the default shell is PowerShell and the command is already a
+	// self-contained PowerShell invocation (as produced by powershell.Encode /
+	// powershell.Wrap), run it directly. Otherwise it would be nested inside a
+	// second `powershell -c "..."`, spawning a redundant powershell.exe that
+	// endpoint protection flags as an encoded-command / LOLBIN-chain attack.
+	if argv, ok := unnestPowershell(c.Shell, usercmd); ok {
+		cmd = argv[0]
+		cmdArgs = append(cmdArgs, argv[1:]...)
+	} else if len(c.Shell) > 0 {
 		shellCommand, shellArgs := c.Shell[0], c.Shell[1:]
 		cmd = shellCommand
 		cmdArgs = append(cmdArgs, shellArgs...)
@@ -246,4 +255,21 @@ func (c *CommandRunner) Exec(usercmd string, args []string) (*shared.Command, er
 
 	// all other errors are real errors and not expected
 	return &c.Command, err
+}
+
+// unnestPowershell returns the argv to run usercmd directly, without wrapping
+// it in the shell, when both the shell and the command are PowerShell. This
+// avoids spawning powershell.exe inside powershell.exe. It only fires for the
+// PowerShell shell (Windows local default) so unix `sh -c` behavior and plain
+// commands (e.g. `hostname`) are untouched.
+func unnestPowershell(shell []string, usercmd string) ([]string, bool) {
+	if len(shell) == 0 {
+		return nil, false
+	}
+	switch strings.ToLower(shell[0]) {
+	case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+		return powershell.SplitInvocation(usercmd)
+	default:
+		return nil, false
+	}
 }

--- a/providers/os/resources/powershell/encode.go
+++ b/providers/os/resources/powershell/encode.go
@@ -6,10 +6,68 @@ package powershell
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"golang.org/x/text/encoding/unicode"
 )
+
+// interpreters holds the executable names that Encode/EncodeUnix/Wrap emit as
+// the leading token of a self-contained PowerShell invocation.
+var interpreters = map[string]bool{
+	"powershell":     true,
+	"powershell.exe": true,
+	"pwsh":           true,
+	"pwsh.exe":       true,
+}
+
+// SplitInvocation parses a command string produced by Encode, EncodeUnix, or
+// Wrap back into an argv ([binary, args...]) so a caller can exec it directly
+// instead of nesting it inside another PowerShell shell. Running a
+// PowerShell invocation through a `powershell -c "..."` shell spawns a
+// redundant second powershell.exe, which endpoint protection (e.g.
+// SentinelOne) flags as an encoded-command / LOLBIN-chain attack pattern.
+//
+// It recognizes the two shapes we emit:
+//
+//	powershell.exe -NoProfile -EncodedCommand <base64>   (Encode / EncodeUnix)
+//	powershell -c "<script>"                             (Wrap)
+//
+// Returns ok=false for anything else so callers keep their existing behavior.
+func SplitInvocation(cmd string) (argv []string, ok bool) {
+	trimmed := strings.TrimSpace(cmd)
+	sp := strings.IndexAny(trimmed, " \t")
+	if sp < 0 {
+		return nil, false
+	}
+	bin := trimmed[:sp]
+	if !interpreters[strings.ToLower(bin)] {
+		return nil, false
+	}
+	rest := strings.TrimSpace(trimmed[sp+1:])
+
+	// Encode / EncodeUnix form: -NoProfile -EncodedCommand <base64>.
+	// The base64 payload never contains whitespace, so this is unambiguous.
+	if enc, found := strings.CutPrefix(rest, "-NoProfile -EncodedCommand "); found {
+		enc = strings.TrimSpace(enc)
+		if enc == "" || strings.ContainsAny(enc, " \t") {
+			return nil, false
+		}
+		return []string{bin, "-NoProfile", "-EncodedCommand", enc}, true
+	}
+
+	// Wrap form: -c "<script>". Wrap builds this as `powershell -c "` + cmd + `"`,
+	// so the script is the content between the outer double quotes.
+	if script, found := strings.CutPrefix(rest, "-c "); found {
+		script = strings.TrimSpace(script)
+		if len(script) >= 2 && strings.HasPrefix(script, `"`) && strings.HasSuffix(script, `"`) {
+			script = script[1 : len(script)-1]
+			return []string{bin, "-c", script}, true
+		}
+	}
+
+	return nil, false
+}
 
 // Encode encodes a long powershell script as base64 and returns the wrapped command
 //

--- a/providers/os/resources/powershell/encode_test.go
+++ b/providers/os/resources/powershell/encode_test.go
@@ -15,3 +15,55 @@ func TestPowershellEncoding(t *testing.T) {
 	cmd := string("dir \"c:\\program files\" ")
 	assert.Equal(t, expected, powershell.Encode(cmd))
 }
+
+func TestSplitInvocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		wantArgv []string
+		wantOK   bool
+	}{
+		{
+			name:     "Encode output round-trips to direct argv",
+			cmd:      powershell.Encode("Get-CimInstance -ClassName Win32_Bios"),
+			wantArgv: []string{"powershell.exe", "-NoProfile", "-EncodedCommand", powershell.Encode("Get-CimInstance -ClassName Win32_Bios")[len("powershell.exe -NoProfile -EncodedCommand "):]},
+			wantOK:   true,
+		},
+		{
+			name:     "EncodeUnix output round-trips to direct argv",
+			cmd:      powershell.EncodeUnix("hostname"),
+			wantArgv: []string{"pwsh", "-NoProfile", "-EncodedCommand", powershell.EncodeUnix("hostname")[len("pwsh -NoProfile -EncodedCommand "):]},
+			wantOK:   true,
+		},
+		{
+			name:     "Wrap output unwraps to a single -c script",
+			cmd:      powershell.Wrap("Get-NetAdapter | ConvertTo-Json"),
+			wantArgv: []string{"powershell", "-c", "Get-NetAdapter | ConvertTo-Json"},
+			wantOK:   true,
+		},
+		{
+			name:   "plain command is not a powershell invocation",
+			cmd:    "hostname",
+			wantOK: false,
+		},
+		{
+			name:   "non-powershell binary is left alone",
+			cmd:    "cmd /c echo hi",
+			wantOK: false,
+		},
+		{
+			name:   "empty encoded payload is rejected",
+			cmd:    "powershell.exe -NoProfile -EncodedCommand ",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			argv, ok := powershell.SplitInvocation(tc.cmd)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantArgv, argv)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A customer's SentinelOne agent (26.1.2.177, ~2026-07-17) began classifying `cnspec.exe serve` as **Malware / Suspicious** on Windows 11 Enterprise multi-session hosts. The trigger is the *shape* of how the os provider shells out to PowerShell on the **local** connection.

The threat export shows the actual command lines cnspec spawned:

```
powershell.exe -c "powershell.exe -NoProfile -EncodedCommand <b64>"   ← SMBIOS Get-CimInstance, Azure IMDS Invoke-RestMethod
powershell.exe -c hostname                                            ← os.hostname (single process)
os.exe run_as_plugin --log-level info                                 ← provider plugin (reported NotSigned, see below)
```

That **double `powershell.exe`** is a textbook LOLBIN-chain + encoded/obfuscated-command + AMSI-evasion pattern, which the new S1 heuristics score on. It raised: *"An encoded PowerShell command was detected"*, *"Indirect command was executed"*, *"Lolbins were chained together"*, *"Suspicious WMI query"* (Get-CimInstance), *"PowerShell encoded command connected to the web"* (IMDS Invoke-RestMethod).

## Root cause

The local Windows connection defaults its shell to `powershell -c` (`local.go`). But every `powershell.Encode()` / `powershell.Wrap()` helper already returns a **complete** PowerShell invocation. `CommandRunner.Exec` then nests it inside a second `powershell -c "…"`, spawning a redundant powershell.exe.

The **SSH** connection runs the same command raw (one process), so it was never affected — this is unique to the local connection (i.e. `cnspec serve` scanning its own host). It's a long-standing pattern; S1's update newly flags it, so this is not a regression on our side.

## Fix

- `powershell.SplitInvocation()` — parses the output of `Encode` / `EncodeUnix` / `Wrap` back into an argv (single source of truth for the emitted format).
- `unnestPowershell()` in the local runner — when the shell is powershell/pwsh **and** the command is already a self-contained PowerShell invocation, exec it directly → **one** process: `powershell.exe -NoProfile -EncodedCommand <b64>`.

Plain commands (`hostname`) still route through `powershell -c`; unix `sh -c` is untouched.

## Testing

- Unit tests in `encode_test.go` cover Encode/EncodeUnix/Wrap round-trips + negative cases.
- `go build ./...`, `go vet`, `gofmt` clean.
- ✅ **Verified live on Windows Server 2022** that the double-PowerShell nesting is eliminated (see comment below: 2 processes → 1). Draft pending confirmation with the actual SentinelOne agent that the indicators clear (test box has no S1).

## Out of scope (separate follow-ups)

1. **Unsigned provider binary.** The trace reports `os.exe` as `NotSigned`, raising the *"signed process loaded a suspicious unsigned library"* indicator. The release pipeline *has* signed Windows providers via Azure Trusted Signing since 2024 (`scripts/provider_bundler.sh`, #3626), so the customer likely runs an os-provider version predating signing — needs its own investigation.
2. **Prefer native APIs** over spawning PowerShell for the hot paths (SMBIOS, IMDS, hostname) to reduce the PowerShell signal further.

The other S1 indicators in the export (Chrome memory access, RDP credential dumping, process hollowing, root-cert install) are storyline over-correlation with no matching command in the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
