### PR TITLE
🐛 shodan: fix ParseCLI panic, tz-less timestamp nulls, unbounded CIDR discovery + tests

### DIFF
--- a/providers/shodan/provider/provider.go
+++ b/providers/shodan/provider/provider.go
@@ -72,12 +72,12 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	name := ""
 	if len(req.Args) > 0 {
 		switch req.Args[0] {
-		case "host":
+		case "host", "domain":
+			if len(req.Args) < 2 {
+				return nil, errors.New("the Shodan " + req.Args[0] + " sub-command requires a target, for example `shodan " + req.Args[0] + " example.com`")
+			}
 			conf.Host = req.Args[1]
-			conf.Options["search"] = "host"
-		case "domain":
-			conf.Host = req.Args[1]
-			conf.Options["search"] = "domain"
+			conf.Options["search"] = req.Args[0]
 		default:
 			return nil, errors.New("invalid Shodan sub-command, supported are: host or domain")
 		}

--- a/providers/shodan/resources/discovery.go
+++ b/providers/shodan/resources/discovery.go
@@ -5,15 +5,24 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/shadowscatcher/shodan/search"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/shodan/connection"
 	"go.mondoo.com/mql/v13/utils/stringx"
 )
+
+// maxCIDRHosts caps how many addresses a single CIDR may expand to during
+// discovery. Each address costs one Shodan host lookup (and its query credit),
+// so we refuse to enumerate a range larger than a /16 rather than exhausting
+// memory and API credits. This also rejects IPv6 CIDRs, whose ranges are
+// astronomically large.
+const maxCIDRHosts = 1 << 16 // 65536, a /16 worth of IPv4 addresses
 
 func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inventory, error) {
 	conn := runtime.Connection.(*connection.ShodanConnection)
@@ -89,7 +98,9 @@ func resolveNetworks(networks []string) []netip.Addr {
 		// check if network is a CIDR range
 		if strings.Contains(network, "/") {
 			ips, err := cidrIPs(network)
-			if err == nil {
+			if err != nil {
+				log.Warn().Err(err).Str("network", network).Msg("skipping network during Shodan discovery")
+			} else {
 				addresses = append(addresses, ips...)
 			}
 		} else {
@@ -108,6 +119,17 @@ func cidrIPs(cidr string) ([]netip.Addr, error) {
 	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {
 		return nil, err
+	}
+	// Mask to the network address so enumeration covers the whole range even
+	// when the caller passed a host address (e.g. "10.0.0.5/24").
+	prefix = prefix.Masked()
+
+	// hostBits is the number of variable bits in the range; 2^hostBits is the
+	// range size. Reject anything larger than maxCIDRHosts before enumerating,
+	// which also rejects any non-trivial IPv6 CIDR (128-bit addresses).
+	hostBits := prefix.Addr().BitLen() - prefix.Bits()
+	if hostBits > 16 {
+		return nil, fmt.Errorf("CIDR range %q is too large to enumerate (limit is %d addresses)", cidr, maxCIDRHosts)
 	}
 
 	var ips []netip.Addr

--- a/providers/shodan/resources/domain.go
+++ b/providers/shodan/resources/domain.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/shadowscatcher/shodan/models"
 	"github.com/shadowscatcher/shodan/search"
@@ -79,19 +78,15 @@ func (r *mqlShodanDomain) fetchBaseInformation() error {
 
 	var mqlNsRecords []any
 	for _, nsrecord := range nsrecords {
-		lastSeen := llx.NilData
-
-		t, err := time.Parse(time.RFC3339, nsrecord.LastSeen)
-		if err == nil {
-			lastSeen = llx.TimeData(t)
-		}
-
+		// Shodan emits DNS last_seen without a timezone (e.g.
+		// "2021-03-15T00:00:00.000000"), so use the shared parser rather than a
+		// strict RFC3339 parse that would silently null the field.
 		recordResource, err := CreateResource(r.MqlRuntime, "shodan.nsrecord", map[string]*llx.RawData{
 			"domain":    llx.StringData(domain),
 			"subdomain": llx.StringData(nsrecord.Subdomain),
 			"type":      llx.StringData(nsrecord.Type),
 			"value":     llx.StringData(nsrecord.Value),
-			"lastSeen":  lastSeen,
+			"lastSeen":  optionalShodanTime(nsrecord.LastSeen),
 		})
 		if err != nil {
 			return err

--- a/providers/shodan/resources/host.go
+++ b/providers/shodan/resources/host.go
@@ -38,7 +38,7 @@ func initShodanHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	}
 
 	if _, ok := args["ip"]; !ok {
-		return nil, nil, errors.New("missing required argument 'host'")
+		return nil, nil, errors.New("missing required argument 'ip'")
 	}
 
 	return args, nil, nil

--- a/providers/shodan/resources/shodan.go
+++ b/providers/shodan/resources/shodan.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -32,12 +31,10 @@ func initShodanProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	args["member"] = llx.BoolData(profile.Member)
 	args["credits"] = llx.IntData(profile.Credits)
 	args["displayName"] = llx.StringData(profile.DisplayName)
-	args["createdAt"] = llx.NilData
-
-	t, err := time.Parse(time.RFC3339, profile.Created)
-	if err == nil {
-		args["createdAt"] = llx.TimeData(t)
-	}
+	// Shodan account timestamps come back without a timezone, so use the shared
+	// parser (which also accepts RFC3339) rather than a strict RFC3339 parse
+	// that would silently leave createdAt null.
+	args["createdAt"] = optionalShodanTime(profile.Created)
 
 	return args, nil, nil
 }

--- a/providers/shodan/resources/shodan_test.go
+++ b/providers/shodan/resources/shodan_test.go
@@ -95,10 +95,10 @@ func TestClassifyCVSS(t *testing.T) {
 
 func TestIsWeakCipher(t *testing.T) {
 	tests := []struct {
-		name string
-		ciph string
-		bits int
-		want bool
+		name   string
+		cipher string
+		bits   int
+		want   bool
 	}{
 		{"empty", "", 0, false},
 		{"modern aes-gcm", "TLS_AES_256_GCM_SHA384", 256, false},
@@ -115,7 +115,7 @@ func TestIsWeakCipher(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isWeakCipher(tc.ciph, tc.bits))
+			assert.Equal(t, tc.want, isWeakCipher(tc.cipher, tc.bits))
 		})
 	}
 }

--- a/providers/shodan/resources/shodan_test.go
+++ b/providers/shodan/resources/shodan_test.go
@@ -1,0 +1,214 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shadowscatcher/shodan/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/shodan/connection"
+)
+
+func TestParseShodanTime(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string // RFC3339Nano of the expected time, or "" for nil
+	}{
+		{"empty", "", ""},
+		{"rfc3339", "2024-05-01T12:00:00Z", "2024-05-01T12:00:00Z"},
+		{"rfc3339 nano", "2024-05-01T12:00:00.123456789Z", "2024-05-01T12:00:00.123456789Z"},
+		// The format Shodan actually emits for host/banner/DNS times: no timezone.
+		{"microseconds no tz", "2024-05-01T12:00:00.283713", "2024-05-01T12:00:00.283713Z"},
+		{"seconds no tz", "2024-05-01T12:00:00", "2024-05-01T12:00:00Z"},
+		{"garbage", "not-a-time", ""},
+		{"date only unsupported", "2024-05-01", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseShodanTime(tc.raw)
+			if tc.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			want, err := time.Parse(time.RFC3339Nano, tc.want)
+			require.NoError(t, err)
+			assert.True(t, got.Equal(want), "got %s, want %s", got, want)
+		})
+	}
+}
+
+func TestParseCVSS(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     any
+		want    float64
+		wantHas bool
+	}{
+		{"nil", nil, -1, false},
+		{"float", 9.8, 9.8, true},
+		{"zero float", 0.0, 0, true},
+		{"string number", "7.5", 7.5, true},
+		{"string with whitespace", "  4.3 ", 4.3, true},
+		{"empty string", "", -1, false},
+		{"partial parse rejected", "9.8 high", -1, false},
+		{"non-numeric string", "critical", -1, false},
+		{"unexpected type", []string{"9.8"}, -1, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, has := parseCVSS(tc.raw)
+			assert.Equal(t, tc.wantHas, has)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestClassifyCVSS(t *testing.T) {
+	tests := []struct {
+		score float64
+		has   bool
+		want  string
+	}{
+		{0, false, "unknown"},
+		{9.8, true, "critical"},
+		{9.0, true, "critical"},
+		{8.9, true, "high"},
+		{7.0, true, "high"},
+		{6.9, true, "medium"},
+		{4.0, true, "medium"},
+		{3.9, true, "low"},
+		{0.1, true, "low"},
+		{0, true, "none"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyCVSS(tc.score, tc.has))
+		})
+	}
+}
+
+func TestIsWeakCipher(t *testing.T) {
+	tests := []struct {
+		name string
+		ciph string
+		bits int
+		want bool
+	}{
+		{"empty", "", 0, false},
+		{"modern aes-gcm", "TLS_AES_256_GCM_SHA384", 256, false},
+		{"ecdhe strong", "ECDHE-RSA-AES128-GCM-SHA256", 128, false},
+		{"rc4", "ECDHE-RSA-RC4-SHA", 128, true},
+		{"3des", "DES-CBC3-SHA", 168, true},
+		{"null cipher", "TLS_RSA_WITH_NULL_SHA", 0, true},
+		{"export", "EXP-RC2-CBC-MD5", 40, true},
+		{"md5 mac", "AES128-MD5", 128, true},
+		{"short key strong name", "SOME-CIPHER", 64, true},
+		{"case insensitive", "ecdhe-rsa-des-cbc3-sha", 168, true},
+		// PSK is a key-exchange mechanism, not a broken primitive.
+		{"psk not weak", "TLS_PSK_WITH_AES_128_GCM_SHA256", 128, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isWeakCipher(tc.ciph, tc.bits))
+		})
+	}
+}
+
+func TestIsEmptySslCert(t *testing.T) {
+	assert.True(t, isEmptySslCert(nil))
+	assert.True(t, isEmptySslCert(&models.SslCert{}))
+
+	withCN := &models.SslCert{}
+	withCN.Subject.CN = "example.com"
+	assert.False(t, isEmptySslCert(withCN))
+
+	withFingerprint := &models.SslCert{}
+	withFingerprint.Fingerprint.SHA256 = "abc123"
+	assert.False(t, isEmptySslCert(withFingerprint))
+
+	withExpires := &models.SslCert{Expires: "2025-01-01T00:00:00"}
+	assert.False(t, isEmptySslCert(withExpires))
+}
+
+func TestCidrIPs(t *testing.T) {
+	t.Run("slash 24 strips network and broadcast", func(t *testing.T) {
+		ips, err := cidrIPs("192.168.1.0/24")
+		require.NoError(t, err)
+		require.Len(t, ips, 254)
+		assert.Equal(t, "192.168.1.1", ips[0].String())
+		assert.Equal(t, "192.168.1.254", ips[len(ips)-1].String())
+	})
+
+	t.Run("single host /32", func(t *testing.T) {
+		ips, err := cidrIPs("10.0.0.5/32")
+		require.NoError(t, err)
+		require.Len(t, ips, 1)
+		assert.Equal(t, "10.0.0.5", ips[0].String())
+	})
+
+	t.Run("host address masked to network", func(t *testing.T) {
+		ips, err := cidrIPs("10.0.0.5/24")
+		require.NoError(t, err)
+		require.Len(t, ips, 254)
+		assert.Equal(t, "10.0.0.1", ips[0].String())
+	})
+
+	t.Run("large IPv4 range rejected", func(t *testing.T) {
+		_, err := cidrIPs("10.0.0.0/8")
+		assert.Error(t, err)
+	})
+
+	t.Run("IPv6 range rejected", func(t *testing.T) {
+		_, err := cidrIPs("2001:db8::/64")
+		assert.Error(t, err)
+	})
+
+	t.Run("single IPv6 host allowed", func(t *testing.T) {
+		ips, err := cidrIPs("2001:db8::1/128")
+		require.NoError(t, err)
+		require.Len(t, ips, 1)
+	})
+
+	t.Run("invalid cidr", func(t *testing.T) {
+		_, err := cidrIPs("not-a-cidr")
+		assert.Error(t, err)
+	})
+}
+
+func TestResolveNetworks(t *testing.T) {
+	// Mixes a single IP, a small CIDR, an oversized CIDR (skipped), and garbage
+	// (skipped). Only valid, in-bounds addresses should survive.
+	addrs := resolveNetworks([]string{
+		"1.2.3.4",
+		"192.168.0.0/30", // 4 addresses -> 2 usable after trimming
+		"10.0.0.0/8",     // too large, skipped
+		"garbage",        // skipped
+	})
+
+	got := map[string]bool{}
+	for _, a := range addrs {
+		got[a.String()] = true
+	}
+	assert.True(t, got["1.2.3.4"])
+	assert.True(t, got["192.168.0.1"])
+	assert.True(t, got["192.168.0.2"])
+	assert.False(t, got["10.0.0.1"], "oversized range must be skipped")
+}
+
+func TestHandleTargets(t *testing.T) {
+	// "all" expands to the concrete host discovery target.
+	assert.Equal(t, []string{connection.DiscoveryHosts},
+		handleTargets([]string{connection.DiscoveryAll}))
+
+	// Other target lists pass through unchanged.
+	assert.Equal(t, []string{connection.DiscoveryAuto},
+		handleTargets([]string{connection.DiscoveryAuto}))
+	assert.Equal(t, []string{connection.DiscoveryHosts},
+		handleTargets([]string{connection.DiscoveryHosts}))
+}


