### PR TITLE
🐛 kustomize: fix integer json6902 patch value query error; surface file-based patch content

### DIFF
--- a/providers/kustomize/resources/kustomize_test.go
+++ b/providers/kustomize/resources/kustomize_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/utils/syncx"
 	kustomizeTypes "sigs.k8s.io/kustomize/api/types"
@@ -48,6 +49,57 @@ func TestReplacementTargetsWithoutFieldPaths(t *testing.T) {
 	targets, err := r.targets()
 	require.NoError(t, err)
 	assert.Len(t, targets, 3, "target with no fieldPaths must still emit one row")
+}
+
+// TestPatchOperationValueSerializesAsDict guards the regression where an
+// integer patch value (e.g. `value: 3`) crashed the `value` accessor: yaml.v3
+// decodes integer scalars to Go `int`, which the llx dict serializer rejects.
+// The decoded operation values must be JSON-native so `.value` serializes
+// cleanly, including integers nested inside maps.
+func TestPatchOperationValueSerializesAsDict(t *testing.T) {
+	patch := &kustomizeTypes.Patch{Patch: "" +
+		"- op: replace\n" +
+		"  path: /spec/replicas\n" +
+		"  value: 3\n" +
+		"- op: add\n" +
+		"  path: /spec/template/spec/containers/0/resources\n" +
+		"  value:\n" +
+		"    limits:\n" +
+		"      cpu: 2\n"}
+
+	p, err := newMqlKustomizePatch(newTestRuntime(), "kustomization.yaml", 0, patch, hintNone)
+	require.NoError(t, err)
+	require.Equal(t, patchFormatJSON6902, p.format)
+
+	ops, err := p.operations()
+	require.NoError(t, err)
+	require.Len(t, ops, 2)
+
+	for _, o := range ops {
+		op := o.(*mqlKustomizePatchOperation)
+		// Result() runs the same raw->primitive conversion the runtime uses
+		// when the field crosses the plugin boundary; a non-JSON-native value
+		// surfaces here as a non-empty Error.
+		res := llx.DictData(op.Value.Data).Result()
+		assert.Empty(t, res.Error, "operation value must serialize as a JSON-native dict")
+	}
+
+	// The bare integer is normalized to float64 (matching the manifest dict path).
+	first := ops[0].(*mqlKustomizePatchOperation)
+	assert.Equal(t, float64(3), first.Value.Data, "integer values normalize to float64")
+}
+
+// TestNewMqlKustomizePatchContentFromFile ensures a file-based patch surfaces
+// the file's body through the `content` field rather than an empty string.
+func TestNewMqlKustomizePatchContentFromFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: myapp\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "patch.yaml"), []byte(body), 0o600))
+
+	p, err := newMqlKustomizePatch(newTestRuntime(), dir, 0, &kustomizeTypes.Patch{Path: "patch.yaml"}, hintNone)
+	require.NoError(t, err)
+	assert.Equal(t, body, p.Content.Data, "file-based patch must expose the file body as content")
+	assert.Equal(t, patchFormatStrategicMerge, p.format)
 }
 
 // TestNewMqlKustomizePatchReadsFile ensures a patch that references a JSON6902

--- a/providers/kustomize/resources/patch.go
+++ b/providers/kustomize/resources/patch.go
@@ -4,6 +4,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -67,8 +68,11 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 	}
 
 	// Read the raw patch bytes: inline content wins, otherwise the file the
-	// patch points at (relative to the kustomization directory).
+	// patch points at (relative to the kustomization directory). `content`
+	// tracks the same bytes so a file-based patch surfaces its body through
+	// the `content` field rather than an empty string.
 	raw := []byte(p.Patch)
