### PR TITLE
✨ gcp: expose network and crypto SDK passthrough fields

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1162,6 +1162,11 @@ var gcpPermissionOverrides = map[string]map[string]string{
 	"artifactregistry": {
 		"GetIamPolicy": "artifactregistry.repositories.getIamPolicy",
 	},
+	"privateca": {
+		// CA pool IAM policy reads use the caPools.getIamPolicy permission; the
+		// generic derivation yields the non-existent "privateca.iamPolicy.get".
+		"GetIamPolicy": "privateca.caPools.getIamPolicy",
+	},
 	"cloudasset": {
 		// Cloud Asset Inventory search methods map to the assets resource with a
 		// search* verb, not the naive "allResources"/"allIamPolicies" derivation.

--- a/providers/gcp/resources/compute_enrichments.go
+++ b/providers/gcp/resources/compute_enrichments.go
@@ -258,18 +258,22 @@ func (g *mqlGcpProjectComputeService) targetHttpsProxies() ([]any, error) {
 		for _, scoped := range page.Items {
 			for _, proxy := range scoped.TargetHttpsProxies {
 				mqlProxy, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.targetHttpsProxy", map[string]*llx.RawData{
-					"id":                 llx.StringData(strconv.FormatUint(proxy.Id, 10)),
-					"projectId":          llx.StringData(projectId),
-					"name":               llx.StringData(proxy.Name),
-					"description":        llx.StringData(proxy.Description),
-					"urlMapUrl":          llx.StringData(proxy.UrlMap),
-					"sslCertificateUrls": llx.ArrayData(convert.SliceAnyToInterface(proxy.SslCertificates), types.String),
-					"sslPolicyUrl":       llx.StringData(proxy.SslPolicy),
-					"quicOverride":       llx.StringData(proxy.QuicOverride),
-					"created":            llx.TimeDataPtr(parseTime(proxy.CreationTimestamp)),
-					"selfLink":           llx.StringData(proxy.SelfLink),
-					"proxyBind":          llx.BoolData(proxy.ProxyBind),
-					"regionUrl":          llx.StringData(proxy.Region),
+					"id":                  llx.StringData(strconv.FormatUint(proxy.Id, 10)),
+					"projectId":           llx.StringData(projectId),
+					"name":                llx.StringData(proxy.Name),
+					"description":         llx.StringData(proxy.Description),
+					"urlMapUrl":           llx.StringData(proxy.UrlMap),
+					"sslCertificateUrls":  llx.ArrayData(convert.SliceAnyToInterface(proxy.SslCertificates), types.String),
+					"sslPolicyUrl":        llx.StringData(proxy.SslPolicy),
+					"quicOverride":        llx.StringData(proxy.QuicOverride),
+					"certificateMap":      llx.StringData(proxy.CertificateMap),
+					"serverTlsPolicy":     llx.StringData(proxy.ServerTlsPolicy),
+					"authorizationPolicy": llx.StringData(proxy.AuthorizationPolicy),
+					"tlsEarlyData":        llx.StringData(proxy.TlsEarlyData),
+					"created":             llx.TimeDataPtr(parseTime(proxy.CreationTimestamp)),
+					"selfLink":            llx.StringData(proxy.SelfLink),
+					"proxyBind":           llx.BoolData(proxy.ProxyBind),
+					"regionUrl":           llx.StringData(proxy.Region),
 				})
 				if err != nil {
 					return err

--- a/providers/gcp/resources/filestore.go
+++ b/providers/gcp/resources/filestore.go
@@ -99,10 +99,22 @@ func (g *mqlGcpProjectFilestoreService) instances() ([]any, error) {
 
 		fileShares := make([]any, 0, len(instance.FileShares))
 		for _, fs := range instance.FileShares {
+			nfsExportOptions := make([]any, 0, len(fs.NfsExportOptions))
+			for _, opt := range fs.NfsExportOptions {
+				nfsExportOptions = append(nfsExportOptions, map[string]any{
+					"ipRanges":   convert.SliceAnyToInterface(opt.IpRanges),
+					"accessMode": opt.AccessMode.String(),
+					"squashMode": opt.SquashMode.String(),
+					"anonUid":    opt.AnonUid,
+					"anonGid":    opt.AnonGid,
+				})
+			}
+
 			mqlFs, err := CreateResource(g.MqlRuntime, "gcp.project.filestoreService.instance.fileShare", map[string]*llx.RawData{
-				"id":         llx.StringData(fmt.Sprintf("%s/fileShares/%s", instance.Name, fs.Name)),
-				"name":       llx.StringData(fs.Name),
-				"capacityGb": llx.IntData(fs.CapacityGb),
+				"id":               llx.StringData(fmt.Sprintf("%s/fileShares/%s", instance.Name, fs.Name)),
+				"name":             llx.StringData(fs.Name),
+				"capacityGb":       llx.IntData(fs.CapacityGb),
+				"nfsExportOptions": llx.ArrayData(nfsExportOptions, types.Dict),
 			})
 			if err != nil {
 				return nil, err

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -5509,6 +5509,10 @@ private gcp.project.kmsService.keyring.cryptokey.version @defaults("name state")
   importTime time
   // The root cause of an import failure
   importFailureReason string
+  // The root cause of a key-generation failure (set when state is GENERATION_FAILED)
+  generationFailureReason string
+  // The root cause of an external-destruction failure (set when state is EXTERNAL_DESTRUCTION_FAILED)
+  externalDestructionFailureReason string
   // Additional fields for configuring external protection level
   externalProtectionLevelOptions gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions
   // Whether the crypto key version is eligible for reimport
@@ -9816,6 +9820,8 @@ private gcp.project.certificateAuthorityService.caPool @defaults("name tier") {
   certificateAuthorities() []gcp.project.certificateAuthorityService.certificateAuthority
   // Certificates in this pool
   certificates() []gcp.project.certificateAuthorityService.certificate
+  // IAM policy bindings on the CA pool, governing who may request certificates from it
+  iamPolicy() []gcp.resourcemanager.binding
 }
 
 // Google Cloud (GCP) Certificate Authority
@@ -10708,6 +10714,14 @@ private gcp.project.filestoreService.instance.fileShare @defaults("name capacity
   name string
   // File share capacity in GiB
   capacityGb int
+  // NFS export access rules
+  //
+  // Each entry controls client access to the share, with keys `ipRanges`
+  // (client IP ranges the rule applies to), `accessMode` (READ_ONLY or
+  // READ_WRITE), `squashMode` (NO_ROOT_SQUASH or ROOT_SQUASH), `anonUid`, and
+  // `anonGid` (the anonymous UID/GID that root is mapped to under
+  // ROOT_SQUASH). An empty `ipRanges` applies the rule to every client.
+  nfsExportOptions []dict
 }
 
 // Google Cloud (GCP) Filestore instance network configuration
@@ -11592,6 +11606,21 @@ private gcp.project.computeService.targetHttpsProxy @defaults("name") {
   sslPolicy() gcp.project.computeService.sslPolicy
   // QUIC override setting (NONE, ENABLE, DISABLE)
   quicOverride string
+  // Certificate Manager certificate map URL presented by this proxy
+  certificateMap string
+  // Network Security server TLS policy URL governing inbound TLS termination
+  //
+  // References a networksecurity ServerTlsPolicy that authenticates inbound
+  // connections. Empty means the proxy applies no server TLS policy, so
+  // communications are not authenticated by one.
+  serverTlsPolicy string
+  // Network Security authorization policy URL restricting inbound traffic. Empty means no authorization policy is applied.
+  authorizationPolicy string
+  // TLS 1.3 early-data (0-RTT) handling
+  //
+  // One of STRICT, PERMISSIVE, DISABLED, or UNRESTRICTED. PERMISSIVE and
+  // UNRESTRICTED accept 0-RTT data, which a network attacker can replay.
+  tlsEarlyData string
   // Creation timestamp
   created time
   // Server-defined URL for the resource

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -7596,6 +7596,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.kmsService.keyring.cryptokey.version.importFailureReason": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetImportFailureReason()).ToDataRes(types.String)
 	},
+	"gcp.project.kmsService.keyring.cryptokey.version.generationFailureReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetGenerationFailureReason()).ToDataRes(types.String)
+	},
+	"gcp.project.kmsService.keyring.cryptokey.version.externalDestructionFailureReason": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetExternalDestructionFailureReason()).ToDataRes(types.String)
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GetExternalProtectionLevelOptions()).ToDataRes(types.Resource("gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions"))
 	},
@@ -11325,6 +11331,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.certificateAuthorityService.caPool.certificates": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).GetCertificates()).ToDataRes(types.Array(types.Resource("gcp.project.certificateAuthorityService.certificate")))
 	},
+	"gcp.project.certificateAuthorityService.caPool.iamPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).GetIamPolicy()).ToDataRes(types.Array(types.Resource("gcp.resourcemanager.binding")))
+	},
 	"gcp.project.certificateAuthorityService.certificateAuthority.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectCertificateAuthorityServiceCertificateAuthority).GetProjectId()).ToDataRes(types.String)
 	},
