### PR TITLE
🐛 datadog: fix ms/seconds timestamp decode, roles/SLO pagination truncation, and a race

### DIFF
--- a/providers/datadog/resources/datadog.go
+++ b/providers/datadog/resources/datadog.go
@@ -62,6 +62,28 @@ func parseTime(s string) *time.Time {
 	return &t
 }
 
+// epochSecondsToTimePtr converts a Unix timestamp in seconds to a *time.Time,
+// returning nil for a zero value (an unset timestamp).
+func epochSecondsToTimePtr(sec int64) *time.Time {
+	if sec == 0 {
+		return nil
+	}
+	t := time.Unix(sec, 0)
+	return &t
+}
+
+// epochMillisToTimePtr converts a Unix timestamp in milliseconds to a *time.Time,
+// returning nil for a zero value (an unset timestamp). Several Datadog APIs report
+// timestamps in milliseconds (RUM applications, security suppressions), so passing
+// the raw value to time.Unix (which expects seconds) yields a date far in the future.
+func epochMillisToTimePtr(ms int64) *time.Time {
+	if ms == 0 {
+		return nil
+	}
+	t := time.UnixMilli(ms)
+	return &t
+}
+
 // fetchUsers fetches all users once and caches the result, shared by users() and serviceAccounts().
 func (r *mqlDatadog) fetchUsers() ([]datadogV2.User, error) {
 	r.usersOnce.Do(func() {
@@ -126,29 +148,41 @@ func (r *mqlDatadog) roles() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DatadogConnection)
 	api := datadogV2.NewRolesApi(conn.ApiClient())
 
-	resp, httpResp, err := api.ListRoles(conn.AuthCtx())
-	if err != nil {
-		if isForbidden(httpResp) {
-			log.Warn().Msg("datadog> roles not available (403 Forbidden)")
-			return nil, nil
-		}
-		return nil, err
-	}
-
 	var all []interface{}
-	for _, role := range resp.GetData() {
-		attrs := role.GetAttributes()
-		res, err := CreateResource(r.MqlRuntime, "datadog.role", map[string]*llx.RawData{
-			"id":         llx.StringData(role.GetId()),
-			"name":       llx.StringData(attrs.GetName()),
-			"userCount":  llx.IntData(int64(attrs.GetUserCount())),
-			"createdAt":  llx.TimeDataPtr(timePtr(attrs.GetCreatedAt())),
-			"modifiedAt": llx.TimeDataPtr(timePtr(attrs.GetModifiedAt())),
-		})
+	pageSize := int64(100)
+	page := int64(0)
+
+	for {
+		resp, httpResp, err := api.ListRoles(conn.AuthCtx(),
+			*datadogV2.NewListRolesOptionalParameters().WithPageSize(pageSize).WithPageNumber(page))
 		if err != nil {
+			if isForbidden(httpResp) {
+				log.Warn().Msg("datadog> roles not available (403 Forbidden)")
+				return nil, nil
+			}
 			return nil, err
 		}
-		all = append(all, res)
+
+		data := resp.GetData()
+		for _, role := range data {
+			attrs := role.GetAttributes()
+			res, err := CreateResource(r.MqlRuntime, "datadog.role", map[string]*llx.RawData{
+				"id":         llx.StringData(role.GetId()),
+				"name":       llx.StringData(attrs.GetName()),
+				"userCount":  llx.IntData(int64(attrs.GetUserCount())),
+				"createdAt":  llx.TimeDataPtr(timePtr(attrs.GetCreatedAt())),
+				"modifiedAt": llx.TimeDataPtr(timePtr(attrs.GetModifiedAt())),
+			})
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, res)
+		}
+
+		if int64(len(data)) < pageSize {
+			break
+		}
+		page++
 	}
 	return all, nil
 }
@@ -363,58 +397,70 @@ func (r *mqlDatadog) slos() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DatadogConnection)
 	api := datadogV1.NewServiceLevelObjectivesApi(conn.ApiClient())
 
