### PR TITLE
🐛 slack: fix userGroups listing failure on empty lifecycle user IDs

### DIFF
--- a/providers/slack/resources/conversations.go
+++ b/providers/slack/resources/conversations.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -212,10 +213,21 @@ func (s *mqlSlackConversation) members() ([]any, error) {
 		}
 
 		for i := range members {
-
 			user := findUser(members[i])
 			if user == nil {
-				return nil, errors.New("could not find user " + members[i])
+				// The member is not part of this workspace's user list, which
+				// happens for external participants in Slack Connect / shared
+				// channels. Resolve them directly; skip only if that also fails,
+				// rather than failing the entire members list.
+				ext, err := NewResource(s.MqlRuntime, "slack.user", map[string]*llx.RawData{
+					"id": llx.StringData(members[i]),
+				})
+				if err != nil {
+					log.Warn().Str("user", members[i]).Str("channel", s.Id.Data).
+						Msg("slack: skipping conversation member that could not be resolved")
+					continue
+				}
+				user = ext.(*mqlSlackUser)
 			}
 			list = append(list, user)
 		}

--- a/providers/slack/resources/slack.lr
+++ b/providers/slack/resources/slack.lr
@@ -200,11 +200,11 @@ slack.userGroup @defaults("handle") {
   // Timestamp when the group was deleted
   deleted time
   // User that created the group
-  createdBy slack.user
+  createdBy() slack.user
   // User that updated the group
-  updatedBy slack.user
+  updatedBy() slack.user
   // User that deleted the group
-  deletedBy slack.user
+  deletedBy() slack.user
   // Total number of users in a group
   userCount int
   // Members of the group

--- a/providers/slack/resources/slack.lr.go
+++ b/providers/slack/resources/slack.lr.go
@@ -1494,7 +1494,7 @@ func (c *mqlSlackEnterpriseUser) GetIsOwner() *plugin.TValue[bool] {
 type mqlSlackUserGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlSlackUserGroupInternal it will be used here
+	mqlSlackUserGroupInternal
 	Id          plugin.TValue[string]
 	TeamId      plugin.TValue[string]
 	Name        plugin.TValue[string]
@@ -1585,15 +1585,51 @@ func (c *mqlSlackUserGroup) GetDeleted() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlSlackUserGroup) GetCreatedBy() *plugin.TValue[*mqlSlackUser] {
-	return &c.CreatedBy
+	return plugin.GetOrCompute[*mqlSlackUser](&c.CreatedBy, func() (*mqlSlackUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("slack.userGroup", c.__id, "createdBy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlSlackUser), nil
+			}
+		}
+
+		return c.createdBy()
+	})
 }
 
 func (c *mqlSlackUserGroup) GetUpdatedBy() *plugin.TValue[*mqlSlackUser] {
-	return &c.UpdatedBy
+	return plugin.GetOrCompute[*mqlSlackUser](&c.UpdatedBy, func() (*mqlSlackUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("slack.userGroup", c.__id, "updatedBy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlSlackUser), nil
+			}
+		}
+
+		return c.updatedBy()
+	})
 }
 
 func (c *mqlSlackUserGroup) GetDeletedBy() *plugin.TValue[*mqlSlackUser] {
-	return &c.DeletedBy
+	return plugin.GetOrCompute[*mqlSlackUser](&c.DeletedBy, func() (*mqlSlackUser, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("slack.userGroup", c.__id, "deletedBy")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlSlackUser), nil
+			}
+		}
+
+		return c.deletedBy()
+	})
 }
 
 func (c *mqlSlackUserGroup) GetUserCount() *plugin.TValue[int64] {

--- a/providers/slack/resources/slack_test.go
+++ b/providers/slack/resources/slack_test.go
@@ -1,0 +1,129 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func strVal(s string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+}
+
+// TestUserGroupOptionalUserRefsNullWhenEmpty is the regression test for the
+// userGroups listing failing whenever a lifecycle user ID was empty. deletedBy
+// is empty for every group that has not been deleted; the old code eagerly
+// resolved it via NewResource -> GetUsersInfo(""), which errored and failed the
+// entire userGroups query. The accessors must now return a null reference
+// (no lookup) when the cached ID is empty.
+func TestUserGroupOptionalUserRefsNullWhenEmpty(t *testing.T) {
+	cases := []struct {
+		name   string
+		call   func(*mqlSlackUserGroup) (*mqlSlackUser, error)
+		field  func(*mqlSlackUserGroup) plugin.TValue[*mqlSlackUser]
+		setKey func(*mqlSlackUserGroup, string)
+	}{
+		{"createdBy", (*mqlSlackUserGroup).createdBy, func(g *mqlSlackUserGroup) plugin.TValue[*mqlSlackUser] { return g.CreatedBy }, func(g *mqlSlackUserGroup, v string) { g.cacheCreatedBy = v }},
+		{"updatedBy", (*mqlSlackUserGroup).updatedBy, func(g *mqlSlackUserGroup) plugin.TValue[*mqlSlackUser] { return g.UpdatedBy }, func(g *mqlSlackUserGroup, v string) { g.cacheUpdatedBy = v }},
+		{"deletedBy", (*mqlSlackUserGroup).deletedBy, func(g *mqlSlackUserGroup) plugin.TValue[*mqlSlackUser] { return g.DeletedBy }, func(g *mqlSlackUserGroup, v string) { g.cacheDeletedBy = v }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" empty -> null ref", func(t *testing.T) {
+			g := &mqlSlackUserGroup{}
+			tc.setKey(g, "")
+
+			res, err := tc.call(g)
+			if err != nil {
+				t.Fatalf("expected no error for empty %s, got %v", tc.name, err)
+			}
+			if res != nil {
+				t.Fatalf("expected nil resource for empty %s, got %v", tc.name, res)
+			}
+			field := tc.field(g)
+			if !field.IsSet() || !field.IsNull() {
+				t.Fatalf("expected %s to be set+null, got state %v", tc.name, field.State)
+			}
+		})
+	}
+}
+
+func TestResourceIDs(t *testing.T) {
+	t.Run("slack.user", func(t *testing.T) {
+		u := &mqlSlackUser{TeamId: strVal("T123"), Id: strVal("U456")}
+		got, _ := u.id()
+		if want := "slack.user/T123/U456"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slack.enterpriseUser", func(t *testing.T) {
+		e := &mqlSlackEnterpriseUser{EnterpriseId: strVal("E1"), Id: strVal("U9")}
+		got, _ := e.id()
+		if want := "slack.enterpriseUser/E1/U9"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slack.userGroup", func(t *testing.T) {
+		g := &mqlSlackUserGroup{Id: strVal("S01")}
+		got, _ := g.id()
+		if want := "slack.userGroup/S01"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slack.conversation", func(t *testing.T) {
+		c := &mqlSlackConversation{Id: strVal("C77")}
+		got, _ := c.id()
+		if want := "slack.conversation/C77"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slack.team", func(t *testing.T) {
+		team := &mqlSlackTeam{Id: strVal("T123")}
+		got, _ := team.id()
+		if want := "slack.team/T123"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("slack.login composite key", func(t *testing.T) {
+		l := &mqlSlackLogin{
+			UserID:    strVal("U1"),
+			Ip:        strVal("1.2.3.4"),
+			UserAgent: strVal("Mozilla/5.0"),
+		}
+		got, _ := l.id()
+		if want := "slack.login/user/U1/ip/1.2.3.4/useragent/Mozilla/5.0"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestNewTopicAndPurpose(t *testing.T) {
+	ts := slack.JSONTime(1_600_000_000)
+	want := time.Unix(1_600_000_000, 0)
+
+	topic := newTopic(slack.Topic{Value: "hello", Creator: "U1", LastSet: ts})
+	if topic.Value != "hello" || topic.Creator != "U1" {
+		t.Errorf("topic fields mismatch: %+v", topic)
+	}
+	if topic.LastSet == nil || !topic.LastSet.Equal(want) {
+		t.Errorf("topic.LastSet = %v, want %v", topic.LastSet, want)
+	}
+
+	purpose := newPurpose(slack.Purpose{Value: "goal", Creator: "U2", LastSet: ts})
+	if purpose.Value != "goal" || purpose.Creator != "U2" {
+		t.Errorf("purpose fields mismatch: %+v", purpose)
+	}
+	if purpose.LastSet == nil || !purpose.LastSet.Equal(want) {
+		t.Errorf("purpose.LastSet = %v, want %v", purpose.LastSet, want)
+	}
+}

--- a/providers/slack/resources/usergroups.go
+++ b/providers/slack/resources/usergroups.go
@@ -41,33 +41,22 @@ func (s *mqlSlack) userGroups() ([]any, error) {
 	return list, nil
 }
 
+// mqlSlackUserGroupInternal caches the user IDs backing the lifecycle
+// createdBy()/updatedBy()/deletedBy() typed references. These IDs are often
+// empty (deletedBy is empty for every group that has not been deleted), so
+// they are resolved lazily and guarded rather than looked up eagerly.
+type mqlSlackUserGroupInternal struct {
+	cacheCreatedBy string
+	cacheUpdatedBy string
+	cacheDeletedBy string
+}
+
 func newMqlSlackUserGroup(runtime *plugin.Runtime, userGroup slack.UserGroup) (any, error) {
 	dateCreate := userGroup.DateCreate.Time()
 	dateUpdate := userGroup.DateUpdate.Time()
 	dateDelete := userGroup.DateDelete.Time()
 
-	createdBy, err := NewResource(runtime, "slack.user", map[string]*llx.RawData{
-		"id": llx.StringData(userGroup.CreatedBy),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	updatedBy, err := NewResource(runtime, "slack.user", map[string]*llx.RawData{
-		"id": llx.StringData(userGroup.UpdatedBy),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	deletedBy, err := NewResource(runtime, "slack.user", map[string]*llx.RawData{
-		"id": llx.StringData(userGroup.DeletedBy),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return CreateResource(runtime, "slack.userGroup", map[string]*llx.RawData{
+	r, err := CreateResource(runtime, "slack.userGroup", map[string]*llx.RawData{
 		"id":          llx.StringData(userGroup.ID),
 		"teamId":      llx.StringData(userGroup.TeamID),
 		"name":        llx.StringData(userGroup.Name),
@@ -77,20 +66,59 @@ func newMqlSlackUserGroup(runtime *plugin.Runtime, userGroup slack.UserGroup) (a
 		"created":     llx.TimeData(dateCreate),
 		"updated":     llx.TimeData(dateUpdate),
 		"deleted":     llx.TimeData(dateDelete),
-		"createdBy":   llx.ResourceData(createdBy, "slack.user"),
-		"updatedBy":   llx.ResourceData(updatedBy, "slack.user"),
-		"deletedBy":   llx.ResourceData(deletedBy, "slack.user"),
 		"userCount":   llx.IntData(int64(userGroup.UserCount)),
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	mqlGroup := r.(*mqlSlackUserGroup)
+	mqlGroup.cacheCreatedBy = userGroup.CreatedBy
+	mqlGroup.cacheUpdatedBy = userGroup.UpdatedBy
+	mqlGroup.cacheDeletedBy = userGroup.DeletedBy
+	return mqlGroup, nil
 }
 
 func (x *mqlSlackUserGroup) id() (string, error) {
 	return "slack.userGroup/" + x.Id.Data, nil
 }
 
+// userRef resolves a slack.user reference for the given ID, or returns a null
+// reference when the ID is empty. deletedBy is empty for every group that has
+// not been deleted, and createdBy/updatedBy can be empty for auto-provisioned
+// groups; resolving an empty ID would fail the whole userGroups listing.
+func (s *mqlSlackUserGroup) userRef(id string, field *plugin.TValue[*mqlSlackUser]) (*mqlSlackUser, error) {
+	if id == "" {
+		*field = plugin.TValue[*mqlSlackUser]{State: plugin.StateIsSet | plugin.StateIsNull}
+		return nil, nil
+	}
+	r, err := NewResource(s.MqlRuntime, "slack.user", map[string]*llx.RawData{
+		"id": llx.StringData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlSlackUser), nil
+}
+
+func (s *mqlSlackUserGroup) createdBy() (*mqlSlackUser, error) {
+	return s.userRef(s.cacheCreatedBy, &s.CreatedBy)
+}
+
+func (s *mqlSlackUserGroup) updatedBy() (*mqlSlackUser, error) {
+	return s.userRef(s.cacheUpdatedBy, &s.UpdatedBy)
+}
+
+func (s *mqlSlackUserGroup) deletedBy() (*mqlSlackUser, error) {
+	return s.userRef(s.cacheDeletedBy, &s.DeletedBy)
+}
+
 func (s *mqlSlackUserGroup) members() ([]any, error) {
 	conn := s.MqlRuntime.Connection.(*connection.SlackConnection)
 	client := conn.Client()
+	if client == nil {
+		return nil, errors.New("cannot retrieve new data while using a mock connection")
+	}
 
 	userID := s.Id.Data
 

--- a/providers/slack/resources/users.go
+++ b/providers/slack/resources/users.go
@@ -92,9 +92,6 @@ func (s *mqlSlackUsers) admins() ([]any, error) {
 		cur := all[i]
 		usr := cur.(*mqlSlackUser)
 		isAdmin := usr.IsAdmin.Data
-		if err != nil {
-			return nil, err
-		}
 		if isAdmin == true {
 			res = append(res, cur)
 		}


### PR DESCRIPTION
## Summary

Static bug review of the `slack` provider surfaced one HIGH defect that breaks an entire resource plus a few smaller robustness issues. This PR fixes them and adds the provider's first resource-layer unit tests.

### HIGH — `slack.userGroups` fails on virtually every real workspace

`newMqlSlackUserGroup` eagerly resolved the `createdBy`/`updatedBy`/`deletedBy` typed user references via `NewResource("slack.user", {id})`. `NewResource` runs the user `init` **eagerly**, so an empty ID called `GetUsersInfo("")` — which returns either an API error or zero users, and **both branches error**. `slack.UserGroup.DeletedBy` is empty for every group that has not been deleted (i.e. almost all of them), so the error propagated up and failed the whole `slack.userGroups` listing.

**Fix:** convert the three lifecycle fields to guarded computed accessors — the same pattern `conversation.creator()` already uses. They return a null reference when the cached ID is empty and resolve lazily otherwise. The raw IDs are cached on a new `mqlSlackUserGroupInternal` struct. `.lr.versions` and `.resources.json` are byte-identical after regen (field name/type/version unchanged), so this is not a schema-breaking change.

### MEDIUM — `conversation.members` errored on Slack Connect / shared channels

`members()` looked members up only in the connected workspace's user list and hard-errored (`could not find user X`) on a miss. External participants in `isExtShared` / shared channels are never in that list, so the whole `.members` call failed for those channels. Now it resolves the unknown member directly and skips (with a warning) only if that also fails, instead of failing the entire list.

### LOW

- **`userGroup.members`**: added the mock-connection nil-client guard every other accessor already has (was a nil-deref panic path on mock connections).
- **`users.admins`**: removed a dead `if err != nil` check left over from copy-paste.

### Tests

The resource layer had no unit tests. Added `slack_test.go` covering:
- the empty-ID → null-reference regression for `createdBy`/`updatedBy`/`deletedBy` (the HIGH fix),
- the id / cache-key builders (`slack.user`, `slack.enterpriseUser`, `slack.userGroup`, `slack.conversation`, `slack.team`, and the composite `slack.login` key),
- the `newTopic` / `newPurpose` converters.

## Not included (needs live verification)

`conversation.members` also skips members entirely when `is_channel` is false (DMs, MPIMs, legacy private channels) via `if !isChannel { return empty }`. Whether this silently drops data depends on the exact `is_channel` value per channel type, which can't be confirmed statically — flagged for verification against a live workspace rather than changed blindly here.

## Test plan

- [x] `go build ./...` (slack module)
- [x] `go vet ./resources/...`
- [x] `go test ./resources/...` — passes
- [x] `mqlr generate` clean; only `slack.lr.go` changed among generated files