@@ -12135,6 +12144,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.filestoreService.instance.fileShare.capacityGb": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFilestoreServiceInstanceFileShare).GetCapacityGb()).ToDataRes(types.Int)
 	},
+	"gcp.project.filestoreService.instance.fileShare.nfsExportOptions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectFilestoreServiceInstanceFileShare).GetNfsExportOptions()).ToDataRes(types.Array(types.Dict))
+	},
 	"gcp.project.filestoreService.instance.network.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectFilestoreServiceInstanceNetwork).GetId()).ToDataRes(types.String)
 	},
@@ -12881,6 +12893,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.computeService.targetHttpsProxy.quicOverride": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetQuicOverride()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpsProxy.certificateMap": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetCertificateMap()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpsProxy.serverTlsPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetServerTlsPolicy()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpsProxy.authorizationPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetAuthorizationPolicy()).ToDataRes(types.String)
+	},
+	"gcp.project.computeService.targetHttpsProxy.tlsEarlyData": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetTlsEarlyData()).ToDataRes(types.String)
 	},
 	"gcp.project.computeService.targetHttpsProxy.created": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).GetCreated()).ToDataRes(types.Time)
@@ -25473,6 +25497,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).ImportFailureReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.kmsService.keyring.cryptokey.version.generationFailureReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).GenerationFailureReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.kmsService.keyring.cryptokey.version.externalDestructionFailureReason": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).ExternalDestructionFailureReason, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectKmsServiceKeyringCryptokeyVersion).ExternalProtectionLevelOptions, ok = plugin.RawToTValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionExternalProtectionLevelOptions](v.Value, v.Error)
 		return
