### PR TITLE
🐛 digitalocean: fix 5 __id collisions, 3 dict-type field errors, dead findings pagination

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -9493,7 +9493,12 @@ func createDigitaloceanVectorDatabase(runtime *plugin.Runtime, args map[string]*
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("digitalocean.vectorDatabase", res.__id)
@@ -13510,7 +13515,12 @@ func createDigitaloceanVpcNatGateway(runtime *plugin.Runtime, args map[string]*l
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("digitalocean.vpcNatGateway", res.__id)
@@ -13649,7 +13659,12 @@ func createDigitaloceanNfs(runtime *plugin.Runtime, args map[string]*llx.RawData
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("digitalocean.nfs", res.__id)
@@ -14055,7 +14070,12 @@ func createDigitaloceanDropletAutoscalePool(runtime *plugin.Runtime, args map[st
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("digitalocean.dropletAutoscalePool", res.__id)
@@ -16046,7 +16066,12 @@ func createDigitaloceanGradientaiDedicatedInferenceEndpoint(runtime *plugin.Runt
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("digitalocean.gradientai.dedicatedInferenceEndpoint", res.__id)

--- a/providers/digitalocean/resources/digitalocean_dict_test.go
+++ b/providers/digitalocean/resources/digitalocean_dict_test.go
@@ -1,0 +1,153 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertDictSerializable enforces the same contract as llx's dict2primitive:
+// a value stored in a `dict`/`[]dict` field must be one of bool, int64,
+// float64, string, []any, map[string]any, or nil. Anything else (a raw SDK
+// *int32, int32, []string, *time.Time, ...) trips the converter's default
+// branch and surfaces to the user as
+// "failed to convert dict to primitive, unsupported child type: ...".
+// The recursion mirrors dict2primitive so nested values are checked too.
+func assertDictSerializable(t *testing.T, path string, v any) {
+	t.Helper()
+	switch x := v.(type) {
+	case nil, bool, int64, float64, string:
+		// JSON-native scalars — fine.
+	case []any:
+		for i, e := range x {
+			assertDictSerializable(t, path, e)
+			_ = i
+		}
+	case map[string]any:
+		for k, e := range x {
+			assertDictSerializable(t, path+"."+k, e)
+		}
+	default:
+		t.Fatalf("dict value %q is not JSON-native (%T); dict2primitive will reject it", path, v)
+	}
+}
+
+func TestSecretVersionDict_Serializable(t *testing.T) {
+	// Timestamps must be strings, not *time.Time.
+	d := secretVersionDict(&godo.SecretVersion{
+		Version:   3,
+		CreatedAt: "2026-01-02T15:04:05Z",
+		UpdatedAt: "2026-01-03T15:04:05Z",
+	})
+	for k, v := range d {
+		assertDictSerializable(t, "secretVersion."+k, v)
+	}
+	assert.Equal(t, int64(3), d["version"])
+	assert.Equal(t, "2026-01-02T15:04:05Z", d["createdAt"])
+	assert.Equal(t, "2026-01-03T15:04:05Z", d["updatedAt"])
+}
+
+func TestSpacesCorsRuleDict_Serializable(t *testing.T) {
+	tests := []struct {
+		name string
+		rule s3types.CORSRule
+	}{
+		{
+			name: "fully populated",
+			rule: s3types.CORSRule{
+				ID:             aws.String("rule-1"),
+				AllowedHeaders: []string{"*"},
+				AllowedMethods: []string{"GET", "PUT"},
+				AllowedOrigins: []string{"https://example.com"},
+				ExposeHeaders:  []string{"ETag"},
+				MaxAgeSeconds:  aws.Int32(3600),
+			},
+		},
+		{
+			// The common case: required members only, nil max-age. This is
+			// what used to error (raw []string + nil *int32 in the dict).
+			name: "required members only, nil maxAge",
+			rule: s3types.CORSRule{
+				AllowedMethods: []string{"GET"},
+				AllowedOrigins: []string{"*"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := spacesCorsRuleDict(tt.rule)
+			for k, v := range d {
+				assertDictSerializable(t, "corsRule."+k, v)
+			}
+			// []string must be widened to []any.
+			methods, ok := d["allowedMethods"].([]any)
+			require.True(t, ok, "allowedMethods must be []any, got %T", d["allowedMethods"])
+			assert.NotEmpty(t, methods)
+			// nil max-age must be omitted, not stored as a typed nil.
+			if tt.rule.MaxAgeSeconds == nil {
+				_, present := d["maxAgeSeconds"]
+				assert.False(t, present, "maxAgeSeconds must be omitted when nil")
+			} else {
+				assert.Equal(t, int64(3600), d["maxAgeSeconds"])
+			}
+		})
+	}
+}
+
+func TestSpacesLifecycleRuleDict_Serializable(t *testing.T) {
+	tests := []struct {
+		name        string
+		rule        s3types.LifecycleRule
+		wantExpDays bool
+	}{
+		{
+			name: "expiration + noncurrent + abort days set",
+			rule: s3types.LifecycleRule{
+				ID:                          aws.String("lc-1"),
+				Status:                      s3types.ExpirationStatusEnabled,
+				Filter:                      &s3types.LifecycleRuleFilter{Prefix: aws.String("logs/")},
+				Expiration:                  &s3types.LifecycleExpiration{Days: aws.Int32(30)},
+				NoncurrentVersionExpiration: &s3types.NoncurrentVersionExpiration{NoncurrentDays: aws.Int32(7)},
+				AbortIncompleteMultipartUpload: &s3types.AbortIncompleteMultipartUpload{
+					DaysAfterInitiation: aws.Int32(1),
+				},
+			},
+			wantExpDays: true,
+		},
+		{
+			// A status-only rule (no day counts) must not store typed-nil *int32.
+			name:        "no day counts",
+			rule:        s3types.LifecycleRule{Status: s3types.ExpirationStatusEnabled},
+			wantExpDays: false,
+		},
+		{
+			// Present sub-struct but nil Days pointer — must be omitted.
+			name: "expiration present but nil Days",
+			rule: s3types.LifecycleRule{
+				Status:     s3types.ExpirationStatusEnabled,
+				Expiration: &s3types.LifecycleExpiration{},
+			},
+			wantExpDays: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := spacesLifecycleRuleDict(tt.rule)
+			for k, v := range d {
+				assertDictSerializable(t, "lifecycleRule."+k, v)
+			}
+			_, present := d["expirationDays"]
+			assert.Equal(t, tt.wantExpDays, present)
+			if tt.wantExpDays {
+				assert.Equal(t, int64(30), d["expirationDays"])
+			}
+		})
+	}
+}

--- a/providers/digitalocean/resources/digitalocean_droplet_autoscale.go
+++ b/providers/digitalocean/resources/digitalocean_droplet_autoscale.go
@@ -114,6 +114,10 @@ func (r *mqlDigitalocean) dropletAutoscalePools() ([]interface{}, error) {
 	return all, nil
 }
 
+func (r *mqlDigitaloceanDropletAutoscalePool) id() (string, error) {
+	return "digitalocean.dropletAutoscalePool/" + r.Id.Data, nil
+}
+
 func (r *mqlDigitaloceanDropletAutoscalePool) members() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()

--- a/providers/digitalocean/resources/digitalocean_functions_paging_test.go
+++ b/providers/digitalocean/resources/digitalocean_functions_paging_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListOpenWhiskActions_Paginates verifies the hand-rolled OpenWhisk
+// pagination loop follows the limit/skip cursor across pages instead of
+// stopping after the first. The endpoint returns a full page (200) then a
+// short page (3), so a correct loop yields 203 actions; a truncating loop
+// would return only the first 200.
+func TestListOpenWhiskActions_Paginates(t *testing.T) {
+	const fullPage = 200
+	const tail = 3
+
+	var seenSkips []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/namespaces/_/actions", r.URL.Path)
+		// basic auth must be forwarded
+		u, p, ok := r.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "uuid-1", u)
+		assert.Equal(t, "key-1", p)
+
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		assert.Equal(t, fullPage, limit)
+		skip, _ := strconv.Atoi(r.URL.Query().Get("skip"))
+		seenSkips = append(seenSkips, skip)
+
+		count := 0
+		switch skip {
+		case 0:
+			count = fullPage
+		case fullPage:
+			count = tail
+		default:
+			t.Fatalf("unexpected skip %d — loop paged too far", skip)
+		}
+
+		page := make([]owAction, count)
+		for i := range page {
+			page[i] = owAction{Name: fmt.Sprintf("action-%d", skip+i)}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(page))
+	}))
+	defer srv.Close()
+
+	actions, err := listOpenWhiskActions(context.Background(), srv.URL, "uuid-1", "key-1")
+	require.NoError(t, err)
+	assert.Len(t, actions, fullPage+tail, "all pages should be aggregated")
+	assert.Equal(t, []int{0, fullPage}, seenSkips, "skip should advance by the page size")
+	// spot-check that later-page actions actually made it in
+	assert.Equal(t, "action-0", actions[0].Name)
+	assert.Equal(t, fmt.Sprintf("action-%d", fullPage+tail-1), actions[len(actions)-1].Name)
+}
+
+// TestListOpenWhiskActions_SinglePage confirms a short first page ends the
+// loop immediately (no spurious second request).
+func TestListOpenWhiskActions_SinglePage(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		page := []owAction{{Name: "only"}}
+		require.NoError(t, json.NewEncoder(w).Encode(page))
+	}))
+	defer srv.Close()
+
+	actions, err := listOpenWhiskActions(context.Background(), srv.URL, "u", "k")
+	require.NoError(t, err)
+	assert.Len(t, actions, 1)
+	assert.Equal(t, 1, calls, "a short first page must not trigger a second request")
+}
+
+// TestListOpenWhiskActions_ErrorStatus confirms a non-200 status surfaces as
+// an error rather than being decoded as an empty action list.
+func TestListOpenWhiskActions_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	_, err := listOpenWhiskActions(context.Background(), srv.URL, "u", "k")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}

