### PR TITLE
🐛 aws: fix nil-runtime panic in elasticache cluster kmsKey

### DIFF
--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -213,7 +213,11 @@ func (a *mqlAwsElasticacheCluster) tags() (map[string]any, error) {
 func (a *mqlAwsElasticacheCluster) kmsKey() (*mqlAwsKmsKey, error) {
 	// The KMS key protecting a cluster's data at rest lives on its replication
 	// group, so delegate through the group rather than fetching replication
-	// groups a second time.
+	// groups a second time. A cluster with no replication group has no key.
+	if a.cacheReplicationGroupId == nil || *a.cacheReplicationGroupId == "" {
+		a.KmsKey.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
 	rg := a.GetReplicationGroup()
 	if rg.Error != nil {
 		return nil, rg.Error


### PR DESCRIPTION
## What

Fixes a nil pointer dereference that crashes the entire `go-test-providers` CI job (introduced by #9329).

`TestElasticacheClusterKmsKey` constructs a bare `&mqlAwsElasticacheCluster{}` (no `MqlRuntime`) and calls `kmsKey()`. `kmsKey()` delegated straight to the **generated** `GetReplicationGroup()` accessor, whose first statement is a recording check (`if c.MqlRuntime.HasRecording`) — dereferencing the nil `MqlRuntime` and panicking with SIGSEGV before the hand-written `replicationGroup()` null guard could run. The panic aborted `make providers/test` (`exit code 2`).

## Fix

Short-circuit on `cacheReplicationGroupId` directly at the top of `kmsKey()`. A cluster with no replication group has no KMS key (the key only ever comes from the replication group), so the set-but-null state resolves without ever touching the runtime — which is exactly the property the unit test asserts.

## Verification

```
--- PASS: TestElasticacheClusterKmsKey (0.00s)
    --- PASS: TestElasticacheClusterKmsKey/nil_replication_group_ID_sets_null_state
    --- PASS: TestElasticacheClusterKmsKey/empty_replication_group_ID_sets_null_state
```
