### PR TITLE
🧹 nextdns: harden profile init assertion + add pure-Go unit tests

### DIFF
--- a/providers/nextdns/connection/connection_test.go
+++ b/providers/nextdns/connection/connection_test.go
@@ -1,0 +1,91 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func expectedAccountID(apiKey string) string {
+	sum := sha256.Sum256([]byte(apiKey))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+func TestNewNextdnsConnection_AccountIDDerivation(t *testing.T) {
+	// Ensure the environment never leaks a real key into the config-credential cases.
+	t.Setenv("NEXTDNS_API_KEY", "")
+
+	t.Run("account id is the truncated sha256 fingerprint of the key", func(t *testing.T) {
+		conf := &inventory.Config{
+			Credentials: []*vault.Credential{vault.NewPasswordCredential("", "secret-key")},
+		}
+		conn, err := NewNextdnsConnection(1, &inventory.Asset{}, conf)
+		require.NoError(t, err)
+
+		id := conn.AccountID()
+		assert.Len(t, id, 16)
+		assert.Equal(t, expectedAccountID("secret-key"), id)
+	})
+
+	t.Run("id is deterministic and distinct per key", func(t *testing.T) {
+		mk := func(key string) string {
+			conf := &inventory.Config{
+				Credentials: []*vault.Credential{vault.NewPasswordCredential("", key)},
+			}
+			conn, err := NewNextdnsConnection(1, &inventory.Asset{}, conf)
+			require.NoError(t, err)
+			return conn.AccountID()
+		}
+
+		assert.Equal(t, mk("key-a"), mk("key-a"), "same key must yield the same account id")
+		assert.NotEqual(t, mk("key-a"), mk("key-b"), "different keys must yield different account ids")
+	})
+
+	t.Run("config credential is preferred over the environment", func(t *testing.T) {
+		t.Setenv("NEXTDNS_API_KEY", "env-key")
+		conf := &inventory.Config{
+			Credentials: []*vault.Credential{vault.NewPasswordCredential("", "config-key")},
+		}
+		conn, err := NewNextdnsConnection(1, &inventory.Asset{}, conf)
+		require.NoError(t, err)
+		assert.Equal(t, expectedAccountID("config-key"), conn.AccountID())
+	})
+
+	t.Run("falls back to the environment when no config credential is present", func(t *testing.T) {
+		t.Setenv("NEXTDNS_API_KEY", "env-key")
+		conn, err := NewNextdnsConnection(1, &inventory.Asset{}, &inventory.Config{})
+		require.NoError(t, err)
+		assert.Equal(t, expectedAccountID("env-key"), conn.AccountID())
+	})
+
+	t.Run("errors when no key is available anywhere", func(t *testing.T) {
+		t.Setenv("NEXTDNS_API_KEY", "")
+		_, err := NewNextdnsConnection(1, &inventory.Asset{}, &inventory.Config{})
+		require.Error(t, err)
+	})
+}
+
+func TestNextdnsConnection_ProfileID(t *testing.T) {
+	t.Setenv("NEXTDNS_API_KEY", "some-key")
+
+	t.Run("empty when the connection is account-scoped", func(t *testing.T) {
+		conn, err := NewNextdnsConnection(1, &inventory.Asset{}, &inventory.Config{})
+		require.NoError(t, err)
+		assert.Equal(t, "", conn.ProfileID())
+	})
+
+	t.Run("returns the scoped profile option", func(t *testing.T) {
+		conf := &inventory.Config{Options: map[string]string{OptionProfile: "abc123"}}
+		conn, err := NewNextdnsConnection(1, &inventory.Asset{}, conf)
+		require.NoError(t, err)
+		assert.Equal(t, "abc123", conn.ProfileID())
+	})
+}

--- a/providers/nextdns/resources/discovery_test.go
+++ b/providers/nextdns/resources/discovery_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers/nextdns/connection"
+)
+
+func TestHandleTargets(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected []string
+	}{
+		{
+			name:     "all expands to account and profiles",
+			targets:  []string{connection.DiscoveryAll},
+			expected: []string{connection.DiscoveryAccounts, connection.DiscoveryProfiles},
+		},
+		{
+			name:     "auto discovers profiles only (no empty account asset)",
+			targets:  []string{connection.DiscoveryAuto},
+			expected: []string{connection.DiscoveryProfiles},
+		},
+		{
+			name:     "explicit accounts stays accounts only",
+			targets:  []string{connection.DiscoveryAccounts},
+			expected: []string{connection.DiscoveryAccounts},
+		},
+		{
+			name:     "explicit profiles stays profiles only",
+			targets:  []string{connection.DiscoveryProfiles},
+			expected: []string{connection.DiscoveryProfiles},
+		},
+		{
+			name:     "all wins even when combined with an explicit target",
+			targets:  []string{connection.DiscoveryProfiles, connection.DiscoveryAll},
+			expected: []string{connection.DiscoveryAccounts, connection.DiscoveryProfiles},
+		},
+		{
+			name:     "empty targets discovers nothing",
+			targets:  []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, handleTargets(tc.targets))
+		})
+	}
+}

