### PR TITLE
🌟 azure: expose network manager network group static members

### DIFF
--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -1746,8 +1746,32 @@ private azure.subscription.networkService.networkManager.networkGroup @defaults(
   memberType string
   // Resource GUID of the group
   resourceGuid string
+  // Statically-defined members of the group
+  staticMembers() []azure.subscription.networkService.networkManager.networkGroup.staticMember
   // Creation and last-modification provenance recorded by Azure Resource Manager
   systemMetadata() azure.subscription.systemData
+}
+
+// Network manager network group static member
+//
+// A resource explicitly added to a network group, as opposed to one
+// matched by an Azure Policy membership rule. Names the member resource
+// (a virtual network, or a subnet when the group's member type is
+// Subnet) and the region it lives in. Static membership determines
+// which virtual networks a manager's connectivity and security admin
+// configurations actually apply to. Select by the member's Azure
+// resource ID.
+private azure.subscription.networkService.networkManager.networkGroup.staticMember @defaults("name region") {
+  // Static member resource ID
+  id string
+  // Static member name
+  name string
+  // ARM resource ID of the member resource (a virtual network or a subnet)
+  resourceId string
+  // Region the member resource lives in
+  region string
+  // The member virtual network, when the group's member type is VirtualNetwork
+  virtualNetwork() azure.subscription.networkService.virtualNetwork
 }
 
 // Network manager security admin configuration

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -49,6 +49,7 @@ const (
 	ResourceAzureSubscriptionNetworkService                                                           string = "azure.subscription.networkService"
 	ResourceAzureSubscriptionNetworkServiceNetworkManager                                             string = "azure.subscription.networkService.networkManager"
 	ResourceAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup                                 string = "azure.subscription.networkService.networkManager.networkGroup"
+	ResourceAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember                     string = "azure.subscription.networkService.networkManager.networkGroup.staticMember"
 	ResourceAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration                   string = "azure.subscription.networkService.networkManager.securityAdminConfiguration"
 	ResourceAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationRuleCollection     string = "azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection"
 	ResourceAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfigurationRuleCollectionRule string = "azure.subscription.networkService.networkManager.securityAdminConfiguration.ruleCollection.rule"
@@ -627,6 +628,10 @@ func init() {
 		"azure.subscription.networkService.networkManager.networkGroup": {
 			Init:   initAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup,
 			Create: createAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup,
+		},
+		"azure.subscription.networkService.networkManager.networkGroup.staticMember": {
+			// to override args, implement: initAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember,
 		},
 		"azure.subscription.networkService.networkManager.securityAdminConfiguration": {
 			// to override args, implement: initAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4335,8 +4340,26 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.networkService.networkManager.networkGroup.resourceGuid": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).GetResourceGuid()).ToDataRes(types.String)
 	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMembers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).GetStaticMembers()).ToDataRes(types.Array(types.Resource("azure.subscription.networkService.networkManager.networkGroup.staticMember")))
+	},
 	"azure.subscription.networkService.networkManager.networkGroup.systemMetadata": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).GetSystemMetadata()).ToDataRes(types.Resource("azure.subscription.systemData"))
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.resourceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).GetResourceId()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).GetRegion()).ToDataRes(types.String)
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.virtualNetwork": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).GetVirtualNetwork()).ToDataRes(types.Resource("azure.subscription.networkService.virtualNetwork"))
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerSecurityAdminConfiguration).GetId()).ToDataRes(types.String)
@@ -21684,8 +21707,36 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).ResourceGuid, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMembers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).StaticMembers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.networkService.networkManager.networkGroup.systemMetadata": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup).SystemMetadata, ok = plugin.RawToTValue[*mqlAzureSubscriptionSystemData](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.resourceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).ResourceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.networkService.networkManager.networkGroup.staticMember.virtualNetwork": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).VirtualNetwork, ok = plugin.RawToTValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.networkService.networkManager.securityAdminConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -49424,6 +49475,7 @@ type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup struct {
 	Description       plugin.TValue[string]
 	MemberType        plugin.TValue[string]
 	ResourceGuid      plugin.TValue[string]
+	StaticMembers     plugin.TValue[[]any]
 	SystemMetadata    plugin.TValue[*mqlAzureSubscriptionSystemData]
 }
 