--- a/providers/digitalocean/resources/digitalocean_gradientai_inference.go
+++ b/providers/digitalocean/resources/digitalocean_gradientai_inference.go
@@ -257,6 +257,10 @@ func (r *mqlDigitaloceanGradientai) dedicatedInferenceEndpoints() ([]interface{}
 	return all, nil
 }
 
+func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) id() (string, error) {
+	return "digitalocean.gradientai.dedicatedInferenceEndpoint/" + r.Id.Data, nil
+}
+
 func (r *mqlDigitaloceanGradientaiDedicatedInferenceEndpoint) vpc() (*mqlDigitaloceanVpc, error) {
 	return resolveVpcRef(r.MqlRuntime, &r.Vpc, r.VpcUuid.Data)
 }

--- a/providers/digitalocean/resources/digitalocean_id_test.go
+++ b/providers/digitalocean/resources/digitalocean_id_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func strVal(s string) plugin.TValue[string] {
+	return plugin.TValue[string]{Data: s, State: plugin.StateIsSet}
+}
+
+// TestResourceIDsAreUniquePerInstance guards against the __id-collision class:
+// a list-created resource with no id() method and no explicit "__id" arg gets
+// the empty cache key "<name>\x00", so every instance aliases to the first.
+// Each resource below previously lacked an id() method; this test asserts the
+// id() exists, embeds the resource's own id, and differs across two instances.
+func TestResourceIDsAreUniquePerInstance(t *testing.T) {
+	type idFn func() (string, error)
+	tests := []struct {
+		name string
+		a    idFn
+		b    idFn
+	}{
+		{
+			name: "digitalocean.nfs",
+			a:    (&mqlDigitaloceanNfs{Id: strVal("nfs-a")}).id,
+			b:    (&mqlDigitaloceanNfs{Id: strVal("nfs-b")}).id,
+		},
+		{
+			name: "digitalocean.vpcNatGateway",
+			a:    (&mqlDigitaloceanVpcNatGateway{Id: strVal("gw-a")}).id,
+			b:    (&mqlDigitaloceanVpcNatGateway{Id: strVal("gw-b")}).id,
+		},
+		{
+			name: "digitalocean.dropletAutoscalePool",
+			a:    (&mqlDigitaloceanDropletAutoscalePool{Id: strVal("pool-a")}).id,
+			b:    (&mqlDigitaloceanDropletAutoscalePool{Id: strVal("pool-b")}).id,
+		},
+		{
+			name: "digitalocean.vectorDatabase",
+			a:    (&mqlDigitaloceanVectorDatabase{Id: strVal("vdb-a")}).id,
+			b:    (&mqlDigitaloceanVectorDatabase{Id: strVal("vdb-b")}).id,
+		},
+		{
+			name: "digitalocean.gradientai.dedicatedInferenceEndpoint",
+			a:    (&mqlDigitaloceanGradientaiDedicatedInferenceEndpoint{Id: strVal("ep-a")}).id,
+			b:    (&mqlDigitaloceanGradientaiDedicatedInferenceEndpoint{Id: strVal("ep-b")}).id,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idA, err := tt.a()
+			require.NoError(t, err)
+			idB, err := tt.b()
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, idA, "id() must not be empty (empty => cache collision)")
+			assert.NotEqual(t, idA, idB, "distinct instances must get distinct __ids")
+			assert.Contains(t, idA, tt.name+"/", "id() should be namespaced by resource type")
+			assert.Contains(t, idA, "-a", "id() must embed the instance's own id")
+		})
+	}
+}