@@ -30889,6 +30921,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).Certificates, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"gcp.project.certificateAuthorityService.caPool.iamPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectCertificateAuthorityServiceCaPool).IamPolicy, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.certificateAuthorityService.certificateAuthority.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectCertificateAuthorityServiceCertificateAuthority).__id, ok = v.Value.(string)
 		return
@@ -32065,6 +32101,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectFilestoreServiceInstanceFileShare).CapacityGb, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"gcp.project.filestoreService.instance.fileShare.nfsExportOptions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectFilestoreServiceInstanceFileShare).NfsExportOptions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.filestoreService.instance.network.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectFilestoreServiceInstanceNetwork).__id, ok = v.Value.(string)
 		return
@@ -33183,6 +33223,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.computeService.targetHttpsProxy.quicOverride": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).QuicOverride, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpsProxy.certificateMap": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).CertificateMap, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpsProxy.serverTlsPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).ServerTlsPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpsProxy.authorizationPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).AuthorizationPolicy, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.computeService.targetHttpsProxy.tlsEarlyData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceTargetHttpsProxy).TlsEarlyData, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.computeService.targetHttpsProxy.created": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -58647,21 +58703,23 @@ type mqlGcpProjectKmsServiceKeyringCryptokeyVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectKmsServiceKeyringCryptokeyVersionInternal it will be used here
-	ResourcePath                   plugin.TValue[string]
-	Name                           plugin.TValue[string]
-	State                          plugin.TValue[string]
-	ProtectionLevel                plugin.TValue[string]
-	Algorithm                      plugin.TValue[string]
-	Attestation                    plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionAttestation]
-	Created                        plugin.TValue[*time.Time]
-	Generated                      plugin.TValue[*time.Time]
-	Destroyed                      plugin.TValue[*time.Time]
-	DestroyEventTime               plugin.TValue[*time.Time]
-	ImportJob                      plugin.TValue[string]
-	ImportTime                     plugin.TValue[*time.Time]
-	ImportFailureReason            plugin.TValue[string]
-	ExternalProtectionLevelOptions plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionExternalProtectionLevelOptions]
-	ReimportEligible               plugin.TValue[bool]
+	ResourcePath                     plugin.TValue[string]
+	Name                             plugin.TValue[string]
+	State                            plugin.TValue[string]
+	ProtectionLevel                  plugin.TValue[string]
+	Algorithm                        plugin.TValue[string]
+	Attestation                      plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionAttestation]
+	Created                          plugin.TValue[*time.Time]
+	Generated                        plugin.TValue[*time.Time]
+	Destroyed                        plugin.TValue[*time.Time]
+	DestroyEventTime                 plugin.TValue[*time.Time]
+	ImportJob                        plugin.TValue[string]
+	ImportTime                       plugin.TValue[*time.Time]
+	ImportFailureReason              plugin.TValue[string]
+	GenerationFailureReason          plugin.TValue[string]
+	ExternalDestructionFailureReason plugin.TValue[string]
+	ExternalProtectionLevelOptions   plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionExternalProtectionLevelOptions]
+	ReimportEligible                 plugin.TValue[bool]
 }
 
 // createGcpProjectKmsServiceKeyringCryptokeyVersion creates a new instance of this resource
