### PR TITLE
🐛 depsdev: fix scorecard/scorecardCheck __id collision across projects

### DIFF
--- a/providers/depsdev/connection/parse_test.go
+++ b/providers/depsdev/connection/parse_test.go
@@ -1,0 +1,68 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseGoMod(t *testing.T) {
+	goMod := `module example.com/test
+
+go 1.25
+
+require (
+	github.com/rs/zerolog v1.33.0
+	golang.org/x/mod v0.20.0
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+)
+
+require github.com/stretchr/testify v1.9.0
+`
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(path, []byte(goMod), 0o600); err != nil {
+		t.Fatalf("failed to write test go.mod: %v", err)
+	}
+
+	deps, err := parseGoMod(path)
+	if err != nil {
+		t.Fatalf("parseGoMod returned error: %v", err)
+	}
+
+	// Only direct dependencies should be returned; indirect ones dropped.
+	want := map[string]string{
+		"github.com/rs/zerolog":       "v1.33.0",
+		"golang.org/x/mod":            "v0.20.0",
+		"github.com/stretchr/testify": "v1.9.0",
+	}
+
+	if len(deps) != len(want) {
+		t.Fatalf("expected %d direct deps, got %d: %+v", len(want), len(deps), deps)
+	}
+
+	for _, d := range deps {
+		v, ok := want[d.Path]
+		if !ok {
+			t.Errorf("unexpected dependency %q (indirect deps should be excluded)", d.Path)
+			continue
+		}
+		if d.Version != v {
+			t.Errorf("dependency %q: got version %q, want %q", d.Path, d.Version, v)
+		}
+	}
+}
+
+func TestParseGoModMissingFile(t *testing.T) {
+	if _, err := parseGoMod(filepath.Join(t.TempDir(), "does-not-exist.mod")); err == nil {
+		t.Fatal("expected error for missing go.mod, got nil")
+	}
+}

--- a/providers/depsdev/resources/api.go
+++ b/providers/depsdev/resources/api.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,11 @@ import (
 	"strings"
 	"time"
 )
+
+// errNotGitHubProject marks a project identifier that is not a github.com
+// repository (e.g. a GitLab or Bitbucket source). Callers use it to tell a
+// genuinely-unsupported project apart from a real GitHub API failure.
+var errNotGitHubProject = errors.New("not a GitHub repository")
 
 const depsDevBaseURL = "https://api.deps.dev/v3"
 const githubAPIBaseURL = "https://api.github.com"
@@ -172,16 +178,26 @@ type githubRepoResponse struct {
 	Archived bool `json:"archived"`
 }
 