@@ -49496,6 +49548,22 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetResour
 	return &c.ResourceGuid
 }
 
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetStaticMembers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.StaticMembers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.networkManager.networkGroup", c.__id, "staticMembers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.staticMembers()
+	})
+}
+
 func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetSystemMetadata() *plugin.TValue[*mqlAzureSubscriptionSystemData] {
 	return plugin.GetOrCompute[*mqlAzureSubscriptionSystemData](&c.SystemMetadata, func() (*mqlAzureSubscriptionSystemData, error) {
 		if c.MqlRuntime.HasRecording {
@@ -49509,6 +49577,87 @@ func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) GetSystem
 		}
 
 		return c.systemMetadata()
+	})
+}
+
+// mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember for the azure.subscription.networkService.networkManager.networkGroup.staticMember resource
+type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMemberInternal
+	Id             plugin.TValue[string]
+	Name           plugin.TValue[string]
+	ResourceId     plugin.TValue[string]
+	Region         plugin.TValue[string]
+	VirtualNetwork plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork]
+}
+
+// createAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember creates a new instance of this resource
+func createAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.networkService.networkManager.networkGroup.staticMember", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) MqlName() string {
+	return "azure.subscription.networkService.networkManager.networkGroup.staticMember"
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) GetResourceId() *plugin.TValue[string] {
+	return &c.ResourceId
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) GetVirtualNetwork() *plugin.TValue[*mqlAzureSubscriptionNetworkServiceVirtualNetwork] {
+	return plugin.GetOrCompute[*mqlAzureSubscriptionNetworkServiceVirtualNetwork](&c.VirtualNetwork, func() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.networkService.networkManager.networkGroup.staticMember", c.__id, "virtualNetwork")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+			}
+		}
+
+		return c.virtualNetwork()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -3839,6 +3839,13 @@ azure.subscription.networkService.networkManager.networkGroup.memberType 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.name 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.provisioningState 13.25.1
 azure.subscription.networkService.networkManager.networkGroup.resourceGuid 13.25.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember.id 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember.name 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember.region 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember.resourceId 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMember.virtualNetwork 13.32.1
+azure.subscription.networkService.networkManager.networkGroup.staticMembers 13.32.1
 azure.subscription.networkService.networkManager.networkGroup.systemMetadata 13.28.1
 azure.subscription.networkService.networkManager.networkGroup.type 13.25.1
 azure.subscription.networkService.networkManager.networkGroups 13.25.1

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.32.0",
-  "generated_at": "2026-07-21T12:54:57-07:00",
+  "generated_at": "2026-07-21T13:04:38-07:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -194,6 +194,7 @@
     "Microsoft.Network/securityPerimeterProfiles/read",
     "Microsoft.Network/securityPerimeters/read",
     "Microsoft.Network/serviceEndpointPolicies/read",
+    "Microsoft.Network/staticMembers/read",
     "Microsoft.Network/trafficManagerProfiles/read",
     "Microsoft.Network/vPNGateways/read",
     "Microsoft.Network/vPNServerConfigurations/read",
@@ -1500,6 +1501,12 @@
       "service": "Microsoft.Network",
       "action": "NewListPager",
       "source_file": "network.go"
+    },
+    {
+      "permission": "Microsoft.Network/staticMembers/read",
+      "service": "Microsoft.Network",
+      "action": "NewListPager",
+      "source_file": "network_avnm.go"
     },
     {
       "permission": "Microsoft.Network/trafficManagerProfiles/read",

--- a/providers/azure/resources/network_avnm.go
+++ b/providers/azure/resources/network_avnm.go
@@ -200,6 +200,85 @@ func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) systemMet
 	return systemMetadataFromRaw(a.MqlRuntime, a.Id.Data, a.cacheSystemData, &a.SystemMetadata)
 }
 