-	resp, httpResp, err := api.ListSLOs(conn.AuthCtx())
-	if err != nil {
-		if isForbidden(httpResp) {
-			log.Warn().Msg("datadog> SLOs not available (403 Forbidden)")
-			return nil, nil
-		}
-		return nil, err
-	}
-
 	var all []interface{}
-	for _, s := range resp.GetData() {
-		tags := toAnyStrings(s.GetTags())
+	limit := int64(1000)
+	offset := int64(0)
 
-		creator := ""
-		if c, ok := s.GetCreatorOk(); ok && c != nil {
-			creator = c.GetEmail()
-		}
-
-		targetThreshold := float64(0)
-		warningThreshold := float64(0)
-		timeframe := ""
-		if thresholds := s.GetThresholds(); len(thresholds) > 0 {
-			targetThreshold = thresholds[0].GetTarget()
-			if w, ok := thresholds[0].GetWarningOk(); ok && w != nil {
-				warningThreshold = *w
-			}
-			timeframe = string(thresholds[0].GetTimeframe())
-		}
-
-		monitorIds := make([]interface{}, len(s.GetMonitorIds()))
-		for i, id := range s.GetMonitorIds() {
-			monitorIds[i] = id
-		}
-
-		res, err := CreateResource(r.MqlRuntime, "datadog.slo", map[string]*llx.RawData{
-			"id":               llx.StringData(s.GetId()),
-			"name":             llx.StringData(s.GetName()),
-			"type":             llx.StringData(string(s.GetType())),
-			"description":      llx.StringData(s.GetDescription()),
-			"tags":             llx.ArrayData(tags, "\x02"),
-			"targetThreshold":  llx.FloatData(targetThreshold),
-			"warningThreshold": llx.FloatData(warningThreshold),
-			"timeframe":        llx.StringData(timeframe),
-			"creator":          llx.StringData(creator),
-			"createdAt":        llx.TimeDataPtr(timePtr(time.Unix(s.GetCreatedAt(), 0))),
-			"modifiedAt":       llx.TimeDataPtr(timePtr(time.Unix(s.GetModifiedAt(), 0))),
-			"monitorIds":       llx.ArrayData(monitorIds, "\x05"),
-		})
+	for {
+		resp, httpResp, err := api.ListSLOs(conn.AuthCtx(),
+			*datadogV1.NewListSLOsOptionalParameters().WithLimit(limit).WithOffset(offset))
 		if err != nil {
+			if isForbidden(httpResp) {
+				log.Warn().Msg("datadog> SLOs not available (403 Forbidden)")
+				return nil, nil
+			}
 			return nil, err
 		}
-		all = append(all, res)
+
+		data := resp.GetData()
+		for _, s := range data {
+			tags := toAnyStrings(s.GetTags())
+
+			creator := ""
+			if c, ok := s.GetCreatorOk(); ok && c != nil {
+				creator = c.GetEmail()
+			}
+
+			targetThreshold := float64(0)
+			warningThreshold := float64(0)
+			timeframe := ""
+			if thresholds := s.GetThresholds(); len(thresholds) > 0 {
+				targetThreshold = thresholds[0].GetTarget()
+				if w, ok := thresholds[0].GetWarningOk(); ok && w != nil {
+					warningThreshold = *w
+				}
+				timeframe = string(thresholds[0].GetTimeframe())
+			}
+
+			monitorIds := make([]interface{}, len(s.GetMonitorIds()))
+			for i, id := range s.GetMonitorIds() {
+				monitorIds[i] = id
+			}
+
+			res, err := CreateResource(r.MqlRuntime, "datadog.slo", map[string]*llx.RawData{
+				"id":               llx.StringData(s.GetId()),
+				"name":             llx.StringData(s.GetName()),
+				"type":             llx.StringData(string(s.GetType())),
+				"description":      llx.StringData(s.GetDescription()),
+				"tags":             llx.ArrayData(tags, "\x02"),
+				"targetThreshold":  llx.FloatData(targetThreshold),
+				"warningThreshold": llx.FloatData(warningThreshold),
+				"timeframe":        llx.StringData(timeframe),
+				"creator":          llx.StringData(creator),
+				"createdAt":        llx.TimeDataPtr(epochSecondsToTimePtr(s.GetCreatedAt())),
+				"modifiedAt":       llx.TimeDataPtr(epochSecondsToTimePtr(s.GetModifiedAt())),
+				"monitorIds":       llx.ArrayData(monitorIds, "\x05"),
+			})
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, res)
+		}
+
+		if int64(len(data)) < limit {
+			break
+		}
+		offset += limit
 	}
 	return all, nil
 }
