### PR TITLE
🐛 hetzner: fix dict field serialization + discovery nil-map panic

### DIFF
--- a/providers/hetzner/resources/discovery.go
+++ b/providers/hetzner/resources/discovery.go
@@ -27,8 +27,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	assets := []*inventory.Asset{}
 
 	childAsset := func(platform *inventory.Platform, platformID, name, optKey, optVal string) *inventory.Asset {
-		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(c.ID()))
-		cfg.Options[optKey] = optVal
+		cfg := childConfig(conf, c.ID(), optKey, optVal)
 		return &inventory.Asset{
 			PlatformIds: []string{platformID},
 			Name:        name,
@@ -74,6 +73,19 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 	}
 
 	return &inventory.Inventory{Spec: &inventory.InventorySpec{Assets: assets}}, nil
+}
+
+// childConfig clones the connected asset's config for a discovered child asset,
+// stamping the child's discriminating option. Config.Clone leaves Options nil
+// when the source config had no options (an inventory-file or env-token asset
+// that omits them), so guard before writing to avoid a nil-map assignment panic.
+func childConfig(conf *inventory.Config, parentID uint32, optKey, optVal string) *inventory.Config {
+	cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(parentID))
+	if cfg.Options == nil {
+		cfg.Options = map[string]string{}
+	}
+	cfg.Options[optKey] = optVal
+	return cfg
 }
 
 // resolveDiscoveryTargets expands the "auto"/"all" aliases into the full

--- a/providers/hetzner/resources/discovery_test.go
+++ b/providers/hetzner/resources/discovery_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers/hetzner/connection"
+)
+
+func TestChildConfig(t *testing.T) {
+	// Regression: an inventory-file or env-token asset can arrive with a nil
+	// Options map. Config.Clone leaves it nil, so writing the discriminating
+	// option must not panic on a nil-map assignment.
+	t.Run("nil Options does not panic", func(t *testing.T) {
+		conf := &inventory.Config{Type: "hetzner", Options: nil}
+		var cfg *inventory.Config
+		require.NotPanics(t, func() {
+			cfg = childConfig(conf, 1, connection.OptionFirewall, "42")
+		})
+		require.NotNil(t, cfg.Options)
+		assert.Equal(t, "42", cfg.Options[connection.OptionFirewall])
+	})
+
+	t.Run("existing Options are preserved", func(t *testing.T) {
+		conf := &inventory.Config{
+			Type:    "hetzner",
+			Options: map[string]string{connection.OPTION_ENDPOINT: "https://example.test"},
+		}
+		cfg := childConfig(conf, 1, connection.OptionLoadBalancer, "7")
+		assert.Equal(t, "https://example.test", cfg.Options[connection.OPTION_ENDPOINT])
+		assert.Equal(t, "7", cfg.Options[connection.OptionLoadBalancer])
+		// The clone must not mutate the source config's Options.
+		assert.NotContains(t, conf.Options, connection.OptionLoadBalancer)
+	})
+}

--- a/providers/hetzner/resources/helpers.go
+++ b/providers/hetzner/resources/helpers.go
@@ -154,6 +154,25 @@ func timePtrUnix0(t time.Time) *time.Time {
 	return &t
 }
 
