### PR TITLE
fix(os/ports): bound Windows Get-NetTCPConnection output to parsed fields

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -445,7 +445,16 @@ func (p *mqlPorts) listWindows() ([]any, error) {
 	}
 
 	conn := p.MqlRuntime.Connection.(shared.Connection)
-	encodedCmd := powershell.Encode("Get-NetTCPConnection | ConvertTo-Json")
+	// Project only the fields parseWindowsPorts consumes before serializing.
+	// A bare `Get-NetTCPConnection | ConvertTo-Json` emits the full CIM object
+	// per connection (CimClass, CimInstanceProperties, and ~30 null fields);
+	// on a busy host that is a large buffered read + unmarshal that can stall
+	// the provider long enough to miss its heartbeat and get killed (surfaces
+	// as event_name="provider.crashed", resource=port). Select-Object keeps the
+	// payload to the six fields we read; @(...) forces an array so a single
+	// connection still decodes as []WinPort. State is cast to int to match
+	// ports.WinPort.State regardless of how the enum is serialized.
+	encodedCmd := powershell.Encode("@(Get-NetTCPConnection | Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, @{Name='State';Expression={[int]$_.State}}, OwningProcess) | ConvertTo-Json")
 	executedCmd, err := conn.RunCommand(encodedCmd)
 	if err != nil {
 		return nil, err

--- a/providers/os/resources/ports/testdata/windows_tcp_slim.json
+++ b/providers/os/resources/ports/testdata/windows_tcp_slim.json
@@ -1,0 +1,18 @@
+[
+  {
+    "LocalAddress":  "::",
+    "LocalPort":  49672,
+    "RemoteAddress":  "::",
+    "RemotePort":  0,
+    "State":  2,
+    "OwningProcess":  2136
+  },
+  {
+    "LocalAddress":  "10.0.0.5",
+    "LocalPort":  52014,
+    "RemoteAddress":  "93.184.216.34",
+    "RemotePort":  443,
+    "State":  5,
+    "OwningProcess":  4288
+  }
+]

--- a/providers/os/resources/ports/winports_test.go
+++ b/providers/os/resources/ports/winports_test.go
@@ -25,3 +25,37 @@ func TestParseWindowsTCP(t *testing.T) {
 	assert.Equal(t, int64(0), ports[0].RemotePort)
 	assert.Equal(t, "[::]", ports[0].RemoteAddress)
 }
+
+// TestParseWindowsTCPSlim covers the projected output shape produced by
+//
+//	@(Get-NetTCPConnection | Select-Object LocalAddress, LocalPort,
+//	  RemoteAddress, RemotePort, @{Name='State';Expression={[int]$_.State}},
+//	  OwningProcess) | ConvertTo-Json
+//
+// i.e. only the six fields we read, State as an int, always an array. This is
+// what listWindows now asks PowerShell for to keep the payload small.
+func TestParseWindowsTCPSlim(t *testing.T) {
+	data, err := os.Open("./testdata/windows_tcp_slim.json")
+	require.NoError(t, err)
+	defer data.Close()
+
+	ports, err := ParseWindowsNetTCPConnections(data)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(ports))
+
+	// ipv6 listener — the address gets bracketed
+	assert.Equal(t, "[::]", ports[0].LocalAddress)
+	assert.Equal(t, int64(49672), ports[0].LocalPort)
+	assert.Equal(t, "[::]", ports[0].RemoteAddress)
+	assert.Equal(t, int64(0), ports[0].RemotePort)
+	assert.Equal(t, State(Listen), ports[0].State)
+	assert.Equal(t, int64(2136), ports[0].OwningProcess)
+
+	// ipv4 established connection — the address is left as-is
+	assert.Equal(t, "10.0.0.5", ports[1].LocalAddress)
+	assert.Equal(t, int64(52014), ports[1].LocalPort)
+	assert.Equal(t, "93.184.216.34", ports[1].RemoteAddress)
+	assert.Equal(t, int64(443), ports[1].RemotePort)
+	assert.Equal(t, State(Established), ports[1].State)
+	assert.Equal(t, int64(4288), ports[1].OwningProcess)
+}


### PR DESCRIPTION
## What

On Windows, `ports.list` runs:

```powershell
Get-NetTCPConnection | ConvertTo-Json
```

`ConvertTo-Json` serializes the **entire CIM object** per connection — `CimClass`, the `CimInstanceProperties` string array, `CimSystemProperties`, and ~30 extra null fields — even though `parseWindowsPorts` reads only six top-level fields. The committed single-connection fixture (`windows_tcp.json`) is ~85 lines / ~3 KB for **one** connection.

This PR projects the query to just the fields we parse:

```powershell
@(Get-NetTCPConnection | Select-Object LocalAddress, LocalPort, RemoteAddress, RemotePort, @{Name='State';Expression={[int]$_.State}}, OwningProcess) | ConvertTo-Json
```

- `Select-Object …` drops the CIM bloat → payload shrinks ~10–30×.
- `@{Name='State';Expression={[int]$_.State}}` casts `State` to an int so it decodes into `ports.WinPort.State` regardless of how the enum serializes.
- `@(…)` forces an array, so a host with a single connection still decodes as `[]WinPort` (a bare object would fail the `json.Unmarshal` into a slice).

## Why

On busy hosts, `ports.ParseWindowsNetTCPConnections` does `io.ReadAll` + `json.Unmarshal` of the whole blob. With thousands of connections × the full CIM object, that is a large CPU/allocation spike. The provider plugin has a heartbeat watchdog with a short tolerance (client interval `2s` + grace `3s` = **5s**; `providers-sdk/v1/plugin/service.go` `Heartbeat` `os.Exit(4)`s the subprocess if a heartbeat is missed). A parse that stalls the process past that window trips the watchdog; the runtime then sees `codes.Unavailable` and reports every in-flight field RPC as `event_name="provider.crashed"`.

In fleet telemetry this shows up as `resource=port, field=remotePort` being the single most common `provider.crashed` field across many Windows spaces — but that is just **the field in flight when the connection dropped**, not a bug in `remotePort` (which is a stored `int`; there are zero panics in the data). The actual origin is this oversized enumeration. Reducing the payload removes the stall.

## Testing

- `go test ./providers/os/resources/ports/...` — pass (existing `TestParseWindowsTCP` + new `TestParseWindowsTCPSlim`).
- `go build ./providers/os/resources/` — pass.
- Added `testdata/windows_tcp_slim.json` + `TestParseWindowsTCPSlim` asserting the projected shape (six fields, `State` as int, array-wrapped) decodes to the expected `WinPort`s, including the ipv6-bracketing path.

**Verification boundary:** the parser side is covered by unit tests here; the change to the PowerShell command string itself has **not** been exercised against a live Windows host in this change — worth a manual scan against a Windows asset before release to confirm `Select-Object`/`ConvertTo-Json` emits the expected shape end-to-end.

## Follow-ups (not in this PR)

- The 5s heartbeat tolerance + provider `os.Exit` on a missed beat turns *any* provider operation that stalls the process >5s into a fleet-wide "crash." A more general fix is to make the watchdog tolerant of long-running resolvers (keepalive during a call, or an adaptive/larger tolerance) so slow-but-healthy operations aren't killed and mis-reported. Happy to open a separate issue/PR.
- Capturing the subprocess exit reason (signal / peak RSS) in the crash report would disambiguate OOM-kill vs. hang per host (already tracked separately).