@@ -58751,6 +58809,14 @@ func (c *mqlGcpProjectKmsServiceKeyringCryptokeyVersion) GetImportTime() *plugin
 
 func (c *mqlGcpProjectKmsServiceKeyringCryptokeyVersion) GetImportFailureReason() *plugin.TValue[string] {
 	return &c.ImportFailureReason
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyVersion) GetGenerationFailureReason() *plugin.TValue[string] {
+	return &c.GenerationFailureReason
+}
+
+func (c *mqlGcpProjectKmsServiceKeyringCryptokeyVersion) GetExternalDestructionFailureReason() *plugin.TValue[string] {
+	return &c.ExternalDestructionFailureReason
 }
 
 func (c *mqlGcpProjectKmsServiceKeyringCryptokeyVersion) GetExternalProtectionLevelOptions() *plugin.TValue[*mqlGcpProjectKmsServiceKeyringCryptokeyVersionExternalProtectionLevelOptions] {
@@ -71326,6 +71392,7 @@ type mqlGcpProjectCertificateAuthorityServiceCaPool struct {
 	Labels                 plugin.TValue[map[string]any]
 	CertificateAuthorities plugin.TValue[[]any]
 	Certificates           plugin.TValue[[]any]
+	IamPolicy              plugin.TValue[[]any]
 }
 
 // createGcpProjectCertificateAuthorityServiceCaPool creates a new instance of this resource
@@ -71450,6 +71517,22 @@ func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetCertificates() *plug
 		}
 
 		return c.certificates()
+	})
+}
+
+func (c *mqlGcpProjectCertificateAuthorityServiceCaPool) GetIamPolicy() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.IamPolicy, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("gcp.project.certificateAuthorityService.caPool", c.__id, "iamPolicy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.iamPolicy()
 	})
 }
 
@@ -74067,9 +74150,10 @@ type mqlGcpProjectFilestoreServiceInstanceFileShare struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectFilestoreServiceInstanceFileShareInternal it will be used here
-	Id         plugin.TValue[string]
-	Name       plugin.TValue[string]
-	CapacityGb plugin.TValue[int64]
+	Id               plugin.TValue[string]
+	Name             plugin.TValue[string]
+	CapacityGb       plugin.TValue[int64]
+	NfsExportOptions plugin.TValue[[]any]
 }
 
 // createGcpProjectFilestoreServiceInstanceFileShare creates a new instance of this resource
