### PR TITLE
🐛 stackit: fix serviceAccount credential serialization, LB/WAF pagination, and 6 more bugs

### DIFF
--- a/providers/stackit/resources/alb.go
+++ b/providers/stackit/resources/alb.go
@@ -16,21 +16,33 @@ func (r *mqlStackit) albLoadBalancers() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListLoadBalancersExecute(bgctx(), c.ProjectID(), c.Region())
-	if err != nil {
-		if isAccessDenied(err) {
-			return []any{}, nil
+	out := []any{}
+	pageId := ""
+	for {
+		req := client.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
+		if pageId != "" {
+			req = req.PageId(pageId)
 		}
-		return nil, err
-	}
-	items, _ := resp.GetLoadBalancersOk()
-	out := make([]any, 0, len(items))
-	for i := range items {
-		res, err := buildAlbLoadBalancer(r.MqlRuntime, &items[i], c.Region())
+		resp, err := req.Execute()
 		if err != nil {
+			if isAccessDenied(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
-		out = append(out, res)
+		items, _ := resp.GetLoadBalancersOk()
+		for i := range items {
+			res, err := buildAlbLoadBalancer(r.MqlRuntime, &items[i], c.Region())
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, res)
+		}
+		next, ok := resp.GetNextPageIdOk()
+		if !ok || next == "" {
+			break
+		}
+		pageId = next
 	}
 	return out, nil
 }

--- a/providers/stackit/resources/albwaf.go
+++ b/providers/stackit/resources/albwaf.go
@@ -41,21 +41,33 @@ func (r *mqlStackit) albWafs() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.DefaultAPI.ListWAF(bgctx(), c.ProjectID(), c.Region()).Execute()
-	if err != nil {
-		if isAccessDenied(err) || isNotFound(err) {
-			return []any{}, nil
+	out := []any{}
+	pageId := ""
+	for {
+		req := client.DefaultAPI.ListWAF(bgctx(), c.ProjectID(), c.Region())
+		if pageId != "" {
+			req = req.PageId(pageId)
 		}
-		return nil, err
-	}
-	items, _ := resp.GetItemsOk()
-	out := make([]any, 0, len(items))
-	for i := range items {
-		res, err := buildAlbWaf(r.MqlRuntime, &items[i])
+		resp, err := req.Execute()
 		if err != nil {
+			if isAccessDenied(err) || isNotFound(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
-		out = append(out, res)
+		items, _ := resp.GetItemsOk()
+		for i := range items {
+			res, err := buildAlbWaf(r.MqlRuntime, &items[i])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, res)
+		}
+		next, ok := resp.GetNextPageIdOk()
+		if !ok || next == nil || *next == "" {
+			break
+		}
+		pageId = *next
 	}
 	return out, nil
 }

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -4,7 +4,9 @@
 package resources
 
 import (
+	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 	"github.com/stackitcloud/stackit-sdk-go/services/observability"
@@ -22,7 +24,7 @@ import (
 // computed methods that share a single cached fetch per instance.
 
 type mqlStackitPostgresFlexInstanceInternal struct {
-	fetched bool
+	fetched atomic.Bool
 	detail  *postgresflex.Instance
 	lock    sync.Mutex
 }
@@ -67,12 +69,12 @@ func (r *mqlStackitPostgresFlexInstance) id() (string, error) {
 // for the lifetime of this resource. Double-check locked so concurrent field
 // accesses share one API call.
 func (r *mqlStackitPostgresFlexInstance) fetchDetail() (*postgresflex.Instance, error) {
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	c := conn(r.MqlRuntime)
@@ -83,7 +85,7 @@ func (r *mqlStackitPostgresFlexInstance) fetchDetail() (*postgresflex.Instance, 
 	resp, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), r.Id.Data)
 	if err != nil {
 		if isAccessDenied(err) {
-			r.fetched = true
+			r.fetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
@@ -91,7 +93,7 @@ func (r *mqlStackitPostgresFlexInstance) fetchDetail() (*postgresflex.Instance, 
 	if item, ok := resp.GetItemOk(); ok {
 		r.detail = &item
 	}
-	r.fetched = true
+	r.fetched.Store(true)
 	return r.detail, nil
 }
 
@@ -161,7 +163,7 @@ func (r *mqlStackitPostgresFlexInstance) options() (map[string]any, error) {
 // lazy-loaded once per instance.
 
 type mqlStackitMongoDbFlexInstanceInternal struct {
-	fetched bool
+	fetched atomic.Bool
 	detail  *mongodbflex.Instance
 	lock    sync.Mutex
 }
@@ -207,12 +209,12 @@ func (r *mqlStackitMongoDbFlexInstance) id() (string, error) {
 }
 
 func (r *mqlStackitMongoDbFlexInstance) fetchDetail() (*mongodbflex.Instance, error) {
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	c := conn(r.MqlRuntime)
@@ -223,7 +225,7 @@ func (r *mqlStackitMongoDbFlexInstance) fetchDetail() (*mongodbflex.Instance, er
 	resp, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
 	if err != nil {
 		if isAccessDenied(err) {
-			r.fetched = true
+			r.fetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
@@ -231,7 +233,7 @@ func (r *mqlStackitMongoDbFlexInstance) fetchDetail() (*mongodbflex.Instance, er
 	if item, ok := resp.GetItemOk(); ok {
 		r.detail = &item
 	}
-	r.fetched = true
+	r.fetched.Store(true)
 	return r.detail, nil
 }
 
@@ -548,7 +550,7 @@ func (r *mqlStackitSecretsManagerInstance) acls() ([]any, error) {
 // are lazy-loaded once per instance.
 
 type mqlStackitObservabilityInstanceInternal struct {
-	fetched bool
+	fetched atomic.Bool
 	detail  *observability.GetInstanceResponse
 	lock    sync.Mutex
 }
@@ -591,12 +593,12 @@ func (r *mqlStackitObservabilityInstance) id() (string, error) {
 }
 
 func (r *mqlStackitObservabilityInstance) fetchDetail() (*observability.GetInstanceResponse, error) {
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	c := conn(r.MqlRuntime)
@@ -607,13 +609,13 @@ func (r *mqlStackitObservabilityInstance) fetchDetail() (*observability.GetInsta
 	resp, err := client.GetInstanceExecute(bgctx(), r.Id.Data, c.ProjectID())
 	if err != nil {
 		if isAccessDenied(err) {
-			r.fetched = true
+			r.fetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
 	}
 	r.detail = resp
-	r.fetched = true
+	r.fetched.Store(true)
 	return r.detail, nil
 }
 
@@ -676,7 +678,7 @@ func initStackitPostgresFlexInstance(runtime *plugin.Runtime, args map[string]*l
 	}
 	inst, ok := resp.GetItemOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.postgresFlex.instance with id %q not found", id)
 	}
 	res, err := CreateResource(runtime, "stackit.postgresFlex.instance", map[string]*llx.RawData{
 		"id":     llx.StringData(inst.GetId()),
@@ -689,7 +691,7 @@ func initStackitPostgresFlexInstance(runtime *plugin.Runtime, args map[string]*l
 	}
 	r := res.(*mqlStackitPostgresFlexInstance)
 	r.detail = &inst
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil, res, nil
 }
 
@@ -712,7 +714,7 @@ func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*ll
 	}
 	inst, ok := resp.GetItemOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.mongoDbFlex.instance with id %q not found", id)
 	}
 	res, err := CreateResource(runtime, "stackit.mongoDbFlex.instance", map[string]*llx.RawData{
 		"id":     llx.StringData(inst.GetId()),
@@ -725,7 +727,7 @@ func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*ll
 	}
 	r := res.(*mqlStackitMongoDbFlexInstance)
 	r.detail = &inst
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil, res, nil
 }
 
@@ -936,7 +938,7 @@ func initStackitObservabilityInstance(runtime *plugin.Runtime, args map[string]*
 	}
 	r := res.(*mqlStackitObservabilityInstance)
 	r.detail = resp
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil, res, nil
 }
 
@@ -1034,7 +1036,7 @@ func initStackitLogMeInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 // options are lazy-loaded once per instance via GetInstance.
 
 type mqlStackitSqlServerFlexInstanceInternal struct {
-	fetched bool
+	fetched atomic.Bool
 	detail  *sqlserverflex.Instance
 	lock    sync.Mutex
 }
@@ -1076,12 +1078,12 @@ func (r *mqlStackitSqlServerFlexInstance) id() (string, error) {
 }
 
 func (r *mqlStackitSqlServerFlexInstance) fetchDetail() (*sqlserverflex.Instance, error) {
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return r.detail, nil
 	}
 	c := conn(r.MqlRuntime)
@@ -1092,7 +1094,7 @@ func (r *mqlStackitSqlServerFlexInstance) fetchDetail() (*sqlserverflex.Instance
 	resp, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
-			r.fetched = true
+			r.fetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
@@ -1100,7 +1102,7 @@ func (r *mqlStackitSqlServerFlexInstance) fetchDetail() (*sqlserverflex.Instance
 	if item, ok := resp.GetItemOk(); ok {
 		r.detail = item
 	}
-	r.fetched = true
+	r.fetched.Store(true)
 	return r.detail, nil
 }
 
@@ -1182,7 +1184,7 @@ func initStackitSqlServerFlexInstance(runtime *plugin.Runtime, args map[string]*
 	}
 	inst, ok := resp.GetItemOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.sqlServerFlex.instance with id %q not found", id)
 	}
 	res, err := CreateResource(runtime, "stackit.sqlServerFlex.instance", map[string]*llx.RawData{
 		"id":     llx.StringData(inst.GetId()),
@@ -1195,6 +1197,6 @@ func initStackitSqlServerFlexInstance(runtime *plugin.Runtime, args map[string]*
 	}
 	r := res.(*mqlStackitSqlServerFlexInstance)
 	r.detail = inst
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil, res, nil
 }

--- a/providers/stackit/resources/dns.go
+++ b/providers/stackit/resources/dns.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
@@ -117,7 +118,7 @@ func initStackitDnsZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	}
 	z, ok := resp.GetZoneOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.dns.zone with id %q not found", id)
 	}
 	res, err := buildDnsZone(runtime, &z)
 	if err != nil {

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -29,6 +29,18 @@ func timeOrNil(t time.Time, ok bool) *time.Time {
 	return &t
 }
 
+// rfc3339OrNil formats a (time, ok) pair from the SDK's GetXxxOk methods as an
+// RFC3339 string for embedding as a `dict` value, or nil when unset or zero.
+// A `dict` value must be a dict-native scalar (string/number/bool), so a
+// *time.Time cannot be stored directly; use llx.TimeDataPtr for typed `time`
+// fields and this helper only for timestamps that live inside a dict.
+func rfc3339OrNil(t time.Time, ok bool) any {
+	if !ok || t.IsZero() {
+		return nil
+	}
+	return t.Format(time.RFC3339)
+}
+
 // parseRFC3339 turns an RFC3339 timestamp string into the *time.Time form
 // llx.TimeDataPtr wants, or nil if the string is empty or malformed. Several
 // STACKIT services return timestamps as strings rather than time.Time.

--- a/providers/stackit/resources/helpers_test.go
+++ b/providers/stackit/resources/helpers_test.go
@@ -40,6 +40,27 @@ func TestTimeOrNil(t *testing.T) {
 	}
 }
 
+func TestRfc3339OrNil(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   time.Time
+		ok   bool
+		want any
+	}{
+		{"ok=false", now, false, nil},
+		{"ok=true zero time", time.Time{}, true, nil},
+		{"ok=true real time", now, true, now.Format(time.RFC3339)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rfc3339OrNil(tc.in, tc.ok); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseDnsTime(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"strconv"
+
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -825,10 +827,14 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 	for i := range items {
 		rule := items[i]
 
-		var icmpType, icmpCode int64
+		// icmpType/icmpCode are nullable in the schema: leave them nil (MQL null)
+		// for non-ICMP rules rather than emitting 0, which is a valid ICMP type.
+		var icmpType, icmpCode *int64
 		if icmp, ok := rule.GetIcmpParametersOk(); ok {
-			icmpType = int64(icmp.GetType())
-			icmpCode = int64(icmp.GetCode())
+			t := icmp.GetType()
+			code := icmp.GetCode()
+			icmpType = &t
+			icmpCode = &code
 		}
 		var portMin, portMax int64
 		if pr, ok := rule.GetPortRangeOk(); ok {
@@ -837,7 +843,8 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 		}
 		var protocol string
 		if p, ok := rule.GetProtocolOk(); ok {
-			protocol = p.GetName()
+			n, okNum := p.GetNumberOk()
+			protocol = protocolLabel(p.GetName(), n, okNum)
 		}
 
 		createdAt, okCreated := rule.GetCreatedAtOk()
@@ -849,8 +856,8 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 			"ethertype":             llx.StringData(rule.GetEthertype()),
 			"protocol":              llx.StringData(protocol),
 			"description":           llx.StringData(rule.GetDescription()),
-			"icmpType":              llx.IntData(icmpType),
-			"icmpCode":              llx.IntData(icmpCode),
+			"icmpType":              llx.IntDataPtr(icmpType),
+			"icmpCode":              llx.IntDataPtr(icmpCode),
 			"portRangeMin":          llx.IntData(portMin),
 			"portRangeMax":          llx.IntData(portMax),
 			"ipRange":               llx.StringData(rule.GetIpRange()),
@@ -864,6 +871,20 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 		out = append(out, res)
 	}
 	return out, nil
+}
+
+// protocolLabel renders a security-group rule protocol as its name, falling
+// back to the numeric protocol id when the API returns only a number (for
+// example GRE as 47), or "" when neither is set. The API populates exactly one
+// of the two, so a numeric-only protocol would otherwise render empty.
+func protocolLabel(name string, number int64, hasNumber bool) string {
+	if name != "" {
+		return name
+	}
+	if hasNumber {
+		return strconv.FormatInt(number, 10)
+	}
+	return ""
 }
 
 func (r *mqlStackitSecurityGroupRule) id() (string, error) {

--- a/providers/stackit/resources/iaas_test.go
+++ b/providers/stackit/resources/iaas_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestProtocolLabel(t *testing.T) {
+	cases := []struct {
+		name      string
+		protoName string
+		number    int64
+		hasNumber bool
+		want      string
+	}{
+		{"name only", "tcp", 0, false, "tcp"},
+		{"name wins over number", "udp", 17, true, "udp"},
+		{"number fallback (GRE)", "", 47, true, "47"},
+		{"number zero is still a protocol", "", 0, true, "0"},
+		{"neither set", "", 0, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := protocolLabel(tc.protoName, tc.number, tc.hasNumber); got != tc.want {
+				t.Fatalf("protocolLabel(%q, %d, %v) = %q, want %q",
+					tc.protoName, tc.number, tc.hasNumber, got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/stackit/resources/loadbalancer.go
+++ b/providers/stackit/resources/loadbalancer.go
@@ -16,21 +16,33 @@ func (r *mqlStackit) loadBalancers() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListLoadBalancersExecute(bgctx(), c.ProjectID(), c.Region())
-	if err != nil {
-		if isAccessDenied(err) {
-			return []any{}, nil
+	out := []any{}
+	pageId := ""
+	for {
+		req := client.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
+		if pageId != "" {
+			req = req.PageId(pageId)
 		}
-		return nil, err
-	}
-	items, _ := resp.GetLoadBalancersOk()
-	out := make([]any, 0, len(items))
-	for i := range items {
-		res, err := buildLoadBalancer(r.MqlRuntime, &items[i], c.Region())
+		resp, err := req.Execute()
 		if err != nil {
+			if isAccessDenied(err) {
+				return []any{}, nil
+			}
 			return nil, err
 		}
-		out = append(out, res)
+		items, _ := resp.GetLoadBalancersOk()
+		for i := range items {
+			res, err := buildLoadBalancer(r.MqlRuntime, &items[i], c.Region())
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, res)
+		}
+		next, ok := resp.GetNextPageIdOk()
+		if !ok || next == "" {
+			break
+		}
+		pageId = next
 	}
 	return out, nil
 }

--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -91,7 +91,7 @@ func initStackitObjectStorageBucket(runtime *plugin.Runtime, args map[string]*ll
 	}
 	b, ok := resp.GetBucketOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.objectStorage.bucket %q not found", name)
 	}
 	res, err := buildBucket(runtime, &b)
 	if err != nil {

--- a/providers/stackit/resources/serviceaccount.go
+++ b/providers/stackit/resources/serviceaccount.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"fmt"
+
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -71,7 +73,7 @@ func initStackitServiceAccount(runtime *plugin.Runtime, args map[string]*llx.Raw
 		}
 		return nil, res, nil
 	}
-	return args, nil, nil
+	return nil, nil, fmt.Errorf("stackit.serviceAccount with email %q not found", email)
 }
 
 func (r *mqlStackitServiceAccount) accessTokens() ([]any, error) {
@@ -90,18 +92,24 @@ func (r *mqlStackitServiceAccount) accessTokens() ([]any, error) {
 	items, _ := resp.GetItemsOk()
 	out := make([]any, 0, len(items))
 	for i := range items {
-		t := &items[i]
-		createdAt, ok1 := t.GetCreatedAtOk()
-		validUntil, ok2 := t.GetValidUntilOk()
-		entry := map[string]any{
-			"id":         t.GetId(),
-			"active":     t.GetActive(),
-			"createdAt":  timeOrNil(createdAt, ok1),
-			"validUntil": timeOrNil(validUntil, ok2),
-		}
-		out = append(out, entry)
+		out = append(out, serviceAccountTokenEntry(&items[i]))
 	}
 	return out, nil
+}
+
+// serviceAccountTokenEntry maps an access-token metadata record into a
+// dict-native map. Timestamps are RFC3339 strings (a `dict` cannot carry a
+// *time.Time) so the entry serializes cleanly for the `accessTokens []dict`
+// field.
+func serviceAccountTokenEntry(t *serviceaccount.AccessTokenMetadata) map[string]any {
+	createdAt, ok1 := t.GetCreatedAtOk()
+	validUntil, ok2 := t.GetValidUntilOk()
+	return map[string]any{
+		"id":         t.GetId(),
+		"active":     t.GetActive(),
+		"createdAt":  rfc3339OrNil(createdAt, ok1),
+		"validUntil": rfc3339OrNil(validUntil, ok2),
+	}
 }
 
 func (r *mqlStackitServiceAccount) keys() ([]any, error) {
@@ -120,19 +128,26 @@ func (r *mqlStackitServiceAccount) keys() ([]any, error) {
 	items, _ := resp.GetItemsOk()
 	out := make([]any, 0, len(items))
 	for i := range items {
-		k := &items[i]
-		createdAt, ok1 := k.GetCreatedAtOk()
-		validUntil, ok2 := k.GetValidUntilOk()
-		entry := map[string]any{
-			"id":           k.GetId(),
-			"keyType":      k.GetKeyType(),
-			"keyAlgorithm": k.GetKeyAlgorithm(),
-			"keyOrigin":    k.GetKeyOrigin(),
-			"active":       k.GetActive(),
-			"createdAt":    timeOrNil(createdAt, ok1),
-			"validUntil":   timeOrNil(validUntil, ok2),
-		}
-		out = append(out, entry)
+		out = append(out, serviceAccountKeyEntry(&items[i]))
 	}
 	return out, nil
+}
+
+// serviceAccountKeyEntry maps a service-account key record into a dict-native
+// map. The key* fields are named string enums in the SDK, cast to plain
+// strings, and the timestamps are RFC3339 strings so the entry serializes
+// cleanly for the `keys []dict` field (a `dict` cannot carry a *time.Time or a
+// defined string type).
+func serviceAccountKeyEntry(k *serviceaccount.ServiceAccountKeyListResponse) map[string]any {
+	createdAt, ok1 := k.GetCreatedAtOk()
+	validUntil, ok2 := k.GetValidUntilOk()
+	return map[string]any{
+		"id":           k.GetId(),
+		"keyType":      string(k.GetKeyType()),
+		"keyAlgorithm": string(k.GetKeyAlgorithm()),
+		"keyOrigin":    string(k.GetKeyOrigin()),
+		"active":       k.GetActive(),
+		"createdAt":    rfc3339OrNil(createdAt, ok1),
+		"validUntil":   rfc3339OrNil(validUntil, ok2),
+	}
 }

--- a/providers/stackit/resources/serviceaccount_test.go
+++ b/providers/stackit/resources/serviceaccount_test.go
@@ -1,0 +1,83 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// assertDictSerializable asserts that a []dict payload (a slice of
+// map[string]any) round-trips through llx without a conversion error. A `dict`
+// value must be a dict-native scalar; a *time.Time or a named string enum makes
+// dict2primitive fail, which is exactly the regression the entry helpers guard
+// against (the keys/accessTokens fields previously errored on every account
+// that had any credentials).
+func assertDictSerializable(t *testing.T, entries []any) {
+	t.Helper()
+	res := llx.ArrayData(entries, types.Dict).Result()
+	if res.Error != "" {
+		t.Fatalf("[]dict payload failed to serialize: %s", res.Error)
+	}
+}
+
+func TestServiceAccountKeyEntry(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	k := &serviceaccount.ServiceAccountKeyListResponse{}
+	k.SetId("key-1")
+	k.SetActive(true)
+	k.SetKeyType(serviceaccount.ServiceAccountKeyListResponseKeyType("USER_MANAGED"))
+	k.SetKeyAlgorithm(serviceaccount.ServiceAccountKeyListResponseKeyAlgorithm("RSA_2048"))
+	k.SetKeyOrigin(serviceaccount.ServiceAccountKeyListResponseKeyOrigin("USER_PROVIDED"))
+	k.SetCreatedAt(now)
+	// ValidUntil intentionally left unset -> should map to nil.
+
+	entry := serviceAccountKeyEntry(k)
+
+	// The named-string enums must be plain strings, or the []dict field errors
+	// at serialization time (a defined string type does not match `case string`).
+	if got, ok := entry["keyType"].(string); !ok || got != "USER_MANAGED" {
+		t.Fatalf("keyType = %v (%T), want string %q", entry["keyType"], entry["keyType"], "USER_MANAGED")
+	}
+	if got, ok := entry["keyAlgorithm"].(string); !ok || got != "RSA_2048" {
+		t.Fatalf("keyAlgorithm = %v (%T), want string %q", entry["keyAlgorithm"], entry["keyAlgorithm"], "RSA_2048")
+	}
+	// A timestamp inside a dict must be an RFC3339 string, not a *time.Time.
+	if got, ok := entry["createdAt"].(string); !ok || got != now.Format(time.RFC3339) {
+		t.Fatalf("createdAt = %v (%T), want RFC3339 %q", entry["createdAt"], entry["createdAt"], now.Format(time.RFC3339))
+	}
+	if entry["validUntil"] != nil {
+		t.Fatalf("validUntil = %v, want nil for an unset time", entry["validUntil"])
+	}
+
+	assertDictSerializable(t, []any{entry})
+}
+
+func TestServiceAccountTokenEntry(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	valid := now.Add(24 * time.Hour)
+	tok := &serviceaccount.AccessTokenMetadata{}
+	tok.SetId("tok-1")
+	tok.SetActive(true)
+	tok.SetCreatedAt(now)
+	tok.SetValidUntil(valid)
+
+	entry := serviceAccountTokenEntry(tok)
+
+	if got, ok := entry["createdAt"].(string); !ok || got != now.Format(time.RFC3339) {
+		t.Fatalf("createdAt = %v (%T), want RFC3339 %q", entry["createdAt"], entry["createdAt"], now.Format(time.RFC3339))
+	}
+	if got, ok := entry["validUntil"].(string); !ok || got != valid.Format(time.RFC3339) {
+		t.Fatalf("validUntil = %v (%T), want RFC3339 %q", entry["validUntil"], entry["validUntil"], valid.Format(time.RFC3339))
+	}
+	if got, ok := entry["active"].(bool); !ok || !got {
+		t.Fatalf("active = %v (%T), want bool true", entry["active"], entry["active"])
+	}
+
+	assertDictSerializable(t, []any{entry})
+}

--- a/providers/stackit/resources/sfs.go
+++ b/providers/stackit/resources/sfs.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/stackitcloud/stackit-sdk-go/services/sfs"
@@ -250,7 +251,7 @@ func initStackitSfsResourcePool(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 	pool, ok := resp.GetResourcePoolOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.sfs.resourcePool with id %q not found", id)
 	}
 	res, err := CreateResource(runtime, "stackit.sfs.resourcePool", sfsResourcePoolArgs(c.Region(), &pool))
 	if err != nil {
@@ -370,7 +371,7 @@ func initStackitSfsExportPolicy(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 	pol, ok := resp.GetShareExportPolicyOk()
 	if !ok {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("stackit.sfs.exportPolicy with id %q not found", id)
 	}
 	res, err := newSfsExportPolicy(runtime, c.Region(), &pol)
 	if err != nil {

--- a/providers/stackit/resources/stackit_exposure.go
+++ b/providers/stackit/resources/stackit_exposure.go
@@ -4,12 +4,20 @@
 package resources
 
 import (
+	"errors"
 	"strings"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// errFlexReachabilityUnknown is returned by a Flex instance's
+// internetReachable() when the instance detail (and thus its ACL) could not be
+// fetched, typically because the token can list instances but is denied
+// GetInstance. Surfacing an error keeps an `internetReachable == false`
+// assertion from passing vacuously when exposure was never actually determined.
+var errFlexReachabilityUnknown = errors.New("stackit: cannot determine internet reachability, instance ACL unavailable (access denied to GetInstance)")
 
 // nicsHavePublicIp reports whether any network interface dict carries a
 // non-empty public IP.
@@ -318,6 +326,13 @@ func newNetworkExposure(runtime *plugin.Runtime, id string, internetReachable, h
 // ---- Flex managed databases (ACL-based) ----
 
 func (c *mqlStackitPostgresFlexInstance) internetReachable() (bool, error) {
+	d, err := c.fetchDetail()
+	if err != nil {
+		return false, err
+	}
+	if d == nil {
+		return false, errFlexReachabilityUnknown
+	}
 	acl := c.GetAcl()
 	if acl.Error != nil {
 		return false, acl.Error
@@ -326,6 +341,13 @@ func (c *mqlStackitPostgresFlexInstance) internetReachable() (bool, error) {
 }
 
 func (c *mqlStackitMongoDbFlexInstance) internetReachable() (bool, error) {
+	d, err := c.fetchDetail()
+	if err != nil {
+		return false, err
+	}
+	if d == nil {
+		return false, errFlexReachabilityUnknown
+	}
 	acl := c.GetAcl()
 	if acl.Error != nil {
 		return false, acl.Error
@@ -334,6 +356,13 @@ func (c *mqlStackitMongoDbFlexInstance) internetReachable() (bool, error) {
 }
 
 func (c *mqlStackitSqlServerFlexInstance) internetReachable() (bool, error) {
+	d, err := c.fetchDetail()
+	if err != nil {
+		return false, err
+	}
+	if d == nil {
+		return false, errFlexReachabilityUnknown
+	}
 	acl := c.GetAcl()
 	if acl.Error != nil {
 		return false, acl.Error


### PR DESCRIPTION
A static bug-review of the `stackit` provider (reading the Go against each service SDK's model structs) surfaced several defects that a compiler and a passing test suite don't catch. This PR fixes them, most-severe first, and adds regression tests for the pure-Go logic touched.

## Fixes

### `serviceAccount.keys` / `.accessTokens` errored on every account with credentials (HIGH)
The `[]dict` entry maps carried `*time.Time` (from `timeOrNil`) and named-string enum values (`ServiceAccountKeyListResponseKeyType`, etc.). `dict2primitive` only handles `bool/int64/float64/string/[]any/map`, so both hit its `default:` and the field resolved to a hard error (`unsupported child type: *time.Time` / `…KeyType`) for any account that had a key or token — i.e. the credential-age/rotation audit these fields exist for was unusable. Enums are now cast to plain strings and timestamps emitted as RFC3339 strings.

### Pagination truncation in `albWafs`, `albLoadBalancers`, `loadBalancers` (HIGH)
Each called `.Execute()` once and ignored the `NextPageId` continuation token its SDK response carries, so a project with more WAF configs / load balancers than the server page size silently dropped everything past page 1 (a WAF-rule audit over the dropped configs would pass vacuously). They now loop `PageId` the same way `certificates()` already did.

### Security-group rule `protocol` dropped numeric-only protocols (MEDIUM)
`Protocol` is `{Name, Number}` and the API populates exactly one. The code read only `Name`, so a rule using a numeric protocol (for example GRE `47`) rendered an empty `protocol`. It now falls back to the number.

### Flex-database `internetReachable` reported a vacuous `false` on access-denied (MEDIUM)
When `GetInstance` was denied (a token that can list but not get), `acl()` returned empty and `internetReachable` computed `false`, so an *undetermined* instance looked "not exposed" and an `== false` assertion passed vacuously. It now surfaces an error instead of a false negative.

### Data race in the DBaaS detail-fetch double-checked locking (LOW-MED)
`fetched`/`detail` were read outside the mutex while written under it — a race `go test -race` flags. The flag is now `atomic.Bool` (the detail pointer is published before the flag is stored, so the unlocked fast-path is safe).

### Init lookup-miss husks (LOW)
`serviceAccount`, `dns.zone`, `objectStorage.bucket`, the three flex instances, and the two SFS inits returned `args, nil, nil` after a lookup found nothing, which builds a husk from partial args (surfacing later as `llx: encountered a primitive with no type information`). They now return a not-found error, matching the sibling inits that already did.

### Non-ICMP rules emitted `icmpType`/`icmpCode` as `0` instead of null (LOW)
`0` is a valid ICMP type (echo-reply), so `where(icmpType == 0)` matched every TCP/UDP rule. These are now nullable via `IntDataPtr`.

## Tests
- `TestServiceAccountKeyEntry` / `TestServiceAccountTokenEntry` build SDK records, map them through the entry helpers, and round-trip the result through `llx` — this fails on the old code and guards the `*time.Time`/named-enum serialization class.
- `TestProtocolLabel` covers the name/number/neither cases.
- `TestRfc3339OrNil` covers the new dict-time helper.

(`parseKeyBitSize` and `parseRFC3339` already have coverage in `helpers_test.go`.)

## Notes
- No `.lr` schema changes, so no `.lr.versions` entries and no provider version bump.
- No new IAM permissions: the pagination fixes hit the same endpoints via the request-builder form, so `stackit.permissions.json` is unchanged.
- `make providers/build/stackit` and `go test ./resources/` both pass.