+// githubOwnerRepo extracts "owner/repo" from a deps.dev project identifier in
+// the format "github.com/owner/repo" or "github.com/owner/repo/subpath". It
+// returns errNotGitHubProject (wrapped) when the identifier is not a github.com
+// repository.
+func githubOwnerRepo(projectID string) (string, error) {
+	parts := strings.Split(projectID, "/")
+	if len(parts) < 3 || parts[0] != "github.com" {
+		return "", fmt.Errorf("%w: %s", errNotGitHubProject, projectID)
+	}
+	return parts[1] + "/" + parts[2], nil
+}
+
 // fetchGitHubRepo retrieves repository info from the GitHub API.
 // The projectID is expected to be in the format "github.com/owner/repo" or
 // "github.com/owner/repo/subpath" (only owner/repo is used).
 func fetchGitHubRepo(client *http.Client, projectID string) (*githubRepoResponse, error) {
-	// Extract owner/repo from "github.com/owner/repo[/...]"
-	parts := strings.Split(projectID, "/")
-	if len(parts) < 3 || parts[0] != "github.com" {
-		return nil, fmt.Errorf("project %q is not a GitHub repository", projectID)
+	ownerRepo, err := githubOwnerRepo(projectID)
+	if err != nil {
+		return nil, err
 	}
-	ownerRepo := parts[1] + "/" + parts[2]
 
 	u := fmt.Sprintf("%s/repos/%s", githubAPIBaseURL, ownerRepo)
 	req, err := http.NewRequest("GET", u, nil)

--- a/providers/depsdev/resources/api_test.go
+++ b/providers/depsdev/resources/api_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGithubOwnerRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		projectID string
+		want      string
+		wantErr   bool // errNotGitHubProject expected
+	}{
+		{name: "plain repo", projectID: "github.com/rs/zerolog", want: "rs/zerolog"},
+		{name: "repo with subpath", projectID: "github.com/aws/aws-sdk-go-v2/config", want: "aws/aws-sdk-go-v2"},
+		{name: "gitlab is not github", projectID: "gitlab.com/foo/bar", wantErr: true},
+		{name: "bitbucket is not github", projectID: "bitbucket.org/foo/bar", wantErr: true},
+		{name: "too few segments", projectID: "github.com/onlyowner", wantErr: true},
+		{name: "empty", projectID: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := githubOwnerRepo(tt.projectID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.projectID, got)
+				}
+				if !errors.Is(err, errNotGitHubProject) {
+					t.Fatalf("expected errNotGitHubProject for %q, got %v", tt.projectID, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.projectID, err)
+			}
+			if got != tt.want {
+				t.Fatalf("githubOwnerRepo(%q) = %q, want %q", tt.projectID, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/depsdev/resources/package.go
+++ b/providers/depsdev/resources/package.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -14,13 +15,13 @@ import (
 )
 
 type mqlDepsdevPackageInternal struct {
-	fetched bool
+	fetched atomic.Bool
 	lock    sync.Mutex
 }
 
 type mqlDepsdevPackageVersionInternal struct {
 	packageName string
-	fetched     bool
+	fetched     atomic.Bool
 	lock        sync.Mutex
 }
 
@@ -49,12 +50,12 @@ func (r *mqlDepsdevPackage) id() (string, error) {
 // fetchPackageInfo fetches all version data from deps.dev and populates
 // versions, latestVersion, and latestPublished in one call.
 func (r *mqlDepsdevPackage) fetchPackageInfo() error {
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 
@@ -109,7 +110,7 @@ func (r *mqlDepsdevPackage) fetchPackageInfo() error {
 		r.LatestPublished = plugin.TValue[*time.Time]{Data: nil, State: plugin.StateIsSet | plugin.StateIsNull}
 	}
 
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil
 }
 
@@ -192,12 +193,12 @@ func (r *mqlDepsdevPackageVersion) id() (string, error) {
 // fetchVersionDetail fetches the version detail from deps.dev and populates
 // licenses, links, registries, slsaProvenances, and relatedProjects in one call.
 func (r *mqlDepsdevPackageVersion) fetchVersionDetail() error {
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 
@@ -261,7 +262,7 @@ func (r *mqlDepsdevPackageVersion) fetchVersionDetail() error {
 	}
 	r.RelatedProjects = plugin.TValue[[]any]{Data: related, State: plugin.StateIsSet}
 
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil
 }
 

--- a/providers/depsdev/resources/project.go
+++ b/providers/depsdev/resources/project.go
@@ -6,18 +6,20 @@ package resources
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/depsdev/connection"
+	"go.mondoo.com/mql/v13/types"
 )
 
 type mqlDepsdevProjectInternal struct {
-	fetched         bool
+	fetched         atomic.Bool
 	lock            sync.Mutex
-	archivedFetched bool
+	archivedFetched atomic.Bool
 	archivedLock    sync.Mutex
 }
 
@@ -43,12 +45,12 @@ func (r *mqlDepsdevProject) id() (string, error) {
 
 // fetchProjectInfo fetches project data from deps.dev and populates all fields.
 func (r *mqlDepsdevProject) fetchProjectInfo() error {
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.fetched {
+	if r.fetched.Load() {
 		return nil
 	}
 
@@ -76,7 +78,7 @@ func (r *mqlDepsdevProject) fetchProjectInfo() error {
 		r.Scorecard = plugin.TValue[*mqlDepsdevScorecard]{Data: nil, State: plugin.StateIsSet | plugin.StateIsNull}
 	}
 
-	r.fetched = true
+	r.fetched.Store(true)
 	return nil
 }
 
@@ -88,7 +90,12 @@ func (r *mqlDepsdevProject) buildScorecard(sc *depsDevScorecardResponse) (*mqlDe
 			docURL = c.Documentation.ShortDescription
 		}
 
+		// Pass __id explicitly: CreateResource calls id() before projectID is set
+		// below, so id() would otherwise build a key with an empty project id and
+		// collide across projects that share a check name (the OpenSSF check names
+		// are a fixed set, identical across every project).
 		check, err := CreateResource(r.MqlRuntime, "depsdev.scorecardCheck", map[string]*llx.RawData{
+			"__id":          llx.StringData("depsdev.scorecardCheck/" + r.Id.Data + "/" + c.Name),
 			"name":          llx.StringData(c.Name),
 			"score":         llx.IntData(int64(c.Score)),
 			"reason":        llx.StringData(c.Reason),
@@ -103,10 +110,13 @@ func (r *mqlDepsdevProject) buildScorecard(sc *depsDevScorecardResponse) (*mqlDe
 	}
 
 	scorecardDate := sc.Date
+	// Pass __id explicitly for the same reason as the checks above: projectID is
+	// assigned after CreateResource returns, so id() cannot build the key from it.
 	res, err := CreateResource(r.MqlRuntime, "depsdev.scorecard", map[string]*llx.RawData{
+		"__id":         llx.StringData("depsdev.scorecard/" + r.Id.Data + "/" + scorecardDate.Format(time.RFC3339)),
 		"overallScore": llx.FloatData(sc.OverallScore),
 		"date":         llx.TimeData(scorecardDate),
-		"checks":       llx.ArrayData(checks, "\x12depsdev.scorecardCheck"),
+		"checks":       llx.ArrayData(checks, types.Resource("depsdev.scorecardCheck")),
 	})
 	if err != nil {
 		return nil, err
@@ -147,12 +157,12 @@ func (r *mqlDepsdevProject) scorecard() (*mqlDepsdevScorecard, error) {
 }
 
 func (r *mqlDepsdevProject) archived() (bool, error) {
-	if r.archivedFetched {
+	if r.archivedFetched.Load() {
 		return r.Archived.Data, nil
 	}
 	r.archivedLock.Lock()
 	defer r.archivedLock.Unlock()
-	if r.archivedFetched {
+	if r.archivedFetched.Load() {
 		return r.Archived.Data, nil
 	}
 
@@ -160,13 +170,25 @@ func (r *mqlDepsdevProject) archived() (bool, error) {
 
 	repo, err := fetchGitHubRepo(conn.HttpClient, r.Id.Data)
 	if err != nil {
-		log.Warn().Str("project", r.Id.Data).Msg("cannot determine archived status for non-GitHub project")
+		if !errors.Is(err, errNotGitHubProject) {
+			// A real GitHub API failure (rate limit, 5xx, network). Surface it
+			// rather than silently reporting the dependency as "not archived":
+			// unauthenticated GitHub is limited to 60 requests/hour, so a large
+			// go.mod without GITHUB_TOKEN would otherwise mask every lookup.
+			return false, err
+		}
+		// Not a github.com project (e.g. GitLab, Bitbucket): the archived state is
+		// genuinely unavailable here, so degrade to null.
+		log.Debug().Str("project", r.Id.Data).Msg("archived status unavailable for non-GitHub project")
 		r.Archived = plugin.TValue[bool]{Data: false, State: plugin.StateIsSet | plugin.StateIsNull}
-		r.archivedFetched = true
+		r.archivedFetched.Store(true)
 		return false, nil
 	}
 
-	r.archivedFetched = true
+	// Set the field before the flag so the unlocked fast-path above observes a
+	// populated value once it sees archivedFetched == true.
+	r.Archived = plugin.TValue[bool]{Data: repo.Archived, State: plugin.StateIsSet}
+	r.archivedFetched.Store(true)
 	return repo.Archived, nil
 }
 


### PR DESCRIPTION
## Problem

`buildScorecard` created `depsdev.scorecard` and `depsdev.scorecardCheck` resources without an explicit `__id`, while their `id()` methods derive the key from `projectID` — a field only assigned on the `Internal` struct **after** `CreateResource` returns. So `id()` ran with an empty `projectID` and produced project-independent cache keys:

```
depsdev.scorecardCheck//<Name>    // OpenSSF check names are a fixed set, identical across every project
depsdev.scorecard//<Date>
```

`CreateResource` returns the already-cached resource on a key match, so on a multi-dependency scan every project after the first **aliased the first-scanned project's scorecard checks** — reporting the wrong scores/reasons with no error — and, for any two projects sharing a scorecard evaluation date, its `overallScore` too. In a supply-chain audit this silently returns the wrong project's security posture.

The provider already handles this correctly for `packageVersion` and `relatedProject` (they pass `__id` explicitly with an explanatory comment); `buildScorecard` had simply missed the same fix.

## Fix

- Pass `__id` explicitly in both `CreateResource` calls in `buildScorecard`, built from `r.Id.Data` (available at that point), mirroring the existing `packageVersion`/`relatedProject` pattern.

## Also included

- **`archived()` error handling** — a real GitHub API failure (rate limit / 5xx / network) was conflated with "not a GitHub project" and silently reported as `null`. Unauthenticated GitHub is limited to 60 req/hr, so a large `go.mod` without `GITHUB_TOKEN` would mask every lookup. Now only a genuine non-`github.com` project degrades to null; real API failures are surfaced. A new sentinel error `errNotGitHubProject` (via an extracted `githubOwnerRepo` helper) distinguishes the two.
- **`archived()` cache consistency** — the success path now sets the `Archived` field before flipping the fetched flag, so the unlocked fast-path read observes a populated value.
- **Data race** — the lazy-load double-check flags (`fetched`, `archivedFetched`) are now `atomic.Bool`, removing the race on the unlocked fast-path read.
- **Wrong type byte** — the `checks` `ArrayData` call used a hand-typed `"\x12"` escape (byte 18) instead of the resource type prefix (byte 27); replaced with `types.Resource("depsdev.scorecardCheck")`.
- **Tests** — added unit coverage for `githubOwnerRepo` (parser + sentinel error) and `parseGoMod` (direct-vs-indirect dependency filtering), the provider's untested pure-Go logic.

## Verification

- `go build ./...`, `go vet`, `go test ./resources/... ./connection/...` (incl. `-race`) all pass.
- No `.lr` changes, so no codegen or `.lr.versions` bumps; `go.mod` unchanged.
