### PR TITLE
🐛 gcp: expose disabled/exclusions on project log sinks and metrics

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1355,6 +1355,10 @@ var gcpPermissionOverrides = map[string]map[string]string{
 		// logging.cmekSettings.get permission (verified against GCP testable
 		// permissions at project and organization scope).
 		"Projects.GetCmekSettings": "logging.settings.get",
+		// Log-based metrics list under the "logMetrics" resource; the generic
+		// derivation from Projects.Metrics.List yields the non-existent
+		// "logging.metrics.list".
+		"Metrics.List": "logging.logMetrics.list",
 	},
 	"resourcemanager": {
 		// Listing liens has no dedicated permission; it requires

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -5914,6 +5914,8 @@ private gcp.project.loggingservice.metric @defaults("description filter") {
   description string
   // Advanced log filter
   filter string
+  // Whether the metric is disabled. A disabled metric stops matching new log entries.
+  disabled bool
   // Whether the filter matches IAM policy mutations (SetIamPolicy)
   filtersIamChanges() bool
   // Whether the filter matches audit-config mutations (auditConfigDelta on SetIamPolicy)
@@ -5962,6 +5964,15 @@ private gcp.project.loggingservice.sink @defaults("destination") {
   //
   // When true, the sink also receives log entries (recursively) from any contained folders, billing accounts, or projects.
   includeChildren bool
+  // Whether the sink is disabled. A disabled sink stops exporting log entries.
+  disabled bool
+  // Per-sink exclusion filters
+  //
+  // Each entry drops matching log entries from this sink's export before they
+  // reach the destination, with keys `name` (the exclusion identifier),
+  // `description`, `filter` (the advanced log filter selecting entries to
+  // drop), and `disabled` (whether the exclusion is currently inactive).
+  exclusions []dict
   // Whether the sink exports every log entry because its filter is empty
   capturesAllLogs() bool
 }

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -7905,6 +7905,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.loggingservice.metric.filter": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFilter()).ToDataRes(types.String)
 	},
+	"gcp.project.loggingservice.metric.disabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceMetric).GetDisabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.loggingservice.metric.filtersIamChanges": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceMetric).GetFiltersIamChanges()).ToDataRes(types.Bool)
 	},
@@ -7955,6 +7958,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.loggingservice.sink.includeChildren": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceSink).GetIncludeChildren()).ToDataRes(types.Bool)
+	},
+	"gcp.project.loggingservice.sink.disabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceSink).GetDisabled()).ToDataRes(types.Bool)
+	},
+	"gcp.project.loggingservice.sink.exclusions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceSink).GetExclusions()).ToDataRes(types.Array(types.Dict))
 	},
 	"gcp.project.loggingservice.sink.capturesAllLogs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceSink).GetCapturesAllLogs()).ToDataRes(types.Bool)