@@ -74119,6 +74203,10 @@ func (c *mqlGcpProjectFilestoreServiceInstanceFileShare) GetName() *plugin.TValu
 
 func (c *mqlGcpProjectFilestoreServiceInstanceFileShare) GetCapacityGb() *plugin.TValue[int64] {
 	return &c.CapacityGb
+}
+
+func (c *mqlGcpProjectFilestoreServiceInstanceFileShare) GetNfsExportOptions() *plugin.TValue[[]any] {
+	return &c.NfsExportOptions
 }
 
 // mqlGcpProjectFilestoreServiceInstanceNetwork for the gcp.project.filestoreService.instance.network resource
@@ -76967,22 +77055,26 @@ type mqlGcpProjectComputeServiceTargetHttpsProxy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectComputeServiceTargetHttpsProxyInternal it will be used here
-	Id                 plugin.TValue[string]
-	ProjectId          plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Description        plugin.TValue[string]
-	UrlMapUrl          plugin.TValue[string]
-	UrlMap             plugin.TValue[*mqlGcpProjectComputeServiceUrlMap]
-	SslCertificateUrls plugin.TValue[[]any]
-	SslCertificates    plugin.TValue[[]any]
-	SslPolicyUrl       plugin.TValue[string]
-	SslPolicy          plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy]
-	QuicOverride       plugin.TValue[string]
-	Created            plugin.TValue[*time.Time]
-	SelfLink           plugin.TValue[string]
-	ProxyBind          plugin.TValue[bool]
-	RegionUrl          plugin.TValue[string]
-	Region             plugin.TValue[*mqlGcpProjectComputeServiceRegion]
+	Id                  plugin.TValue[string]
+	ProjectId           plugin.TValue[string]
+	Name                plugin.TValue[string]
+	Description         plugin.TValue[string]
+	UrlMapUrl           plugin.TValue[string]
+	UrlMap              plugin.TValue[*mqlGcpProjectComputeServiceUrlMap]
+	SslCertificateUrls  plugin.TValue[[]any]
+	SslCertificates     plugin.TValue[[]any]
+	SslPolicyUrl        plugin.TValue[string]
+	SslPolicy           plugin.TValue[*mqlGcpProjectComputeServiceSslPolicy]
+	QuicOverride        plugin.TValue[string]
+	CertificateMap      plugin.TValue[string]
+	ServerTlsPolicy     plugin.TValue[string]
+	AuthorizationPolicy plugin.TValue[string]
+	TlsEarlyData        plugin.TValue[string]
+	Created             plugin.TValue[*time.Time]
+	SelfLink            plugin.TValue[string]
+	ProxyBind           plugin.TValue[bool]
+	RegionUrl           plugin.TValue[string]
+	Region              plugin.TValue[*mqlGcpProjectComputeServiceRegion]
 }
 
 // createGcpProjectComputeServiceTargetHttpsProxy creates a new instance of this resource
@@ -77100,6 +77192,22 @@ func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetSslPolicy() *plugin.TVa
 
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetQuicOverride() *plugin.TValue[string] {
 	return &c.QuicOverride
+}
+
+func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetCertificateMap() *plugin.TValue[string] {
+	return &c.CertificateMap
+}
+
+func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetServerTlsPolicy() *plugin.TValue[string] {
+	return &c.ServerTlsPolicy
+}
+
+func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetAuthorizationPolicy() *plugin.TValue[string] {
+	return &c.AuthorizationPolicy
+}
+
+func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetTlsEarlyData() *plugin.TValue[string] {
+	return &c.TlsEarlyData
 }
 
 func (c *mqlGcpProjectComputeServiceTargetHttpsProxy) GetCreated() *plugin.TValue[*time.Time] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -873,6 +873,7 @@ gcp.project.certificateAuthorityService 11.5.1
 gcp.project.certificateAuthorityService.caPool 11.5.1
 gcp.project.certificateAuthorityService.caPool.certificateAuthorities 11.5.1
 gcp.project.certificateAuthorityService.caPool.certificates 11.5.1
