### PR TITLE
🐛 llx: guard nil field in WatchAndUpdate callback (#9349)

### DIFF
--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -842,9 +842,15 @@ func runResourceFunction(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint
 
 	// watch this field in the resource
 	err := e.ctx.runtime.WatchAndUpdate(rr, chunk.Id, wid, func(fieldData any, fieldError error) {
+		// A field can be missing from the schema when the compiled bundle and
+		// the loaded provider disagree (e.g. the provider was updated at runtime
+		// independently of the bundle version). Fall back to Unset rather than
+		// crash, but log it so the schema mismatch stays observable.
 		fieldType := types.Unset
 		if field := resource.Fields[chunk.Id]; field != nil {
 			fieldType = types.Type(field.Type)
+		} else {
+			log.Warn().Str("resource", rr.MqlName()).Str("field", chunk.Id).Msg("exec> field missing from schema in WatchAndUpdate callback")
 		}
 		data := &RawData{
 			Type:  fieldType,

--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -842,8 +842,12 @@ func runResourceFunction(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint
 
 	// watch this field in the resource
 	err := e.ctx.runtime.WatchAndUpdate(rr, chunk.Id, wid, func(fieldData any, fieldError error) {
+		fieldType := types.Unset
+		if field := resource.Fields[chunk.Id]; field != nil {
+			fieldType = types.Type(field.Type)
+		}
 		data := &RawData{
-			Type:  types.Type(resource.Fields[chunk.Id].Type),
+			Type:  fieldType,
 			Value: fieldData,
 			Error: fieldError,
 		}


### PR DESCRIPTION
## Summary

Fixes #9349.

`runResourceFunction` in `llx/builtin.go` panicked with a nil-pointer dereference in the `WatchAndUpdate` callback closure. The callback built a `RawData` using `types.Type(resource.Fields[chunk.Id].Type)` without checking whether the field exists in the resource schema. `resource.Fields` is a map — a missing `chunk.Id` returns a nil `*Field`, and `.Type` on it segfaults, aborting the entire scan.

This is reachable when a compiled query bundle watches a field name that the running provider's schema doesn't define (a bundle/provider schema mismatch, e.g. when the provider is updated at runtime independently of the version the bundle was compiled against).

The error path of the same function already guards this exact expression against nil; the success/callback path just missed the check.

## Fix

Mirror the existing nil-guard, falling back to `types.Unset`:

```go
fieldType := types.Unset
if field := resource.Fields[chunk.Id]; field != nil {
    fieldType = types.Type(field.Type)
}
```

A missing field now yields a graceful `Unset`-typed result instead of crashing the process.

## Testing

- `go build ./llx/` ✅
- `go test ./llx/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)