### PR TITLE
⚡ os: use native APIs for hostname, IMDS, and SMBIOS on local connections

### DIFF
--- a/providers/os/id/azcompute/azcompute.go
+++ b/providers/os/id/azcompute/azcompute.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -17,6 +19,9 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
 	"go.mondoo.com/mql/v13/utils/multierr"
 )
+
+// var so tests can override the endpoint
+var imdsBaseURL = "http://169.254.169.254"
 
 const (
 	// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=windows#supported-api-versions
@@ -138,7 +143,34 @@ func (m *commandInstanceMetadata) Identify() (Identity, error) {
 	}, nil
 }
 
+// httpMetadata fetches an IMDS endpoint over HTTP (local connection path).
+func (m *commandInstanceMetadata) httpMetadata(endpoint string) ([]byte, error) {
+	url := fmt.Sprintf("%s/metadata/%s?api-version=%s", imdsBaseURL, endpoint, IMDSApiVersion)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Metadata", "true")
+
+	// link-local, never via a proxy
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: &http.Transport{Proxy: nil},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return io.ReadAll(resp.Body)
+}
+
 func (m *commandInstanceMetadata) instanceDocument() ([]byte, error) {
+	if m.conn.Type() == shared.Type_Local {
+		return m.httpMetadata("instance")
+	}
+
 	var (
 		cmd *shared.Command
 		err error
@@ -161,6 +193,10 @@ func (m *commandInstanceMetadata) instanceDocument() ([]byte, error) {
 }
 
 func (m *commandInstanceMetadata) loadbalancerDocument() ([]byte, error) {
+	if m.conn.Type() == shared.Type_Local {
+		return m.httpMetadata("loadbalancer")
+	}
+
 	var (
 		cmd *shared.Command
 		err error

--- a/providers/os/id/azcompute/azcompute.go
+++ b/providers/os/id/azcompute/azcompute.go
@@ -20,8 +20,13 @@ import (
 	"go.mondoo.com/mql/v13/utils/multierr"
 )
 
-// var so tests can override the endpoint
-var imdsBaseURL = "http://169.254.169.254"
+const defaultIMDSBaseURL = "http://169.254.169.254"
+
+// reused across the instance+loadbalancer calls per identification
+var imdsHTTPClient = &http.Client{
+	Timeout:   10 * time.Second,
+	Transport: &http.Transport{Proxy: nil}, // link-local, never via a proxy
+}
 
 const (
 	// https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=windows#supported-api-versions
@@ -70,7 +75,7 @@ type InstanceIdentifier interface {
 
 func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier, error) {
 	if pf.IsFamily(inventory.FAMILY_UNIX) || pf.IsFamily(inventory.FAMILY_WINDOWS) {
-		return &commandInstanceMetadata{conn, pf}, nil
+		return &commandInstanceMetadata{conn: conn, platform: pf}, nil
 	}
 	return nil, errors.New("azure compute id detector is not supported for your asset: " + pf.Name + " " + pf.Version)
 }
@@ -78,6 +83,15 @@ func Resolve(conn shared.Connection, pf *inventory.Platform) (InstanceIdentifier
 type commandInstanceMetadata struct {
 	conn     shared.Connection
 	platform *inventory.Platform
+	// imdsBaseURL overrides the IMDS endpoint in tests; defaultIMDSBaseURL when empty.
+	imdsBaseURL string
+}
+
+func (m *commandInstanceMetadata) baseURL() string {
+	if m.imdsBaseURL != "" {
+		return m.imdsBaseURL
+	}
+	return defaultIMDSBaseURL
 }
 
 func (m *commandInstanceMetadata) RawMetadata() (any, error) {
@@ -145,25 +159,27 @@ func (m *commandInstanceMetadata) Identify() (Identity, error) {
 
 // httpMetadata fetches an IMDS endpoint over HTTP (local connection path).
 func (m *commandInstanceMetadata) httpMetadata(endpoint string) ([]byte, error) {
-	url := fmt.Sprintf("%s/metadata/%s?api-version=%s", imdsBaseURL, endpoint, IMDSApiVersion)
+	url := fmt.Sprintf("%s/metadata/%s?api-version=%s", m.baseURL(), endpoint, IMDSApiVersion)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Metadata", "true")
 
-	// link-local, never via a proxy
-	client := &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: &http.Transport{Proxy: nil},
-	}
-	resp, err := client.Do(req)
+	resp, err := imdsHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	return io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IMDS %s returned HTTP %d: %s", endpoint, resp.StatusCode, string(body))
+	}
+	return body, nil
 }
 
 func (m *commandInstanceMetadata) instanceDocument() ([]byte, error) {

--- a/providers/os/id/azcompute/azcompute_test.go
+++ b/providers/os/id/azcompute/azcompute_test.go
@@ -6,11 +6,15 @@ package azcompute
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/os/connection/local"
 	"go.mondoo.com/mql/v13/providers/os/connection/mock"
 	"go.mondoo.com/mql/v13/providers/os/detector"
 )
@@ -254,4 +258,29 @@ func expectedRawMetadataLoadbalancer() string {
     }
   }
 `
+}
+
+func TestLocalHTTPMetadata(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "true", r.Header.Get("Metadata"))
+		if strings.Contains(r.URL.Path, "/metadata/instance") {
+			_, _ = w.Write([]byte(`{"compute":{"resourceId":"/subscriptions/sub-123/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm","subscriptionId":"sub-123","tags":""}}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	old := imdsBaseURL
+	imdsBaseURL = srv.URL
+	defer func() { imdsBaseURL = old }()
+
+	conn := local.NewConnection(0, &inventory.Config{}, &inventory.Asset{})
+	require.Equal(t, "local", string(conn.Type()))
+
+	md := commandInstanceMetadata{conn, &inventory.Platform{Name: "windows", Family: []string{"windows"}}}
+	ident, err := md.Identify()
+	require.NoError(t, err)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-123/resourcegroups/rg/providers/microsoft.compute/virtualmachines/vm", ident.InstanceID)
+	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-123", ident.AccountID)
 }

--- a/providers/os/id/azcompute/azcompute_test.go
+++ b/providers/os/id/azcompute/azcompute_test.go
@@ -25,7 +25,7 @@ func TestCommandProviderLinux(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	metadata := commandInstanceMetadata{conn, platform}
+	metadata := commandInstanceMetadata{conn: conn, platform: platform}
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
@@ -48,7 +48,7 @@ func TestCommandProviderWindows(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	metadata := commandInstanceMetadata{conn, platform}
+	metadata := commandInstanceMetadata{conn: conn, platform: platform}
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
@@ -71,7 +71,7 @@ func TestCommandProviderLinuxNoLoadbalancerInformation(t *testing.T) {
 	platform, ok := detector.DetectOS(conn)
 	require.True(t, ok)
 
-	metadata := commandInstanceMetadata{conn, platform}
+	metadata := commandInstanceMetadata{conn: conn, platform: platform}
 	ident, err := metadata.Identify()
 
 	assert.Nil(t, err)
@@ -271,16 +271,33 @@ func TestLocalHTTPMetadata(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	old := imdsBaseURL
-	imdsBaseURL = srv.URL
-	defer func() { imdsBaseURL = old }()
-
 	conn := local.NewConnection(0, &inventory.Config{}, &inventory.Asset{})
 	require.Equal(t, "local", string(conn.Type()))
 
-	md := commandInstanceMetadata{conn, &inventory.Platform{Name: "windows", Family: []string{"windows"}}}
+	md := commandInstanceMetadata{
+		conn:        conn,
+		platform:    &inventory.Platform{Name: "windows", Family: []string{"windows"}},
+		imdsBaseURL: srv.URL,
+	}
 	ident, err := md.Identify()
 	require.NoError(t, err)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-123/resourcegroups/rg/providers/microsoft.compute/virtualmachines/vm", ident.InstanceID)
 	assert.Equal(t, "//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-123", ident.AccountID)
+}
+
+func TestLocalHTTPMetadataErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	md := commandInstanceMetadata{
+		conn:        local.NewConnection(0, &inventory.Config{}, &inventory.Asset{}),
+		platform:    &inventory.Platform{Name: "windows", Family: []string{"windows"}},
+		imdsBaseURL: srv.URL,
+	}
+	_, err := md.Identify()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 500")
 }

--- a/providers/os/id/hostname/hostname.go
+++ b/providers/os/id/hostname/hostname.go
@@ -6,6 +6,8 @@ package hostname
 import (
 	"fmt"
 	"io"
+	"os"
+	"runtime"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -51,6 +53,17 @@ func Hostname(conn shared.Connection, pf *inventory.Platform) (string, bool) {
 			return hostname, true
 		}
 		log.Debug().Err(err).Str("ipversion", "IPv6").Msg("could not detect hostname")
+	}
+
+	// On local Windows, resolve in-process to avoid spawning `powershell -c hostname`.
+	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
+		if hn, err := os.Hostname(); err == nil {
+			if hn = strings.TrimSpace(hn); hn != "" {
+				return hn, true
+			}
+		} else {
+			log.Debug().Err(err).Msg("could not resolve hostname via os.Hostname, falling back to command")
+		}
 	}
 
 	// This is the preferred way to get the hostname on windows, it is important to not use the -f flag here

--- a/providers/os/resources/smbios/smbios_other.go
+++ b/providers/os/resources/smbios/smbios_other.go
@@ -1,0 +1,13 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+// +build !windows
+
+package smbios
+
+import "go.mondoo.com/mql/v13/providers/os/connection/shared"
+
+func fetchWindowsSmbios(conn shared.Connection) (smbiosWindows, error) {
+	return fetchWindowsSmbiosPowershell(conn)
+}

--- a/providers/os/resources/smbios/smbios_windows.go
+++ b/providers/os/resources/smbios/smbios_windows.go
@@ -7,6 +7,7 @@
 package smbios
 
 import (
+	"fmt"
 	"runtime"
 	"strconv"
 	"time"
@@ -28,8 +29,14 @@ func fetchWindowsSmbios(conn shared.Connection) (smbiosWindows, error) {
 	return fetchWindowsSmbiosPowershell(conn)
 }
 
-func nativeWindowsSmbios() (smbiosWindows, error) {
-	var out smbiosWindows
+func nativeWindowsSmbios() (out smbiosWindows, err error) {
+	// the wmi lib can panic on unexpected COM variant types; recover so we
+	// fall back to PowerShell instead of crashing the scan
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic querying smbios via WMI: %v", r)
+		}
+	}()
 
 	type win32Bios struct {
 		Manufacturer      string
@@ -67,9 +74,11 @@ func nativeWindowsSmbios() (smbiosWindows, error) {
 	}
 
 	type win32SystemEnclosure struct {
-		Manufacturer   string
-		Model          *string
-		ChassisTypes   []uint16
+		Manufacturer string
+		Model        *string
+		// int32, not uint16: the COM SAFEARRAY returns VT_I4 elements and the
+		// wmi lib panics calling reflect.Value.Uint on them.
+		ChassisTypes   []int32
 		Version        string
 		SerialNumber   string
 		SMBIOSAssetTag string

--- a/providers/os/resources/smbios/smbios_windows.go
+++ b/providers/os/resources/smbios/smbios_windows.go
@@ -45,8 +45,8 @@ func nativeWindowsSmbios() (out smbiosWindows, err error) {
 		SerialNumber      string
 	}
 	var bios []win32Bios
-	if err := wmi.Query("SELECT Manufacturer, SMBIOSBIOSVersion, ReleaseDate, SerialNumber FROM Win32_Bios", &bios); err != nil {
-		return out, err
+	if qErr := wmi.Query("SELECT Manufacturer, SMBIOSBIOSVersion, ReleaseDate, SerialNumber FROM Win32_Bios", &bios); qErr != nil {
+		return out, qErr
 	}
 	if len(bios) > 0 {
 		out.Bios = smbiosWinBios{
@@ -66,8 +66,8 @@ func nativeWindowsSmbios() (out smbiosWindows, err error) {
 		SerialNumber string
 	}
 	var baseboard []win32BaseBoard
-	if err := wmi.Query("SELECT Manufacturer, Product, Version, SerialNumber FROM Win32_BaseBoard", &baseboard); err != nil {
-		return out, err
+	if qErr := wmi.Query("SELECT Manufacturer, Product, Version, SerialNumber FROM Win32_BaseBoard", &baseboard); qErr != nil {
+		return out, qErr
 	}
 	if len(baseboard) > 0 {
 		out.BaseBoard = smbiosBaseBoard(baseboard[0])
@@ -84,8 +84,8 @@ func nativeWindowsSmbios() (out smbiosWindows, err error) {
 		SMBIOSAssetTag string
 	}
 	var chassis []win32SystemEnclosure
-	if err := wmi.Query("SELECT Manufacturer, Model, ChassisTypes, Version, SerialNumber, SMBIOSAssetTag FROM Win32_SystemEnclosure", &chassis); err != nil {
-		return out, err
+	if qErr := wmi.Query("SELECT Manufacturer, Model, ChassisTypes, Version, SerialNumber, SMBIOSAssetTag FROM Win32_SystemEnclosure", &chassis); qErr != nil {
+		return out, qErr
 	}
 	for _, ch := range chassis {
 		types := make([]string, 0, len(ch.ChassisTypes))
@@ -111,8 +111,8 @@ func nativeWindowsSmbios() (out smbiosWindows, err error) {
 		IdentifyingNumber string
 	}
 	var product []win32ComputerSystemProduct
-	if err := wmi.Query("SELECT Vendor, Name, Version, SKUNumber, UUID, IdentifyingNumber FROM Win32_ComputerSystemProduct", &product); err != nil {
-		return out, err
+	if qErr := wmi.Query("SELECT Vendor, Name, Version, SKUNumber, UUID, IdentifyingNumber FROM Win32_ComputerSystemProduct", &product); qErr != nil {
+		return out, qErr
 	}
 	if len(product) > 0 {
 		out.SystemProduct = smbiosSystemProduct(product[0])

--- a/providers/os/resources/smbios/smbios_windows.go
+++ b/providers/os/resources/smbios/smbios_windows.go
@@ -1,0 +1,113 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+// +build windows
+
+package smbios
+
+import (
+	"runtime"
+	"strconv"
+	"time"
+
+	wmi "github.com/StackExchange/wmi"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+)
+
+// native WMI on local Windows; PowerShell otherwise or on failure
+func fetchWindowsSmbios(conn shared.Connection) (smbiosWindows, error) {
+	if conn.Type() == shared.Type_Local && runtime.GOOS == "windows" {
+		winBios, err := nativeWindowsSmbios()
+		if err == nil {
+			return winBios, nil
+		}
+		log.Debug().Err(err).Msg("could not query smbios via WMI, falling back to PowerShell")
+	}
+	return fetchWindowsSmbiosPowershell(conn)
+}
+
+func nativeWindowsSmbios() (smbiosWindows, error) {
+	var out smbiosWindows
+
+	type win32Bios struct {
+		Manufacturer      string
+		SMBIOSBIOSVersion string
+		ReleaseDate       time.Time
+		SerialNumber      string
+	}
+	var bios []win32Bios
+	if err := wmi.Query("SELECT Manufacturer, SMBIOSBIOSVersion, ReleaseDate, SerialNumber FROM Win32_Bios", &bios); err != nil {
+		return out, err
+	}
+	if len(bios) > 0 {
+		out.Bios = smbiosWinBios{
+			Manufacturer:      bios[0].Manufacturer,
+			SMBIOSBIOSVersion: bios[0].SMBIOSBIOSVersion,
+			SerialNumber:      bios[0].SerialNumber,
+		}
+		if !bios[0].ReleaseDate.IsZero() {
+			out.Bios.ReleaseDate = bios[0].ReleaseDate.Format(time.RFC3339)
+		}
+	}
+
+	type win32BaseBoard struct {
+		Manufacturer string
+		Product      string
+		Version      string
+		SerialNumber string
+	}
+	var baseboard []win32BaseBoard
+	if err := wmi.Query("SELECT Manufacturer, Product, Version, SerialNumber FROM Win32_BaseBoard", &baseboard); err != nil {
+		return out, err
+	}
+	if len(baseboard) > 0 {
+		out.BaseBoard = smbiosBaseBoard(baseboard[0])
+	}
+
+	type win32SystemEnclosure struct {
+		Manufacturer   string
+		Model          *string
+		ChassisTypes   []uint16
+		Version        string
+		SerialNumber   string
+		SMBIOSAssetTag string
+	}
+	var chassis []win32SystemEnclosure
+	if err := wmi.Query("SELECT Manufacturer, Model, ChassisTypes, Version, SerialNumber, SMBIOSAssetTag FROM Win32_SystemEnclosure", &chassis); err != nil {
+		return out, err
+	}
+	for _, ch := range chassis {
+		types := make([]string, 0, len(ch.ChassisTypes))
+		for _, t := range ch.ChassisTypes {
+			types = append(types, strconv.Itoa(int(t)))
+		}
+		out.Chassis = append(out.Chassis, smbiosChassis{
+			Manufacturer:   ch.Manufacturer,
+			Model:          ch.Model,
+			ChassisTypes:   &smbiosChassisTypes{ChassisTypes: types},
+			Version:        ch.Version,
+			SerialNumber:   ch.SerialNumber,
+			SMBIOSAssetTag: ch.SMBIOSAssetTag,
+		})
+	}
+
+	type win32ComputerSystemProduct struct {
+		Vendor            string
+		Name              string
+		Version           string
+		SKUNumber         string
+		UUID              string
+		IdentifyingNumber string
+	}
+	var product []win32ComputerSystemProduct
+	if err := wmi.Query("SELECT Vendor, Name, Version, SKUNumber, UUID, IdentifyingNumber FROM Win32_ComputerSystemProduct", &product); err != nil {
+		return out, err
+	}
+	if len(product) > 0 {
+		out.SystemProduct = smbiosSystemProduct(product[0])
+	}
+
+	return out, nil
+}

--- a/providers/os/resources/smbios/win.go
+++ b/providers/os/resources/smbios/win.go
@@ -144,20 +144,7 @@ func (s *WindowsSmbiosManager) Info() (*SmBiosInfo, error) {
 		return s.smInfo, nil
 	}
 
-	c, err := s.provider.RunCommand(powershell.Encode(smbiosWindowsScript))
-	if err != nil {
-		return nil, err
-	}
-
-	if c.ExitStatus != 0 {
-		stderr, err := io.ReadAll(c.Stderr)
-		if err != nil {
-			return nil, err
-		}
-		return nil, errors.New("failed to retrieve smbios info: " + string(stderr))
-	}
-
-	winBios, err := ParseWindowsSmbiosInfo(c.Stdout)
+	winBios, err := fetchWindowsSmbios(s.provider)
 	if err != nil {
 		return nil, err
 	}
@@ -203,6 +190,26 @@ func toString(i *string) string {
 		return ""
 	}
 	return *i
+}
+
+// remote path, and fallback for the local native path
+func fetchWindowsSmbiosPowershell(conn shared.Connection) (smbiosWindows, error) {
+	var winBios smbiosWindows
+
+	c, err := conn.RunCommand(powershell.Encode(smbiosWindowsScript))
+	if err != nil {
+		return winBios, err
+	}
+
+	if c.ExitStatus != 0 {
+		stderr, err := io.ReadAll(c.Stderr)
+		if err != nil {
+			return winBios, err
+		}
+		return winBios, errors.New("failed to retrieve smbios info: " + string(stderr))
+	}
+
+	return ParseWindowsSmbiosInfo(c.Stdout)
 }
 
 func ParseWindowsSmbiosInfo(r io.Reader) (smbiosWindows, error) {


### PR DESCRIPTION
## Motivation

Follow-up to #9305 (SentinelOne flagging `cnspec.exe serve` on Windows). That PR stopped nesting PowerShell inside PowerShell; this one removes the PowerShell spawn entirely for three hot paths when scanning the **local** host, so there's less for endpoint protection to flag and it's faster.

All three gate on `conn.Type() == shared.Type_Local`. Remote connections (SSH / WinRM) keep the existing command paths, so there is **no behavior change for remote scans**. Follows the established `platformid.windowsMachineId` / `detector/windows.GetWmiInformation` pattern (local-native + PowerShell fallback, build-tag split).

## Changes

| Path | Local now uses | Fallback / remote |
|---|---|---|
| **hostname** | `os.Hostname()` in-process | `powershell -c hostname` |
| **Azure IMDS** | direct Go HTTP GET, returns raw JSON like the unix `curl` path | `Invoke-RestMethod` (win) / `curl` (unix) |
| **SMBIOS** | WMI via `StackExchange/wmi` (`Win32_Bios`/`BaseBoard`/`SystemEnclosure`/`ComputerSystemProduct`) | encoded PowerShell script, also used if the native query fails |

New files: `resources/smbios/smbios_windows.go` (native WMI), `resources/smbios/smbios_other.go` (fallback dispatch). SMBIOS `win.go` refactored so the mapping to `SmBiosInfo` is shared between both paths.

## Verified live on Windows Server 2022 (EC2)

Ran the **real** package code path (`local.NewConnection` → `smbios.ResolveManager` → `nativeWindowsSmbios`, and `hostname.Hostname`) on an actual Windows host:

- `hostname` → `EC2AMAZ-B96TDOB` ✓
- SMBIOS native → BIOS `Amazon EC2 / 1.0`, SysInfo `t3.medium` + UUID, Chassis `Type=1` — **matches the PowerShell path field-for-field**.
- IMDS parsing covered by a new httptest-backed unit test (`TestLocalHTTPMetadata`).

### Bug caught by live testing (second commit)

`Win32_SystemEnclosure.ChassisTypes` comes back from the COM SAFEARRAY as `VT_I4`, so `[]uint16` makes the `StackExchange/wmi` lib **panic** (`reflect.Value.Uint on int32`) — which would crash the scan. Fixed to `[]int32`, and the native path is now wrapped in `defer/recover` so any future WMI surprise falls back to PowerShell instead of panicking.

## Notes

- `bios.releaseDate` on local Windows is now RFC3339 (`2017-10-16T00:00:00Z`) instead of the old PowerShell `/Date(1508112000000)/`. Net improvement; local-Windows only (remote unchanged).
- Draft because IMDS could not be exercised against real Azure infra (test box is EC2); the parse path is unit-tested and the SMBIOS/hostname paths are fully verified on live Windows.

Builds + `go vet` clean on darwin and `GOOS=windows`; smbios/hostname/azcompute test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)