### PR TITLE
🐛 grafana: fix service-account pagination truncation + testability

### DIFF
--- a/providers/grafana/resources/alerting.go
+++ b/providers/grafana/resources/alerting.go
@@ -131,53 +131,62 @@ func (c *mqlGrafanaContactPoint) isHttps() (bool, error) {
 	return strings.HasPrefix(strings.ToLower(u), "https://"), nil
 }
 
-func (c *mqlGrafanaContactPoint) tlsSkipVerify() (bool, error) {
-	s := c.contactPointSettings()
-	if s == nil {
-		return false, nil
+// contactPointTLSSkipVerify reports whether the contact-point settings disable
+// TLS server-certificate verification. httpConfig.tlsConfig is the standard
+// Alertmanager-style nested key; a top-level tlsConfig is the flatter
+// Grafana-managed key.
+func contactPointTLSSkipVerify(settings map[string]any) bool {
+	if settings == nil {
+		return false
 	}
-	// httpConfig is the standard Alertmanager-style nested key; tlsConfig is the
-	// flatter Grafana-managed key.
-	if hc, ok := s["httpConfig"].(map[string]any); ok {
+	if hc, ok := settings["httpConfig"].(map[string]any); ok {
 		if tls, ok := hc["tlsConfig"].(map[string]any); ok {
 			if v, ok := tls["insecureSkipVerify"].(bool); ok && v {
-				return true, nil
+				return true
 			}
 		}
 	}
-	if tls, ok := s["tlsConfig"].(map[string]any); ok {
+	if tls, ok := settings["tlsConfig"].(map[string]any); ok {
 		if v, ok := tls["insecureSkipVerify"].(bool); ok && v {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
-// hasHttpAuth reports whether basic-auth or bearer-token auth is configured on
-// the contact point, indicating the alert receiver requires authentication.
-func (c *mqlGrafanaContactPoint) hasHttpAuth() (bool, error) {
-	s := c.contactPointSettings()
-	if s == nil {
-		return false, nil
+func (c *mqlGrafanaContactPoint) tlsSkipVerify() (bool, error) {
+	return contactPointTLSSkipVerify(c.contactPointSettings()), nil
+}
+
+// contactPointHasHTTPAuth reports whether basic-auth or bearer-token auth is
+// configured on the contact point, indicating the alert receiver requires
+// authentication.
+func contactPointHasHTTPAuth(settings map[string]any) bool {
+	if settings == nil {
+		return false
 	}
-	if _, ok := s["username"]; ok {
-		return true, nil
+	if _, ok := settings["username"]; ok {
+		return true
 	}
-	if _, ok := s["authorizationCredentials"]; ok {
-		return true, nil
+	if _, ok := settings["authorizationCredentials"]; ok {
+		return true
 	}
-	if hc, ok := s["httpConfig"].(map[string]any); ok {
+	if hc, ok := settings["httpConfig"].(map[string]any); ok {
 		if _, ok := hc["basicAuth"]; ok {
-			return true, nil
+			return true
 		}
 		if _, ok := hc["bearerToken"]; ok {
-			return true, nil
+			return true
 		}
 		if _, ok := hc["authorization"]; ok {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
+}
+
+func (c *mqlGrafanaContactPoint) hasHttpAuth() (bool, error) {
+	return contactPointHasHTTPAuth(c.contactPointSettings()), nil
 }
 
 // initGrafanaNotificationPolicy delegates to the parent grafana resource when

--- a/providers/grafana/resources/alerting_test.go
+++ b/providers/grafana/resources/alerting_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactPointTLSSkipVerify(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		want     bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", map[string]any{}, false},
+		{
+			"flat tlsConfig skip",
+			map[string]any{"tlsConfig": map[string]any{"insecureSkipVerify": true}},
+			true,
+		},
+		{
+			"flat tlsConfig no skip",
+			map[string]any{"tlsConfig": map[string]any{"insecureSkipVerify": false}},
+			false,
+		},
+		{
+			"nested httpConfig.tlsConfig skip",
+			map[string]any{"httpConfig": map[string]any{"tlsConfig": map[string]any{"insecureSkipVerify": true}}},
+			true,
+		},
+		{
+			// insecureSkipVerify carried as a string must not be read as a bool.
+			"non-bool insecureSkipVerify ignored",
+			map[string]any{"tlsConfig": map[string]any{"insecureSkipVerify": "true"}},
+			false,
+		},
+		{
+			// tlsConfig present but the wrong shape must not panic.
+			"tlsConfig wrong type",
+			map[string]any{"tlsConfig": "oops"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, contactPointTLSSkipVerify(tt.settings))
+		})
+	}
+}
+
+func TestContactPointHasHTTPAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings map[string]any
+		want     bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", map[string]any{}, false},
+		{"top-level username", map[string]any{"username": "alice"}, true},
+		{"authorizationCredentials", map[string]any{"authorizationCredentials": "xxx"}, true},
+		{"nested basicAuth", map[string]any{"httpConfig": map[string]any{"basicAuth": map[string]any{"user": "a"}}}, true},
+		{"nested bearerToken", map[string]any{"httpConfig": map[string]any{"bearerToken": "t"}}, true},
+		{"nested authorization", map[string]any{"httpConfig": map[string]any{"authorization": map[string]any{}}}, true},
+		{"httpConfig wrong type", map[string]any{"httpConfig": "oops"}, false},
+		{"no auth keys", map[string]any{"url": "https://x", "httpConfig": map[string]any{"proxyUrl": "p"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, contactPointHasHTTPAuth(tt.settings))
+		})
+	}
+}

--- a/providers/grafana/resources/datasources.go
+++ b/providers/grafana/resources/datasources.go
@@ -167,18 +167,23 @@ func (d *mqlGrafanaDatasource) tlsSkipVerify() (bool, error) {
 	return boolFromJsonData(d.jsonDataMap(), "tlsSkipVerify"), nil
 }
 
-// tlsClientAuth is true if the datasource is configured for mutual TLS, either
-// via the tlsAuth flag in jsonData or by having a stored tlsClientCert secret.
-func (d *mqlGrafanaDatasource) tlsClientAuth() (bool, error) {
-	if boolFromJsonData(d.jsonDataMap(), "tlsAuth") {
-		return true, nil
+// datasourceTLSClientAuth is true if the datasource is configured for mutual
+// TLS, either via the tlsAuth flag in jsonData or by having a stored
+// tlsClientCert / tlsClientKey secret listed in secureJsonFields.
+func datasourceTLSClientAuth(jsonData map[string]any, secureFields []any) bool {
+	if boolFromJsonData(jsonData, "tlsAuth") {
+		return true
 	}
-	for _, f := range d.SecureJsonFields.Data {
+	for _, f := range secureFields {
 		if s, ok := f.(string); ok && (s == "tlsClientCert" || s == "tlsClientKey") {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
+}
+
+func (d *mqlGrafanaDatasource) tlsClientAuth() (bool, error) {
+	return datasourceTLSClientAuth(d.jsonDataMap(), d.SecureJsonFields.Data), nil
 }
 
 func (d *mqlGrafanaDatasource) oauthPassThru() (bool, error) {

--- a/providers/grafana/resources/datasources_test.go
+++ b/providers/grafana/resources/datasources_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatasourceTLSClientAuth(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonData     map[string]any
+		secureFields []any
+		want         bool
+	}{
+		{"nothing configured", nil, nil, false},
+		{"tlsAuth bool", map[string]any{"tlsAuth": true}, nil, true},
+		{"tlsAuth string", map[string]any{"tlsAuth": "true"}, nil, true},
+		{"tlsAuth false", map[string]any{"tlsAuth": false}, nil, false},
+		{"tlsClientCert secret present", nil, []any{"tlsClientCert"}, true},
+		{"tlsClientKey secret present", nil, []any{"httpHeaderValue1", "tlsClientKey"}, true},
+		{"unrelated secret only", nil, []any{"basicAuthPassword"}, false},
+		// A non-string element in secureFields must not panic.
+		{"non-string secure field", nil, []any{42, "tlsClientCert"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, datasourceTLSClientAuth(tt.jsonData, tt.secureFields))
+		})
+	}
+}

--- a/providers/grafana/resources/service_accounts.go
+++ b/providers/grafana/resources/service_accounts.go
@@ -57,8 +57,8 @@ const (
 
 // fetchServiceAccountPage fetches a single page of service accounts and closes
 // the response body before returning, avoiding FD leaks in pagination loops.
-func fetchServiceAccountPage(ctx context.Context, conn *connection.GrafanaConnection, page int) (*grafanaServiceAccountsResponse, error) {
-	path := fmt.Sprintf("/api/serviceaccounts/search?perpage=%d&page=%d", serviceAccountPageSize, page)
+func fetchServiceAccountPage(ctx context.Context, conn *connection.GrafanaConnection, page, perPage int) (*grafanaServiceAccountsResponse, error) {
+	path := fmt.Sprintf("/api/serviceaccounts/search?perpage=%d&page=%d", perPage, page)
 	resp, err := conn.Get(ctx, path)
 	if err != nil {
 		return nil, err
@@ -76,35 +76,52 @@ func fetchServiceAccountPage(ctx context.Context, conn *connection.GrafanaConnec
 	return &result, nil
 }
 
-func (g *mqlGrafana) serviceAccounts() ([]interface{}, error) {
-	conn, err := grafanaConnection(g.MqlRuntime)
-	if err != nil {
-		return nil, err
+// serviceAccountPageCount computes how many pages to fetch given the reported
+// totalCount and the number of items the server actually returned on page 1.
+//
+// It keys off the effective first-page length rather than the requested
+// perpage, which keeps it correct across all three server behaviors:
+//   - honors perpage (firstPageLen == request): standard ceil(total/perpage);
+//   - caps perpage below the request (firstPageLen < request): pages are sized
+//     to what the server actually returned, so nothing is truncated;
+//   - ignores perpage and returns everything in one page (firstPageLen >=
+//     totalCount): a single page, so we never re-fetch and duplicate rows.
+//
+// The caller must fetch pages 2..N with perPage set to firstPageLen so the
+// server-side offsets line up with this page count.
+func serviceAccountPageCount(totalCount, firstPageLen int) int {
+	if firstPageLen <= 0 || firstPageLen >= totalCount {
+		return 1
 	}
+	return (totalCount + firstPageLen - 1) / firstPageLen
+}
 
-	// Fetch page 1 first to learn totalCount, then fan out remaining pages
-	// concurrently. The previous sequential loop was O(N) round trips on the
-	// critical path; this is O(N/pageFanout) for the same byte volume.
-	first, err := fetchServiceAccountPage(context.Background(), conn, 1)
+// fetchAllServiceAccounts fetches every service account across all pages of
+// /api/serviceaccounts/search. It fetches page 1 to learn totalCount, then fans
+// out the remaining pages concurrently. The previous sequential loop was O(N)
+// round trips on the critical path; this is O(N/pageFanout) for the same byte
+// volume. Pagination is planned off the effective first-page length (see
+// serviceAccountPageCount), so a server that caps or ignores perpage neither
+// truncates nor duplicates.
+func fetchAllServiceAccounts(ctx context.Context, conn *connection.GrafanaConnection) ([]grafanaServiceAccountJSON, error) {
+	first, err := fetchServiceAccountPage(ctx, conn, 1, serviceAccountPageSize)
 	if err != nil {
 		return nil, err
 	}
 
 	allSAs := first.ServiceAccounts
-	// Compute remaining pages from totalCount. Guard against a short first page
-	// (server returned all results in one call) before fanning out.
-	totalPages := 1
-	if first.TotalCount > serviceAccountPageSize && len(first.ServiceAccounts) >= serviceAccountPageSize {
-		totalPages = (first.TotalCount + serviceAccountPageSize - 1) / serviceAccountPageSize
-	}
+	// Subsequent pages must use the same effective size so offsets line up with
+	// the page count computed by serviceAccountPageCount.
+	effectivePerPage := len(first.ServiceAccounts)
+	totalPages := serviceAccountPageCount(first.TotalCount, effectivePerPage)
 	if totalPages > 1 {
 		pages := make([][]grafanaServiceAccountJSON, totalPages-1)
-		grp, ctx := errgroup.WithContext(context.Background())
+		grp, grpCtx := errgroup.WithContext(ctx)
 		grp.SetLimit(pageFanout)
 		for i := range totalPages - 1 {
 			page := i + 2 // pages 2..totalPages
 			grp.Go(func() error {
-				result, err := fetchServiceAccountPage(ctx, conn, page)
+				result, err := fetchServiceAccountPage(grpCtx, conn, page, effectivePerPage)
 				if err != nil {
 					return err
 				}
@@ -118,6 +135,19 @@ func (g *mqlGrafana) serviceAccounts() ([]interface{}, error) {
 		for _, p := range pages {
 			allSAs = append(allSAs, p...)
 		}
+	}
+	return allSAs, nil
+}
+
+func (g *mqlGrafana) serviceAccounts() ([]interface{}, error) {
+	conn, err := grafanaConnection(g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+
+	allSAs, err := fetchAllServiceAccounts(context.Background(), conn)
+	if err != nil {
+		return nil, err
 	}
 
 	list := make([]interface{}, 0, len(allSAs))

--- a/providers/grafana/resources/service_accounts_test.go
+++ b/providers/grafana/resources/service_accounts_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -58,13 +57,68 @@ func newPagedServer(t *testing.T, totalCount int, hits *atomic.Int32) *httptest.
 	}))
 }
 
+// newCappingPagedServer models a Grafana instance that silently caps the page
+// size below the requested perpage: it clamps the effective perPage to maxPerPage
+// and computes offsets from that clamped value (as Grafana's search service does).
+func newCappingPagedServer(t *testing.T, totalCount, maxPerPage int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 {
+			page = 1
+		}
+		perPage, _ := strconv.Atoi(r.URL.Query().Get("perpage"))
+		if perPage < 1 || perPage > maxPerPage {
+			perPage = maxPerPage
+		}
+		start := (page - 1) * perPage
+		end := min(start+perPage, totalCount)
+		var items []grafanaServiceAccountJSON
+		if start < totalCount {
+			items = make([]grafanaServiceAccountJSON, end-start)
+			for i := range items {
+				items[i] = grafanaServiceAccountJSON{ID: start + i + 1, Name: fmt.Sprintf("sa-%d", start+i+1)}
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(grafanaServiceAccountsResponse{
+			TotalCount:      totalCount,
+			ServiceAccounts: items,
+			Page:            page,
+			PerPage:         perPage,
+		})
+	}))
+}
+
+// newAllInOnePageServer models a Grafana instance that ignores perpage and
+// returns every service account in a single page regardless of the page param.
+func newAllInOnePageServer(t *testing.T, totalCount int, hits *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits != nil {
+			hits.Add(1)
+		}
+		items := make([]grafanaServiceAccountJSON, totalCount)
+		for i := range items {
+			items[i] = grafanaServiceAccountJSON{ID: i + 1, Name: fmt.Sprintf("sa-%d", i+1)}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(grafanaServiceAccountsResponse{
+			TotalCount:      totalCount,
+			ServiceAccounts: items,
+			Page:            1,
+			PerPage:         totalCount,
+		})
+	}))
+}
+
 func TestFetchServiceAccountPage(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		srv := newPagedServer(t, 5, nil)
 		t.Cleanup(srv.Close)
 		conn := newTestConn(t, srv.URL)
 
-		page, err := fetchServiceAccountPage(context.Background(), conn, 1)
+		page, err := fetchServiceAccountPage(context.Background(), conn, 1, serviceAccountPageSize)
 		require.NoError(t, err)
 		assert.Equal(t, 5, page.TotalCount)
 		assert.Len(t, page.ServiceAccounts, 5)
@@ -77,50 +131,104 @@ func TestFetchServiceAccountPage(t *testing.T) {
 		t.Cleanup(srv.Close)
 		conn := newTestConn(t, srv.URL)
 
-		_, err := fetchServiceAccountPage(context.Background(), conn, 1)
+		_, err := fetchServiceAccountPage(context.Background(), conn, 1, serviceAccountPageSize)
 		require.Error(t, err)
 	})
 }
 
-// TestServiceAccountPagination_FetchesAllPages verifies the parallel pagination
-// loop reads every page when totalCount > pageSize and returns the union.
+func TestServiceAccountPageCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalCount   int
+		firstPageLen int
+		want         int
+	}{
+		{"empty org", 0, 0, 1},
+		{"single short page", 5, 5, 1},
+		{"exactly one full page", 1000, 1000, 1},
+		{"one over a full page", 1001, 1000, 2},
+		{"three full pages plus one", serviceAccountPageSize*3 + 1, serviceAccountPageSize, 4},
+		// Server caps perpage below our request (e.g. returns 100 despite perpage=1000):
+		// pages must be sized to what the server actually returned, not truncated.
+		{"server caps perpage", 250, 100, 3},
+		{"server caps perpage exact multiple", 300, 100, 3},
+		// Server ignores perpage and returns everything in page 1: must stay one
+		// page so we never re-fetch and duplicate rows.
+		{"server ignores perpage", 2500, 2500, 1},
+		// Defensive: a zero first page with a positive total must not divide by zero.
+		{"zero first page nonzero total", 500, 0, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, serviceAccountPageCount(tt.totalCount, tt.firstPageLen))
+		})
+	}
+}
+
+// assertUniqueIDs fails if the collected service accounts contain any duplicate
+// IDs — the signature of a pagination loop that re-fetches the same page.
+func assertUniqueIDs(t *testing.T, sas []grafanaServiceAccountJSON, wantLen int) {
+	t.Helper()
+	assert.Len(t, sas, wantLen)
+	seen := make(map[int]bool, len(sas))
+	for _, sa := range sas {
+		require.False(t, seen[sa.ID], "duplicate service account ID %d — pagination re-fetched a page", sa.ID)
+		seen[sa.ID] = true
+	}
+}
+
+// TestServiceAccountPagination_FetchesAllPages drives the real
+// fetchAllServiceAccounts against a server that honors perpage, verifying every
+// page is read exactly once and the union is complete with no duplicates.
 func TestServiceAccountPagination_FetchesAllPages(t *testing.T) {
-	// Use a smaller "page size" by overriding the query param expectation:
-	// the server uses whatever perpage the client sends, so we just need
-	// totalCount > serviceAccountPageSize to trigger multi-page fetch.
-	// To keep the test fast we ride at exactly serviceAccountPageSize * 3 + 1.
 	const total = serviceAccountPageSize*3 + 1
 	var hits atomic.Int32
 	srv := newPagedServer(t, total, &hits)
 	t.Cleanup(srv.Close)
 	conn := newTestConn(t, srv.URL)
 
-	// Drive the pagination directly via fetchServiceAccountPage to keep this
-	// test focused (the full serviceAccounts() method also calls CreateResource
-	// which needs a Runtime). We reproduce the loop's shape inline.
-	first, err := fetchServiceAccountPage(context.Background(), conn, 1)
+	got, err := fetchAllServiceAccounts(context.Background(), conn)
 	require.NoError(t, err)
-	collected := first.ServiceAccounts
-
-	totalPages := (total + serviceAccountPageSize - 1) / serviceAccountPageSize
-	require.Equal(t, 4, totalPages)
-
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-	for p := 2; p <= totalPages; p++ {
-		wg.Go(func() {
-			page, err := fetchServiceAccountPage(context.Background(), conn, p)
-			require.NoError(t, err)
-			mu.Lock()
-			collected = append(collected, page.ServiceAccounts...)
-			mu.Unlock()
-		})
-	}
-	wg.Wait()
-
-	assert.Equal(t, total, len(collected), "all pages must be collected")
-	assert.Equal(t, int32(totalPages), hits.Load(),
+	assertUniqueIDs(t, got, total)
+	// 4 pages at serviceAccountPageSize each (3 full + 1 remainder).
+	assert.Equal(t, int32(4), hits.Load(),
 		"server hit exactly once per page — pagination must not retry or duplicate")
+}
+
+// TestServiceAccountPagination_ServerCapsPerPage guards the fix for the
+// truncation bug: when the server returns fewer items than the requested
+// perpage (e.g. an instance that caps the search page size) while totalCount
+// reports more, the loop must page off the effective size and still collect
+// every account rather than stopping after page 1.
+func TestServiceAccountPagination_ServerCapsPerPage(t *testing.T) {
+	const (
+		total      = 250
+		perPageCap = 100
+	)
+	srv := newCappingPagedServer(t, total, perPageCap)
+	t.Cleanup(srv.Close)
+	conn := newTestConn(t, srv.URL)
+
+	got, err := fetchAllServiceAccounts(context.Background(), conn)
+	require.NoError(t, err)
+	assertUniqueIDs(t, got, total) // must be all 250, not truncated to 100
+}
+
+// TestServiceAccountPagination_ServerIgnoresPerPage guards the other tail: a
+// server that ignores perpage and returns every row in page 1 must not trigger
+// a second fetch (which would duplicate rows).
+func TestServiceAccountPagination_ServerIgnoresPerPage(t *testing.T) {
+	const total = serviceAccountPageSize*2 + 37
+	var hits atomic.Int32
+	srv := newAllInOnePageServer(t, total, &hits)
+	t.Cleanup(srv.Close)
+	conn := newTestConn(t, srv.URL)
+
+	got, err := fetchAllServiceAccounts(context.Background(), conn)
+	require.NoError(t, err)
+	assertUniqueIDs(t, got, total)
+	assert.Equal(t, int32(1), hits.Load(),
+		"server returned everything in page 1 — must not re-fetch")
 }
 
 // TestServiceAccountTokens_HasExpirationLogic exercises the simplified


### PR DESCRIPTION
## What

Fixes a silent-truncation bug in `grafana.serviceAccounts` pagination, found during a static bug review of the grafana provider, plus testability refactors and the missing unit coverage.

### The bug

`serviceAccounts()` gated its multi-page fan-out on:

```go
if first.TotalCount > serviceAccountPageSize && len(first.ServiceAccounts) >= serviceAccountPageSize {
```

The extra `len(first.ServiceAccounts) >= serviceAccountPageSize` condition means that if a Grafana instance ever returns a **first page shorter than the requested `perpage=1000`** while `totalCount` still reports more (an instance that caps the search page size, or a proxy trimming the page), the fan-out is skipped and the result silently truncates to a single page — a security audit would then miss service accounts with no error.

### The fix

Plan pagination off the **effective first-page length** (what the server actually returned) rather than the requested perpage, via a new pure `serviceAccountPageCount(totalCount, firstPageLen)` helper. This stays correct across all three server behaviors:

| Server behavior | Old code | New code |
|---|---|---|
| Honors `perpage` | ✅ correct | ✅ correct |
| **Caps `perpage` below request** | ❌ truncates to page 1 | ✅ collects all |
| Ignores `perpage` (all rows in page 1) | ✅ one page | ✅ one page (no dup re-fetch) |

Subsequent pages are fetched with the same effective size so server-side offsets line up. The "all rows in page 1" case — which the old `len >=` guard existed to protect against duplicate re-fetches — stays handled (`firstPageLen >= totalCount → 1 page`).

## Refactors (for testability)

- Extracted the fetch/pagination loop into `fetchAllServiceAccounts`, testable without a Runtime (the old loop was inlined in `serviceAccounts()`, which needs `CreateResource`).
- Pulled the contact-point and datasource security predicates (`tlsSkipVerify`, `hasHttpAuth`, `tlsClientAuth`) into pure helpers, mirroring the existing `contactPointURL` pattern. Behavior unchanged.

## Tests

- `serviceAccountPageCount` unit table — all three behaviors + edge cases (empty org, exact multiples, zero first page).
- Integration tests driving the real `fetchAllServiceAccounts` against honors / caps / ignores-perpage test servers, asserting no truncation and no duplicate IDs (with `-race`).
- Table tests for the extracted contact-point and datasource predicates, including non-bool / wrong-shape inputs that must not panic.

No schema or `.lr` changes; no provider version bump.
