### PR TITLE
✨ aws: add tags to WAF acl, rule group, ip set, regex pattern set

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -804,6 +804,8 @@ private aws.waf.acl @defaults("name") {
   // CloudFront distributions) and for regional web ACLs with no load balancer
   // association.
   associatedLoadBalancers() []aws.elb.loadbalancer
+  // Tags on the web ACL
+  tags() map[string]string
 }
 
 // Amazon WAF v2 RuleGroup
@@ -824,6 +826,8 @@ private aws.waf.rulegroup @defaults("name") {
   rules() []aws.waf.rule
   // Scope either REGIONAL or CLOUDFRONT
   scope string
+  // Tags on the rule group
+  tags() map[string]string
 }
 
 // Amazon WAF rule
@@ -1253,6 +1257,8 @@ private aws.waf.ipset @defaults("name") {
   addressType() string
   // List of IP address ranges in CIDR notation
   addresses() dict
+  // Tags on the IP set
+  tags() map[string]string
 }
 
 // Amazon WAF regex pattern set
@@ -1273,6 +1279,8 @@ private aws.waf.regexPatternSet @defaults("name") {
   description string
   // List of regular expression patterns
   regularExpressions []string
+  // Tags on the regex pattern set
+  tags() map[string]string
 }
 
 // Amazon WAF ACL logging configuration

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5491,6 +5491,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.acl.associatedLoadBalancers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafAcl).GetAssociatedLoadBalancers()).ToDataRes(types.Array(types.Resource("aws.elb.loadbalancer")))
 	},
+	"aws.waf.acl.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafAcl).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.waf.rulegroup.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRulegroup).GetArn()).ToDataRes(types.String)
 	},
@@ -5508,6 +5511,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.waf.rulegroup.scope": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRulegroup).GetScope()).ToDataRes(types.String)
+	},
+	"aws.waf.rulegroup.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRulegroup).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.waf.rule.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRule).GetId()).ToDataRes(types.String)
@@ -5950,6 +5956,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.waf.ipset.addresses": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafIpset).GetAddresses()).ToDataRes(types.Dict)
 	},
+	"aws.waf.ipset.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafIpset).GetTags()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"aws.waf.regexPatternSet.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRegexPatternSet).GetArn()).ToDataRes(types.String)
 	},
@@ -5967,6 +5976,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.waf.regexPatternSet.regularExpressions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafRegexPatternSet).GetRegularExpressions()).ToDataRes(types.Array(types.String))
+	},
+	"aws.waf.regexPatternSet.tags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsWafRegexPatternSet).GetTags()).ToDataRes(types.Map(types.String, types.String))
 	},
 	"aws.waf.acl.loggingConfiguration.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsWafAclLoggingConfiguration).GetArn()).ToDataRes(types.String)
@@ -36094,6 +36106,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWafAcl).AssociatedLoadBalancers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.waf.acl.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafAcl).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.waf.rulegroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRulegroup).__id, ok = v.Value.(string)
 		return
@@ -36120,6 +36136,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.waf.rulegroup.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRulegroup).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.waf.rulegroup.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRulegroup).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.waf.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36834,6 +36854,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsWafIpset).Addresses, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"aws.waf.ipset.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafIpset).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
 	"aws.waf.regexPatternSet.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRegexPatternSet).__id, ok = v.Value.(string)
 		return
@@ -36860,6 +36884,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.waf.regexPatternSet.regularExpressions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsWafRegexPatternSet).RegularExpressions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.waf.regexPatternSet.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsWafRegexPatternSet).Tags, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"aws.waf.acl.loggingConfiguration.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -81939,6 +81967,7 @@ type mqlAwsWafAcl struct {
 	LoggingConfiguration     plugin.TValue[*mqlAwsWafAclLoggingConfiguration]
 	AssociatedResources      plugin.TValue[[]any]
 	AssociatedLoadBalancers  plugin.TValue[[]any]
+	Tags                     plugin.TValue[map[string]any]
 }
 
 // createAwsWafAcl creates a new instance of this resource