+// deprecationDict renders an hcloud DeprecationInfo as a dict with RFC3339
+// timestamp strings. Times are formatted to strings because the dict-to-
+// primitive converter only accepts bool/int64/float64/string/[]any/map values;
+// a raw time.Time would fail serialization when the field is queried. Returns an
+// empty dict when the resource is not deprecated.
+func deprecationDict(d *hcloud.DeprecationInfo) map[string]any {
+	out := map[string]any{}
+	if d == nil {
+		return out
+	}
+	if !d.Announced.IsZero() {
+		out["announced"] = d.Announced.Format(time.RFC3339)
+	}
+	if !d.UnavailableAfter.IsZero() {
+		out["unavailableAfter"] = d.UnavailableAfter.Format(time.RFC3339)
+	}
+	return out
+}
+
 func dnsPtrSliceFromMap(m map[string]string) []any {
 	if len(m) == 0 {
 		return []any{}

--- a/providers/hetzner/resources/hetzner_dict_serialization_test.go
+++ b/providers/hetzner/resources/hetzner_dict_serialization_test.go
@@ -1,0 +1,117 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// requireDictSerializes runs a dict through the exact llx conversion path a
+// queried `dict` field takes. The dict-to-primitive converter only accepts
+// bool/int64/float64/string/[]any/map[string]any; a raw `int` or `time.Time`
+// errors here, which is how the load balancer health-check and deprecation
+// dicts silently broke. This is the regression guard for those bugs.
+func requireDictSerializes(t *testing.T, d map[string]any) {
+	t.Helper()
+	res := llx.DictData(d).Result()
+	require.Empty(t, res.Error, "dict must serialize through the llx dict converter")
+}
+
+// requireDictArraySerializes is requireDictSerializes for a `[]dict` field.
+func requireDictArraySerializes(t *testing.T, a []any) {
+	t.Helper()
+	res := llx.ArrayData(a, types.Dict).Result()
+	require.Empty(t, res.Error, "[]dict must serialize through the llx dict converter")
+}
+
+func TestDeprecationDict(t *testing.T) {
+	t.Run("nil is an empty dict and serializes", func(t *testing.T) {
+		d := deprecationDict(nil)
+		assert.Equal(t, map[string]any{}, d)
+		requireDictSerializes(t, d)
+	})
+
+	t.Run("deprecated uses RFC3339 strings and serializes", func(t *testing.T) {
+		announced := time.Date(2025, 9, 24, 12, 0, 0, 0, time.UTC)
+		unavailable := time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC)
+		d := deprecationDict(&hcloud.DeprecationInfo{
+			Announced:        announced,
+			UnavailableAfter: unavailable,
+		})
+		// Values must be strings, not time.Time — a time.Time fails serialization.
+		assert.Equal(t, "2025-09-24T12:00:00Z", d["announced"])
+		assert.Equal(t, "2026-03-24T12:00:00Z", d["unavailableAfter"])
+		requireDictSerializes(t, d)
+	})
+
+	t.Run("zero timestamps are omitted", func(t *testing.T) {
+		d := deprecationDict(&hcloud.DeprecationInfo{})
+		assert.NotContains(t, d, "announced")
+		assert.NotContains(t, d, "unavailableAfter")
+		requireDictSerializes(t, d)
+	})
+}
+
+func TestLoadBalancerHealthCheckDict(t *testing.T) {
+	t.Run("tcp check widens int ports and serializes", func(t *testing.T) {
+		d := loadBalancerHealthCheckDict(hcloud.LoadBalancerServiceHealthCheck{
+			Protocol: hcloud.LoadBalancerServiceProtocolTCP,
+			Port:     80,
+			Interval: 15 * time.Second,
+			Timeout:  10 * time.Second,
+			Retries:  3,
+		})
+		// Port and Retries are hcloud `int` — must be widened to int64 to serialize.
+		assert.Equal(t, int64(80), d["port"])
+		assert.Equal(t, int64(3), d["retries"])
+		assert.Equal(t, float64(15), d["interval"])
+		requireDictSerializes(t, d)
+	})
+
+	t.Run("http check with nested dict serializes", func(t *testing.T) {
+		d := loadBalancerHealthCheckDict(hcloud.LoadBalancerServiceHealthCheck{
+			Protocol: hcloud.LoadBalancerServiceProtocolHTTP,
+			Port:     443,
+			Interval: 15 * time.Second,
+			Timeout:  10 * time.Second,
+			Retries:  3,
+			HTTP: &hcloud.LoadBalancerServiceHealthCheckHTTP{
+				Domain:      "example.com",
+				Path:        "/health",
+				Response:    "OK",
+				StatusCodes: []string{"200", "201"},
+				TLS:         true,
+			},
+		})
+		requireDictSerializes(t, d)
+	})
+}
+
+func TestLoadBalancerHealthStatusDicts(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		a := loadBalancerHealthStatusDicts(nil)
+		assert.Empty(t, a)
+		requireDictArraySerializes(t, a)
+	})
+
+	t.Run("widens int listenPort and serializes", func(t *testing.T) {
+		a := loadBalancerHealthStatusDicts([]hcloud.LoadBalancerTargetHealthStatus{
+			{ListenPort: 443, Status: hcloud.LoadBalancerTargetHealthStatusStatusHealthy},
+			{ListenPort: 80, Status: hcloud.LoadBalancerTargetHealthStatusStatusUnhealthy},
+		})
+		require.Len(t, a, 2)
+		first := a[0].(map[string]any)
+		// ListenPort is hcloud `int` — must be widened to int64 to serialize.
+		assert.Equal(t, int64(443), first["listenPort"])
+		assert.Equal(t, "healthy", first["status"])
+		requireDictArraySerializes(t, a)
+	})
+}

