### PR TITLE
✨ arista: report chassis model as platform runtime

### DIFF
--- a/providers/arista/provider/provider.go
+++ b/providers/arista/provider/provider.go
@@ -166,10 +166,12 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AristaConnecti
 	asset.Name = conn.Conf.Host
 	version := ""
 	arch := ""
+	model := ""
 	aristaVersion, err := conn.GetVersion()
 	if err == nil {
 		version = aristaVersion.Version
 		arch = aristaVersion.Architecture
+		model = aristaVersion.ModelName
 	}
 
 	platform := &inventory.Platform{
@@ -179,6 +181,15 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.AristaConnecti
 	}
 	if pi, ok := PlatformByName("arista-eos"); ok {
 		pi.Apply(platform)
+	}
+	// Report the chassis model as the platform runtime so the server can scope
+	// EOS advisories to the device's hardware family (models named in a CVE's
+	// affected[].platforms). This is set AFTER Apply, which overwrites Runtime
+	// with the catalog's "arista" marker; the device is still classified as an
+	// Arista EOS asset by its "arista-eos" platform name. Mirrors how the Junos
+	// provider reports its hardware model.
+	if model != "" {
+		platform.Runtime = model
 	}
 	asset.Platform = platform
 


### PR DESCRIPTION
## What

The Arista EOS provider now reports the chassis model (from `show version`) as
the platform runtime, e.g. `DCS-7280SR3AK-48C10`.

## Why

Some Arista EOS security advisories affect only a subset of hardware platforms.
Reporting the chassis model lets the vulnerability database reduce the device to
its hardware family and scope those advisories to the devices they actually
apply to, instead of flagging every EOS device. This mirrors how the Junos
provider reports its hardware model.

## Notes

The runtime is set after `PlatformInfo.Apply` (which writes the catalog's
`arista` runtime marker); the device is still classified as an Arista EOS asset
by its `arista-eos` platform name. When the model is unavailable the runtime is
left unset and the device is matched on version alone, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