@@ -82088,6 +82117,12 @@ func (c *mqlAwsWafAcl) GetAssociatedLoadBalancers() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsWafAcl) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsWafRulegroup for the aws.waf.rulegroup resource
 type mqlAwsWafRulegroup struct {
 	MqlRuntime *plugin.Runtime
@@ -82099,6 +82134,7 @@ type mqlAwsWafRulegroup struct {
 	Description plugin.TValue[string]
 	Rules       plugin.TValue[[]any]
 	Scope       plugin.TValue[string]
+	Tags        plugin.TValue[map[string]any]
 }
 
 // createAwsWafRulegroup creates a new instance of this resource
@@ -82172,6 +82208,12 @@ func (c *mqlAwsWafRulegroup) GetRules() *plugin.TValue[[]any] {
 
 func (c *mqlAwsWafRulegroup) GetScope() *plugin.TValue[string] {
 	return &c.Scope
+}
+
+func (c *mqlAwsWafRulegroup) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsWafRule for the aws.waf.rule resource
@@ -84196,6 +84238,7 @@ type mqlAwsWafIpset struct {
 	Description plugin.TValue[string]
 	AddressType plugin.TValue[string]
 	Addresses   plugin.TValue[any]
+	Tags        plugin.TValue[map[string]any]
 }
 
 // createAwsWafIpset creates a new instance of this resource
@@ -84267,6 +84310,12 @@ func (c *mqlAwsWafIpset) GetAddresses() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlAwsWafIpset) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
+}
+
 // mqlAwsWafRegexPatternSet for the aws.waf.regexPatternSet resource
 type mqlAwsWafRegexPatternSet struct {
 	MqlRuntime *plugin.Runtime
@@ -84278,6 +84327,7 @@ type mqlAwsWafRegexPatternSet struct {
 	Name               plugin.TValue[string]
 	Description        plugin.TValue[string]
 	RegularExpressions plugin.TValue[[]any]
+	Tags               plugin.TValue[map[string]any]
 }
 
 // createAwsWafRegexPatternSet creates a new instance of this resource
@@ -84339,6 +84389,12 @@ func (c *mqlAwsWafRegexPatternSet) GetDescription() *plugin.TValue[string] {
 
 func (c *mqlAwsWafRegexPatternSet) GetRegularExpressions() *plugin.TValue[[]any] {
 	return &c.RegularExpressions
+}
+
+func (c *mqlAwsWafRegexPatternSet) GetTags() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 // mqlAwsWafAclLoggingConfiguration for the aws.waf.acl.loggingConfiguration resource

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10512,6 +10512,7 @@ aws.waf.acl.managedByFirewallManager 11.15.2
 aws.waf.acl.name 11.15.2
 aws.waf.acl.rules 11.15.2
 aws.waf.acl.scope 11.15.2
+aws.waf.acl.tags 13.49.1
 aws.waf.acl.tokenDomains 13.49.1
 aws.waf.acl.visibilityConfig 13.49.1
 aws.waf.acls 11.15.2
@@ -10524,6 +10525,7 @@ aws.waf.ipset.description 11.15.2
 aws.waf.ipset.id 11.15.2
 aws.waf.ipset.name 11.15.2
 aws.waf.ipset.scope 11.15.2
+aws.waf.ipset.tags 13.49.1
 aws.waf.regexPatternSet 11.16.1
 aws.waf.regexPatternSet.arn 11.16.1
 aws.waf.regexPatternSet.description 11.16.1
@@ -10531,6 +10533,7 @@ aws.waf.regexPatternSet.id 11.16.1
 aws.waf.regexPatternSet.name 11.16.1
 aws.waf.regexPatternSet.regularExpressions 11.16.1
 aws.waf.regexPatternSet.scope 11.16.1
+aws.waf.regexPatternSet.tags 13.49.1
 aws.waf.regexPatternSets 11.16.1
 aws.waf.rule 11.15.2
 aws.waf.rule.action 11.15.2
@@ -10705,6 +10708,7 @@ aws.waf.rulegroup.id 11.15.2
 aws.waf.rulegroup.name 11.15.2
 aws.waf.rulegroup.rules 11.15.2
 aws.waf.rulegroup.scope 11.15.2
+aws.waf.rulegroup.tags 13.49.1
 aws.waf.scope 11.15.2
 aws.workdocs 11.15.5
 aws.workdocs.document 13.21.4

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.49.0",
-  "generated_at": "2026-07-21T12:54:57-07:00",
+  "generated_at": "2026-07-21T13:17:48-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -943,6 +943,7 @@
     "wafv2:ListRegexPatternSets",
     "wafv2:ListResourcesForWebACL",
     "wafv2:ListRuleGroups",
+    "wafv2:ListTagsForResource",
     "wafv2:ListWebACLs",
     "workdocs:DescribeFolderContents",
     "workdocs:DescribeUsers",
@@ -6801,6 +6802,12 @@
       "permission": "wafv2:ListRuleGroups",
       "service": "wafv2",
       "action": "ListRuleGroups",
+      "source_file": "aws_waf.go"
+    },
+    {
+      "permission": "wafv2:ListTagsForResource",
+      "service": "wafv2",
+      "action": "ListTagsForResource",
       "source_file": "aws_waf.go"
     },
     {

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -34,6 +34,58 @@ func (a *mqlAwsWaf) id() (string, error) {
 	return "aws.waf", nil
 }
 
+// wafTagsForArn lists the tags on a WAF resource, resolving the WAF endpoint
+// from the resource's scope. Returns nil on access-denied so a missing
+// wafv2:ListTagsForResource permission degrades gracefully.
+func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, error) {
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Wafv2(wafRegionForScope(scope))
+	ctx := context.Background()
+
+	tags := map[string]any{}
+	var nextMarker *string
+	for {
+		resp, err := svc.ListTagsForResource(ctx, &wafv2.ListTagsForResourceInput{
+			ResourceARN: &arn,
+			NextMarker:  nextMarker,
+		})
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		if resp.TagInfoForResource != nil {
+			for _, t := range resp.TagInfoForResource.TagList {
+				if t.Key != nil {
+					tags[*t.Key] = convert.ToValue(t.Value)
+				}
+			}
+		}
+		if resp.NextMarker == nil {
+			break
+		}
+		nextMarker = resp.NextMarker
+	}
+	return tags, nil
+}
+
+func (a *mqlAwsWafAcl) tags() (map[string]any, error) {
+	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+}
+
+func (a *mqlAwsWafRulegroup) tags() (map[string]any, error) {
+	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+}
+
+func (a *mqlAwsWafIpset) tags() (map[string]any, error) {
+	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+}
+
+func (a *mqlAwsWafRegexPatternSet) tags() (map[string]any, error) {
+	return wafTagsForArn(a.MqlRuntime, a.Scope.Data, a.Arn.Data)
+}
+
 func (a *mqlAwsWafAcl) id() (string, error) {
 	return a.Arn.Data, nil
 }


### PR DESCRIPTION
## What

No WAF resource exposed tags. Adds a lazy `tags()` accessor to `aws.waf.acl`, `aws.waf.rulegroup`, `aws.waf.ipset`, and `aws.waf.regexPatternSet`, backed by a shared `wafTagsForArn` helper that calls `ListTagsForResource` (paginated) and resolves the WAF endpoint from the resource's `scope` (CLOUDFRONT → us-east-1, else regional). Degrades to null on access-denied.

## Why

Finishes the WAF coverage from the audit — tags were the one field missing across every WAF resource, needed for ownership/environment filtering (`aws.waf.acls.where(tags["env"] == "prod")`).

## Notes

- Adds `wafv2:ListTagsForResource` to `aws.permissions.json` (the one new API call).
- Lazy accessors — no cost unless `tags` is queried.
- New `.lr.versions` entries at `13.49.1`.

## Test plan

- [x] `mqlr generate` + `make providers/build/aws` clean, `go vet` clean
- [ ] Live query (batched separately): `aws.waf.acls { name tags }`, `aws.waf.ipSets { name tags }`, `aws.waf.regexPatternSets { name tags }`, and rule groups
