### PR TITLE
🎉 os-13.36.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.35.4",
+	Version: "13.36.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.36.0)
- fix(os/ports): bound Windows Get-NetTCPConnection output to parsed fields (#9309)
- ⚡ os: use native APIs for hostname, IMDS, and SMBIOS on local connections (#9306)
- 🐛 os: don't nest PowerShell inside PowerShell on local Windows (#9305)
- ✨ github/gitlab: discover CloudFormation, Dockerfile, Bicep, Helm, and Kustomize IaC (#8314)