### PR TITLE
🐛 vsphere: fix advanced-settings map-order + __id collisions and harden degrade paths

### DIFF
--- a/providers/vsphere/resources/host.go
+++ b/providers/vsphere/resources/host.go
@@ -503,6 +503,21 @@ func (v *mqlVsphereHost) vmknics() ([]any, error) {
 	return mqlVmknics, nil
 }
 
+// parseVibDate parses a VIB's date column (esxcli reports "2020-07-16"),
+// returning nil for an empty or unparseable value. A single VIB with a missing
+// date must not sink the whole host's package list, so we degrade that one
+// field to null rather than erroring the accessor.
+func parseVibDate(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
 func (v *mqlVsphereHost) packages() ([]any, error) {
 	esxiClient, err := v.esxiClient()
 	if err != nil {
@@ -517,28 +532,16 @@ func (v *mqlVsphereHost) packages() ([]any, error) {
 	for i := range vibs {
 		vib := vibs[i]
 
-		// parse timestamps in format "2020-07-16"
-		format := "2006-01-02"
-		var creationDate *time.Time
-		parsedCreation, err := time.Parse(format, vib.CreationDate)
-		if err != nil {
-			return nil, errors.New("cannot parse vib creationDate: " + vib.CreationDate)
-		}
-		creationDate = &parsedCreation
-
-		var installDate *time.Time
-		parsedInstall, err := time.Parse(format, vib.InstallDate)
-		if err != nil {
-			return nil, errors.New("cannot parse vib installDate: " + vib.InstallDate)
-		}
-		installDate = &parsedInstall
-
 		mqlVib, err := CreateResource(v.MqlRuntime, "vsphere.host.vib", map[string]*llx.RawData{
+			// __id must be host-scoped: a VIB ID is identical on every host
+			// running the same ESXi build, so keying only on it would alias
+			// (and clobber) the per-host installDate/status across hosts.
+			"__id":            llx.StringData(esxiClient.InventoryPath + "/vib/" + vib.ID),
 			"id":              llx.StringData(vib.ID),
 			"name":            llx.StringData(vib.Name),
 			"acceptanceLevel": llx.StringData(vib.AcceptanceLevel),
-			"creationDate":    llx.TimeDataPtr(creationDate),
-			"installDate":     llx.TimeDataPtr(installDate),
+			"creationDate":    llx.TimeDataPtr(parseVibDate(vib.CreationDate)),
+			"installDate":     llx.TimeDataPtr(parseVibDate(vib.InstallDate)),
 			"status":          llx.StringData(vib.Status),
 			"vendor":          llx.StringData(vib.Vendor),
 			"version":         llx.StringData(vib.Version),
@@ -931,8 +934,11 @@ func (v *mqlVsphereHost) firewallRulesets() ([]any, error) {
 	if v.host == nil || v.host.Config == nil || v.host.Config.Firewall == nil {
 		return []any{}, nil
 	}
-	hostPath := ""
-	if v.InventoryPath.Error == nil {
+	// Prefer the readable inventory path, but fall back to the host moid (always
+	// unique) so the sub-resource __ids can never collapse to "/..." and alias
+	// across hosts if InventoryPath is unset.
+	hostPath := v.Moid.Data
+	if v.InventoryPath.Error == nil && v.InventoryPath.Data != "" {
 		hostPath = v.InventoryPath.Data
 	}
 
@@ -1012,8 +1018,11 @@ func (v *mqlVsphereHost) iscsiAdapters() ([]any, error) {
 	if v.host == nil || v.host.Config == nil || v.host.Config.StorageDevice == nil {
 		return []any{}, nil
 	}
-	hostPath := ""
-	if v.InventoryPath.Error == nil {
+	// Prefer the readable inventory path, but fall back to the host moid (always
+	// unique) so the sub-resource __ids can never collapse to "/..." and alias
+	// across hosts if InventoryPath is unset.
+	hostPath := v.Moid.Data
+	if v.InventoryPath.Error == nil && v.InventoryPath.Data != "" {
 		hostPath = v.InventoryPath.Data
 	}
 

--- a/providers/vsphere/resources/host_identity_test.go
+++ b/providers/vsphere/resources/host_identity_test.go
@@ -1,0 +1,57 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	vimtypes "github.com/vmware/govmomi/vim25/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func idInfo(key, value string) vimtypes.HostSystemIdentificationInfo {
+	return vimtypes.HostSystemIdentificationInfo{
+		IdentifierType:  &vimtypes.ElementDescription{Key: key},
+		IdentifierValue: value,
+	}
+}
+
+func TestClassifyIdentifyingInfo(t *testing.T) {
+	t.Run("promotes known keys and bags the rest", func(t *testing.T) {
+		asset, service, installDate, oem := classifyIdentifyingInfo([]vimtypes.HostSystemIdentificationInfo{
+			idInfo("AssetTag", "ASSET-123"),
+			idInfo("ServiceTag", "SVC-456"),
+			idInfo("HostInstallDate", "2023-05-01T10:00:00Z"),
+			idInfo("EnclosureSerialNumberTag", "ENC-789"),
+		})
+		assert.Equal(t, "ASSET-123", asset)
+		assert.Equal(t, "SVC-456", service)
+		assert.False(t, installDate.IsZero())
+		assert.Equal(t, 2023, installDate.Year())
+		assert.Equal(t, map[string]any{"EnclosureSerialNumberTag": "ENC-789"}, oem)
+	})
+
+	t.Run("missing install date leaves it zero without error", func(t *testing.T) {
+		_, _, installDate, oem := classifyIdentifyingInfo([]vimtypes.HostSystemIdentificationInfo{
+			idInfo("AssetTag", "A"),
+		})
+		assert.True(t, installDate.IsZero())
+		assert.Empty(t, oem)
+	})
+
+	t.Run("non-RFC3339 install date is ignored, not fatal", func(t *testing.T) {
+		_, _, installDate, _ := classifyIdentifyingInfo([]vimtypes.HostSystemIdentificationInfo{
+			idInfo("HostInstallDate", "2023-05-01"), // not RFC3339
+		})
+		assert.True(t, installDate.IsZero())
+	})
+
+	t.Run("empty key is not bagged", func(t *testing.T) {
+		_, _, _, oem := classifyIdentifyingInfo([]vimtypes.HostSystemIdentificationInfo{
+			idInfo("", "orphan"),
+		})
+		assert.Empty(t, oem)
+	})
+}

--- a/providers/vsphere/resources/host_pure_test.go
+++ b/providers/vsphere/resources/host_pure_test.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVibDate(t *testing.T) {
+	t.Run("valid date parses", func(t *testing.T) {
+		got := parseVibDate("2020-07-16")
+		require.NotNil(t, got)
+		assert.Equal(t, 2020, got.Year())
+		assert.Equal(t, 7, int(got.Month()))
+		assert.Equal(t, 16, got.Day())
+	})
+
+	// A VIB with a missing/blank date must degrade that one field to null and
+	// must NOT sink the whole host's package list (the pre-fix behavior).
+	t.Run("empty string yields nil, not an error", func(t *testing.T) {
+		assert.Nil(t, parseVibDate(""))
+	})
+
+	t.Run("unparseable value yields nil", func(t *testing.T) {
+		assert.Nil(t, parseVibDate("not-a-date"))
+		assert.Nil(t, parseVibDate("2020/07/16"))     // wrong separators
+		assert.Nil(t, parseVibDate("2020-07-16 UTC")) // trailing junk
+	})
+}

--- a/providers/vsphere/resources/resourceclient/esxi.go
+++ b/providers/vsphere/resources/resourceclient/esxi.go
@@ -664,6 +664,44 @@ func (s EsxiAdvancedSetting) Overridden() bool {
 	return s.Default != s.Value
 }
 
+// esxiColumn returns the single value for an esxcli result column, or "" when
+// the column is absent or carries anything other than exactly one value. An
+// empty XML element decodes to a present, len-1 slice holding "", so an absent
+// value and a genuinely empty value both collapse to "" here.
+func esxiColumn(val map[string][]string, key string) string {
+	if v, ok := val[key]; ok && len(v) == 1 {
+		return v[0]
+	}
+	return ""
+}
+
+// buildAdvancedSetting maps one `system settings advanced list` DataObject into
+// an EsxiAdvancedSetting. esxcli emits BOTH the integer and the string variant
+// of the value/default columns for every setting; the variant that doesn't
+// apply is present but empty (`DefaultStringValue :` for an integer setting).
+// The Type column ("integer" or "string") tells us which pair is authoritative,
+// so we select on it rather than writing both variants to the same field and
+// letting Go's randomized map-iteration order decide the winner (which produced
+// nondeterministic empty/wrong Default and Value between scans).
+func buildAdvancedSetting(val map[string][]string) EsxiAdvancedSetting {
+	setting := EsxiAdvancedSetting{
+		Description: esxiColumn(val, "Description"),
+	}
+	if path := esxiColumn(val, "Path"); path != "" {
+		setting.Path = path
+		setting.Key = strings.ReplaceAll(strings.TrimPrefix(path, "/"), "/", ".")
+	}
+	if esxiColumn(val, "Type") == "string" {
+		setting.Default = esxiColumn(val, "DefaultStringValue")
+		setting.Value = esxiColumn(val, "StringValue")
+	} else {
+		// integer (the only other advertised type) uses the numeric columns
+		setting.Default = esxiColumn(val, "DefaultIntValue")
+		setting.Value = esxiColumn(val, "IntValue")
+	}
+	return setting
+}
+
 // $ESXCli.system.settings.advanced.list()
 // DefaultIntValue    : 1
 // DefaultStringValue :
@@ -691,31 +729,7 @@ func (esxi *Esxi) AdvancedSettings() ([]EsxiAdvancedSetting, error) {
 
 	settings := []EsxiAdvancedSetting{}
 	for _, val := range res.Values {
-		setting := EsxiAdvancedSetting{}
-
-		for k := range val {
-			if len(val[k]) == 1 {
-				value := val[k][0]
-				switch k {
-				case "Path":
-					setting.Path = value
-					setting.Key = strings.ReplaceAll(strings.TrimPrefix(value, "/"), "/", ".")
-				case "Description":
-					setting.Description = value
-				case "DefaultIntValue":
-					setting.Default = value
-				case "DefaultStringValue":
-					setting.Default = value
-				case "StringValue":
-					setting.Value = value
-				case "IntValue":
-					setting.Value = value
-				}
-			} else {
-				log.Error().Str("key", k).Msg("Vibs> unsupported key")
-			}
-		}
-		settings = append(settings, setting)
+		settings = append(settings, buildAdvancedSetting(val))
 	}
 
 	// fetch kernel settings

--- a/providers/vsphere/resources/resourceclient/esxi_test.go
+++ b/providers/vsphere/resources/resourceclient/esxi_test.go
@@ -34,3 +34,75 @@ func TestEsxcliNamespaceUnavailableRegex(t *testing.T) {
 		assert.False(t, esxcliNamespaceUnavailableRegex.MatchString(msg), "expected no match: %q", msg)
 	}
 }
+
+func TestBuildAdvancedSetting(t *testing.T) {
+	// esxcli emits BOTH the int and string variant of the value/default
+	// columns for every setting; the inapplicable one is present but empty.
+	// buildAdvancedSetting must select the pair named by Type rather than let
+	// map-iteration order pick a winner.
+	t.Run("integer setting ignores the empty string columns", func(t *testing.T) {
+		val := map[string][]string{
+			"Path":               {"/DataMover/HardwareAcceleratedMove"},
+			"Description":        {"Enable hardware accelerated VMFS data movement"},
+			"Type":               {"integer"},
+			"DefaultIntValue":    {"1"},
+			"DefaultStringValue": {""},
+			"IntValue":           {"0"},
+			"StringValue":        {""},
+			"MaxValue":           {"1"},
+			"MinValue":           {"0"},
+		}
+		// Run many times: map iteration order is randomized, so the old
+		// dual-write code would flip Default/Value between iterations.
+		for i := range 200 {
+			s := buildAdvancedSetting(val)
+			assert.Equal(t, "1", s.Default, "iteration %d", i)
+			assert.Equal(t, "0", s.Value, "iteration %d", i)
+			assert.Equal(t, "DataMover.HardwareAcceleratedMove", s.Key)
+			assert.Equal(t, "/DataMover/HardwareAcceleratedMove", s.Path)
+			assert.Equal(t, "Enable hardware accelerated VMFS data movement", s.Description)
+			assert.True(t, s.Overridden(), "1 != 0 is an override")
+		}
+	})
+
+	t.Run("string setting reads the string columns", func(t *testing.T) {
+		val := map[string][]string{
+			"Path":               {"/Syslog/global/logHost"},
+			"Type":               {"string"},
+			"DefaultIntValue":    {"0"},
+			"DefaultStringValue": {""},
+			"IntValue":           {"0"},
+			"StringValue":        {"tcp://loghost:514"},
+		}
+		for i := range 200 {
+			s := buildAdvancedSetting(val)
+			assert.Equal(t, "", s.Default, "iteration %d", i)
+			assert.Equal(t, "tcp://loghost:514", s.Value, "iteration %d", i)
+			assert.Equal(t, "Syslog.global.logHost", s.Key)
+			assert.True(t, s.Overridden(), "empty default != set value")
+		}
+	})
+
+	t.Run("matching int default and value is not an override", func(t *testing.T) {
+		val := map[string][]string{
+			"Path":            {"/Net/BlockGuestBPDU"},
+			"Type":            {"integer"},
+			"DefaultIntValue": {"0"},
+			"IntValue":        {"0"},
+		}
+		s := buildAdvancedSetting(val)
+		assert.Equal(t, "0", s.Default)
+		assert.Equal(t, "0", s.Value)
+		assert.False(t, s.Overridden())
+	})
+
+	t.Run("absent or multi-valued columns yield empty", func(t *testing.T) {
+		s := buildAdvancedSetting(map[string][]string{
+			"Type":            {"integer"},
+			"DefaultIntValue": {"1", "2"}, // malformed: not len-1
+		})
+		assert.Equal(t, "", s.Default)
+		assert.Equal(t, "", s.Value)
+		assert.Equal(t, "", s.Path)
+	})
+}

--- a/providers/vsphere/resources/tags.go
+++ b/providers/vsphere/resources/tags.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/tags"
 	vmwaretypes "github.com/vmware/govmomi/vim25/types"
@@ -206,14 +207,21 @@ func attachedTagRefs(runtime *plugin.Runtime, moid string) ([]any, error) {
 
 	conn := runtime.Connection.(*connection.VsphereConnection)
 	ctx := context.Background()
+	// tagRefs is the typed sibling of the best-effort mo.ManagedEntity.Tag
+	// string field (see BatchGetTags in common.go): when the vAPI is
+	// unreachable (direct ESXi connection, or a token without vAPI scope) it
+	// degrades to an empty list rather than erroring the whole object, so the
+	// two tag views stay consistent.
 	rc, err := conn.RestClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to vAPI: %w", err)
+		log.Debug().Err(err).Msg("vsphere> vAPI rest client unavailable; returning no tag refs")
+		return []any{}, nil
 	}
 
 	tagIDs, err := tags.NewManager(rc).ListAttachedTags(ctx, ref)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list attached tags: %w", err)
+		log.Debug().Err(err).Msg("vsphere> ListAttachedTags failed; returning no tag refs")
+		return []any{}, nil
 	}
 	return resolveTagRefs(runtime, tagIDs)
 }

--- a/providers/vsphere/resources/tasks_test.go
+++ b/providers/vsphere/resources/tasks_test.go
@@ -1,0 +1,74 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	vmwaretypes "github.com/vmware/govmomi/vim25/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchedulerType(t *testing.T) {
+	cases := []struct {
+		sched vmwaretypes.BaseTaskScheduler
+		want  string
+	}{
+		{&vmwaretypes.OnceTaskScheduler{}, "Once"},
+		{&vmwaretypes.AfterStartupTaskScheduler{}, "AfterStartup"},
+		{&vmwaretypes.HourlyTaskScheduler{}, "Hourly"},
+		{&vmwaretypes.DailyTaskScheduler{}, "Daily"},
+		{&vmwaretypes.WeeklyTaskScheduler{}, "Weekly"},
+		{&vmwaretypes.MonthlyByDayTaskScheduler{}, "Monthly"},
+		{&vmwaretypes.MonthlyByWeekdayTaskScheduler{}, "Monthly"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, schedulerType(c.sched))
+	}
+}
+
+func TestActionName(t *testing.T) {
+	assert.Equal(t, "PowerOnVM_Task", actionName(&vmwaretypes.MethodAction{Name: "PowerOnVM_Task"}))
+	assert.Equal(t, "", actionName(nil))
+	// non-method actions fall back to their type name
+	assert.Equal(t, "RunScriptAction", actionName(&vmwaretypes.RunScriptAction{}))
+}
+
+func TestTaskUser(t *testing.T) {
+	assert.Equal(t, "DOMAIN\\admin", taskUser(&vmwaretypes.TaskReasonUser{UserName: "DOMAIN\\admin"}))
+	// system- and schedule-initiated tasks have no user
+	assert.Equal(t, "", taskUser(&vmwaretypes.TaskReasonSystem{}))
+	assert.Equal(t, "", taskUser(&vmwaretypes.TaskReasonSchedule{}))
+}
+
+func TestEventEntity(t *testing.T) {
+	t.Run("vm takes precedence and yields moid+name", func(t *testing.T) {
+		moid, name := eventEntity(&vmwaretypes.Event{
+			Vm: &vmwaretypes.VmEventArgument{
+				EntityEventArgument: vmwaretypes.EntityEventArgument{Name: "web-01"},
+				Vm:                  vmwaretypes.ManagedObjectReference{Type: "VirtualMachine", Value: "vm-42"},
+			},
+		})
+		assert.Equal(t, "web-01", name)
+		assert.Contains(t, moid, "vm-42")
+	})
+
+	t.Run("host entity", func(t *testing.T) {
+		moid, name := eventEntity(&vmwaretypes.Event{
+			Host: &vmwaretypes.HostEventArgument{
+				EntityEventArgument: vmwaretypes.EntityEventArgument{Name: "esxi-1"},
+				Host:                vmwaretypes.ManagedObjectReference{Type: "HostSystem", Value: "host-9"},
+			},
+		})
+		assert.Equal(t, "esxi-1", name)
+		assert.Contains(t, moid, "host-9")
+	})
+
+	t.Run("entity-less event (e.g. session login) yields empty", func(t *testing.T) {
+		moid, name := eventEntity(&vmwaretypes.Event{})
+		assert.Equal(t, "", moid)
+		assert.Equal(t, "", name)
+	})
+}

--- a/providers/vsphere/resources/vsphere.go
+++ b/providers/vsphere/resources/vsphere.go
@@ -72,6 +72,14 @@ func (v *mqlVsphere) ssoLockoutPolicy() (*mqlVsphereSsoLockoutPolicy, error) {
 	conn := v.MqlRuntime.Connection.(*connection.VsphereConnection)
 	ctx := context.Background()
 
+	// SSO is a vCenter-only service; on a direct ESXi connection there is no
+	// SSO admin endpoint, so degrade to null rather than failing every policy
+	// that touches this field on a mixed fleet.
+	if !conn.Client().IsVC() {
+		v.SsoLockoutPolicy.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	admin, err := conn.SsoAdminClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to SSO admin: %w", err)
@@ -196,9 +204,15 @@ func (v *mqlVsphere) roles() ([]any, error) {
 	mqlRoles := make([]any, len(rolesList))
 	for i, r := range rolesList {
 		var label, summary string
-		if d := r.Info.GetDescription(); d != nil {
-			label = d.Label
-			summary = d.Summary
+		// r.Info is a BaseDescription interface with no omitempty tag; an
+		// absent element decodes to a nil interface, and calling a method on
+		// it would panic (and crash the whole scan, since blocks run in
+		// goroutines). Guard the interface before dereferencing it.
+		if r.Info != nil {
+			if d := r.Info.GetDescription(); d != nil {
+				label = d.Label
+				summary = d.Summary
+			}
 		}
 		mqlRole, err := CreateResource(v.MqlRuntime, "vsphere.role", map[string]*llx.RawData{
 			"roleId":     llx.IntData(int64(r.RoleId)),
@@ -314,6 +328,12 @@ func (v *mqlVsphere) folders() ([]any, error) {
 func (v *mqlVsphere) identitySources() ([]any, error) {
 	conn := v.MqlRuntime.Connection.(*connection.VsphereConnection)
 	ctx := context.Background()
+
+	// Identity sources live in vCenter SSO; a direct ESXi connection has none,
+	// so return an empty list rather than erroring the query on a mixed fleet.
+	if !conn.Client().IsVC() {
+		return []any{}, nil
+	}
 
 	admin, err := conn.SsoAdminClient(ctx)
 	if err != nil {

--- a/providers/vsphere/resources/vsphere.lr.go
+++ b/providers/vsphere/resources/vsphere.lr.go
@@ -5891,7 +5891,12 @@ func createVulnPackage(runtime *plugin.Runtime, args map[string]*llx.RawData) (p
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("vuln.package", res.__id)

--- a/providers/vsphere/resources/vulnmgmt.go
+++ b/providers/vsphere/resources/vulnmgmt.go
@@ -269,3 +269,11 @@ func (a *mqlVulnAdvisory) id() (string, error) {
 func (c *mqlVulnCve) id() (string, error) {
 	return c.Id.Data, c.Id.Error
 }
+
+// id keys each package by name+version. Without it every vuln.package would
+// share the empty cache key "vuln.package\x00" and collapse onto the first
+// package created (see mql CreateResource caching), so vulnmgmt.packages would
+// report that one package once per row.
+func (p *mqlVulnPackage) id() (string, error) {
+	return p.Name.Data + "-" + p.Version.Data, p.Name.Error
+}

--- a/providers/vsphere/resources/vulnmgmt.go
+++ b/providers/vsphere/resources/vulnmgmt.go
@@ -275,5 +275,11 @@ func (c *mqlVulnCve) id() (string, error) {
 // package created (see mql CreateResource caching), so vulnmgmt.packages would
 // report that one package once per row.
 func (p *mqlVulnPackage) id() (string, error) {
-	return p.Name.Data + "-" + p.Version.Data, p.Name.Error
+	if err := p.Name.Error; err != nil {
+		return "", err
+	}
+	if err := p.Version.Error; err != nil {
+		return "", err
+	}
+	return p.Name.Data + "-" + p.Version.Data, nil
 }

--- a/providers/vsphere/resources/vulnmgmt_test.go
+++ b/providers/vsphere/resources/vulnmgmt_test.go
@@ -40,3 +40,29 @@ func TestVulnmgmtSoftFailsWhenReportUnavailable(t *testing.T) {
 
 	assert.True(t, v.warnedUnavailable)
 }
+
+func TestVulnPackageID(t *testing.T) {
+	// Every vuln.package must produce a distinct, stable __id from its name and
+	// version. Without this id() method they would all share the empty cache
+	// key and collapse onto the first package (see the id() doc comment).
+	pkg := func(name, version string) *mqlVulnPackage {
+		return &mqlVulnPackage{
+			Name:    plugin.TValue[string]{Data: name, State: plugin.StateIsSet},
+			Version: plugin.TValue[string]{Data: version, State: plugin.StateIsSet},
+		}
+	}
+
+	id, err := pkg("openssl", "1.1.1k").id()
+	require.NoError(t, err)
+	assert.Equal(t, "openssl-1.1.1k", id)
+
+	// distinct packages must not collide
+	other, err := pkg("glibc", "2.34").id()
+	require.NoError(t, err)
+	assert.NotEqual(t, id, other)
+
+	// same name, different version stays distinct
+	v1, _ := pkg("kernel", "5.10.1").id()
+	v2, _ := pkg("kernel", "5.10.2").id()
+	assert.NotEqual(t, v1, v2)
+}


### PR DESCRIPTION
## Summary

Static bug-review fixes across the `vsphere` provider. No `.lr` schema changes (no version bump); every fix is Go-only plus new unit tests for the pure-Go logic where these bugs lived.

## Fixes (severity-ranked)

**1 — HIGH: `AdvancedSettings()` returned nondeterministic wrong data.** esxcli emits *both* the integer and the string variant of the value/default columns for every ESXi advanced setting, with the inapplicable variant present but empty. The old parse loop wrote both variants to the same struct field inside a `for k := range val` over a Go map, so randomized iteration order decided the winner — `Default`/`Value` (and the derived `Overridden()`) came back empty or correct differently between scans for integer-typed settings. Now disambiguated on the `Type` column via a pure `buildAdvancedSetting` helper.

**2 — HIGH: every `vuln.package` collided on an empty `__id`.** `mqlVulnPackage` had no `id()` method and none was passed, so all packages shared cache key `vuln.package\x00` and collapsed onto the first one — `vulnmgmt.packages` reported that one package once per row (on upstream-platform-connected scans). Added the `name+version` `id()`, matching the `os` provider this was copied from.

**3 — MEDIUM: `vsphere.host.vib` `__id` aliased across hosts.** It keyed on the bare VIB ID, which is identical on every host of the same ESXi build, so per-host `installDate`/`status` were clobbered by the first host on a vCenter. Now host-scoped via `InventoryPath`, like every sibling host sub-resource.

**4 — MEDIUM: one bad VIB date sank the whole host package list.** `time.Parse` on an empty/missing date errored the entire `packages()` accessor. Now degrades that one field to null via a tolerant `parseVibDate` helper.

**5 — LOW: `roles()` could panic the scan.** `r.Info` is a `BaseDescription` interface with no `omitempty`; an absent element is a nil interface and calling a method on it panics (crashing the scan, since blocks run in goroutines). Guarded.

**6 — LOW: degrade SSO/tag accessors instead of hard-failing.** `ssoLockoutPolicy`/`identitySources` are vCenter-only; they now return null/empty on direct-ESXi connections instead of erroring on a mixed fleet. `tagRefs` degrades to an empty list when the vAPI is unreachable, matching the best-effort `BatchGetTags` contract its string sibling (`.tags`) already uses.

**7 — LOW: `firewallRulesets`/`iscsiAdapters` `__id` fallback.** They now fall back to the host moid when `InventoryPath` is unset, so their sub-resource ids can never collapse to `/...` and alias across hosts.

## Tests

Added unit tests for pure-Go logic that previously had none and where the bugs lived: `buildAdvancedSetting` (runs 200x to prove determinism), `parseVibDate`, `vuln.package` `id()`, `classifyIdentifyingInfo`, and the `tasks.go` scheduler/action/user/entity mappers.

```
ok  go.mondoo.com/mql/v13/providers/vsphere/resources
ok  go.mondoo.com/mql/v13/providers/vsphere/resources/resourceclient
```

## Verification

`go build ./...`, `go vet ./resources/...`, and `go test ./resources/...` all pass. Findings #3/#4 (multi-host VIB aliasing, empty VIB dates) are worth a follow-up live check against a real multi-host vCenter, but the code paths are fixed unconditionally.