+type mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMemberInternal struct {
+	cacheMemberType string
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) id() (string, error) {
+	return a.Id.Data, nil
+}
+
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup) staticMembers() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	ctx := context.Background()
+	resourceID, err := ParseResourceID(a.Id.Data)
+	if err != nil {
+		return nil, err
+	}
+	managerName, err := resourceID.Component("networkManagers")
+	if err != nil {
+		return nil, err
+	}
+	groupName, err := resourceID.Component("networkGroups")
+	if err != nil {
+		return nil, err
+	}
+	client, err := network.NewStaticMembersClient(resourceID.SubscriptionID, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := []any{}
+	pager := client.NewListPager(resourceID.ResourceGroup, managerName, groupName, &network.StaticMembersClientListOptions{})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range page.Value {
+			if m == nil {
+				continue
+			}
+			var resourceId, region string
+			if p := m.Properties; p != nil {
+				resourceId = convert.ToValue(p.ResourceID)
+				region = convert.ToValue(p.Region)
+			}
+			mqlMember, err := CreateResource(a.MqlRuntime, "azure.subscription.networkService.networkManager.networkGroup.staticMember",
+				map[string]*llx.RawData{
+					"id":         llx.StringDataPtr(m.ID),
+					"name":       llx.StringDataPtr(m.Name),
+					"resourceId": llx.StringData(resourceId),
+					"region":     llx.StringData(region),
+				})
+			if err != nil {
+				return nil, err
+			}
+			mqlMember.(*mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember).cacheMemberType = a.MemberType.Data
+			res = append(res, mqlMember)
+		}
+	}
+	return res, nil
+}
+
+// virtualNetwork resolves a static member's resource to its typed virtual
+// network. Returns null for members whose group is subnet-typed, since the
+// member ID then points at a subnet rather than a virtual network.
+func (a *mqlAzureSubscriptionNetworkServiceNetworkManagerNetworkGroupStaticMember) virtualNetwork() (*mqlAzureSubscriptionNetworkServiceVirtualNetwork, error) {
+	if a.cacheMemberType != "VirtualNetwork" || a.ResourceId.Data == "" {
+		a.VirtualNetwork.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	res, err := NewResource(a.MqlRuntime, "azure.subscription.networkService.virtualNetwork", map[string]*llx.RawData{
+		"id": llx.StringData(a.ResourceId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureSubscriptionNetworkServiceVirtualNetwork), nil
+}
+
 // initAzureSubscriptionNetworkServiceNetworkManagerNetworkGroup resolves a
 // network group by its ARM ID so typed references to it (from admin rule
 // collections and connectivity configurations) populate fully.


### PR DESCRIPTION
## What

Adds **network group static members** — `staticMembers()` on `azure.subscription.networkService.networkManager.networkGroup`.

## Why

An Azure Virtual Network Manager network group previously exposed only its `memberType`, with no way to see which resources it actually contains. Static membership determines what a manager's connectivity and security-admin configurations apply to — so you couldn't tell what an admin rule collection actually governs.

```mql
# Which VNets a network group contains
azure.subscription.networkService.networkManagers.first.networkGroups.
  where(memberType == "VirtualNetwork").first.staticMembers {
    virtualNetwork.name region
  }
```

## Fields

`resourceId`, `region`, and a typed **`virtualNetwork()`** accessor.

## Design notes

- `virtualNetwork()` resolves the member to its typed virtual network (via the VNet's existing by-id init) when the group is `VirtualNetwork`-typed, and returns null for `Subnet`-typed groups (whose members are subnets, not VNets). The member type is cached from the parent group.
- `resourceId` stays a raw string because it's heterogeneous — a VNet ID or a subnet ID depending on the group's member type — so a single typed accessor can't round-trip it.
- `Microsoft.Network/staticMembers/read` follows the existing flat-form convention used by the sibling AVNM permissions in this provider (`adminRules`, `connectivityConfigurations`, `securityAdminConfigurations`).

## Scope

This is the first slice of the AVNM/NSP coverage gap. AVNM **deployment status** and NSP **perimeter links** / **cross-perimeter access rules** are the natural follow-ups.

## Testing

`mqlr generate` (two passes), `make providers/build/azure`, `go vet`, `go test ./resources/` all pass. Live verification pending (batched with other Azure PRs).
