### PR TITLE
🐛 arista: fix running-config parser panic + deprecate fabricated boundaryType

### DIFF
--- a/providers/arista/resources/arista.lr
+++ b/providers/arista/resources/arista.lr
@@ -372,8 +372,12 @@ arista.eos.spt.mstInterface @defaults("name") {
   // designated bridge and port; `regionalRootAddress` and
   // `regionalRootPriority` identify the MST regional root.
   detail dict
-  // Interface Boundary Type
-  boundaryType string
+  // Interface boundary type
+  //
+  // Deprecated, please use state. This field never carried a distinct
+  // boundary type: it returns the same value as state. It will be removed in
+  // a future major release once a real boundary source is wired up.
+  boundaryType @maturity("deprecated") string
   // BPDU transaction counters for the interface
   //
   // Keys `bpduSent`, `bpduReceived`, `bpduTaggedError`, `bpduOtherError`,

--- a/providers/arista/resources/arista_eos.go
+++ b/providers/arista/resources/arista_eos.go
@@ -408,7 +408,11 @@ func (a *mqlAristaEosInterface) duplex() (string, error) {
 	if tv.Data == nil {
 		return "", nil
 	}
-	if duplex, ok := tv.Data.(map[string]any)["duplex"].(string); ok {
+	status, ok := tv.Data.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	if duplex, ok := status["duplex"].(string); ok {
 		return duplex, nil
 	}
 	return "", nil
@@ -422,7 +426,11 @@ func (a *mqlAristaEosInterface) autoNegotiate() (bool, error) {
 	if tv.Data == nil {
 		return false, nil
 	}
-	if autoNeg, ok := tv.Data.(map[string]any)["autoNegotiateActive"].(bool); ok {
+	status, ok := tv.Data.(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if autoNeg, ok := status["autoNegotiateActive"].(bool); ok {
 		return autoNeg, nil
 	}
 	return false, nil
@@ -469,6 +477,11 @@ func (a *mqlAristaEosStp) mstInstances() ([]any, error) {
 		mstInstance := mstInstances[mstk]
 
 		m := aristaMstInstanceID.FindStringSubmatch(mstk)
+		// Same guard as the pre-fetch loop above: a key without a trailing
+		// instance number does not match, and m[1] below would panic on nil.
+		if m == nil {
+			continue
+		}
 
 		bridge, err := convert.JsonToDict(mstInstance.Bridge)
 		if err != nil {
@@ -512,7 +525,9 @@ func (a *mqlAristaEosStp) mstInstances() ([]any, error) {
 				"portNumber":           llx.IntData(int64(iface.PortNumber)),
 				"isEdgePort":           llx.BoolData(iface.IsEdgePort),
 				"detail":               llx.DictData(detail),
-				"boundaryType":         llx.StringData(iface.State),
+				// Deprecated: duplicates state; no real boundary source exists
+				// in the SDK response yet.
+				"boundaryType": llx.StringData(iface.State),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/arista/resources/eos/config.go
+++ b/providers/arista/resources/eos/config.go
@@ -45,6 +45,14 @@ func ParseConfig(in io.Reader) map[string]any {
 		if indent > 0 {
 			level = indent / 3
 		}
+		// An ascent only ever pushes one stack entry, so a line that is
+		// indented more than one level deeper than the previous line (e.g. an
+		// indented banner or comment block that isn't real config nesting)
+		// would later be popped by more than was pushed, underflowing the
+		// stack. Clamp to one level deeper to keep the stack balanced.
+		if level > lastDepth+1 {
+			level = lastDepth + 1
+		}
 
 		if level > lastDepth {
 			// add level to stack
@@ -97,6 +105,13 @@ func GetSection(in io.Reader, section string) string {
 		level := 0
 		if indent > 0 {
 			level = indent / 3
+		}
+		// An ascent only ever pushes one key, so clamp a multi-level indent
+		// jump (e.g. an indented banner line) to one level deeper. Without
+		// this a later dedent pops more than was pushed and slices keyStack
+		// to a negative length, panicking the whole query.
+		if level > lastDepth+1 {
+			level = lastDepth + 1
 		}
 
 		if level > lastDepth {

--- a/providers/arista/resources/eos/config_test.go
+++ b/providers/arista/resources/eos/config_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +50,36 @@ func TestGetSection(t *testing.T) {
 	section = GetSection(bytes.NewReader(data), "management telnet")
 	expected = "shutdown\nidle-timeout 0\nsession-limit 20\nsession-limit per-host 20\n"
 	assert.Equal(t, expected, section)
+}
+
+// A running-config can contain lines indented more than one level deeper than
+// the previous line (an indented login/motd banner is the common case). Such a
+// jump must not underflow the parser's stack. Both functions previously
+// panicked with "slice bounds out of range" on this input.
+const deepIndentConfig = `management ssh
+   no shutdown
+banner login
+         welcome to the switch
+                  please authenticate
+EOF
+management telnet
+   shutdown
+   idle-timeout 0
+`
+
+func TestGetSection_DeepIndentDoesNotPanic(t *testing.T) {
+	var section string
+	assert.NotPanics(t, func() {
+		section = GetSection(strings.NewReader(deepIndentConfig), "management telnet")
+	})
+	// The parser must still recover and read a section that follows the
+	// irregularly-indented banner block.
+	assert.Equal(t, "shutdown\nidle-timeout 0\n", section)
+}
+
+func TestParseConfig_DeepIndentDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		dict := ParseConfig(strings.NewReader(deepIndentConfig))
+		assert.NotNil(t, dict)
+	})
 }

--- a/providers/arista/resources/eos/security.go
+++ b/providers/arista/resources/eos/security.go
@@ -128,24 +128,20 @@ func ParseAaaConfig(runningConfig string) *AaaConfig {
 		}
 	}
 
-	// DefaultLoginPermitsLocalOnly: the "default" login list contains "local"
-	// with no `group` token preceding it — i.e. local is reachable without
-	// going through remote AAA.
+	// DefaultLoginPermitsLocalOnly: methods in the "default" login list are
+	// tried in order, so local authentication is reachable without a working
+	// remote source whenever "local" appears before the first "group" (remote
+	// AAA) method, or when there is no remote group at all. A "group" that
+	// precedes "local" makes local a fallback, not the primary source, so it
+	// does not count.
 	if methods, ok := cfg.AuthenticationLogin["default"]; ok {
-		hasGroup := false
 		for _, m := range methods {
 			if m == "group" {
-				hasGroup = true
 				break
 			}
-		}
-		// If there's no remote group at all, local is the only source.
-		if !hasGroup {
-			for _, m := range methods {
-				if m == "local" {
-					cfg.DefaultLoginPermitsLocalOnly = true
-					break
-				}
+			if m == "local" {
+				cfg.DefaultLoginPermitsLocalOnly = true
+				break
 			}
 		}
 	}

--- a/providers/arista/resources/eos/security_test.go
+++ b/providers/arista/resources/eos/security_test.go
@@ -43,6 +43,17 @@ func TestParseAaaConfig_LocalOnly(t *testing.T) {
 	assert.True(t, a.DefaultLoginPermitsLocalOnly)
 }
 
+func TestParseAaaConfig_LocalBeforeGroup(t *testing.T) {
+	// "local" precedes "group", so local authenticates without a working
+	// remote source (the worse hardening posture). Order matters: presence of
+	// a group token alone must not clear the flag.
+	cfg := `aaa authentication login default local group tacacs+
+`
+	a := ParseAaaConfig(cfg)
+	assert.Equal(t, []string{"local", "group", "tacacs+"}, a.AuthenticationLogin["default"])
+	assert.True(t, a.DefaultLoginPermitsLocalOnly)
+}
+
 func TestParseAaaConfig_NoConfig(t *testing.T) {
 	a := ParseAaaConfig("")
 	assert.Empty(t, a.AuthenticationLogin)


### PR DESCRIPTION
Fixes found by a static bug-review of the arista provider. Every finding is a silent-wrong-data or panic bug that a passing test suite wouldn't catch. Regression tests added for the pure-Go logic touched.

## HIGH — running-config parser panics on a multi-level indent jump
`GetSection`/`ParseConfig` (`eos/config.go`) push exactly one entry per indent-level ascent but pop the full `levelDiff` on a dedent. A line indented more than one level deeper than its predecessor therefore gets popped by more than was pushed, slicing the stack to a negative length and panicking. The common real-world trigger is an **indented login/motd banner** reproduced verbatim in `show running-config`.

`GetSection` parses the entire running-config on every call and is reached by `arista.eos.runningConfig.section(name:)` plus the `management ssh` / `management telnet` / `control-plane` security resources — so any of those queries crash on a device with an indented banner.

Fix: clamp a multi-level jump to one level deeper, enforcing the "at most one level per line" invariant the push-1 logic already assumes. No-op for well-formed configs; graceful for irregular ones. Same latent bug fixed in `ParseConfig`'s `stack[level]` indexing.

## HIGH — `boundaryType` returned fabricated data
`arista.eos.spt.mstInterface.boundaryType` was populated with `iface.State` — a byte-for-byte duplicate of the sibling `state` field — not a real boundary type. The goeapi JSON model has no boundary source. Marked `@maturity("deprecated")` pointing at `state` (non-breaking; value preserved). A real boundary type would need a new SDK struct field + live verification (follow-up).

## MEDIUM — `mstInstances()` nil-deref
The main loop dereferenced `m[1]` from an unguarded `FindStringSubmatch` while the pre-fetch loop 15 lines up guarded the same call. Added the matching `if m == nil { continue }`.

## MEDIUM — AAA "local only" ignored method order
`DefaultLoginPermitsLocalOnly` checked only for the *presence* of a `group` token, so `aaa authentication login default local group tacacs+` (local first — local authenticates with no working remote, the worse posture) was reported `false`. Method lists are tried in order; the check is now order-sensitive (true iff `local` precedes the first `group`).

## LOW — bare outer type-assertion in interface status accessors
`duplex()`/`autoNegotiate()` comma-ok'd the inner assertion but not `tv.Data.(map[string]any)`. A non-map status would panic. Now comma-ok'd.

## Tests
- `eos/config_test.go`: deep-indent (banner) no-panic cases for `GetSection` and `ParseConfig`, asserting recovery of a following section.
- `eos/security_test.go`: `local`-before-`group` ordering case for `DefaultLoginPermitsLocalOnly`.

`go test ./resources/eos/...` passes; `go build`/`go vet` clean.

## Test-coverage note
The resource layer (`arista_eos.go`) still has no unit tests; the pure-Go logic in `eos/` is otherwise well covered. The `config.go` indent-stack machine had no direct test before this PR — now added.
