### PR TITLE
🐛 terraform: fix HCL object-key panic + expand dynamic blocks in values()

### DIFF
--- a/providers/terraform/resources/hcl.go
+++ b/providers/terraform/resources/hcl.go
@@ -648,12 +648,22 @@ func hclBodyToValuesDict(rawBody hcl.Body, ctx *hcl.EvalContext) (map[string]any
 	}
 
 	for _, block := range body.Blocks {
-		child, err := hclBodyToValuesDict(block.Body, ctx)
-		if err != nil {
-			return nil, err
+		// Expand `dynamic "X"` blocks into the `X` blocks they generate, exactly
+		// as listHclBlocks does for blocks(). Terraform plan/state already expose
+		// the generated blocks under their real type, so without this the HCL
+		// values() folds them under a "dynamic" key (nested under "content") and a
+		// policy written as values["X"] silently sees nothing on an HCL asset while
+		// matching on the plan/state asset. normalizeHclSyntaxBlock returns the
+		// block unchanged when it is not a dynamic block, so static blocks keep
+		// their existing shape.
+		for _, nb := range normalizeHclSyntaxBlock(block) {
+			child, err := hclBodyToValuesDict(nb.Body, ctx)
+			if err != nil {
+				return nil, err
+			}
+			existing, _ := dict[nb.Type].([]any)
+			dict[nb.Type] = append(existing, child)
 		}
-		existing, _ := dict[block.Type].([]any)
-		dict[block.Type] = append(existing, child)
 	}
 
 	return dict, nil
@@ -1016,13 +1026,38 @@ func GetKeyString(key any) string {
 	case []string:
 		return strings.Join(v, ",")
 	case []any:
-		s := ""
+		var sb strings.Builder
 		for i := range v {
-			s = s + v[i].(string)
+			sb.WriteString(keyScalarToString(v[i]))
 		}
-		return s
+		return sb.String()
 	default:
-		return key.(string)
+		return keyScalarToString(key)
+	}
+}
+
+// keyScalarToString renders an evaluated object key as the string Terraform
+// itself would use for a map key. Object keys resolve to whatever type the key
+// expression evaluates to: with variable resolution active a `{ (var.x) = ... }`
+// key can be a number/bool/null, and a bareword numeric key like `{ 8080 = ... }`
+// always evaluates to a number. A bare `key.(string)` assertion on any of those
+// panics, and because query blocks run in goroutines that panic crashes the
+// entire scan rather than one query. Stringify each scalar kind explicitly and
+// treat null/unknown keys as empty.
+func keyScalarToString(key any) string {
+	switch k := key.(type) {
+	case string:
+		return k
+	case bool:
+		return strconv.FormatBool(k)
+	case float64:
+		return strconv.FormatFloat(k, 'f', -1, 64)
+	case int64:
+		return strconv.FormatInt(k, 10)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(k)
 	}
 }
 

--- a/providers/terraform/resources/hcl_test.go
+++ b/providers/terraform/resources/hcl_test.go
@@ -551,3 +551,123 @@ resource "google_sql_database_instance" "example" {
 	assert.Equal(t, "skip_show_database", flags[0].(map[string]any)["name"])
 	assert.Equal(t, "local_infile", flags[1].(map[string]any)["name"])
 }
