### PR TITLE
🐛 ipmi: fix BCD firmware/version decode, boot-options panic, and 2 more

### DIFF
--- a/providers/ipmi/connection/client/decode.go
+++ b/providers/ipmi/connection/client/decode.go
@@ -3,6 +3,8 @@
 
 package client
 
+import "fmt"
+
 // Pure bit decoders for IPMI response bytes, kept separate so they can be
 // unit tested without an IPMI transport. Bit layouts come from IPMI 2.0
 // §20.1 (Get Device ID), §28.2 (Get Chassis Status), and §28.13 (Get System
@@ -12,6 +14,21 @@ package client
 // bits in id1, high 4 bits in the low nibble of id2.
 func decodeManufacturerID(id1 uint16, id2 uint8) OemVendorID {
 	return OemVendorID(uint32(id1) | (uint32(id2)&0x0F)<<16)
+}
+
+// decodeFirmwareRevision formats the BMC firmware revision per §20.1. The
+// major revision is the low 7 bits of byte 1 (binary encoded); the minor
+// revision (byte 2) is BCD encoded, so it is rendered with %x to print its
+// decimal digits (BCD 0x10 -> "10", not the "16" that %d would produce).
+func decodeFirmwareRevision(rev1, rev2 uint8) string {
+	return fmt.Sprintf("%d.%02x", rev1&0x7F, rev2)
+}
+
+// decodeIPMIVersion decodes the BCD-encoded IPMI version byte (§20.1): the
+// major version is the low nibble and the minor version the high nibble, so
+// 0x02 -> "2.0" and 0x51 -> "1.5".
+func decodeIPMIVersion(b uint8) string {
+	return fmt.Sprintf("%d.%d", b&0x0F, (b>>4)&0x0F)
 }
 
 func decodePowerRestorePolicy(powerState uint8) string {

--- a/providers/ipmi/connection/client/decode_test.go
+++ b/providers/ipmi/connection/client/decode_test.go
@@ -34,6 +34,46 @@ func TestDecodeManufacturerID(t *testing.T) {
 	}
 }
 
