### PR TITLE
🐛 vllm: guard endpoint init against non-string method + null model created time

### DIFF
--- a/providers/vllm/connection/connection.go
+++ b/providers/vllm/connection/connection.go
@@ -485,6 +485,30 @@ func ObservationAnonymousAccessible(obs EndpointObservation) (bool, bool) {
 	}
 }
 
+// CategoryAnonymousAccessible aggregates the anonymous-access verdict across all
+// observations in a functional category. It returns (true, true) as soon as any
+// endpoint in the category is anonymously accessible; otherwise it returns
+// (false, true) when at least one endpoint had a known verdict, and
+// (false, false) when every endpoint in the category was unknown (so the caller
+// can report null rather than a misleading "not exposed").
+func CategoryAnonymousAccessible(observations []EndpointObservation, category string) (bool, bool) {
+	known := false
+	for _, obs := range observations {
+		if obs.Spec.Category != category {
+			continue
+		}
+		accessible, ok := ObservationAnonymousAccessible(obs)
+		if !ok {
+			continue
+		}
+		known = true
+		if accessible {
+			return true, true
+		}
+	}
+	return false, known
+}
+
 func ObservationRequiresAuth(obs EndpointObservation) (bool, bool) {
 	if obs.AnonymousStatusCode == nil || *obs.AnonymousStatusCode == http.StatusNotFound || *obs.AnonymousStatusCode >= 500 {
 		return false, false

--- a/providers/vllm/connection/helpers_test.go
+++ b/providers/vllm/connection/helpers_test.go
@@ -1,0 +1,207 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "adds default scheme", raw: "example.com:8000", want: "http://example.com:8000"},
+		{name: "keeps https", raw: "https://example.com", want: "https://example.com"},
+		{name: "trims trailing slash", raw: "https://example.com/base/", want: "https://example.com/base"},
+		{name: "strips query and fragment", raw: "http://example.com/p?token=secret#frag", want: "http://example.com/p"},
+		{name: "trims surrounding whitespace", raw: "  http://example.com  ", want: "http://example.com"},
+		{name: "rejects unsupported scheme", raw: "ftp://example.com", wantErr: true},
+		{name: "rejects missing host", raw: "http://", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeBaseURL(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeBaseURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBaseURLFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    *inventory.Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "base-url option wins and is normalized",
+			conf: &inventory.Config{Options: map[string]string{OptionBaseURL: "https://vllm.example/api/"}},
+			want: "https://vllm.example/api",
+		},
+		{
+			name: "builds from host, port, scheme and path",
+			conf: &inventory.Config{Host: "example.com", Port: 8000, Runtime: "https", Path: "/api"},
+			want: "https://example.com:8000/api",
+		},
+		{
+			name: "defaults scheme to http when runtime empty",
+			conf: &inventory.Config{Host: "example.com", Port: 8000},
+			want: "http://example.com:8000",
+		},
+		{
+			name:    "missing host is an error",
+			conf:    &inventory.Config{Runtime: "https"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := baseURLFromConfig(tt.conf)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("baseURLFromConfig = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIKeyFromConfig(t *testing.T) {
+	t.Run("reads from environment", func(t *testing.T) {
+		t.Setenv("VLLM_API_KEY", "env-key")
+		if got := apiKeyFromConfig(&inventory.Config{}); got != "env-key" {
+			t.Fatalf("got %q, want env-key", got)
+		}
+	})
+
+	t.Run("option overrides environment", func(t *testing.T) {
+		t.Setenv("VLLM_API_KEY", "env-key")
+		conf := &inventory.Config{Options: map[string]string{OptionAPIKey: "option-key"}}
+		if got := apiKeyFromConfig(conf); got != "option-key" {
+			t.Fatalf("got %q, want option-key", got)
+		}
+	})
+
+	t.Run("password credential overrides option", func(t *testing.T) {
+		t.Setenv("VLLM_API_KEY", "env-key")
+		conf := &inventory.Config{
+			Options:     map[string]string{OptionAPIKey: "option-key"},
+			Credentials: []*vault.Credential{vault.NewPasswordCredential("", "cred-key")},
+		}
+		if got := apiKeyFromConfig(conf); got != "cred-key" {
+			t.Fatalf("got %q, want cred-key", got)
+		}
+	})
+
+	t.Run("trims surrounding whitespace", func(t *testing.T) {
+		t.Setenv("VLLM_API_KEY", "  spaced-key  ")
+		if got := apiKeyFromConfig(&inventory.Config{}); got != "spaced-key" {
+			t.Fatalf("got %q, want spaced-key", got)
+		}
+	})
+
+	t.Run("empty when nothing configured", func(t *testing.T) {
+		t.Setenv("VLLM_API_KEY", "")
+		if got := apiKeyFromConfig(&inventory.Config{}); got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestCategoryAnonymousAccessible(t *testing.T) {
+	obs := func(category string, status *int) EndpointObservation {
+		return EndpointObservation{Spec: EndpointSpec{Category: category}, AnonymousStatusCode: status}
+	}
+
+	tests := []struct {
+		name           string
+		observations   []EndpointObservation
+		category       string
+		wantAccessible bool
+		wantKnown      bool
+	}{
+		{
+			name: "any accessible endpoint wins",
+			observations: []EndpointObservation{
+				obs("development", intPtr(404)),
+				obs("development", intPtr(200)),
+			},
+			category:       "development",
+			wantAccessible: true,
+			wantKnown:      true,
+		},
+		{
+			name: "all known but not accessible",
+			observations: []EndpointObservation{
+				obs("development", intPtr(401)),
+				obs("development", intPtr(403)),
+			},
+			category:       "development",
+			wantAccessible: false,
+			wantKnown:      true,
+		},
+		{
+			name: "all unknown reports not known",
+			observations: []EndpointObservation{
+				obs("development", intPtr(500)),
+				obs("development", nil),
+			},
+			category:       "development",
+			wantAccessible: false,
+			wantKnown:      false,
+		},
+		{
+			name: "ignores other categories",
+			observations: []EndpointObservation{
+				obs("profiler", intPtr(200)),
+			},
+			category:       "development",
+			wantAccessible: false,
+			wantKnown:      false,
+		},
+		{
+			name:           "no observations",
+			observations:   nil,
+			category:       "development",
+			wantAccessible: false,
+			wantKnown:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessible, known := CategoryAnonymousAccessible(tt.observations, tt.category)
+			if accessible != tt.wantAccessible || known != tt.wantKnown {
+				t.Fatalf("CategoryAnonymousAccessible = (%v, %v), want (%v, %v)",
+					accessible, known, tt.wantAccessible, tt.wantKnown)
+			}
+		})
+	}
+}

--- a/providers/vllm/resources/vllm.go
+++ b/providers/vllm/resources/vllm.go
@@ -111,7 +111,7 @@ func (r *mqlVllm) models() ([]any, error) {
 			"root":        llx.StringData(c.Root),
 			"parent":      llx.StringData(c.Parent),
 			"maxModelLen": llx.IntData(c.MaxModelLen),
-			"created":     llx.TimeData(time.Unix(c.Created, 0)),
+			"created":     llx.TimeDataPtr(modelCreatedTime(c.Created)),
 			"ownedBy":     llx.StringData(c.OwnedBy),
 		})
 		if err != nil {
@@ -121,6 +121,17 @@ func (r *mqlVllm) models() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// modelCreatedTime converts a vLLM model card's Unix creation timestamp into a
+// time pointer, returning nil when the server did not report one (a zero value)
+// so the field resolves to null instead of the Unix epoch.
+func modelCreatedTime(unix int64) *time.Time {
+	if unix <= 0 {
+		return nil
+	}
+	t := time.Unix(unix, 0)
+	return &t
 }
 
 func (r *mqlVllmModel) id() (string, error) {
@@ -283,7 +294,12 @@ func initVllmEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		args["method"] = llx.StringData(http.MethodGet)
 	}
 	if method, ok := args["method"]; ok {
-		args["method"] = llx.StringData(strings.ToUpper(method.Value.(string)))
+		raw, isString := method.Value.(string)
+		if !isString || raw == "" {
+			args["method"] = llx.StringData(http.MethodGet)
+		} else {
+			args["method"] = llx.StringData(strings.ToUpper(raw))
+		}
 	}
 	return args, nil, nil
 }
@@ -454,21 +470,8 @@ func categoryAnonymousAccessibleKnown(runtime *plugin.Runtime, category string) 
 	if err != nil {
 		return false, false, err
 	}
-	knownCount := 0
-	for _, obs := range observations {
-		if obs.Spec.Category != category {
-			continue
-		}
-		accessible, known := connection.ObservationAnonymousAccessible(obs)
-		if !known {
-			continue
-		}
-		knownCount++
-		if accessible {
-			return true, true, nil
-		}
-	}
-	return false, knownCount > 0, nil
+	accessible, known := connection.CategoryAnonymousAccessible(observations, category)
+	return accessible, known, nil
 }
 
 func endpointObservation(runtime *plugin.Runtime, method string, path string) (connection.EndpointObservation, error) {

--- a/providers/vllm/resources/vllm_test.go
+++ b/providers/vllm/resources/vllm_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers/vllm/connection"
+)
+
+func TestModelCreatedTime(t *testing.T) {
+	tests := []struct {
+		name string
+		unix int64
+		want *time.Time
+	}{
+		{name: "zero is null", unix: 0, want: nil},
+		{name: "negative is null", unix: -1, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modelCreatedTime(tt.unix); got != tt.want {
+				t.Fatalf("modelCreatedTime(%d) = %v, want %v", tt.unix, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("positive returns unix time", func(t *testing.T) {
+		got := modelCreatedTime(1700000000)
+		if got == nil {
+			t.Fatal("expected non-nil time")
+		}
+		if !got.Equal(time.Unix(1700000000, 0)) {
+			t.Fatalf("modelCreatedTime = %v, want %v", got, time.Unix(1700000000, 0))
+		}
+	})
+}
+
+func TestInitVllmEndpoint(t *testing.T) {
+	t.Run("requires path", func(t *testing.T) {
+		_, _, err := initVllmEndpoint(nil, map[string]*llx.RawData{})
+		if err == nil {
+			t.Fatal("expected error when path is missing")
+		}
+	})
+
+	t.Run("defaults method to GET", func(t *testing.T) {
+		args, _, err := initVllmEndpoint(nil, map[string]*llx.RawData{
+			"path": llx.StringData("/docs"),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := args["method"].Value.(string); got != http.MethodGet {
+			t.Fatalf("method = %q, want GET", got)
+		}
+	})
+
+	t.Run("uppercases method", func(t *testing.T) {
+		args, _, err := initVllmEndpoint(nil, map[string]*llx.RawData{
+			"path":   llx.StringData("/v1/models"),
+			"method": llx.StringData("get"),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := args["method"].Value.(string); got != http.MethodGet {
+			t.Fatalf("method = %q, want GET", got)
+		}
+	})
+
+	// Regression: a null (non-string) method arg must not panic on the
+	// type assertion, and should fall back to GET.
+	t.Run("null method falls back to GET without panicking", func(t *testing.T) {
+		args, _, err := initVllmEndpoint(nil, map[string]*llx.RawData{
+			"path":   llx.StringData("/docs"),
+			"method": llx.NilData,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := args["method"].Value.(string); got != http.MethodGet {
+			t.Fatalf("method = %q, want GET", got)
+		}
+	})
+}
+
+func TestEndpointSpecFor(t *testing.T) {
+	t.Run("known spec keeps its category", func(t *testing.T) {
+		spec := endpointSpecFor(http.MethodGet, "/docs")
+		if spec.Category != "documentation" {
+			t.Fatalf("category = %q, want documentation", spec.Category)
+		}
+		if spec.Body != "" {
+			t.Fatalf("body = %q, want empty", spec.Body)
+		}
+	})
+
+	t.Run("lowercase method matches known spec", func(t *testing.T) {
+		spec := endpointSpecFor("get", "/docs")
+		if spec.Method != http.MethodGet || spec.Category != "documentation" {
+			t.Fatalf("spec = %+v, want GET/documentation", spec)
+		}
+	})
+
+	t.Run("unknown GET is a custom spec without body", func(t *testing.T) {
+		spec := endpointSpecFor(http.MethodGet, "/private/route")
+		if spec.Category != "custom" {
+			t.Fatalf("category = %q, want custom", spec.Category)
+		}
+		if spec.Body != "" {
+			t.Fatalf("body = %q, want empty", spec.Body)
+		}
+	})
+
+	t.Run("unknown POST is a custom spec with body", func(t *testing.T) {
+		spec := endpointSpecFor(http.MethodPost, "/private/route")
+		if spec.Category != "custom" {
+			t.Fatalf("category = %q, want custom", spec.Category)
+		}
+		if spec.Body != connection.NewPostBody() {
+			t.Fatalf("body = %q, want %q", spec.Body, connection.NewPostBody())
+		}
+	})
+}


### PR DESCRIPTION
## What

Fixes two defects surfaced by a static bug review of the `vllm` provider and expands unit-test coverage of its pure-Go logic. Go-only; no schema changes (no codegen, no `.lr.versions` bump).

### Fixes

**1. Panic on a non-string `method` arg in `vllm.endpoint` init**
`initVllmEndpoint` used a bare `method.Value.(string)` assertion. `vllm.endpoint(path: "/x", method: null)` sets `method.Value == nil`, so the assertion panicked in the init goroutine. Now guarded with comma-ok, falling back to `GET` on a missing/empty/non-string method.

**2. `vllm.model.created` reported the Unix epoch instead of null**
`time.Unix(c.Created, 0)` turned a model card with no creation timestamp (`Created == 0`) into `1970-01-01T00:00:00Z`. It now resolves to null via a small `modelCreatedTime` helper, so audits can tell "unknown" from a real date.

### Test coverage

The category-exposure aggregation behind `devEndpointsExposed`/`profilerEndpointsExposed` was extracted into a pure `connection.CategoryAnonymousAccessible` helper so it can be unit-tested without HTTP. New table tests cover the previously-untested pure-Go logic where a wrong-data bug would hide:

- `normalizeBaseURL`, `baseURLFromConfig`, `apiKeyFromConfig` (env/option/credential precedence)
- `CategoryAnonymousAccessible` (any-accessible-wins, all-known-not-accessible, all-unknown, category filtering)
- `modelCreatedTime`, `endpointSpecFor`
- `initVllmEndpoint`, including a regression test for the null-method panic

## Test plan

- `go test ./connection/... ./resources/... ./provider/...` — all green
- `go vet ./...` clean, `gofmt` applied