+	content := p.Patch
 	if len(raw) == 0 && p.Path != "" {
 		// Best-effort read; a missing/unreadable file falls back to
 		// strategic-merge with no operations rather than failing the audit.
@@ -97,6 +101,7 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 			switch {
 			case readErr == nil:
 				raw = data
+				content = string(data)
 			case !os.IsNotExist(readErr):
 				// A genuinely missing file is the expected best-effort case; any
 				// other read failure would silently misclassify the patch, so
@@ -114,7 +119,7 @@ func newMqlKustomizePatch(runtime *plugin.Runtime, kustPath string, index int, p
 
 	res, err := CreateResource(runtime, "kustomize.patch", map[string]*llx.RawData{
 		"__id":                     llx.StringData(id),
-		"content":                  llx.StringData(p.Patch),
+		"content":                  llx.StringData(content),
 		"path":                     llx.StringData(p.Path),
 		"format":                   llx.StringData(format),
 		"targetGroup":              llx.StringData(targetGroup),
@@ -187,6 +192,13 @@ func decodeJSON6902(raw []byte) ([]jsonPatchOp, bool) {
 
 		pathVal, _ := elem["path"].(string)
 		value, hasValue := elem["value"]
+		if hasValue {
+			// yaml.v3 decodes integer scalars to Go `int`, which the llx dict
+			// serializer rejects (it accepts only int64/float64 among numbers).
+			// Normalize every value to JSON-native types so a common patch such
+			// as `value: 3` doesn't error when the `value` field is queried.
+			value = toJSONNative(value)
+		}
 
 		ops = append(ops, jsonPatchOp{
 			op:       opStr,
@@ -196,6 +208,28 @@ func decodeJSON6902(raw []byte) ([]jsonPatchOp, bool) {
 		})
 	}
 	return ops, true
+}
+
+// toJSONNative round-trips a yaml.v3-decoded value through encoding/json so
+// every number, map, and slice is expressed with the JSON-native Go types the
+// llx dict serializer accepts (float64/string/bool/[]any/map[string]any/nil).
+// yaml.v3 hands back Go `int` for integer scalars, which dict serialization
+// rejects; the round-trip converts those to float64. On the (practically
+// impossible for yaml-derived data) marshal error, the original value is
+// returned unchanged so behavior is never worse than before.
+func toJSONNative(v any) any {
+	if v == nil {
+		return nil
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return v
+	}
+	var out any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return v
+	}
+	return out
 }
 
 func (c *mqlKustomizePatch) operations() ([]any, error) {


### PR DESCRIPTION
## Summary

Fixes two bugs in the kustomize provider's patch resources, surfaced by a static bug-review pass, plus regression tests.

### 1. HIGH — `kustomize.patch.operation.value` errors at query time on integer values

A JSON6902 patch with an integer value — the single most common case:

```yaml
- op: replace
  path: /spec/replicas
  value: 3
```

made `kustomize.kustomizations.patches.operations { value }` **error** instead of returning the operation. `yaml.v3` decodes integer scalars to Go `int`, but the llx dict serializer (`dict2primitive`, `llx/data_conversions.go`) accepts only `int64`/`float64` among numbers and returns `failed to convert dict to primitive, unsupported child type: int`. The value was handed to `llx.DictData` straight from the yaml decode — unlike the sibling `manifest` dict, which is laundered through `convert.JsonToDict` (a JSON round-trip that yields `float64`).

Any integer anywhere in the value (bare, or nested inside a map/array) triggered it. A policy auditing "does this patch weaken a security control" silently failed to evaluate on these patches.

**Fix:** normalize every decoded operation value through a JSON round-trip (`toJSONNative`) so integers become `float64` and the field serializes cleanly — matching the `manifest` path.

### 2. MEDIUM — `kustomize.patch.content` empty for file-based patches

For a file-referenced patch (`patches: [{ path: patch.yaml }]`, a common idiom) the `content` field returned `""`, even though the schema documents it as *"inline YAML or file content"*. The file bytes were read for format classification and then discarded, so a content-based audit saw nothing.

**Fix:** populate `content` with the resolved file body.

## Tests

- `TestPatchOperationValueSerializesAsDict` — drives the exact `raw -> primitive` path via `RawData.Result()` (the same conversion the runtime runs at the plugin boundary), including a bare `value: 3` and a nested `limits: {cpu: 2}`, and asserts the integer normalizes to `float64`.
- `TestNewMqlKustomizePatchContentFromFile` — a file-based patch exposes the file body through `content`.

Discovery logic (`loadKustomizations`) is already covered by the existing `connection` package tests.

## Verification

- `go test ./resources/... ./connection/...` — pass
- `make providers/build/kustomize` — clean, no generated-file drift