+gcp.project.certificateAuthorityService.caPool.iamPolicy 13.32.1
 gcp.project.certificateAuthorityService.caPool.issuancePolicy 11.5.1
 gcp.project.certificateAuthorityService.caPool.kmsKey 13.19.2
 gcp.project.certificateAuthorityService.caPool.labels 11.5.1
@@ -2436,6 +2437,8 @@ gcp.project.computeService.targetHttpProxy.urlMap 11.6.6
 gcp.project.computeService.targetHttpProxy.urlMapUrl 11.6.6
 gcp.project.computeService.targetHttpsProxies 11.6.6
 gcp.project.computeService.targetHttpsProxy 11.6.6
+gcp.project.computeService.targetHttpsProxy.authorizationPolicy 13.32.1
+gcp.project.computeService.targetHttpsProxy.certificateMap 13.32.1
 gcp.project.computeService.targetHttpsProxy.created 11.6.6
 gcp.project.computeService.targetHttpsProxy.description 11.6.6
 gcp.project.computeService.targetHttpsProxy.id 11.6.6
@@ -2446,10 +2449,12 @@ gcp.project.computeService.targetHttpsProxy.quicOverride 11.6.6
 gcp.project.computeService.targetHttpsProxy.region 13.16.3
 gcp.project.computeService.targetHttpsProxy.regionUrl 11.6.6
 gcp.project.computeService.targetHttpsProxy.selfLink 11.6.6
+gcp.project.computeService.targetHttpsProxy.serverTlsPolicy 13.32.1
 gcp.project.computeService.targetHttpsProxy.sslCertificateUrls 11.6.6
 gcp.project.computeService.targetHttpsProxy.sslCertificates 13.21.2
 gcp.project.computeService.targetHttpsProxy.sslPolicy 11.6.6
 gcp.project.computeService.targetHttpsProxy.sslPolicyUrl 11.6.6
+gcp.project.computeService.targetHttpsProxy.tlsEarlyData 13.32.1
 gcp.project.computeService.targetHttpsProxy.urlMap 11.6.6
 gcp.project.computeService.targetHttpsProxy.urlMapUrl 11.6.6
 gcp.project.computeService.targetPool 13.6.1
@@ -3187,6 +3192,7 @@ gcp.project.filestoreService.instance.fileShare 11.6.6
 gcp.project.filestoreService.instance.fileShare.capacityGb 11.6.6
 gcp.project.filestoreService.instance.fileShare.id 11.6.6
 gcp.project.filestoreService.instance.fileShare.name 11.6.6
+gcp.project.filestoreService.instance.fileShare.nfsExportOptions 13.32.1
 gcp.project.filestoreService.instance.fileShares 11.6.6
 gcp.project.filestoreService.instance.kmsKey 13.19.2
 gcp.project.filestoreService.instance.kmsKeyName 11.6.6
@@ -3804,11 +3810,13 @@ gcp.project.kmsService.keyring.cryptokey.version.attestation.format 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.created 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.destroyEventTime 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.destroyed 9.0.0
+gcp.project.kmsService.keyring.cryptokey.version.externalDestructionFailureReason 13.32.1
 gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions.cryptoKeyVersionName 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions.ekmConnectionKeyPath 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions.externalKeyUri 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.generated 9.0.0
+gcp.project.kmsService.keyring.cryptokey.version.generationFailureReason 13.32.1
 gcp.project.kmsService.keyring.cryptokey.version.importFailureReason 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.importJob 9.0.0
 gcp.project.kmsService.keyring.cryptokey.version.importTime 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.32.0",
-  "generated_at": "2026-07-21T12:20:42-07:00",
+  "generated_at": "2026-07-21T12:32:09-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -238,6 +238,7 @@
     "osconfig.patchDeployments.list",
     "osconfig.vulnerabilityReports.get",
     "policyanalyzer.serviceAccountLastAuthenticationActivities.query",
