### PR TITLE
🎉 aws-13.50.0, azure-13.33.0, gcp-13.33.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.49.0",
+	Version:         "13.50.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:      "azure",
 	ID:        "go.mondoo.com/cnquery/v9/providers/azure",
-	Version:   "13.32.0",
+	Version:   "13.33.0",
 	Platforms: resources.Platforms,
 	ConnectionTypes: []string{
 		provider.ConnectionType,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.32.0",
+	Version: "13.33.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
Minor version bump for the **aws**, **gcp**, and **azure** providers, releasing everything merged since the last release ([#9280](https://github.com/mondoohq/mql/pull/9280)).

| Provider | Old | New |
|----------|-----|-----|
| aws   | 13.49.0 | **13.50.0** |
| azure | 13.32.0 | **13.33.0** |
| gcp   | 13.32.0 | **13.33.0** |

## AWS (13.50.0)

- ⭐ Add `aws.elasticache.replicationGroup` resource (#9329)
- ⭐ Add ELB SSL policies, trust stores, and listener rules (#9332)
- ✨ Expand ACM certificate detail + typed issuing CA (#9326)
- ✨ Add tags to WAF ACL, rule group, IP set, regex pattern set (#9334)
- ✨ Expose WAF enforcement and observability config (#9322)
- ✨ Expose SSM node/association/patch fields already fetched (#9318)
- ✨ Expose CloudWatch alarm + SSM compliance fields already fetched (#9314)
- 🐛 Fix WAF tag pagination and Monitor metric-alert api-version (#9340)
- 🐛 Fix nil-runtime panic in elasticache cluster kmsKey (#9339)

## Azure (13.33.0)

- 🌟 Expose Microsoft Sentinel incidents (#9319)
- 🌟 Expose Sentinel watchlists and automation rules (#9321)
- 🌟 Expose Azure Monitor action groups (#9323)
- 🌟 Expose Monitor metric alerts and scheduled query rules (#9324)
- 🌟 Expose per-resource policy compliance states (#9327)
- 🌟 Expose Defender for APIs collections (#9331)
- 🌟 Expose network manager network group static members (#9333)
- 🌟 Expose ML workspace managed-network outbound rules (#9335)
- 🌟 Expose PIM role management policies (#9317)
- 🌟 Expose Service Bus and Event Hub SAS authorization rules (#9315)
- 🐛 Fix WAF tag pagination and Monitor metric-alert api-version (#9340)

## GCP (13.33.0)

- ✨ Expose 5 posture-relevant SDK resource types (#9316)
- ✨ Expose workload-posture SDK fields on Cloud Run, GKE, Functions (#9325)
- ✨ Expose network and crypto SDK passthrough fields (#9330)
- 🐛 Expose disabled/exclusions on project log sinks and metrics (#9328)

## Shared

- 🧹 Update deps for mql and providers 20260721 (#9312)