--- a/providers/digitalocean/resources/digitalocean_networking.go
+++ b/providers/digitalocean/resources/digitalocean_networking.go
@@ -92,6 +92,10 @@ func (r *mqlDigitalocean) vpcNatGateways() ([]interface{}, error) {
 	return all, nil
 }
 
+func (r *mqlDigitaloceanVpcNatGateway) id() (string, error) {
+	return "digitalocean.vpcNatGateway/" + r.Id.Data, nil
+}
+
 func (r *mqlDigitaloceanVpcNatGateway) vpcs() ([]interface{}, error) {
 	return vpcRefsByUUIDs(r.MqlRuntime, r.vpcUUIDs)
 }

--- a/providers/digitalocean/resources/digitalocean_nfs.go
+++ b/providers/digitalocean/resources/digitalocean_nfs.go
@@ -79,6 +79,10 @@ func (r *mqlDigitalocean) nfsShares() ([]interface{}, error) {
 	return all, nil
 }
 
+func (r *mqlDigitaloceanNfs) id() (string, error) {
+	return "digitalocean.nfs/" + r.Id.Data, nil
+}
+
 func (r *mqlDigitaloceanNfs) vpcs() ([]interface{}, error) {
 	uuids := make([]string, 0, len(r.VpcIds.Data))
 	for _, v := range r.VpcIds.Data {

--- a/providers/digitalocean/resources/digitalocean_secrets.go
+++ b/providers/digitalocean/resources/digitalocean_secrets.go
@@ -95,20 +95,18 @@ func (r *mqlDigitaloceanSecret) versions() ([]interface{}, error) {
 		if v == nil {
 			continue
 		}
-
-		var createdAt, updatedAt *time.Time
-		if t, perr := time.Parse(time.RFC3339, v.CreatedAt); perr == nil {
-			createdAt = &t
-		}
-		if t, perr := time.Parse(time.RFC3339, v.UpdatedAt); perr == nil {
-			updatedAt = &t
-		}
-
-		out = append(out, map[string]interface{}{
-			"version":   int64(v.Version),
-			"createdAt": createdAt,
-			"updatedAt": updatedAt,
-		})
+		out = append(out, secretVersionDict(v))
 	}
 	return out, nil
+}
+
+// secretVersionDict builds the dict for one secret version. dict values
+// must be JSON-native (dict2primitive rejects *time.Time), so the API's
+// RFC3339 timestamps are kept as strings.
+func secretVersionDict(v *godo.SecretVersion) map[string]interface{} {
+	return map[string]interface{}{
+		"version":   int64(v.Version),
+		"createdAt": v.CreatedAt,
+		"updatedAt": v.UpdatedAt,
+	}
 }

--- a/providers/digitalocean/resources/digitalocean_security_scan.go
+++ b/providers/digitalocean/resources/digitalocean_security_scan.go
@@ -104,33 +104,37 @@ func (r *mqlDigitaloceanSecurityScan) findings() ([]interface{}, error) {
 	conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
 	client := conn.Client()
 
+	// GetScan decodes into a struct that carries no pagination links, so
+	// godo never populates resp.Links for this endpoint (unlike ListScans).
+	// Drive pagination off the returned page size instead: keep advancing
+	// while a full page comes back, bounded by maxPages so a misbehaving
+	// cursor can't hang the scan.
+	const perPage = 200
+	const maxPages = 1000
 	var all []interface{}
-	opt := &godo.ScanFindingsOptions{ListOptions: godo.ListOptions{PerPage: 200}}
-	for {
-		scan, resp, err := client.Security.GetScan(context.Background(), r.Id.Data, opt)
+	opt := &godo.ScanFindingsOptions{ListOptions: godo.ListOptions{PerPage: perPage, Page: 1}}
+	for page := 0; page < maxPages; page++ {
+		scan, _, err := client.Security.GetScan(context.Background(), r.Id.Data, opt)
 		if err != nil {
 			return nil, err
 		}
-		if scan != nil {
-			for _, f := range scan.Findings {
-				if f == nil {
-					continue
-				}
-				mqlFinding, err := r.newFinding(f)
-				if err != nil {
-					return nil, err
-				}
-				all = append(all, mqlFinding)
-			}
-		}
-		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+		if scan == nil {
 			break
 		}
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
+		for _, f := range scan.Findings {
+			if f == nil {
+				continue
+			}
+			mqlFinding, err := r.newFinding(f)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, mqlFinding)
 		}
-		opt.Page = page + 1
+		if len(scan.Findings) < perPage {
+			break
+		}
+		opt.Page++
 	}
 	return all, nil
 }

--- a/providers/digitalocean/resources/digitalocean_spaces.go
+++ b/providers/digitalocean/resources/digitalocean_spaces.go
@@ -313,14 +313,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 	corsRules := []interface{}{}
 	if c, err := client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: aws.String(name)}); err == nil {
 		for _, rule := range c.CORSRules {
-			corsRules = append(corsRules, map[string]interface{}{
-				"id":             aws.ToString(rule.ID),
-				"allowedHeaders": rule.AllowedHeaders,
-				"allowedMethods": rule.AllowedMethods,
-				"allowedOrigins": rule.AllowedOrigins,
-				"exposeHeaders":  rule.ExposeHeaders,
-				"maxAgeSeconds":  rule.MaxAgeSeconds,
-			})
+			corsRules = append(corsRules, spacesCorsRuleDict(rule))
 		}
 	} else if !isNoSuchConfiguration(err) {
 		return nil, err
@@ -329,23 +322,7 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 	lifecycleRules := []interface{}{}
 	if l, err := client.GetBucketLifecycleConfiguration(ctx, &s3.GetBucketLifecycleConfigurationInput{Bucket: aws.String(name)}); err == nil {
 		for _, rule := range l.Rules {
-			entry := map[string]interface{}{
-				"id":     aws.ToString(rule.ID),
-				"status": string(rule.Status),
-			}
-			if f := rule.Filter; f != nil {
-				entry["prefix"] = aws.ToString(f.Prefix)
-			}
-			if rule.Expiration != nil {
-				entry["expirationDays"] = rule.Expiration.Days
-			}
-			if rule.NoncurrentVersionExpiration != nil {
-				entry["noncurrentVersionExpirationDays"] = rule.NoncurrentVersionExpiration.NoncurrentDays
-			}
-			if rule.AbortIncompleteMultipartUpload != nil {
-				entry["abortIncompleteMultipartUploadDays"] = rule.AbortIncompleteMultipartUpload.DaysAfterInitiation
-			}
-			lifecycleRules = append(lifecycleRules, entry)
+			lifecycleRules = append(lifecycleRules, spacesLifecycleRuleDict(rule))
 		}
 	} else if !isNoSuchConfiguration(err) {
 		return nil, err
@@ -369,6 +346,46 @@ func newSpacesBucket(runtime *plugin.Runtime, client *s3.Client, region string, 
 		"corsRules":            llx.ArrayData(corsRules, types.Dict),
 		"lifecycleRules":       llx.ArrayData(lifecycleRules, types.Dict),
 	})
+}
+
+// spacesCorsRuleDict builds the dict for one CORS rule. dict values must
+// be JSON-native, so the SDK's []string members are widened to []any and
+// the *int32 max-age is dereferenced to int64 (only when the API set it).
+func spacesCorsRuleDict(rule s3types.CORSRule) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":             aws.ToString(rule.ID),
+		"allowedHeaders": toStringSlice(rule.AllowedHeaders),
+		"allowedMethods": toStringSlice(rule.AllowedMethods),
+		"allowedOrigins": toStringSlice(rule.AllowedOrigins),
+		"exposeHeaders":  toStringSlice(rule.ExposeHeaders),
+	}
+	if rule.MaxAgeSeconds != nil {
+		entry["maxAgeSeconds"] = int64(*rule.MaxAgeSeconds)
+	}
+	return entry
+}
+
+// spacesLifecycleRuleDict builds the dict for one lifecycle rule. The SDK
+// models the day-counts as *int32; dict values must be JSON-native int64,
+// so each is dereferenced only when the API actually set it.
+func spacesLifecycleRuleDict(rule s3types.LifecycleRule) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":     aws.ToString(rule.ID),
+		"status": string(rule.Status),
+	}
+	if f := rule.Filter; f != nil {
+		entry["prefix"] = aws.ToString(f.Prefix)
+	}
+	if rule.Expiration != nil && rule.Expiration.Days != nil {
+		entry["expirationDays"] = int64(*rule.Expiration.Days)
+	}
+	if rule.NoncurrentVersionExpiration != nil && rule.NoncurrentVersionExpiration.NoncurrentDays != nil {
+		entry["noncurrentVersionExpirationDays"] = int64(*rule.NoncurrentVersionExpiration.NoncurrentDays)
+	}
+	if rule.AbortIncompleteMultipartUpload != nil && rule.AbortIncompleteMultipartUpload.DaysAfterInitiation != nil {
+		entry["abortIncompleteMultipartUploadDays"] = int64(*rule.AbortIncompleteMultipartUpload.DaysAfterInitiation)
+	}
+	return entry
 }
 
 // noSuchConfigurationCodes are the S3 error codes returned for