+
+// TestKeyScalarToString covers every scalar kind an evaluated object key can
+// take. A number/bool/null key used to reach a bare `key.(string)` assertion in
+// GetKeyString and panic; each kind must now stringify (or empty) instead.
+func TestKeyScalarToString(t *testing.T) {
+	assert.Equal(t, "http", keyScalarToString("http"))
+	assert.Equal(t, "8080", keyScalarToString(float64(8080)))
+	assert.Equal(t, "8080.5", keyScalarToString(float64(8080.5)))
+	assert.Equal(t, "42", keyScalarToString(int64(42)))
+	assert.Equal(t, "true", keyScalarToString(true))
+	assert.Equal(t, "false", keyScalarToString(false))
+	assert.Equal(t, "", keyScalarToString(nil))
+}
+
+// TestGetKeyString covers the container branches of GetKeyString, including a
+// []any that holds non-string scalars (which previously panicked on the
+// v[i].(string) assertion).
+func TestGetKeyString(t *testing.T) {
+	assert.Equal(t, "keytest", GetKeyString("keytest"))
+	assert.Equal(t, "key,thing", GetKeyString([]string{"key", "thing"}))
+	assert.Equal(t, "keything", GetKeyString([]any{"key", "thing"}))
+	assert.Equal(t, "a8080true", GetKeyString([]any{"a", float64(8080), true}))
+	assert.Equal(t, "8080", GetKeyString(float64(8080)))
+	assert.Equal(t, "", GetKeyString(nil))
+}
+
+// TestGetCtyValue_ObjectNumericKey is a regression test: a map literal with a
+// numeric key (e.g. `{ 8080 = "http" }`, common in port/priority maps) is valid
+// HCL whose key evaluates to a number. GetKeyString used to assert it as a
+// string and panic, and because query blocks run in goroutines that panic
+// crashes the whole scan. The key must stringify and the object must resolve.
+func TestGetCtyValue_ObjectNumericKey(t *testing.T) {
+	attrs := parseAttrs(t, `ports = { 8080 = "http", 443 = "https" }`)
+	got, err := hclResolvedAttributesToDict(attrs, nil)
+	require.NoError(t, err)
+
+	m, ok := got["ports"].(map[string]any)
+	require.True(t, ok, "ports should be a map, got %#v", got["ports"])
+	assert.Equal(t, "http", m["8080"])
+	assert.Equal(t, "https", m["443"])
+}
+
+// TestGetCtyValue_ObjectResolvedScalarKey verifies the same panic path is safe
+// when variable resolution turns a `{ (var.x) = ... }` key into a real scalar.
+func TestGetCtyValue_ObjectResolvedScalarKey(t *testing.T) {
+	attrs := parseAttrs(t, `m = { (var.port) = "http" }`)
+	ctx := resolvingCtx(map[string]cty.Value{
+		"port": cty.NumberIntVal(8080),
+	}, nil)
+	got, err := hclResolvedAttributesToDict(attrs, ctx)
+	require.NoError(t, err)
+
+	m, ok := got["m"].(map[string]any)
+	require.True(t, ok, "m should be a map, got %#v", got["m"])
+	assert.Equal(t, "http", m["8080"])
+}
+
+// TestHclBodyToValuesDict_DynamicBlockExpanded verifies that values() expands a
+// `dynamic "X"` block into the `X` blocks it generates, matching how Terraform
+// plan/state expose the already-expanded blocks. Without this a policy written
+// as values["ingress"] silently sees nothing on an HCL asset while matching on
+// the plan/state asset.
+func TestHclBodyToValuesDict_DynamicBlockExpanded(t *testing.T) {
+	body := resourceBody(t, `
+resource "aws_security_group" "example" {
+  name = "example"
+
+  dynamic "ingress" {
+    for_each = var.rules
+    content {
+      from_port = ingress.value.port
+      protocol  = "tcp"
+    }
+  }
+}
+`)
+
+	values, err := hclBodyToValuesDict(body, nil)
+	require.NoError(t, err)
+
+	// The dynamic wrapper must not leak through as a "dynamic" key.
+	_, hasDynamic := values["dynamic"]
+	assert.False(t, hasDynamic, "dynamic wrapper should be expanded, got keys %#v", values)
+
+	ingress, ok := values["ingress"].([]any)
+	require.True(t, ok, "ingress should be []any, got %#v", values["ingress"])
+	require.Len(t, ingress, 1)
+	assert.Equal(t, "tcp", ingress[0].(map[string]any)["protocol"])
+}
+
+// TestHclBodyToValuesDict_DynamicBlockNested verifies a dynamic block nested
+// inside a static block also expands to its real type.
+func TestHclBodyToValuesDict_DynamicBlockNested(t *testing.T) {
+	body := resourceBody(t, `
+resource "aws_appautoscaling_policy" "example" {
+  step_scaling_policy_configuration {
+    dynamic "step_adjustment" {
+      for_each = var.steps
+      content {
+        scaling_adjustment = step_adjustment.value.adjustment
+      }
+    }
+  }
+}
+`)
+
+	values, err := hclBodyToValuesDict(body, nil)
+	require.NoError(t, err)
+
+	cfg, ok := values["step_scaling_policy_configuration"].([]any)
+	require.True(t, ok)
+	require.Len(t, cfg, 1)
+
+	inner := cfg[0].(map[string]any)
+	_, hasDynamic := inner["dynamic"]
+	assert.False(t, hasDynamic, "nested dynamic wrapper should be expanded, got %#v", inner)
+	steps, ok := inner["step_adjustment"].([]any)
+	require.True(t, ok, "step_adjustment should be []any, got %#v", inner["step_adjustment"])
+	require.Len(t, steps, 1)
+}

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -58,6 +58,14 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 		return nil, err
 	}
 
+	// conn.Plan() returns nil for non-plan assets (HCL/state). The terraform.plan
+	// init pre-fills resourceChanges with an empty list on those assets so this
+	// accessor is not normally reached, but guard here to match the sibling
+	// accessors (providerConfig/resources) and stay panic-safe if that changes.
+	if plan == nil {
+		return []any{}, nil
+	}
+
 	if plan.ResourceChanges == nil {
 		return nil, nil
 	}