@@ -25932,6 +25941,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectLoggingserviceMetric).Filter, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.loggingservice.metric.disabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceMetric).Disabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.loggingservice.metric.filtersIamChanges": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceMetric).FiltersIamChanges, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -26002,6 +26015,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.loggingservice.sink.includeChildren": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceSink).IncludeChildren, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.sink.disabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceSink).Disabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.sink.exclusions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceSink).Exclusions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.loggingservice.sink.capturesAllLogs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -59922,6 +59943,7 @@ type mqlGcpProjectLoggingserviceMetric struct {
 	ProjectId                      plugin.TValue[string]
 	Description                    plugin.TValue[string]
 	Filter                         plugin.TValue[string]
+	Disabled                       plugin.TValue[bool]
 	FiltersIamChanges              plugin.TValue[bool]
 	FiltersAuditConfigChanges      plugin.TValue[bool]
 	FiltersRouteChanges            plugin.TValue[bool]
@@ -59985,6 +60007,10 @@ func (c *mqlGcpProjectLoggingserviceMetric) GetDescription() *plugin.TValue[stri
 
 func (c *mqlGcpProjectLoggingserviceMetric) GetFilter() *plugin.TValue[string] {
 	return &c.Filter
+}
+
+func (c *mqlGcpProjectLoggingserviceMetric) GetDisabled() *plugin.TValue[bool] {
+	return &c.Disabled
 }
 
 func (c *mqlGcpProjectLoggingserviceMetric) GetFiltersIamChanges() *plugin.TValue[bool] {
@@ -60069,6 +60095,8 @@ type mqlGcpProjectLoggingserviceSink struct {
 	Filter          plugin.TValue[string]
 	WriterIdentity  plugin.TValue[string]
 	IncludeChildren plugin.TValue[bool]
+	Disabled        plugin.TValue[bool]
+	Exclusions      plugin.TValue[[]any]
 	CapturesAllLogs plugin.TValue[bool]
 }
 
@@ -60147,6 +60175,14 @@ func (c *mqlGcpProjectLoggingserviceSink) GetWriterIdentity() *plugin.TValue[str
 
 func (c *mqlGcpProjectLoggingserviceSink) GetIncludeChildren() *plugin.TValue[bool] {
 	return &c.IncludeChildren
+}
+
+func (c *mqlGcpProjectLoggingserviceSink) GetDisabled() *plugin.TValue[bool] {
+	return &c.Disabled
+}
+
+func (c *mqlGcpProjectLoggingserviceSink) GetExclusions() *plugin.TValue[[]any] {
+	return &c.Exclusions
 }
 
 func (c *mqlGcpProjectLoggingserviceSink) GetCapturesAllLogs() *plugin.TValue[bool] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3904,6 +3904,7 @@ gcp.project.loggingservice.exclusions 13.6.1
 gcp.project.loggingservice.metric 9.0.0
 gcp.project.loggingservice.metric.alertPolicies 9.0.0
 gcp.project.loggingservice.metric.description 9.0.0
+gcp.project.loggingservice.metric.disabled 13.32.1
 gcp.project.loggingservice.metric.filter 9.0.0
 gcp.project.loggingservice.metric.filtersAuditConfigChanges 13.12.2
 gcp.project.loggingservice.metric.filtersCustomRoleChanges 13.21.2
@@ -3921,6 +3922,8 @@ gcp.project.loggingservice.projectId 9.0.0
 gcp.project.loggingservice.sink 9.0.0
 gcp.project.loggingservice.sink.capturesAllLogs 13.18.1
 gcp.project.loggingservice.sink.destination 9.0.0
+gcp.project.loggingservice.sink.disabled 13.32.1
+gcp.project.loggingservice.sink.exclusions 13.32.1
 gcp.project.loggingservice.sink.filter 9.0.0
 gcp.project.loggingservice.sink.id 9.0.0
 gcp.project.loggingservice.sink.includeChildren 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.32.0",
-  "generated_at": "2026-07-21T08:12:38-07:00",
+  "generated_at": "2026-07-21T12:20:42-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -202,6 +202,7 @@
     "ids.endpoints.list",
     "logging.buckets.list",
     "logging.exclusions.list",
+    "logging.logMetrics.list",
     "logging.settings.get",
     "logging.sinks.list",
     "logging.views.list",
@@ -1524,6 +1525,12 @@
       "permission": "logging.exclusions.list",
       "service": "logging",
       "action": "Exclusions.List",
+      "source_file": "logging.go"
+    },
+    {
+      "permission": "logging.logMetrics.list",
+      "service": "logging",
+      "action": "Metrics.List",
       "source_file": "logging.go"
     },
     {

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -16,8 +16,6 @@ import (
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 
-	"cloud.google.com/go/logging/logadmin"
-	"google.golang.org/api/iterator"
 	"google.golang.org/api/logging/v2"
 	"google.golang.org/api/option"
 )
@@ -193,37 +191,35 @@ func (g *mqlGcpProjectLoggingservice) metrics() ([]any, error) {
 	}
 	projectId := g.ProjectId.Data
 
-	creds, err := conn.Credentials(logging.CloudPlatformReadOnlyScope, logging.LoggingReadScope)
+	client, err := conn.Client(logging.CloudPlatformReadOnlyScope, logging.LoggingReadScope)
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
-	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
+	loggingSvc, err := logging.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
 
 	var metrics []any
-	it := logadminClient.Metrics(ctx)
-	for {
-		m, err := it.Next()
-		if err == iterator.Done {
-			break
+	req := loggingSvc.Projects.Metrics.List(fmt.Sprintf("projects/%s", projectId))
+	if err := req.Pages(ctx, func(page *logging.ListLogMetricsResponse) error {
+		for _, m := range page.Metrics {
+			metric, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.metric", map[string]*llx.RawData{
+				"id":          llx.StringData(m.Name),
+				"projectId":   llx.StringData(projectId),
+				"description": llx.StringData(m.Description),
+				"filter":      llx.StringData(m.Filter),
+				"disabled":    llx.BoolData(m.Disabled),
+			})
+			if err != nil {
+				return err
+			}
+			metrics = append(metrics, metric)
 		}
-		if err != nil {
-			return nil, err
-		}
-		metric, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.metric", map[string]*llx.RawData{
-			"id":          llx.StringData(m.ID),
-			"projectId":   llx.StringData(projectId),
-			"description": llx.StringData(m.Description),
-			"filter":      llx.StringData(m.Filter),
-		})
-		if err != nil {
-			return nil, err
-		}
-		metrics = append(metrics, metric)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return metrics, nil
 }
@@ -314,44 +310,52 @@ func (g *mqlGcpProjectLoggingservice) sinks() ([]any, error) {
 	}
 	projectId := g.ProjectId.Data
 
-	creds, err := conn.Credentials(logging.CloudPlatformReadOnlyScope, logging.LoggingReadScope)
+	client, err := conn.Client(logging.CloudPlatformReadOnlyScope, logging.LoggingReadScope)
 	if err != nil {
 		return nil, err
 	}
-
 	ctx := context.Background()
-	logadminClient, err := logadmin.NewClient(ctx, projectId, option.WithCredentials(creds), connection.GRPCClientTraceOption())
+	loggingSvc, err := logging.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
 
 	var sinks []any
-	it := logadminClient.Sinks(ctx)
-	for {
-		s, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		args := map[string]*llx.RawData{
-			"id":              llx.StringData(s.ID),
-			"projectId":       llx.StringData(projectId),
-			"destination":     llx.StringData(s.Destination),
-			"filter":          llx.StringData(s.Filter),
-			"writerIdentity":  llx.StringData(s.WriterIdentity),
-			"includeChildren": llx.BoolData(s.IncludeChildren),
-		}
-		if !strings.HasPrefix(s.Destination, "storage.googleapis.com/") {
-			args["storageBucket"] = llx.NilData
-		}
-		sink, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.sink", args)
-		if err != nil {
-			return nil, err
-		}
+	req := loggingSvc.Projects.Sinks.List(fmt.Sprintf("projects/%s", projectId))
+	if err := req.Pages(ctx, func(page *logging.ListSinksResponse) error {
+		for _, s := range page.Sinks {
+			exclusions := []any{}
+			for _, e := range s.Exclusions {
+				exclusions = append(exclusions, map[string]any{
+					"name":        e.Name,
+					"description": e.Description,
+					"filter":      e.Filter,
+					"disabled":    e.Disabled,
+				})
+			}
 
-		sinks = append(sinks, sink)
+			args := map[string]*llx.RawData{
+				"id":              llx.StringData(s.Name),
+				"projectId":       llx.StringData(projectId),
+				"destination":     llx.StringData(s.Destination),
+				"filter":          llx.StringData(s.Filter),
+				"writerIdentity":  llx.StringData(s.WriterIdentity),
+				"includeChildren": llx.BoolData(s.IncludeChildren),
+				"disabled":        llx.BoolData(s.Disabled),
+				"exclusions":      llx.ArrayData(exclusions, types.Dict),
+			}
+			if !strings.HasPrefix(s.Destination, "storage.googleapis.com/") {
+				args["storageBucket"] = llx.NilData
+			}
+			sink, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.sink", args)
+			if err != nil {
+				return err
+			}
+			sinks = append(sinks, sink)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return sinks, nil
 }

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -241,6 +241,7 @@ var validatedGCPPermissions = []string{
 	"ids.endpoints.list",
 	"logging.buckets.list",
 	"logging.exclusions.list",
+	"logging.logMetrics.list",
 	"logging.settings.get",
 	"logging.sinks.list",
 	"logging.views.list",


### PR DESCRIPTION
## What

Project-level Cloud Logging **sinks** and **metrics** were built from the `logadmin` gRPC wrapper, which does not surface the `disabled` flag (or a sink's per-sink exclusions). A disabled sink or metric silently stops exporting/matching log entries, so the omission hid a real posture signal — one the organization- and folder-level sinks already expose (they use REST).

This switches both project creators to the REST `logging/v2` API (the same path org/folder sinks already use) and adds the missing fields.

### New fields

| Resource | Fields |
|---|---|
| `gcp.project.loggingservice.sink` | `disabled` (bool), `exclusions` ([]dict: name/description/filter/disabled) |
| `gcp.project.loggingservice.metric` | `disabled` (bool) |

### Permissions extractor fix

`Projects.Metrics.List` was mapped by the generic derivation to `logging.metrics.list`, which is not a real GCP permission — log-based metrics list under the `logMetrics` resource. Added an override so it maps to `logging.logMetrics.list`, and updated the validated-permissions list. (`logging.sinks.list` was already present from the org/folder path.)

## Testing

- `make providers/build/gcp` — builds clean; permissions manifest regenerated (274, with the corrected `logging.logMetrics.list`).
- `go test ./resources/` — passes, including `TestGCPPermissionsMatchValidatedList`.
- `.lr.versions` entries auto-assigned `13.32.1`; no `config.go` version bump.

Live validation against real GCP infra is deferred to a batch verification pass.