--- a/providers/digitalocean/resources/digitalocean_vectordatabases.go
+++ b/providers/digitalocean/resources/digitalocean_vectordatabases.go
@@ -78,6 +78,10 @@ func (r *mqlDigitalocean) vectorDatabases() ([]interface{}, error) {
 	return all, nil
 }
 
+func (r *mqlDigitaloceanVectorDatabase) id() (string, error) {
+	return "digitalocean.vectorDatabase/" + r.Id.Data, nil
+}
+
 func (r *mqlDigitaloceanVectorDatabaseBackup) id() (string, error) {
 	return "digitalocean.vectorDatabase.backup/" + r.VectorDatabaseId.Data + "/" + r.BackupId.Data, nil
 }


### PR DESCRIPTION
## What

A static bug-review of the `digitalocean` provider surfaced three defect classes that hand users **wrong data with no error** — the worst kind, because the wrong answer looks valid. This fixes all three and adds regression tests.

### 1. `__id` collisions — silent wrong inventory (HIGH)

Five list-created resources had **no `id()` method** and passed **no explicit `"__id"`**, so their generated `createXxx` had no cache-key fallback. Every instance got the empty key `"<name>\x00"` and aliased to the first — an account with ≥2 of any of them returned the first object repeated N times (and, for a couple, post-create mutation of the shared object corrupted its typed refs). Fixed by adding `id()` methods and regenerating so the fallback is emitted:

