### PR TITLE
🐛 aws/azure: fix WAF tag pagination and Monitor metric-alert api-version

### DIFF
--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -62,7 +62,11 @@ func wafTagsForArn(runtime *plugin.Runtime, scope, arn string) (map[string]any, 
 				}
 			}
 		}
-		if resp.NextMarker == nil {
+		// WAFv2 signals the end of pagination with an empty-but-non-nil
+		// NextMarker. Passing that empty string back to ListTagsForResource
+		// fails validation ("Member must have length greater than or equal to
+		// 1"), so treat empty the same as nil.
+		if resp.NextMarker == nil || *resp.NextMarker == "" {
 			break
 		}
 		nextMarker = resp.NextMarker

--- a/providers/azure/resources/monitor.go
+++ b/providers/azure/resources/monitor.go
@@ -557,8 +557,16 @@ func (a *mqlAzureSubscriptionMonitorService) metricAlerts() ([]any, error) {
 	ctx := context.Background()
 	token := conn.Token()
 	subId := a.SubscriptionId.Data
+	// The armmonitor SDK pins the metricAlerts client to an api-version
+	// (2026-01-01) that the Microsoft.Insights/metricAlerts resource type does
+	// not serve, so ListBySubscription 404s with InvalidResourceType. Override
+	// it to the newest api-version the service actually supports for this
+	// resource type. Scoped to this client only, so sibling Monitor clients
+	// (action groups, scheduled query rules) keep their own versions.
+	metricAlertOpts := conn.ClientOptions()
+	metricAlertOpts.APIVersion = "2024-03-01-preview"
 	client, err := monitor.NewMetricAlertsClient(subId, token, &arm.ClientOptions{
-		ClientOptions: conn.ClientOptions(),
+		ClientOptions: metricAlertOpts,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What

Fixes two provider bugs found while verifying recently-merged PRs against live AWS and Azure infrastructure.

### 1. `aws.waf.*` `tags()` — WAFv2 pagination (bug shipped in #9334)

`tags()` on `aws.waf.acl`, `aws.waf.ipset`, `aws.waf.rulegroup`, and `aws.waf.regexPatternSet` errored on every resource:

```
WAFV2: ListTagsForResource, ValidationException: Value '' at 'nextMarker' failed
to satisfy constraint: Member must have length greater than or equal to 1
```

WAFv2's `ListTagsForResource` signals end-of-pagination with an **empty-but-non-nil** `NextMarker`. The loop only treated `nil` as the terminator, so it made a second call with an empty marker, which the API rejects. Fix: treat an empty `NextMarker` the same as `nil`.

### 2. `azure.subscription.monitorService.metricAlerts()` — api-version (bug shipped in #9324)

`metricAlerts()` 404'd on every subscription:

```
GET .../providers/Microsoft.Insights/metricAlerts
RESPONSE 404 InvalidResourceType — resource type 'metricalerts' could not be found
for api version '2026-01-01'. Supported: 2018-03-01, 2024-01-01-preview, 2024-03-01-preview.
```

The `armmonitor` SDK pins the metricAlerts client to api-version `2026-01-01`, which the `Microsoft.Insights/metricAlerts` resource type does not serve. Fix: override just that client's api-version to `2024-03-01-preview` (newest supported) via `ClientOptions.APIVersion`, leaving the sibling action-group and scheduled-query clients on their own versions.

## Verification

Both fixes were verified against live cloud infrastructure:

- **WAF** — `tags()` now returns the full tag set on ip sets, rule groups, and regex pattern sets.
- **metricAlerts** — now lists with all fields populated (criteria, scopes, severity, windowSize, and the typed `actionGroups` reference).

No schema changes, so no `.lr.versions` updates. No permissions changes.
