### PR TITLE
🛑 alicloud: export platform catalog + rename account asset to alicloud-account (13.2.0)

### DIFF
--- a/apps/provider-scaffold/template/config/config.go.template
+++ b/apps/provider-scaffold/template/config/config.go.template
@@ -5,6 +5,7 @@ package config
 
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"{{ .GoPackage }}/connection"
 	"{{ .GoPackage }}/provider"
 )
 
@@ -22,4 +23,5 @@ var Config = plugin.Provider{
 			Flags:     []plugin.Flag{},
 		},
 	},
+	Platforms: connection.Platforms,
 }

--- a/apps/provider-scaffold/template/connection/connection.go.template
+++ b/apps/provider-scaffold/template/connection/connection.go.template
@@ -8,6 +8,14 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+// Platforms is the static catalog of platforms this provider emits. The build
+// exports it into dist/{{ .ProviderID }}.json so the CLI and generated docs can
+// list what the provider supports. Add an entry here for every platform your
+// asset discovery produces.
+var Platforms = []*plugin.PlatformInfo{
+	{Name: "{{ .ProviderID }}", Title: "{{ .ProviderName }}", Family: []string{"{{ .ProviderID }}"}, Kind: []string{"api"}, Runtime: []string{"{{ .ProviderID }}"}},
+}
+
 type {{ .CamelcaseProviderID }}Connection struct {
 	plugin.Connection
 	Conf     *inventory.Config

--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "alicloud",
 	ID:              "go.mondoo.com/mql/providers/alicloud",
-	Version:         "13.1.2",
+	Version:         "13.2.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{

--- a/providers/alicloud/config/config.go
+++ b/providers/alicloud/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/alicloud/connection"
 	"go.mondoo.com/mql/v13/providers/alicloud/provider"
 	"go.mondoo.com/mql/v13/providers/alicloud/resources"
 )
@@ -13,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "alicloud",
 	ID:              "go.mondoo.com/mql/providers/alicloud",
-	Version:         "13.1.1",
+	Version:         "13.1.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{
@@ -99,4 +100,5 @@ Examples:
 			},
 		},
 	},
+	Platforms: connection.Platforms,
 }