--- a/providers/hetzner/resources/hetzner_iso.go
+++ b/providers/hetzner/resources/hetzner_iso.go
@@ -35,11 +35,7 @@ func (h *mqlHetzner) isos() ([]any, error) {
 }
 
 func newMqlHetznerIso(runtime *plugin.Runtime, iso *hcloud.ISO) (*mqlHetznerIso, error) {
-	dep := map[string]any{}
-	if iso.Deprecation != nil {
-		dep["announced"] = iso.Deprecation.Announced
-		dep["unavailableAfter"] = iso.Deprecation.UnavailableAfter
-	}
+	dep := deprecationDict(iso.Deprecation)
 	arch := ""
 	if iso.Architecture != nil {
 		arch = string(*iso.Architecture)

--- a/providers/hetzner/resources/hetzner_loadbalancer.go
+++ b/providers/hetzner/resources/hetzner_loadbalancer.go
@@ -193,23 +193,32 @@ func (r *mqlHetznerLoadBalancerService) id() (string, error) {
 	return fmt.Sprintf("hetzner.loadBalancer/%d/service/%d", r.LoadBalancerId.Data, r.ListenPort.Data), nil
 }
 
-func newMqlHetznerLoadBalancerService(runtime *plugin.Runtime, lbID int64, s hcloud.LoadBalancerService) (*mqlHetznerLoadBalancerService, error) {
-	hc := map[string]any{
-		"protocol": string(s.HealthCheck.Protocol),
-		"port":     s.HealthCheck.Port,
-		"interval": s.HealthCheck.Interval.Seconds(),
-		"timeout":  s.HealthCheck.Timeout.Seconds(),
-		"retries":  s.HealthCheck.Retries,
+// loadBalancerHealthCheckDict renders a service health check as a dict. Port and
+// Retries are hcloud `int` fields, so they are widened to int64: the dict-to-
+// primitive converter only accepts int64 (a raw int fails serialization when the
+// healthCheck field is queried).
+func loadBalancerHealthCheckDict(hc hcloud.LoadBalancerServiceHealthCheck) map[string]any {
+	out := map[string]any{
+		"protocol": string(hc.Protocol),
+		"port":     int64(hc.Port),
+		"interval": hc.Interval.Seconds(),
+		"timeout":  hc.Timeout.Seconds(),
+		"retries":  int64(hc.Retries),
 	}
-	if s.HealthCheck.HTTP != nil {
-		hc["http"] = map[string]any{
-			"domain":      s.HealthCheck.HTTP.Domain,
-			"path":        s.HealthCheck.HTTP.Path,
-			"response":    s.HealthCheck.HTTP.Response,
-			"statusCodes": stringSlice(s.HealthCheck.HTTP.StatusCodes),
-			"tls":         s.HealthCheck.HTTP.TLS,
+	if hc.HTTP != nil {
+		out["http"] = map[string]any{
+			"domain":      hc.HTTP.Domain,
+			"path":        hc.HTTP.Path,
+			"response":    hc.HTTP.Response,
+			"statusCodes": stringSlice(hc.HTTP.StatusCodes),
+			"tls":         hc.HTTP.TLS,
 		}
 	}
+	return out
+}
+
+func newMqlHetznerLoadBalancerService(runtime *plugin.Runtime, lbID int64, s hcloud.LoadBalancerService) (*mqlHetznerLoadBalancerService, error) {
+	hc := loadBalancerHealthCheckDict(s.HealthCheck)
 
 	http := map[string]any{
 		"cookieName":     s.HTTP.CookieName,
@@ -274,14 +283,22 @@ func (r *mqlHetznerLoadBalancerTarget) id() (string, error) {
 	return fmt.Sprintf("hetzner.loadBalancer/%d/target/%s", r.LoadBalancerId.Data, key), nil
 }
 
-func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx int, t hcloud.LoadBalancerTarget) (*mqlHetznerLoadBalancerTarget, error) {
-	healthStatus := make([]any, 0, len(t.HealthStatus))
-	for _, hs := range t.HealthStatus {
-		healthStatus = append(healthStatus, map[string]any{
-			"listenPort": hs.ListenPort,
+// loadBalancerHealthStatusDicts renders a target's per-listener health status as
+// dicts. ListenPort is an hcloud `int`, widened to int64 so the healthStatus
+// []dict field serializes (a raw int fails the dict-to-primitive converter).
+func loadBalancerHealthStatusDicts(statuses []hcloud.LoadBalancerTargetHealthStatus) []any {
+	out := make([]any, 0, len(statuses))
+	for _, hs := range statuses {
+		out = append(out, map[string]any{
+			"listenPort": int64(hs.ListenPort),
 			"status":     string(hs.Status),
 		})
 	}
+	return out
+}
+
+func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx int, t hcloud.LoadBalancerTarget) (*mqlHetznerLoadBalancerTarget, error) {
+	healthStatus := loadBalancerHealthStatusDicts(t.HealthStatus)
 
 	labelSelector := ""
 	if t.LabelSelector != nil {

--- a/providers/hetzner/resources/hetzner_servertype.go
+++ b/providers/hetzner/resources/hetzner_servertype.go
@@ -83,11 +83,7 @@ func newMqlHetznerServerTypeLocation(runtime *plugin.Runtime, serverTypeID int64
 	if stl.Location != nil {
 		locationID = stl.Location.ID
 	}
-	dep := map[string]any{}
-	if stl.Deprecation != nil {
-		dep["announced"] = stl.Deprecation.Announced
-		dep["unavailableAfter"] = stl.Deprecation.UnavailableAfter
-	}
+	dep := deprecationDict(stl.Deprecation)
 	res, err := CreateResource(runtime, "hetzner.serverType.location", map[string]*llx.RawData{
 		"__id":         llx.StringData(fmt.Sprintf("hetzner.serverType.location/%d/%d", serverTypeID, locationID)),
 		"serverTypeId": llx.IntData(serverTypeID),

--- a/providers/hetzner/resources/hetzner_storagebox.go
+++ b/providers/hetzner/resources/hetzner_storagebox.go
@@ -162,7 +162,7 @@ func (m *mqlHetznerStorageBox) snapshots() ([]any, error) {
 }
 
 func (r *mqlHetznerStorageBoxSubaccount) id() (string, error) {
-	return fmt.Sprintf("hetzner.storageBox.subaccount/%d", r.Id.Data), nil
+	return fmt.Sprintf("hetzner.storageBox.subaccount/%d/%d", r.StorageBoxId.Data, r.Id.Data), nil
 }
 
 func newMqlHetznerStorageBoxSubaccount(runtime *plugin.Runtime, storageBoxID int64, sa *hcloud.StorageBoxSubaccount) (*mqlHetznerStorageBoxSubaccount, error) {
@@ -175,7 +175,7 @@ func newMqlHetznerStorageBoxSubaccount(runtime *plugin.Runtime, storageBoxID int
 		webdav = sa.AccessSettings.WebDAVEnabled
 	}
 	res, err := CreateResource(runtime, "hetzner.storageBox.subaccount", map[string]*llx.RawData{
-		"__id":                llx.StringData(fmt.Sprintf("hetzner.storageBox.subaccount/%d", sa.ID)),
+		"__id":                llx.StringData(fmt.Sprintf("hetzner.storageBox.subaccount/%d/%d", storageBoxID, sa.ID)),
 		"id":                  llx.IntData(sa.ID),
 		"storageBoxId":        llx.IntData(storageBoxID),
 		"name":                llx.StringData(sa.Name),
@@ -198,12 +198,12 @@ func newMqlHetznerStorageBoxSubaccount(runtime *plugin.Runtime, storageBoxID int
 }
 
 func (r *mqlHetznerStorageBoxSnapshot) id() (string, error) {
-	return fmt.Sprintf("hetzner.storageBox.snapshot/%d", r.Id.Data), nil
+	return fmt.Sprintf("hetzner.storageBox.snapshot/%d/%d", r.StorageBoxId.Data, r.Id.Data), nil
 }
 
 func newMqlHetznerStorageBoxSnapshot(runtime *plugin.Runtime, storageBoxID int64, sn *hcloud.StorageBoxSnapshot) (*mqlHetznerStorageBoxSnapshot, error) {
 	res, err := CreateResource(runtime, "hetzner.storageBox.snapshot", map[string]*llx.RawData{
-		"__id":           llx.StringData(fmt.Sprintf("hetzner.storageBox.snapshot/%d", sn.ID)),
+		"__id":           llx.StringData(fmt.Sprintf("hetzner.storageBox.snapshot/%d/%d", storageBoxID, sn.ID)),
 		"id":             llx.IntData(sn.ID),
 		"storageBoxId":   llx.IntData(storageBoxID),
 		"name":           llx.StringData(sn.Name),


### PR DESCRIPTION
Static bug review of the hetzner provider surfaced a cluster of defects that compiled cleanly and returned no error until a specific field was queried, then failed with wrong data or a crash.

## The bug class: non-serializable values in `dict` fields
The llx dict-to-primitive converter accepts only `bool/int64/float64/string/[]any/map[string]any`. A plain Go `int` or a `time.Time` in a dict hits the default branch and returns `"failed to convert dict to primitive, unsupported child type: …"` — **at query time**, not build time (verified with a runtime probe). Four sites hit this:

| Field | Bad value | Query that broke |
|---|---|---|
| `hetzner.loadBalancer.service.healthCheck` | `Port`, `Retries` (hcloud `int`) | `hetzner.loadBalancers { services { healthCheck } }` — every LB service has a health check |
| `hetzner.loadBalancer.target.healthStatus` | `ListenPort` (`int`) | `hetzner.loadBalancers { targets { healthStatus } }` |
| `hetzner.iso.deprecation` | `time.Time` | `hetzner.isos { deprecation }` — any deprecated ISO |
| `hetzner.serverType.location.deprecation` | `time.Time` | `hetzner.serverTypes { locations { deprecation } }` — any deprecated type |

The sibling builders (`hetzner_zone.go`, `hetzner_storagebox.go`) already convert `int64(...)`, so this was a missed-conversion oversight, not a convention. Fixed by widening the ints to `int64` and formatting the timestamps as RFC3339 strings via a new shared `deprecationDict` helper.

## Also fixed
- **Discovery nil-map panic** — `Config.Clone` leaves `Options` nil when the source config had none (an inventory-file / env-token asset that omits them). The subsequent `cfg.Options[key] = val` then panicked, crashing the whole scan. Guarded in a new testable `childConfig` helper.
- **Storage box subaccount/snapshot `__id`** — keyed on the bare leaf ID; made it a parent-composite (`<storageBoxId>/<id>`) to match the provider's other sub-resources and rule out cross-box cache aliasing.

## Testing
- `hetzner_dict_serialization_test.go` — runs each dict builder's output through the **real llx converter** and asserts it serializes; also locks the value types (`int64`, RFC3339 string). This guard would have caught all four serialization bugs.
- `discovery_test.go` — `childConfig` with nil `Options` (regression for the panic) and with existing options (no source mutation).

All resource tests pass; provider builds and vets clean. No `.lr` changes, so no codegen or permissions drift.