@@ -892,6 +938,15 @@ func (r *mqlDatadog) integrationAwsAccounts() ([]interface{}, error) {
 			filterTags = []interface{}{}
 		}
 
+		// The v2 API models region selection as either "include all" or an
+		// explicit "include only" list; expose the latter. It has no notion of
+		// excluded regions, so excludedRegions stays empty (retained for
+		// backward-compat with the v1-era schema).
+		includedRegions := []interface{}{}
+		if ar, ok := attrs.GetAwsRegionsOk(); ok && ar != nil && ar.AWSRegionsIncludeOnly != nil {
+			includedRegions = toAnyStrings(ar.AWSRegionsIncludeOnly.GetIncludeOnly())
+		}
+
 		res, err := CreateResource(r.MqlRuntime, "datadog.integration.aws", map[string]*llx.RawData{
 			"accountId":                 llx.StringData(attrs.GetAwsAccountId()),
 			"roleName":                  llx.StringData(roleName),
@@ -902,6 +957,7 @@ func (r *mqlDatadog) integrationAwsAccounts() ([]interface{}, error) {
 			"hostTags":                  llx.ArrayData([]interface{}{}, "\x02"),
 			"accountTags":               llx.ArrayData(accountTags, "\x02"),
 			"excludedRegions":           llx.ArrayData([]interface{}{}, "\x02"),
+			"includedRegions":           llx.ArrayData(includedRegions, "\x02"),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/datadog/resources/datadog.lr
+++ b/providers/datadog/resources/datadog.lr
@@ -464,7 +464,7 @@ datadog.applicationKey @defaults("id name") {
 // the account, so auditing it exposes the delegation trust that grants
 // Datadog access. The metricsEnabled, resourceCollectionEnabled, and
 // logsEnabled flags show which data streams are active, while
-// excludedRegions and filterTags narrow what Datadog ingests.
+// includedRegions and filterTags narrow what Datadog ingests.
 datadog.integration.aws @defaults("accountId") {
   // AWS account ID
   accountId string
@@ -483,7 +483,16 @@ datadog.integration.aws @defaults("accountId") {
   // Account tags
   accountTags []string
   // Excluded regions
+  //
+  // Always empty. The Datadog v2 AWS integration API expresses region
+  // selection as includedRegions (an allowlist) rather than an exclusion
+  // list. Retained for backward compatibility with the earlier schema.
   excludedRegions []string
+  // Included regions
+  //
+  // Explicit allowlist of AWS regions Datadog collects data from. Empty
+  // when the account is configured to collect from all regions.
+  includedRegions []string
 }
 
 // Datadog Team

--- a/providers/datadog/resources/datadog.lr.go
+++ b/providers/datadog/resources/datadog.lr.go
@@ -620,6 +620,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"datadog.integration.aws.excludedRegions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatadogIntegrationAws).GetExcludedRegions()).ToDataRes(types.Array(types.String))
 	},
+	"datadog.integration.aws.includedRegions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDatadogIntegrationAws).GetIncludedRegions()).ToDataRes(types.Array(types.String))
+	},
 	"datadog.team.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDatadogTeam).GetId()).ToDataRes(types.String)
 	},
@@ -1427,6 +1430,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"datadog.integration.aws.excludedRegions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDatadogIntegrationAws).ExcludedRegions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"datadog.integration.aws.includedRegions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDatadogIntegrationAws).IncludedRegions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"datadog.team.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3189,6 +3196,7 @@ type mqlDatadogIntegrationAws struct {
 	HostTags                  plugin.TValue[[]any]
 	AccountTags               plugin.TValue[[]any]
 	ExcludedRegions           plugin.TValue[[]any]
+	IncludedRegions           plugin.TValue[[]any]
 }
 
 // createDatadogIntegrationAws creates a new instance of this resource