+func TestDecodeFirmwareRevision(t *testing.T) {
+	// Regression test for the bug where the BCD-encoded minor revision was
+	// printed with %d, so firmware "1.10" rendered as "1.16".
+	tests := []struct {
+		name string
+		rev1 uint8
+		rev2 uint8
+		want string
+	}{
+		{"single-digit minor", 9, 0x08, "9.08"},
+		{"BCD minor 10", 1, 0x10, "1.10"},
+		{"BCD minor 23", 2, 0x23, "2.23"},
+		{"BCD minor 99", 3, 0x99, "3.99"},
+		// The device-available bit (byte 1 bit 7) must not leak into the major.
+		{"major masks bit 7", 0x89, 0x01, "9.01"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, decodeFirmwareRevision(tt.rev1, tt.rev2))
+		})
+	}
+}
+
+func TestDecodeIPMIVersion(t *testing.T) {
+	// Regression test for the bug where the raw BCD byte was cast to an int,
+	// so IPMI 1.5 (0x51) reported as 81.
+	tests := []struct {
+		b    uint8
+		want string
+	}{
+		{0x02, "2.0"},
+		{0x51, "1.5"},
+		{0x20, "0.2"},
+		{0x00, "0.0"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, decodeIPMIVersion(tt.b), "b=0x%02X", tt.b)
+	}
+}
+
 func TestDecodePowerRestorePolicy(t *testing.T) {
 	tests := []struct {
 		powerState uint8

--- a/providers/ipmi/connection/client/ipmi.go
+++ b/providers/ipmi/connection/client/ipmi.go
@@ -84,7 +84,7 @@ type DeviceID struct {
 	ProvidesDeviceSDRs      bool                    `json:"providesDeviceSDRs"`
 	DeviceAvailable         bool                    `json:"deviceAvailable"`
 	FirmwareRevision        string                  `json:"firmwareRevision"`
-	IpmiVersion             int64                   `json:"ipmiVersion"`
+	IpmiVersion             string                  `json:"ipmiVersion"`
 	ManufacturerID          int64                   `json:"manufacturerID"`
 	ManufacturerName        string                  `json:"manufacturerName"`
 	ProductID               int64                   `json:"productID"`
@@ -132,11 +132,11 @@ func (c *IpmiClient) DeviceID() (*DeviceID, error) {
 
 	return &DeviceID{
 		DeviceID:           int64(res.DeviceID),
-		DeviceRevision:     int64(res.DeviceRevision & 0x07), // only the last 3 bits 00000111
+		DeviceRevision:     int64(res.DeviceRevision & 0x0F), // §20.1: revision is the low 4 bits
 		ProvidesDeviceSDRs: res.DeviceRevision&0x80 != 0,
 		DeviceAvailable:    res.FirmwareRevision1&0x80 == 0, // 0 - normal operation, 1 - firmware
-		FirmwareRevision:   fmt.Sprintf("%d.%02d", res.FirmwareRevision1&0x7F, res.FirmwareRevision2),
-		IpmiVersion:        int64(res.IPMIVersion),
+		FirmwareRevision:   decodeFirmwareRevision(res.FirmwareRevision1, res.FirmwareRevision2),
+		IpmiVersion:        decodeIPMIVersion(res.IPMIVersion),
 		ManufacturerID:     int64(manufactor),
 		ManufacturerName:   manufactor.String(),
 		ProductID:          int64(product),
@@ -256,6 +256,13 @@ func (c *IpmiClient) ChassisSystemBootOptions() (*ChassisSystemBootOptions, erro
 	err := c.Client.Send(req, res)
 	if err != nil {
 		return nil, err
+	}
+	// The boot-flags parameter carries 5 data bytes (§28.13). The transport
+	// does not enforce that length on the response, so a BMC that returns a
+	// success completion code with a short payload would otherwise panic the
+	// index accesses below (and BootDeviceSelector, which reads Data[1]).
+	if len(res.Data) < 5 {
+		return nil, fmt.Errorf("ipmi: short boot options response, expected 5 data bytes, got %d", len(res.Data))
 	}
 	return &ChassisSystemBootOptions{
 		ParameterVersion:       int64(res.Version),

--- a/providers/ipmi/connection/client/ipmi_test.go
+++ b/providers/ipmi/connection/client/ipmi_test.go
@@ -28,7 +28,7 @@ func TestIpmiDockerSimulator(t *testing.T) {
 		ProvidesDeviceSDRs: false,
 		DeviceAvailable:    true,
 		FirmwareRevision:   "9.08",
-		IpmiVersion:        int64(2),
+		IpmiVersion:        "2.0",
 		ManufacturerID:     int64(4753),
 		ManufacturerName:   "Unknown",
 		ProductID:          int64(3842),

--- a/providers/ipmi/connection/connection.go
+++ b/providers/ipmi/connection/connection.go
@@ -5,6 +5,7 @@ package connection
 
 import (
 	"errors"
+	"sync"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -17,8 +18,9 @@ type IpmiConnection struct {
 	Conf  *inventory.Config
 	asset *inventory.Asset
 	//  custom connection fields
-	client *impi_client.IpmiClient
-	guid   string
+	client   *impi_client.IpmiClient
+	guidLock sync.Mutex
+	guid     string
 }
 
 func NewIpmiConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*IpmiConnection, error) {
@@ -85,6 +87,9 @@ func (c *IpmiConnection) Identifier() (string, error) {
 }
 
 func (c *IpmiConnection) Guid() (string, error) {
+	c.guidLock.Lock()
+	defer c.guidLock.Unlock()
+
 	if c.guid != "" {
 		return c.guid, nil
 	}


### PR DESCRIPTION
## What

Static bug-review of the `ipmi` provider surfaced several defects in the hand-rolled IPMI wire-byte decoding. These are the kind of bugs a compiler and a passing test suite miss: wrong data returned with no error. The provider's integration test (`ipmi_test.go`) is gated behind a `debugtest` build tag and needs a live simulator, so none of these were exercised in CI.

## Fixes

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | High | Firmware **minor** revision is BCD encoded (§20.1) but was printed with `%d`, so firmware `1.10` rendered as `1.16`, `2.23` as `2.35`, etc. | Format the BCD byte with `%x` (matches `ipmitool`). |
| 2 | Med-High | `ChassisSystemBootOptions` indexed `res.Data[0..3]` (and `BootDeviceSelector()`, which reads `Data[1]`) with no length guard. The transport does not enforce the 5-byte boot-flags payload on a *response*, so a BMC returning a success completion code with a short payload would **panic the provider subprocess** for that host. | Guard `len(res.Data) >= 5` and return an error otherwise. |
| 3 | Medium | The IPMI version byte is BCD (major = low nibble, minor = high nibble) but was cast raw to an int, so IPMI 1.5 (`0x51`) reported as `81`. IPMI 2.0 (`0x02`) coincidentally read as `2`, which hid the bug. | Decode to a `"major.minor"` string (`"2.0"`, `"1.5"`). |
| 4 | Low | Device revision is the low 4 bits `[3:0]` (§20.1) but was masked with `0x07`, dropping revisions 8-15. | Mask with `0x0F`. |
| 5 | Low | `Guid()` lazily populated an unlocked cache field. | Guard with a mutex. |

Fix #3 changes the value shape of the `ipmiVersion` key inside the `ipmi.deviceID` dict (number to string). This is not an `.lr` schema field, so there is no codegen or `.lr.versions` change, but a policy keying on the old numeric value would be affected. The old value was wrong for IPMI 1.5 devices and a raw byte otherwise, so the change is intentional.

## Tests

Extracted the firmware/version decoding into pure helpers in `decode.go` (the byte-assembly functions in `ipmi.go` call the transport and were previously untestable in CI) and added table-driven regression tests, including the `1.10`-renders-as-`1.16` and `1.5`-renders-as-`81` cases.

- `go build ./...` — clean
- `go test ./connection/...` — pass
- `go vet -tags debugtest ./connection/client/` — compiles (only pre-existing unkeyed-`Request`-literal warnings remain)

## Left as-is (documented, not bugs)

- `productName` always returns `"Unknown"` (the OEM product table is empty) and the GUID uses only 6 of the 16 bytes — both are honest, pre-existing limitations acknowledged by in-code TODOs, and `productID` / the partial GUID are stable.
- `BIOSMuxControlOverride` masks 2 bits where the field is arguably 3; this only affects reserved values (4-7), never the three defined ones, so decode behavior was left unchanged.