--- a/providers/nextdns/resources/helpers_test.go
+++ b/providers/nextdns/resources/helpers_test.go
@@ -1,0 +1,56 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func TestStrArray(t *testing.T) {
+	t.Run("nil slice", func(t *testing.T) {
+		res := strArray(nil)
+		require.NotNil(t, res)
+		assert.Equal(t, types.Array(types.String), res.Type)
+		assert.Equal(t, []any{}, res.Value)
+	})
+
+	t.Run("values are preserved in order", func(t *testing.T) {
+		res := strArray([]string{"a", "b", "c"})
+		assert.Equal(t, types.Array(types.String), res.Type)
+		assert.Equal(t, []any{"a", "b", "c"}, res.Value)
+	})
+}
+
+func TestIdItemsToStrings(t *testing.T) {
+	t.Run("nil slice yields empty (non-nil) slice", func(t *testing.T) {
+		assert.Equal(t, []string{}, idItemsToStrings(nil))
+	})
+
+	t.Run("extracts ids in order", func(t *testing.T) {
+		items := []idItem{{ID: "ru"}, {ID: "xyz"}, {ID: "pw"}}
+		assert.Equal(t, []string{"ru", "xyz", "pw"}, idItemsToStrings(items))
+	})
+}
+
+func TestTimeOrNil(t *testing.T) {
+	t.Run("nil returns MQL null", func(t *testing.T) {
+		res := timeOrNil(nil)
+		require.NotNil(t, res)
+		assert.Equal(t, types.Nil, res.Type)
+	})
+
+	t.Run("non-nil returns the time value", func(t *testing.T) {
+		ts := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+		res := timeOrNil(&ts)
+		require.NotNil(t, res)
+		assert.Equal(t, types.Time, res.Type)
+		require.IsType(t, &time.Time{}, res.Value)
+		assert.Equal(t, ts, *res.Value.(*time.Time))
+	})
+}

--- a/providers/nextdns/resources/profile.go
+++ b/providers/nextdns/resources/profile.go
@@ -22,8 +22,10 @@ import (
 // findings attributed to that profile. An explicit `id` argument is honored as
 // well; without one, the connection must be scoped to a single profile.
 func initNextdnsProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if id, ok := args["id"]; ok && id.Value != nil && id.Value.(string) != "" {
-		return args, nil, nil
+	if id, ok := args["id"]; ok && id.Value != nil {
+		if s, ok := id.Value.(string); ok && s != "" {
+			return args, nil, nil
+		}
 	}
 
 	conn := runtime.Connection.(*connection.NextdnsConnection)


### PR DESCRIPTION
Follow-up to a static bug review of the `nextdns` provider. This PR contains **only** hardening and test coverage: no schema changes, no behavior changes, no version bump.

## Fix

`initNextdnsProfile` used a bare `id.Value.(string)` assertion on the init arg. It was safe in practice (the `id` field is compiler-typed `string` on every call path), but the bare form differed from the comma-ok idiom the generated code uses for every `__id` assignment. Switched to comma-ok so it degrades gracefully rather than panicking if it ever receives a non-string value.

## Test coverage

The provider previously had no unit tests beyond the platform catalog. Added direct tests for the pure-Go logic where a wrong-data regression would otherwise go uncaught by the compiler and integration suite:

- **`handleTargets`** — `all`/`auto`/explicit discovery-target expansion, the "auto omits the empty account asset" rule, `all`-wins-when-combined, and empty input.
- **`strArray` / `idItemsToStrings` / `timeOrNil`** — order preservation, nil-slice handling, and null-vs-time mapping (`timeOrNil(nil)` must yield MQL null, not a zero time).
- **`accountID` derivation** — deterministic per-key sha256 fingerprint, config-credential-over-env precedence, env fallback, and the no-key-anywhere error path; plus `ProfileID` scoping.

## Out of scope (routed to live verification, not code changes)

The review surfaced two items that depend on the live `/profiles` list response shape and can't be confirmed statically:
- Whether `name`/`fingerprint` (plain stored fields) resolve consistently on the `nextdns.profiles` collection path vs the scoped `nextdns.profile` detail path.
- Whether the `/profiles` list is ever paginated for large accounts.

These are left for a live check against a real account rather than speculative code changes.

## Testing
- `go test ./providers/nextdns/...` passes
- `go build ./...` clean