@@ -3262,6 +3270,10 @@ func (c *mqlDatadogIntegrationAws) GetAccountTags() *plugin.TValue[[]any] {
 
 func (c *mqlDatadogIntegrationAws) GetExcludedRegions() *plugin.TValue[[]any] {
 	return &c.ExcludedRegions
+}
+
+func (c *mqlDatadogIntegrationAws) GetIncludedRegions() *plugin.TValue[[]any] {
+	return &c.IncludedRegions
 }
 
 // mqlDatadogTeam for the datadog.team resource

--- a/providers/datadog/resources/datadog.lr.versions
+++ b/providers/datadog/resources/datadog.lr.versions
@@ -48,6 +48,7 @@ datadog.integration.aws.accountTags 13.0.1
 datadog.integration.aws.excludedRegions 13.0.1
 datadog.integration.aws.filterTags 13.0.1
 datadog.integration.aws.hostTags 13.0.1
+datadog.integration.aws.includedRegions 13.0.17
 datadog.integration.aws.logsEnabled 13.0.1
 datadog.integration.aws.metricsEnabled 13.0.1
 datadog.integration.aws.resourceCollectionEnabled 13.0.1

--- a/providers/datadog/resources/datadog_test.go
+++ b/providers/datadog/resources/datadog_test.go
@@ -1,0 +1,143 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestEpochMillisToTimePtr(t *testing.T) {
+	// 1_700_000_000_000 ms == 2023-11-14T22:13:20Z. Parsing this value as
+	// seconds (the bug this helper fixes) would land in the year ~55871.
+	ms := int64(1_700_000_000_000)
+	got := epochMillisToTimePtr(ms)
+	if got == nil {
+		t.Fatal("expected non-nil time for a non-zero millisecond timestamp")
+	}
+	if y := got.UTC().Year(); y != 2023 {
+		t.Fatalf("expected year 2023, got %d (millisecond value likely parsed as seconds)", y)
+	}
+	if !got.Equal(time.UnixMilli(ms)) {
+		t.Fatalf("expected %v, got %v", time.UnixMilli(ms), *got)
+	}
+}
+
+func TestEpochMillisToTimePtr_Zero(t *testing.T) {
+	if got := epochMillisToTimePtr(0); got != nil {
+		t.Fatalf("expected nil for a zero (unset) timestamp, got %v", *got)
+	}
+}
+
+func TestEpochSecondsToTimePtr(t *testing.T) {
+	// 1_700_000_000 s == 2023-11-14T22:13:20Z.
+	sec := int64(1_700_000_000)
+	got := epochSecondsToTimePtr(sec)
+	if got == nil {
+		t.Fatal("expected non-nil time for a non-zero seconds timestamp")
+	}
+	if y := got.UTC().Year(); y != 2023 {
+		t.Fatalf("expected year 2023, got %d", y)
+	}
+	if !got.Equal(time.Unix(sec, 0)) {
+		t.Fatalf("expected %v, got %v", time.Unix(sec, 0), *got)
+	}
+}
+
+func TestEpochSecondsToTimePtr_Zero(t *testing.T) {
+	if got := epochSecondsToTimePtr(0); got != nil {
+		t.Fatalf("expected nil for a zero (unset) timestamp, got %v", *got)
+	}
+}
+
+// TestEpochUnitsDiverge documents why the seconds vs milliseconds distinction
+// matters: the same numeric value interpreted as seconds vs milliseconds yields
+// timestamps thousands of years apart.
+func TestEpochUnitsDiverge(t *testing.T) {
+	v := int64(1_700_000_000_000)
+	asMillis := epochMillisToTimePtr(v)
+	asSeconds := epochSecondsToTimePtr(v)
+	if asMillis.UTC().Year() == asSeconds.UTC().Year() {
+		t.Fatal("expected millisecond and second interpretations to differ")
+	}
+	if asSeconds.UTC().Year() < 50000 {
+		t.Fatalf("expected the seconds interpretation of a millisecond value to be far in the future, got year %d", asSeconds.UTC().Year())
+	}
+}
+
+func TestTimePtr(t *testing.T) {
+	if got := timePtr(time.Time{}); got != nil {
+		t.Fatalf("expected nil for the zero time, got %v", *got)
+	}
+	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	got := timePtr(now)
+	if got == nil || !got.Equal(now) {
+		t.Fatalf("expected %v, got %v", now, got)
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+	}{
+		{"empty", "", true},
+		{"invalid", "not-a-timestamp", true},
+		{"valid RFC3339", "2024-01-02T03:04:05Z", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseTime(tc.input)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil time")
+			}
+			want, _ := time.Parse(time.RFC3339, tc.input)
+			if !got.Equal(want) {
+				t.Fatalf("expected %v, got %v", want, *got)
+			}
+		})
+	}
+}
+
+func TestToAnyStrings(t *testing.T) {
+	got := toAnyStrings([]string{"a", "b", "c"})
+	if len(got) != 3 {
+		t.Fatalf("expected len 3, got %d", len(got))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if got[i].(string) != want {
+			t.Fatalf("index %d: expected %q, got %v", i, want, got[i])
+		}
+	}
+
+	// A nil slice must produce a non-nil, empty result so it serializes as an
+	// empty array rather than null.
+	empty := toAnyStrings(nil)
+	if empty == nil {
+		t.Fatal("expected non-nil slice for nil input")
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty slice, got len %d", len(empty))
+	}
+}
+
+func TestIsForbidden(t *testing.T) {
+	if isForbidden(nil) {
+		t.Fatal("expected false for a nil response")
+	}
+	if isForbidden(&http.Response{StatusCode: http.StatusOK}) {
+		t.Fatal("expected false for a 200 response")
+	}
+	if !isForbidden(&http.Response{StatusCode: http.StatusForbidden}) {
+		t.Fatal("expected true for a 403 response")
+	}
+}