--- a/providers/alicloud/connection/platform.go
+++ b/providers/alicloud/connection/platform.go
@@ -32,7 +32,7 @@ const (
 // account itself, and the per-object platforms produced by fine-grained asset
 // discovery.
 var Platforms = []*plugin.PlatformInfo{
-	{Name: "alicloud", Title: "Alibaba Cloud account", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alibaba-account", Title: "Alibaba Cloud account", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-ack-cluster", Title: "Alibaba Cloud ACK Cluster", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-alb-loadbalancer", Title: "Alibaba Cloud Application Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-nlb-loadbalancer", Title: "Alibaba Cloud Network Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
@@ -60,7 +60,7 @@ func newPlatform(name, title string, segments []string) *inventory.Platform {
 
 // NewAccountPlatform returns the platform for an Alibaba Cloud account asset.
 func NewAccountPlatform(accountID string) *inventory.Platform {
-	return newPlatform("alicloud", "Alibaba Cloud account "+accountID,
+	return newPlatform("alibaba-account", "Alibaba Cloud account "+accountID,
 		[]string{"technology=alicloud", "kind=account", "account=" + accountID})
 }
 

--- a/providers/alicloud/connection/platform.go
+++ b/providers/alicloud/connection/platform.go
@@ -32,7 +32,7 @@ const (
 // account itself, and the per-object platforms produced by fine-grained asset
 // discovery.
 var Platforms = []*plugin.PlatformInfo{
-	{Name: "alibaba-account", Title: "Alibaba Cloud account", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
+	{Name: "alicloud-account", Title: "Alibaba Cloud account", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-ack-cluster", Title: "Alibaba Cloud ACK Cluster", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-alb-loadbalancer", Title: "Alibaba Cloud Application Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
 	{Name: "alicloud-nlb-loadbalancer", Title: "Alibaba Cloud Network Load Balancer", Family: []string{"alicloud"}, Kind: []string{"api"}, Runtime: []string{"alicloud"}},
@@ -60,7 +60,7 @@ func newPlatform(name, title string, segments []string) *inventory.Platform {
 
 // NewAccountPlatform returns the platform for an Alibaba Cloud account asset.
 func NewAccountPlatform(accountID string) *inventory.Platform {
-	return newPlatform("alibaba-account", "Alibaba Cloud account "+accountID,
+	return newPlatform("alicloud-account", "Alibaba Cloud account "+accountID,
 		[]string{"technology=alicloud", "kind=account", "account=" + accountID})
 }
 

--- a/providers/alicloud/connection/platform_test.go
+++ b/providers/alicloud/connection/platform_test.go
@@ -15,7 +15,7 @@ func TestAlicloudPlatforms(t *testing.T) {
 	for _, pi := range Platforms {
 		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
 	}
-	assert.True(t, PlatformByName("alicloud").Consistent(NewAccountPlatform("1234567890")))
+	assert.True(t, PlatformByName("alibaba-account").Consistent(NewAccountPlatform("1234567890")))
 	assert.True(t, PlatformByName("alicloud-ack-cluster").Consistent(NewAckClusterPlatform("c-abc")))
 	assert.True(t, PlatformByName("alicloud-alb-loadbalancer").Consistent(NewAlbPlatform("alb-abc")))
 	assert.True(t, PlatformByName("alicloud-nlb-loadbalancer").Consistent(NewNlbPlatform("nlb-abc")))

--- a/providers/alicloud/connection/platform_test.go
+++ b/providers/alicloud/connection/platform_test.go
@@ -15,7 +15,7 @@ func TestAlicloudPlatforms(t *testing.T) {
 	for _, pi := range Platforms {
 		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
 	}
-	assert.True(t, PlatformByName("alibaba-account").Consistent(NewAccountPlatform("1234567890")))
+	assert.True(t, PlatformByName("alicloud-account").Consistent(NewAccountPlatform("1234567890")))
 	assert.True(t, PlatformByName("alicloud-ack-cluster").Consistent(NewAckClusterPlatform("c-abc")))
 	assert.True(t, PlatformByName("alicloud-alb-loadbalancer").Consistent(NewAlbPlatform("alb-abc")))
 	assert.True(t, PlatformByName("alicloud-nlb-loadbalancer").Consistent(NewNlbPlatform("nlb-abc")))


### PR DESCRIPTION
## Summary

Two related fixes to the alicloud provider's platform catalog, plus a rename of the top-level asset. **The alicloud provider is released but not yet used by any users (confirmed), so the rename is not a breaking change in practice** — hence a single minor version bump rather than a major.

## 1. Provider advertised zero platforms (the original bug)

`scripts/list-platforms.sh` (which reads each provider's built `dist/<provider>.json` and prints `.Platforms[].name`) listed **none** of the Alibaba Cloud platforms.

Root cause: the provider defines a full platform catalog in `connection/platform.go` (the account plus per-object discovery platforms) and unit-tests it, but `config/config.go` never assigned it to `plugin.Provider.Platforms` — the field marshaled into `dist/alicloud.json` and consumed by CLI/docs tooling. With it unset, `dist/alicloud.json` had no `Platforms` key, so the script emitted nothing. (This is separate from the runtime `asset.Platform` set in `detect()`, which worked fine.)

**Fix:** wire `Platforms: connection.Platforms` into the provider config.

## 2. Renamed the top-level asset `alicloud` → `alicloud-account`

The top-level asset the provider exposes is an **Alibaba Cloud account**, keyed by the numeric account UID (from STS `GetCallerIdentity`). Alibaba calls this an **account** — the AWS-account analog, not a subscription (Azure) or project (GCP). The platform asset was named `alicloud`, which collided with the provider name and didn't say what the asset is.

Renamed the account asset to `alicloud-account` in the catalog, `NewAccountPlatform`, and the unit test — using the `alicloud-` family prefix to stay consistent with the sibling platforms (`alicloud-vpc`, `alicloud-ack-cluster`, …). Unchanged: the provider/connector name (`alicloud`) and the `Family`/`Runtime` provider-identity values.

Regenerated `dist/alicloud.json` now lists:
```
alicloud-account
alicloud-ack-cluster
alicloud-alb-loadbalancer
alicloud-nlb-loadbalancer
alicloud-vpc
alicloud-waf-instance
alicloud-cloud-firewall
```

Minor version bump `13.1.1` → `13.2.0`.

## 3. Prevent recurrence in the scaffold (root cause for future providers)

The `provider-scaffold` templates never emitted a platform catalog nor set the config field, so *every* provider bootstrapped from the scaffold inherited bug #1. The connection template now generates a `Platforms` catalog seeded with the base platform, and the config template wires `Platforms: connection.Platforms`.

## Verification

- `make providers/build/alicloud` regenerates `dist/alicloud.json` with the 7 platforms, account entry named `alicloud-account`.
- `scripts/list-platforms.sh` now lists them.
- `go test ./connection/ -run TestAlicloudPlatforms` passes.
- Generated a throwaway provider from the updated scaffold templates → config wires `Platforms: connection.Platforms`, connection includes the catalog; `go test ./apps/provider-scaffold/...` passes.
