### PR TITLE
🐛 jamf: fix data race in policy/restricted-software detail cache

### DIFF
--- a/providers/jamf/resources/policies.go
+++ b/providers/jamf/resources/policies.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"go.mondoo.com/mql/v13/llx"
@@ -36,9 +37,10 @@ func jamfScopeEntitiesPtr[T any](items *[]T, idName func(T) (any, string)) []int
 
 // mqlJamfPolicyInternal caches the detail record. The list API returns only id
 // and name, so the remaining fields are fetched once, on first access, via
-// GetPolicyByID.
+// GetPolicyByID. detail is an atomic pointer so the lock-free fast path in
+// fetchDetail can read it without racing the write under lock.
 type mqlJamfPolicyInternal struct {
-	detail *jamfpro.ResourcePolicy
+	detail atomic.Pointer[jamfpro.ResourcePolicy]
 	lock   sync.Mutex
 }
 
@@ -79,14 +81,14 @@ func (p *mqlJamfPolicy) id() (string, error) {
 }
 
 func (p *mqlJamfPolicy) fetchDetail() (*jamfpro.ResourcePolicy, error) {
-	if p.detail != nil {
-		return p.detail, nil
+	if d := p.detail.Load(); d != nil {
+		return d, nil
 	}
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	if p.detail != nil {
-		return p.detail, nil
+	if d := p.detail.Load(); d != nil {
+		return d, nil
 	}
 
 	conn := p.MqlRuntime.Connection.(*connection.JamfConnection)
@@ -94,7 +96,7 @@ func (p *mqlJamfPolicy) fetchDetail() (*jamfpro.ResourcePolicy, error) {
 	if err != nil {
 		return nil, err
 	}
-	p.detail = detail
+	p.detail.Store(detail)
 	return detail, nil
 }
 

--- a/providers/jamf/resources/policies_test.go
+++ b/providers/jamf/resources/policies_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyScriptParameters_CollectsOnlyNonEmpty(t *testing.T) {
+	s := jamfpro.PolicySubsetScript{
+		Parameter4:  "four",
+		Parameter5:  "", // dropped
+		Parameter6:  "six",
+		Parameter7:  "",
+		Parameter8:  "",
+		Parameter9:  "nine",
+		Parameter10: "",
+		Parameter11: "eleven",
+	}
+
+	got := policyScriptParameters(s)
+
+	assert.Equal(t, map[string]interface{}{
+		"parameter4":  "four",
+		"parameter6":  "six",
+		"parameter9":  "nine",
+		"parameter11": "eleven",
+	}, got, "only non-empty parameters must appear, keyed by their slot")
+}
+
+func TestPolicyScriptParameters_AllEmptyYieldsEmptyMap(t *testing.T) {
+	got := policyScriptParameters(jamfpro.PolicySubsetScript{})
+	assert.Empty(t, got, "no parameters set → empty map, never nil-keyed junk")
+}
+
+func TestScriptParameters_CollectsOnlyNonEmpty(t *testing.T) {
+	s := jamfpro.ResourceScript{
+		Parameter4:  "a",
+		Parameter7:  "b",
+		Parameter11: "c",
+	}
+
+	got := scriptParameters(s)
+
+	assert.Equal(t, map[string]interface{}{
+		"parameter4":  "a",
+		"parameter7":  "b",
+		"parameter11": "c",
+	}, got)
+}
+
+func TestScriptParameters_AllEmptyYieldsEmptyMap(t *testing.T) {
+	got := scriptParameters(jamfpro.ResourceScript{})
+	assert.Empty(t, got)
+}
+
+func TestJamfScopeEntities_RendersIdNameDicts(t *testing.T) {
+	items := []jamfpro.PolicySubsetComputer{
+		{ID: 1, Name: "mac-1"},
+		{ID: 2, Name: "mac-2"},
+	}
+	idName := func(c jamfpro.PolicySubsetComputer) (any, string) { return int64(c.ID), c.Name }
+
+	got := jamfScopeEntities(items, idName)
+
+	assert.Equal(t, []interface{}{
+		map[string]interface{}{"id": int64(1), "name": "mac-1"},
+		map[string]interface{}{"id": int64(2), "name": "mac-2"},
+	}, got)
+}
+
+func TestJamfScopeEntities_EmptyInputYieldsEmptySlice(t *testing.T) {
+	idName := func(c jamfpro.PolicySubsetComputer) (any, string) { return int64(c.ID), c.Name }
+	got := jamfScopeEntities([]jamfpro.PolicySubsetComputer{}, idName)
+	assert.NotNil(t, got)
+	assert.Len(t, got, 0)
+}
+
+func TestJamfScopeEntitiesPtr_NilSliceYieldsEmptyNonNilSlice(t *testing.T) {
+	// The Jamf policy scope uses pointer slices that are nil when empty. A nil
+	// slice must render as an empty (non-nil) list, not panic and not null, so
+	// `.scope.computers` is always an iterable list in MQL.
+	idName := func(c jamfpro.PolicySubsetComputer) (any, string) { return int64(c.ID), c.Name }
+
+	got := jamfScopeEntitiesPtr(nil, idName)
+
+	assert.NotNil(t, got, "nil pointer slice must not render as MQL null")
+	assert.Len(t, got, 0)
+}
+
+func TestJamfScopeEntitiesPtr_PopulatedSliceRenders(t *testing.T) {
+	items := []jamfpro.PolicySubsetComputer{{ID: 7, Name: "mac-7"}}
+	idName := func(c jamfpro.PolicySubsetComputer) (any, string) { return int64(c.ID), c.Name }
+
+	got := jamfScopeEntitiesPtr(&items, idName)
+
+	assert.Equal(t, []interface{}{
+		map[string]interface{}{"id": int64(7), "name": "mac-7"},
+	}, got)
+}

--- a/providers/jamf/resources/restricted_software.go
+++ b/providers/jamf/resources/restricted_software.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"strconv"
 	"sync"
+	"sync/atomic"
 
 	"github.com/deploymenttheory/go-api-sdk-jamfpro/sdk/jamfpro"
 	"go.mondoo.com/mql/v13/llx"
@@ -14,9 +15,11 @@ import (
 
 // mqlJamfRestrictedSoftwareInternal caches the detail record. The list API
 // returns only id and name, so the remaining fields are fetched once, on
-// first access, via GetRestrictedSoftwareByID.
+// first access, via GetRestrictedSoftwareByID. detail is an atomic pointer so
+// the lock-free fast path in fetchDetail can read it without racing the write
+// under lock.
 type mqlJamfRestrictedSoftwareInternal struct {
-	detail *jamfpro.ResourceRestrictedSoftware
+	detail atomic.Pointer[jamfpro.ResourceRestrictedSoftware]
 	lock   sync.Mutex
 }
 
@@ -49,14 +52,14 @@ func (r *mqlJamfRestrictedSoftware) id() (string, error) {
 }
 
 func (r *mqlJamfRestrictedSoftware) fetchDetail() (*jamfpro.ResourceRestrictedSoftware, error) {
-	if r.detail != nil {
-		return r.detail, nil
+	if d := r.detail.Load(); d != nil {
+		return d, nil
 	}
 
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.detail != nil {
-		return r.detail, nil
+	if d := r.detail.Load(); d != nil {
+		return d, nil
 	}
 
 	conn := r.MqlRuntime.Connection.(*connection.JamfConnection)
@@ -64,7 +67,7 @@ func (r *mqlJamfRestrictedSoftware) fetchDetail() (*jamfpro.ResourceRestrictedSo
 	if err != nil {
 		return nil, err
 	}
-	r.detail = detail
+	r.detail.Store(detail)
 	return detail, nil
 }
 

--- a/providers/jamf/resources/user_by_name.go
+++ b/providers/jamf/resources/user_by_name.go
@@ -26,8 +26,8 @@ func initJamfUserByName(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		// Bare resource access is a valid empty state, not an error.
 		return args, nil, nil
 	}
-	name := nameArg.Value.(string)
-	if name == "" {
+	name, ok := nameArg.Value.(string)
+	if !ok || name == "" {
 		return nil, nil, errors.New("jamf.userByName requires a non-empty name")
 	}
 


### PR DESCRIPTION
## What

Fixes a data race in the lazy detail cache shared by `jamf.policy` and `jamf.restrictedSoftware`, plus a small assertion hardening and unit tests for two previously untested pure-Go helpers.

## The race

Both resources fetch their full record on first field access via a double-checked lock:

```go
if p.detail != nil {        // read WITHOUT holding p.lock
    return p.detail, nil
}
p.lock.Lock()
defer p.lock.Unlock()
if p.detail != nil { ... }
p.detail = detail           // write UNDER p.lock
```

The first `p.detail != nil` reads the pointer with no lock held while another goroutine writes it under the lock. The executor resolves sibling field accessors in parallel goroutines — e.g. `jamf.policies { enabled frequency trigger }` calls `fetchDetail` from three goroutines at once — so this is a genuine data race, caught by the race detector and a violation of the Go memory model.

**Fix:** store the cached detail in an `atomic.Pointer`, so the lock-free fast path reads it safely; the mutex still serializes the one-time fetch.

## Also included

- `initJamfUserByName`: comma-ok guard on the `name` assertion (defensive; the schema enforces `string`, but the bare assertion was a latent panic surface).
- New `policies_test.go` covering the untested pure-Go logic:
  - `scriptParameters` / `policyScriptParameters` — collect only non-empty `parameter4`–`parameter11`.
  - `jamfScopeEntities` / `jamfScopeEntitiesPtr` — a nil pointer slice must render as an empty (non-nil) list, not null and not a panic.

## Testing

- `go test ./resources/... -race` passes.
- `go build ./...` and `go vet` clean.
- No `.lr` / codegen / `.lr.versions` changes.