| Resource | Was returning |
|---|---|
| `digitalocean.nfs` | first NFS share × N |
| `digitalocean.vpcNatGateway` | first gateway × N |
| `digitalocean.dropletAutoscalePool` | first pool × N |
| `digitalocean.vectorDatabase` | first cluster × N |
| `digitalocean.gradientai.dedicatedInferenceEndpoint` | first endpoint × N |

### 2. Non-JSON-native values in `[]dict` fields — query-time errors (HIGH)

llx's `dict2primitive` accepts only `bool/int64/float64/string/[]any/map/nil`; any other Go type hits its `default` branch and errors (`unsupported child type: …`). Three fields stored raw SDK types:

- **`secret.versions`** stored `*time.Time` (errored for every secret with version history) → keep the API's RFC3339 strings.
- **`spacesBucket.corsRules`** stored `[]string` (required members) + `*int32` (errored for any bucket with CORS) → widen `[]string`→`[]any`, deref `*int32`→`int64`.
- **`spacesBucket.lifecycleRules`** stored `*int32` day-counts → `int64`, set only when the API populated them.

### 3. `securityScan.findings` dead pagination — silent truncation (MEDIUM)

The loop broke on `resp.Links`, but godo's `GetScan` decodes into a struct with no links and **never populates `resp.Links`** (unlike `ListScans`), so it always stopped after page 1 and dropped findings past `PerPage`. Reworked to drive pagination off the returned page size, bounded by a `maxPages` guard.

## Tests

- **Dict-serializability guards** for the three builders (extracted as pure functions), asserting every dict value is JSON-native — the exact check that would have caught all three field bugs.
- **`id()`-uniqueness table test** for the five resources — distinct instances must get distinct, id-derived cache keys.
- **`httptest`-backed coverage** of the hand-rolled OpenWhisk pagination loop (multi-page aggregation, single-page early-exit, non-200 → error).

## Verification

- `go build ./...`, `go vet`, and `go test ./resources/...` pass. *(The httptest tests need outbound loopback; run outside a network sandbox.)*
- `mqlr generate` is idempotent; `.lr.versions` and `.resources.json` are unchanged (no new fields, no version bump).

## Not included (left for review / live verification)

- Non-degrading DB sub-accessors (`firewallRules`/`users`/`replicas`/`pools`) on a 403/404 — a judgment call between degrade-to-empty vs. surface-the-permission-error.
- A possible list-vs-get cross-path inconsistency on gradientai agent nested fields (`model`/`knowledgeBases`/`guardrails`/`functions`) — needs live confirmation of whether `ListAgents` returns those objects.