+    "privateca.caPools.getIamPolicy",
     "privateca.caPools.list",
     "privateca.certificateAuthorities.list",
     "privateca.certificateRevocationLists.list",
@@ -1749,6 +1750,12 @@
       "service": "policyanalyzer",
       "action": "Activities.Query",
       "source_file": "iam.go"
+    },
+    {
+      "permission": "privateca.caPools.getIamPolicy",
+      "service": "privateca",
+      "action": "GetIamPolicy",
+      "source_file": "privateca.go"
     },
     {
       "permission": "privateca.caPools.list",

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -695,21 +695,23 @@ func cryptoKeyVersionToMql(runtime *plugin.Runtime, v *kmspb.CryptoKeyVersion) (
 		}
 	}
 	return CreateResource(runtime, "gcp.project.kmsService.keyring.cryptokey.version", map[string]*llx.RawData{
-		"resourcePath":                   llx.StringData(v.Name),
-		"name":                           llx.StringData(parseResourceName(v.Name)),
-		"state":                          llx.StringData(v.State.String()),
-		"protectionLevel":                llx.StringData(v.ProtectionLevel.String()),
-		"algorithm":                      llx.StringData(v.Algorithm.String()),
-		"attestation":                    llx.ResourceData(mqlAttestation, "gcp.project.kmsService.keyring.cryptokey.version.attestation"),
-		"created":                        llx.TimeDataPtr(timestampAsTimePtr(v.CreateTime)),
-		"generated":                      llx.TimeDataPtr(timestampAsTimePtr(v.GenerateTime)),
-		"destroyed":                      llx.TimeDataPtr(timestampAsTimePtr(v.DestroyTime)),
-		"destroyEventTime":               llx.TimeDataPtr(timestampAsTimePtr(v.DestroyEventTime)),
-		"importJob":                      llx.StringData(v.ImportJob),
-		"importTime":                     llx.TimeDataPtr(timestampAsTimePtr(v.ImportTime)),
-		"importFailureReason":            llx.StringData(v.ImportFailureReason),
-		"externalProtectionLevelOptions": llx.ResourceData(mqlExtProtOpts, "gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions"),
-		"reimportEligible":               llx.BoolData(v.ReimportEligible),
+		"resourcePath":                     llx.StringData(v.Name),
+		"name":                             llx.StringData(parseResourceName(v.Name)),
+		"state":                            llx.StringData(v.State.String()),
+		"protectionLevel":                  llx.StringData(v.ProtectionLevel.String()),
+		"algorithm":                        llx.StringData(v.Algorithm.String()),
+		"attestation":                      llx.ResourceData(mqlAttestation, "gcp.project.kmsService.keyring.cryptokey.version.attestation"),
+		"created":                          llx.TimeDataPtr(timestampAsTimePtr(v.CreateTime)),
+		"generated":                        llx.TimeDataPtr(timestampAsTimePtr(v.GenerateTime)),
+		"destroyed":                        llx.TimeDataPtr(timestampAsTimePtr(v.DestroyTime)),
+		"destroyEventTime":                 llx.TimeDataPtr(timestampAsTimePtr(v.DestroyEventTime)),
+		"importJob":                        llx.StringData(v.ImportJob),
+		"importTime":                       llx.TimeDataPtr(timestampAsTimePtr(v.ImportTime)),
+		"importFailureReason":              llx.StringData(v.ImportFailureReason),
+		"generationFailureReason":          llx.StringData(v.GenerationFailureReason),
+		"externalDestructionFailureReason": llx.StringData(v.ExternalDestructionFailureReason),
+		"externalProtectionLevelOptions":   llx.ResourceData(mqlExtProtOpts, "gcp.project.kmsService.keyring.cryptokey.version.externalProtectionLevelOptions"),
+		"reimportEligible":                 llx.BoolData(v.ReimportEligible),
 	})
 }
 

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -277,6 +277,7 @@ var validatedGCPPermissions = []string{
 	"osconfig.patchDeployments.list",
 	"osconfig.vulnerabilityReports.get",
 	"policyanalyzer.serviceAccountLastAuthenticationActivities.query",
+	"privateca.caPools.getIamPolicy",
 	"privateca.caPools.list",
 	"privateca.certificateAuthorities.list",
 	"privateca.certificateRevocationLists.list",

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -12,6 +12,7 @@ import (
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	privateca "cloud.google.com/go/security/privateca/apiv1"
 	"cloud.google.com/go/security/privateca/apiv1/privatecapb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -178,6 +179,7 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) iamPolicy() ([]any, err
 	})
 	if err != nil {
 		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
+			log.Warn().Str("caPool", poolPath).Err(err).Msg("could not retrieve CA pool IAM policy")
 			return nil, nil
 		}
 		return nil, err

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	privateca "cloud.google.com/go/security/privateca/apiv1"
 	"cloud.google.com/go/security/privateca/apiv1/privatecapb"
 	"go.mondoo.com/mql/v13/llx"