--- a/providers/datadog/resources/security.go
+++ b/providers/datadog/resources/security.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
@@ -127,10 +128,10 @@ func (r *mqlDatadog) securitySuppressions() ([]interface{}, error) {
 	for _, s := range resp.GetData() {
 		attrs := s.GetAttributes()
 
+		// expiration_date is a Unix millisecond timestamp.
 		var expirationDate *time.Time
 		if v, ok := attrs.GetExpirationDateOk(); ok && v != nil {
-			t := time.Unix(*v, 0)
-			expirationDate = &t
+			expirationDate = epochMillisToTimePtr(*v)
 		}
 
 		res, err := CreateResource(r.MqlRuntime, "datadog.securitySuppression", map[string]*llx.RawData{
@@ -301,10 +302,11 @@ func (r *mqlDatadog) rumApplications() ([]interface{}, error) {
 			"type": llx.StringData(attrs.GetType()),
 			// clientToken is not available on the list API response (only the create response)
 			"clientToken": llx.StringData(""),
-			"createdAt":   llx.TimeDataPtr(timePtr(time.Unix(attrs.GetCreatedAt(), 0))),
-			"updatedAt":   llx.TimeDataPtr(timePtr(time.Unix(attrs.GetUpdatedAt(), 0))),
-			"orgId":       llx.StringData(strconv.FormatInt(int64(attrs.GetOrgId()), 10)),
-			"isActive":    llx.BoolData(attrs.GetIsActive()),
+			// created_at and updated_at are Unix millisecond timestamps.
+			"createdAt": llx.TimeDataPtr(epochMillisToTimePtr(attrs.GetCreatedAt())),
+			"updatedAt": llx.TimeDataPtr(epochMillisToTimePtr(attrs.GetUpdatedAt())),
+			"orgId":     llx.StringData(strconv.FormatInt(int64(attrs.GetOrgId()), 10)),
+			"isActive":  llx.BoolData(attrs.GetIsActive()),
 		})
 		if err != nil {
 			return nil, err
@@ -403,7 +405,7 @@ func (r *mqlDatadogSyntheticsPrivateLocation) id() (string, error) {
 }
 
 type mqlDatadogSyntheticsPrivateLocationInternal struct {
-	fetched        bool
+	fetched        atomic.Bool
 	cachedDesc     string
 	cachedTags     []string
 	cachedMetadata map[string]interface{}
@@ -411,12 +413,12 @@ type mqlDatadogSyntheticsPrivateLocationInternal struct {
 }
 
 func (r *mqlDatadogSyntheticsPrivateLocation) fetchDetails() error {
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 
@@ -437,7 +439,7 @@ func (r *mqlDatadogSyntheticsPrivateLocation) fetchDetails() error {
 			r.cachedMetadata["restrictedRoles"] = v
 		}
 	}
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil
 }
 


### PR DESCRIPTION
## What

Static bug review of the datadog provider (`/provider-bug-review datadog`) turned up several defects that the compiler and integration tests miss — each produces **wrong data that looks valid, with no error**. This PR fixes all of them and adds unit tests for the pure-Go logic where they lived.

## Findings fixed

| Severity | Resource | Bug |
|---|---|---|
| High | `datadog.roles` | `ListRoles` called with no page params → Datadog's small default page size silently truncated the list past one page. Now paginates like the sibling lists (`apiKeys`, `applicationKeys`, `securityRules`). |
| High | `datadog.rumApplication` | `createdAt`/`updatedAt` are Unix **millisecond** timestamps but were decoded with `time.Unix` (seconds), landing dates thousands of years in the future. Now decoded as ms. |
| High | `datadog.securitySuppression` | `expirationDate` is a Unix **millisecond** timestamp, same seconds-decode bug. Now decoded as ms. |
| Medium | `datadog.slo` | `ListSLOs` defaults to a limit of 1000; larger orgs were truncated. Now loops with limit/offset, preserving the 403 graceful-degrade. |
| Medium | `datadog.integration.aws` | `excludedRegions` was hardcoded empty — the v2 API has no excluded-regions concept (it models region selection as an include-only allowlist). Added `includedRegions` populated from `aws_regions.include_only`; `excludedRegions` documented as always-empty and kept for backward compat. |
| Medium (race) | `datadog.syntheticsPrivateLocation` | `fetchDetails` used a plain-`bool` double-check — an unsynchronized read racing the locked write. Switched the flag to `atomic.Bool`. |

## Approach notes

- The two timestamp helpers `epochMillisToTimePtr` / `epochSecondsToTimePtr` both fix the bug and make the bug class **testable** — the tests assert a known epoch (`1_700_000_000_000 ms`) lands in 2023, not year ~55871. SLO's timestamps (correctly seconds) route through the seconds helper for consistency.
- No API surface changed, so `datadog.permissions.json` is unchanged — these were pure logic bugs, not missing-capability bugs.
- New field `datadog.integration.aws.includedRegions` is additive; `.lr.versions` entry added at `13.0.17` (next patch after the current `13.0.16`). No `config.go` version bump.

## Tests

New `resources/datadog_test.go` covers the pure-Go helpers: the two timestamp conversions (incl. zero→nil and seconds-vs-ms divergence), `timePtr`, `parseTime`, `toAnyStrings`, and `isForbidden`.

```
ok  go.mondoo.com/mql/v13/providers/datadog/resources
```

## Verification

- `make providers/build/datadog` — clean
- `go vet ./resources/` — clean
- `go test ./resources/` — pass
- `make mql/generate` codegen is up to date (regenerated `.lr.go` / `.lr.versions`)

The two remaining single-page lists that *may* paginate (`syntheticsTests`, `securitySuppressions` — the latter's response type is literally `...PaginatedSuppressionsResponse`) could not be confirmed statically and are best checked against a live org via provider-verification; left as-is for now.