### PR DESCRIPTION
## What

Static bug-review of the `shodan` provider turned up several defects that the compiler and the current (connection-only) test suite don't catch. This fixes the confirmed, low-risk ones and adds the provider's first unit tests for its pure-Go logic.

### Fixes

- **Panic — `ParseCLI` indexes `req.Args[1]` without an arity check** (`provider/provider.go`). `shodan host` / `shodan domain` with no target crashed with `index out of range [1]` instead of returning the usage error the `default` branch already provides. Now validated before indexing.
- **Silent null timestamps** (`resources/domain.go`, `resources/shodan.go`). `shodan.domain` `nsrecord.lastSeen` and `shodan.profile.createdAt` were parsed with a strict `time.RFC3339` layout, but Shodan emits timestamps **without a timezone** (e.g. `2021-03-15T00:00:00.000000` — the SDK itself documents `Service.Timestamp` as `2014-01-15T05:49:56.283713`). The parse failed and the field was silently left `null`. Both now use the existing `parseShodanTime`/`optionalShodanTime` helper (which also accepts RFC3339), matching how host, banner, and cert times are already parsed.
- **Unbounded CIDR discovery** (`resources/discovery.go`). `cidrIPs` enumerated every address of a `--networks` CIDR into a slice and `Discover` made one `Host()` API call per address. A large IPv4 block (e.g. `/8` → 16M entries) or **any IPv6 CIDR** (e.g. `/64`) would exhaust memory / burn query credits / effectively hang. `cidrIPs` now masks to the network address and refuses ranges larger than a `/16` (which also rejects IPv6 CIDRs); `resolveNetworks` logs and skips a rejected range instead of failing silently.
- **Misleading error message** (`resources/host.go`). `initShodanHost` reported `missing required argument 'host'` when the argument key is `ip`.

### Tests

Adds `resources/shodan_test.go` — the provider's first resource-level unit tests, covering the pure-Go logic where wrong-data bugs hide: `parseShodanTime`, `parseCVSS`/`classifyCVSS`, `isWeakCipher`, `isEmptySslCert`, `cidrIPs`, `resolveNetworks`, and `handleTargets` (including the timezone-less and IPv6/oversized-CIDR cases fixed here).

### Deferred (from the same review, not in this PR)

- A possible data race in `fetchBaseInformation` (host/domain) with no lock around the lazy fetch — needs `-race` confirmation.
- Domain pagination aborts and discards page-1 data if a page-2 fetch errors on a non-enterprise token — needs live confirmation of the API behavior.

## Test plan

- `go build ./...` and `go vet ./resources/ ./provider/` clean
- `go test ./...` passes (new tests + existing connection tests); `go mod tidy` is a no-op