@@ -18,6 +19,8 @@ import (
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // extractCaPoolName extracts the CA pool name from a GCP Certificate Authority Service resource path.
@@ -146,6 +149,40 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) id() (string, error) {
 		return "", g.ResourcePath.Error
 	}
 	return g.ResourcePath.Data, nil
+}
+
+func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) iamPolicy() ([]any, error) {
+	if g.ResourcePath.Error != nil {
+		return nil, g.ResourcePath.Error
+	}
+	poolPath := g.ResourcePath.Data
+
+	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
+	creds, err := conn.Credentials(privateca.DefaultAuthScopes()...)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client, err := privateca.NewCertificateAuthorityClient(ctx, option.WithCredentials(creds), connection.GRPCClientTraceOption())
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	// Request policy schema version 3 so conditional bindings aren't silently
+	// stripped from the result.
+	policy, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{
+		Resource: poolPath,
+		Options:  &iampb.GetPolicyOptions{RequestedPolicyVersion: 3},
+	})
+	if err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.PermissionDenied {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return iampbBindingsToMql(g.MqlRuntime, poolPath, policy.Bindings)
 }
 
 func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) kmsKey() (*mqlGcpProjectKmsServiceKeyringCryptokey, error) {


### PR DESCRIPTION
## What

Continues the GCP SDK coverage audit (security/posture lens): direct SDK-passthrough fields across compute, filestore, KMS, and Private CA. No derived/computed fields.

### New fields

| Resource | Fields |
|---|---|
| `computeService.targetHttpsProxy` | `certificateMap`, `serverTlsPolicy`, `authorizationPolicy`, `tlsEarlyData` |
| `filestoreService.instance.fileShare` | `nfsExportOptions` ([]dict: ipRanges/accessMode/squashMode/anonUid/anonGid) |
| `kmsService.keyring.cryptokey.version` | `generationFailureReason`, `externalDestructionFailureReason` |
| `certificateAuthorityService.caPool` | `iamPolicy()` |

- The `targetHttpsProxy` fields surface inbound mTLS / authorization-policy / TLS 1.3 0-RTT posture. Exposed as raw reference strings, matching the existing `targetSslProxy.certificateMap` precedent.
- `nfsExportOptions` makes Filestore NFS export access control (client allowlist, RO/RW, root-squash) queryable for the first time.
- The KMS failure-reason scalars parallel the existing `importFailureReason`.
- `caPool.iamPolicy()` returns the raw IAM bindings (who may request certificates). I deliberately did **not** add a derived `public()` boolean, to keep this to raw SDK passthroughs.

### Permissions extractor fix

`GetIamPolicy` on the Private CA client derived to `privateca.iamPolicy.get`, which is not a real GCP permission. Added an override so it maps to `privateca.caPools.getIamPolicy`, and updated the validated-permissions list.

## Testing

- `make providers/build/gcp` — builds clean; permissions manifest regenerated (275).
- `go test ./resources/` — passes, including `TestGCPPermissionsMatchValidatedList`.
- `.lr.versions` entries auto-assigned `13.32.1`; no `config.go` version bump.

Live validation against real GCP infra is deferred to a batch verification pass.