--- a/providers/terraform/resources/tfplan.go
+++ b/providers/terraform/resources/tfplan.go
@@ -59,11 +59,11 @@ func (t *mqlTerraformPlan) resourceChanges() ([]any, error) {
 	}
 
 	// conn.Plan() returns nil for non-plan assets (HCL/state). The terraform.plan
-	// init pre-fills resourceChanges with an empty list on those assets so this
-	// accessor is not normally reached, but guard here to match the sibling
-	// accessors (providerConfig/resources) and stay panic-safe if that changes.
+	// init pre-fills resourceChanges on those assets so this accessor is not
+	// normally reached, but guard here to stay panic-safe if that changes. Return
+	// the same zero-value as the empty-ResourceChanges path below for consistency.
 	if plan == nil {
-		return []any{}, nil
+		return nil, nil
 	}
 
 	if plan.ResourceChanges == nil {

--- a/providers/terraform/resources/tfplan_test.go
+++ b/providers/terraform/resources/tfplan_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/terraform/connection"
+)
+
+// TestTerraformPlanResourceChanges_NilPlan verifies that resourceChanges() does
+// not panic when the connection carries no plan. conn.Plan() returns nil for
+// non-plan assets (HCL/state), and this accessor dereferenced it without a
+// guard while its sibling accessors guarded it. A zero-value Connection mirrors
+// what NewStateConnection / an HCL connection produce (no plan set).
+func TestTerraformPlanResourceChanges_NilPlan(t *testing.T) {
+	runtime := &plugin.Runtime{Connection: &connection.Connection{}}
+	p := &mqlTerraformPlan{}
+	p.MqlRuntime = runtime
+
+	res, err := p.resourceChanges()
+	require.NoError(t, err)
+	assert.Empty(t, res)
+}


### PR DESCRIPTION
## Summary

Fixes three defects found in a static bug-review of the terraform provider's hand-rolled HCL expression evaluator. All three are the "wrong data / crash with no error" kind that a compiler and the existing passing tests do not catch.

## Findings fixed

### 1. HIGH — scan-crashing panic on non-string object keys
`GetKeyString` asserted every evaluated object key as a `string`:

```go
default:
    return key.(string)   // panics on float64 / bool / nil / map
```

A valid HCL map literal with a **numeric key** — e.g. `ports = { 8080 = "http", 443 = "https" }`, common in port/priority/status maps — evaluates the key to a number, and `key.(string)` panics:

```
interface conversion: interface {} is float64, not string
```

Because query blocks run in goroutines, this panic is unrecoverable and **crashes the entire scan**, not just the one query. Variable resolution widens the trigger further: a `{ (var.x) = ... }` key now resolves to the variable's real type (number/bool/null), each of which panicked. Keys are now stringified per scalar kind (null → empty) via a total `keyScalarToString` helper, applied to the `[]any` branch too.

### 2. Correctness — `values()` did not expand `dynamic` blocks
`hclBodyToValuesDict` (backing `terraform.block.values`) exists to expose one dict in the same shape as Terraform plan/state so a single policy body runs against all three backends. But unlike its sibling `blocks()` (fixed in #9086), it did **not** unwrap `dynamic "X"` blocks — so a dynamic block folded under a `"dynamic"` key instead of `"X"`. A policy written as `values["ingress"]` silently returned nothing on an HCL asset while matching on the already-expanded plan/state asset — a vacuous pass/fail. `values()` now runs the same `normalizeHclSyntaxBlock` expansion, including nested dynamic blocks.

### 3. Robustness — missing nil-plan guard
`terraform.plan.resourceChanges` dereferenced `conn.Plan()` without the `nil` guard its sibling accessors (`providerConfig`, `resources`) have. `conn.Plan()` returns nil for non-plan assets. Currently unreachable (the init pre-fills the field on those assets), but a latent panic; guarded to match the siblings.

## Tests
Adds unit tests for the pure-Go logic touched:
- `keyScalarToString` / `GetKeyString` across string, `[]string`, mixed `[]any`, float64, bool, and nil.
- `getCtyValue` object with a numeric key and with a variable-resolved scalar key (no panic, key stringified).
- `hclBodyToValuesDict` dynamic-block expansion, flat and nested.
- `resourceChanges` on a nil plan (no panic, empty result).

No provider version bump (handled by the release flow). `make test/lint`-relevant `gofmt`/`go vet` clean; full `go test ./...` for the provider passes.
