### PR TITLE
🐛 helm: fix helm.resource.template husk + repo version resolution

### DIFF
--- a/providers/helm/connection/fetch.go
+++ b/providers/helm/connection/fetch.go
@@ -177,6 +177,9 @@ type repoIndex struct {
 // isn't valid semver are ignored for ranking; if none parse, the first listed
 // entry is returned so a non-semver repository still resolves to something.
 func latestChartVersion(versions []repoChartVersion) repoChartVersion {
+	if len(versions) == 0 {
+		return repoChartVersion{}
+	}
 	best := versions[0]
 	var bestVer *semver.Version
 	if v, err := semver.NewVersion(best.Version); err == nil {

--- a/providers/helm/connection/fetch.go
+++ b/providers/helm/connection/fetch.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/registry"
@@ -157,18 +158,46 @@ func fetchProvenanceHTTP(chartURL, username, password string) []byte {
 	return prov
 }
 
+// repoChartVersion is one published version of a chart in a repository
+// index.yaml: its version string and the archive URL(s) that serve it.
+type repoChartVersion struct {
+	Version string   `yaml:"version"`
+	URLs    []string `yaml:"urls"`
+}
+
 // repoIndex is the subset of a Helm repository index.yaml we need to map a
 // chart name + version to a downloadable archive URL.
 type repoIndex struct {
-	Entries map[string][]struct {
-		Version string   `yaml:"version"`
-		URLs    []string `yaml:"urls"`
-	} `yaml:"entries"`
+	Entries map[string][]repoChartVersion `yaml:"entries"`
+}
+
+// latestChartVersion returns the highest-semver entry for a chart. `helm repo
+// index` writes entries newest-first, but not every index producer sorts, so
+// we pick by semver rather than trusting file order. Entries whose version
+// isn't valid semver are ignored for ranking; if none parse, the first listed
+// entry is returned so a non-semver repository still resolves to something.
+func latestChartVersion(versions []repoChartVersion) repoChartVersion {
+	best := versions[0]
+	var bestVer *semver.Version
+	if v, err := semver.NewVersion(best.Version); err == nil {
+		bestVer = v
+	}
+	for _, cur := range versions[1:] {
+		cv, err := semver.NewVersion(cur.Version)
+		if err != nil {
+			continue
+		}
+		if bestVer == nil || cv.GreaterThan(bestVer) {
+			best = cur
+			bestVer = cv
+		}
+	}
+	return best
 }
 
 // resolveChartInRepo downloads <repoURL>/index.yaml and resolves a chart
 // name (and optional version) to a concrete archive URL. With no version it
-// picks the first entry, which Helm publishes newest-first.
+// picks the highest-semver entry.
 func resolveChartInRepo(repoURL, chartName, version, username, password string) (string, error) {
 	indexURL := strings.TrimSuffix(repoURL, "/") + "/index.yaml"
 	data, err := httpGetBytes(indexURL, username, password)
@@ -186,7 +215,7 @@ func resolveChartInRepo(repoURL, chartName, version, username, password string) 
 		return "", fmt.Errorf("chart %q not found in repository %q", chartName, repoURL)
 	}
 
-	chosen := versions[0]
+	chosen := latestChartVersion(versions)
 	if version != "" {
 		found := false
 		for _, v := range versions {

--- a/providers/helm/connection/fetch_test.go
+++ b/providers/helm/connection/fetch_test.go
@@ -83,6 +83,13 @@ func TestLatestChartVersion(t *testing.T) {
 		})
 		assert.Equal(t, "latest", got.Version)
 	})
+
+	t.Run("empty slice returns the zero value without panicking", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			got := latestChartVersion(nil)
+			assert.Equal(t, repoChartVersion{}, got)
+		})
+	})
 }
 
 // resolveChartInRepo maps a chart name (+ optional version) from a repository's

--- a/providers/helm/connection/fetch_test.go
+++ b/providers/helm/connection/fetch_test.go
@@ -45,3 +45,94 @@ func TestHttpGetBytesSizeLimit(t *testing.T) {
 		assert.Equal(t, body, string(data))
 	})
 }
+
+// latestChartVersion must pick the highest SEMVER entry, not the first-listed
+// one and not the lexically-largest one (1.10.0 > 1.3.0 in semver but "1.10.0"
+// < "1.3.0" as strings). Non-semver entries are ignored for ranking, and a
+// repository whose versions are all non-semver still resolves to the first.
+func TestLatestChartVersion(t *testing.T) {
+	t.Run("highest semver wins regardless of order", func(t *testing.T) {
+		got := latestChartVersion([]repoChartVersion{
+			{Version: "1.2.0"},
+			{Version: "1.10.0"},
+			{Version: "1.3.0"},
+		})
+		assert.Equal(t, "1.10.0", got.Version)
+	})
+
+	t.Run("prerelease ranks below its release", func(t *testing.T) {
+		got := latestChartVersion([]repoChartVersion{
+			{Version: "2.0.0-rc.1"},
+			{Version: "2.0.0"},
+		})
+		assert.Equal(t, "2.0.0", got.Version)
+	})
+
+	t.Run("non-semver entries are skipped for ranking", func(t *testing.T) {
+		got := latestChartVersion([]repoChartVersion{
+			{Version: "not-a-version"},
+			{Version: "0.1.0"},
+		})
+		assert.Equal(t, "0.1.0", got.Version)
+	})
+
+	t.Run("all non-semver falls back to the first entry", func(t *testing.T) {
+		got := latestChartVersion([]repoChartVersion{
+			{Version: "latest"},
+			{Version: "stable"},
+		})
+		assert.Equal(t, "latest", got.Version)
+	})
+}
+
+// resolveChartInRepo maps a chart name (+ optional version) from a repository's
+// index.yaml to a concrete archive URL: it selects the highest semver when no
+// version is given, matches exactly when one is, resolves repo-relative URLs
+// against the repository base, and errors clearly for missing chart/version.
+func TestResolveChartInRepo(t *testing.T) {
+	const index = `apiVersion: v1
+entries:
+  mychart:
+    - version: 1.2.0
+      urls:
+        - charts/mychart-1.2.0.tgz
+    - version: 1.10.0
+      urls:
+        - https://cdn.example.com/mychart-1.10.0.tgz
+    - version: 1.3.0
+      urls:
+        - charts/mychart-1.3.0.tgz
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/index.yaml" {
+			w.Write([]byte(index))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	t.Run("no version selects the highest semver (absolute URL passthrough)", func(t *testing.T) {
+		url, err := resolveChartInRepo(srv.URL, "mychart", "", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "https://cdn.example.com/mychart-1.10.0.tgz", url)
+	})
+
+	t.Run("explicit version resolves a repo-relative URL against the base", func(t *testing.T) {
+		url, err := resolveChartInRepo(srv.URL, "mychart", "1.2.0", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, srv.URL+"/charts/mychart-1.2.0.tgz", url)
+	})
+
+	t.Run("unknown chart errors", func(t *testing.T) {
+		_, err := resolveChartInRepo(srv.URL, "ghost", "", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found in repository")
+	})
+
+	t.Run("unknown version errors", func(t *testing.T) {
+		_, err := resolveChartInRepo(srv.URL, "mychart", "9.9.9", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "version")
+	})
+}

--- a/providers/helm/go.mod
+++ b/providers/helm/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 replace go.mondoo.com/mql/v13 => ../..
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
@@ -18,7 +19,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect

--- a/providers/helm/resources/helm.go
+++ b/providers/helm/resources/helm.go
@@ -434,6 +434,13 @@ func (c *mqlHelmChart) fetchResources() ([]any, error) {
 			if err != nil {
 				continue
 			}
+			// Wire each resource back to this chart so helm.resource.template
+			// resolves to the real, materialized helm.template (never a husk).
+			for _, r := range resources {
+				if res, ok := r.(*mqlHelmResource); ok {
+					res.ownerChart = c
+				}
+			}
 			c.cachedResources = append(c.cachedResources, resources...)
 		}
 	})

--- a/providers/helm/resources/resource.go
+++ b/providers/helm/resources/resource.go
@@ -31,6 +31,15 @@ func splitYAMLDocuments(content string) []string {
 
 type mqlHelmResourceInternal struct {
 	cacheTemplateKey string
+	// ownerChart/ownerTemplate wire the resource back to the helm.template it
+	// was rendered from. Exactly one is set by the caller of parseK8sResources:
+	// ownerTemplate when the resource comes from helm.template.resources (the
+	// template is already in hand), ownerChart when it comes from the chart-wide
+	// helm.chart.resources/hooks path (the template is resolved lazily through
+	// the chart so template() returns the fully-populated resource rather than a
+	// bare-__id husk). Both stay nil for crds/, which have no backing template.
+	ownerChart    *mqlHelmChart
+	ownerTemplate *mqlHelmTemplate
 }
 
 // parseK8sResources parses rendered YAML content into Kubernetes resource
@@ -79,18 +88,8 @@ func parseK8sResources(runtime *plugin.Runtime, templateKey string, content stri
 			}
 		}
 
-		labelsStr := make(map[string]any, len(labels))
-		for k, v := range labels {
-			if s, ok := v.(string); ok {
-				labelsStr[k] = s
-			}
-		}
-		annotationsStr := make(map[string]any, len(annotations))
-		for k, v := range annotations {
-			if s, ok := v.(string); ok {
-				annotationsStr[k] = s
-			}
-		}
+		labelsStr := scalarStringMap(labels)
+		annotationsStr := scalarStringMap(annotations)
 
 		manifest, err := convert.JsonToDict(obj)
 		if err != nil {
@@ -157,6 +156,45 @@ func parseHookAnnotations(annotations map[string]any) (isHook bool, hookTypes []
 	return isHook, hookTypes, hookWeight, hookDeletePolicies
 }
 
+// scalarStringMap renders a rendered-manifest labels/annotations block as a
+// string->string map. Kubernetes label and annotation values are always
+// strings, but a rendered template can emit an unquoted scalar (e.g.
+// `version: 1.0` unmarshals to a float, `enabled: true` to a bool). Formatting
+// those to their string form — rather than dropping them, as the previous
+// string-only type assertion did — keeps helm.resource.labels/annotations
+// consistent with the same keys visible under helm.resource.manifest.
+// Non-scalar values (nested maps/slices) can't be valid label values and are
+// skipped.
+func scalarStringMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		if s, ok := scalarToString(v); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// scalarToString formats a YAML scalar (as produced by yaml.v3 into any) to
+// the string Kubernetes would store. It reports false for non-scalar or nil
+// values so the caller can skip them.
+func scalarToString(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case int:
+		return strconv.Itoa(t), true
+	case int64:
+		return strconv.FormatInt(t, 10), true
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
 // splitCSV splits a comma-separated annotation value into trimmed,
 // non-empty entries.
 func splitCSV(s string) []any {
@@ -170,15 +208,37 @@ func splitCSV(s string) []any {
 	return out
 }
 
+// template links a rendered resource back to the helm.template it came from.
+//
+// It deliberately does NOT reconstruct the template from its __id via
+// NewResource: helm.template has no init, so NewResource with only "__id"
+// would fabricate a husk whose name/raw/requiresCluster are unset — and since
+// that husk's __id is byte-identical to the real template's, it would poison
+// the shared resource cache and make helm.chart.templates return husks too.
+// Instead we return the already-materialized template: directly when the
+// resource was parsed from a template, or by resolving it through the owning
+// chart's templates() (which builds the real, fully-populated instances).
 func (r *mqlHelmResource) template() (*mqlHelmTemplate, error) {
-	// cacheTemplateKey already uses ":" separator matching the template __id format
-	res, err := NewResource(r.MqlRuntime, "helm.template", map[string]*llx.RawData{
-		"__id": llx.StringData("helm.template:" + r.cacheTemplateKey),
-	})
-	if err != nil {
-		log.Warn().Err(err).Str("templateKey", r.cacheTemplateKey).Msg("failed to resolve helm template for resource")
-		r.Template.State = plugin.StateIsNull | plugin.StateIsSet
-		return nil, nil
+	if r.ownerTemplate != nil {
+		return r.ownerTemplate, nil
 	}
-	return res.(*mqlHelmTemplate), nil
+	if r.ownerChart != nil {
+		templates, err := r.ownerChart.templates()
+		if err != nil {
+			log.Warn().Err(err).Str("templateKey", r.cacheTemplateKey).Msg("failed to resolve helm template for resource")
+			r.Template.State = plugin.StateIsNull | plugin.StateIsSet
+			return nil, nil
+		}
+		// cacheTemplateKey already uses the ":" separator of the template __id.
+		want := "helm.template:" + r.cacheTemplateKey
+		for _, t := range templates {
+			if mqlT, ok := t.(*mqlHelmTemplate); ok && mqlT.__id == want {
+				return mqlT, nil
+			}
+		}
+	}
+	// No backing template (e.g. a resource from crds/, or a resource created
+	// without an owner). Report null rather than a husk.
+	r.Template.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }

--- a/providers/helm/resources/resource_reverselink_test.go
+++ b/providers/helm/resources/resource_reverselink_test.go
@@ -1,0 +1,128 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func newReverseLinkTestChart() *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{Name: "mychart", Version: "1.0.0", APIVersion: "v2"},
+		Templates: []*chart.File{
+			{
+				Name: "templates/cm.yaml",
+				Data: []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\n"),
+			},
+		},
+	}
+}
+
+// Regression for the helm.resource.template husk/cache-poisoning bug.
+//
+// Reached through the chart-wide resources path (helm.chart.resources), the
+// reverse link used to rebuild the template from just its __id via NewResource.
+// helm.template has no init, so that produced a husk with name/raw unset — and
+// because the husk's __id was byte-identical to the real template's, it also
+// poisoned the shared cache, making helm.chart.templates return husks too.
+func TestResourceTemplateReverseLink(t *testing.T) {
+	rt := newTestRuntime()
+	c, err := newMqlHelmChart(rt, newReverseLinkTestChart(), "/charts/mychart", nil)
+	require.NoError(t, err)
+
+	// Reach resources through the chart — the path that used to husk.
+	resources, err := c.resources()
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	res := resources[0].(*mqlHelmResource)
+
+	// The reverse link must resolve to the real, populated template.
+	tmpl, err := res.template()
+	require.NoError(t, err)
+	require.NotNil(t, tmpl)
+	assert.NotZero(t, tmpl.Name.State&plugin.StateIsSet, "template.name must be set, not a husk")
+	assert.Equal(t, "templates/cm.yaml", tmpl.Name.Data)
+	assert.Contains(t, tmpl.Raw.Data, "ConfigMap")
+
+	// Cache must not be poisoned: templates() materialized AFTER the reverse
+	// link was used must still be fully populated (and the same instance).
+	templates, err := c.templates()
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	got := templates[0].(*mqlHelmTemplate)
+	assert.Equal(t, "templates/cm.yaml", got.Name.Data)
+	assert.Contains(t, got.Raw.Data, "ConfigMap")
+	assert.Same(t, tmpl, got, "reverse link and templates() must return the same cached template")
+}
+
+// A resource parsed straight from a template (helm.template.resources) links
+// back to that exact template instance.
+func TestResourceTemplateReverseLinkFromTemplate(t *testing.T) {
+	rt := newTestRuntime()
+	c, err := newMqlHelmChart(rt, newReverseLinkTestChart(), "/charts/mychart", nil)
+	require.NoError(t, err)
+
+	templates, err := c.templates()
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	tmpl := templates[0].(*mqlHelmTemplate)
+
+	resources, err := tmpl.resources()
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	res := resources[0].(*mqlHelmResource)
+
+	back, err := res.template()
+	require.NoError(t, err)
+	require.NotNil(t, back)
+	assert.Same(t, tmpl, back)
+}
+
+// A resource with no backing template (e.g. one created without an owner, as
+// happens for crds/) reports its template as null rather than a husk.
+func TestResourceTemplateReverseLinkNoOwner(t *testing.T) {
+	rt := newTestRuntime()
+	resources, err := parseK8sResources(rt, "mychart/crds/foo.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm", true)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	res := resources[0].(*mqlHelmResource)
+
+	tmpl, err := res.template()
+	require.NoError(t, err)
+	assert.Nil(t, tmpl)
+	assert.NotZero(t, res.Template.State&plugin.StateIsNull, "template must be marked null, not a husk")
+}
+
+// Non-string scalar label/annotation values must be coerced to their string
+// form rather than silently dropped, keeping helm.resource.labels consistent
+// with the same keys under helm.resource.manifest.
+func TestScalarLabelCoercion(t *testing.T) {
+	yaml := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  labels:
+    app: myapp
+    replicas: 3
+    enabled: true
+  annotations:
+    weight: 10`
+
+	rt := newTestRuntime()
+	resources, err := parseK8sResources(rt, "mychart/templates/cm.yaml", yaml, false)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	res := resources[0].(*mqlHelmResource)
+
+	assert.Equal(t, "myapp", res.Labels.Data["app"])
+	assert.Equal(t, "3", res.Labels.Data["replicas"], "numeric label coerced, not dropped")
+	assert.Equal(t, "true", res.Labels.Data["enabled"], "bool label coerced, not dropped")
+	assert.Equal(t, "10", res.Annotations.Data["weight"], "numeric annotation coerced, not dropped")
+}

--- a/providers/helm/resources/template.go
+++ b/providers/helm/resources/template.go
@@ -130,7 +130,19 @@ func (t *mqlHelmTemplate) resources() ([]any, error) {
 		return []any{}, nil
 	}
 	templateKey := t.chartName + "/" + t.Name.Data
-	return parseK8sResources(t.MqlRuntime, templateKey, t.renderedContent, false)
+	resources, err := parseK8sResources(t.MqlRuntime, templateKey, t.renderedContent, false)
+	if err != nil {
+		return nil, err
+	}
+	// These resources came straight from this template, so link them back to it
+	// directly — helm.resource.template then returns this instance without a
+	// chart round-trip.
+	for _, r := range resources {
+		if res, ok := r.(*mqlHelmResource); ok {
+			res.ownerTemplate = t
+		}
+	}
+	return resources, nil
 }
 
 func (t *mqlHelmTemplate) directives() ([]any, error) {


### PR DESCRIPTION
## What

Three defect fixes in the `helm` provider found during a static bug review, each with regression tests. No `.lr`/schema changes, no version bump.

### 1. 🔴 `helm.resource.template` returned a husk and poisoned the template cache

Reached through the chart-wide path (`helm.chart.resources`, `.hooks`, `.crds`), the reverse link rebuilt the template from just its `__id` via `NewResource`. `helm.template` has **no init**, so `NewResource` fabricated a resource with `name`/`raw`/`requiresCluster` **unset** (a husk) — surfacing to users as `cannot convert primitive with NO type information` / null fields on a declared field.

Worse: the husk's `__id` is byte-identical to the real template's, so it poisoned the shared per-asset resource cache. Once a query hit the reverse link, a later `helm.chart.templates { rendered }` returned husks too — a **cross-query correctness bug**.

```
helm.charts { resources { template { name } } }   # name came back null
```

**Fix:** wire each rendered resource back to the template it came from — directly when parsed from a template (`helm.template.resources`), or resolved through the owning chart's materialized `templates()` when parsed chart-wide. Resources with no backing template (`crds/`) now report `null` instead of a husk. No bare-`__id` template is ever created, so the cache can't be poisoned.

Both the husk and the poisoning were confirmed empirically before the fix.

### 2. 🟡 `resolveChartInRepo` assumed `index.yaml` is newest-first

With no `--version`, it took entry `[0]`. Not every index producer sorts, and file/string order mis-ranks (`1.10.0` vs `1.3.0`). Now selects the **highest semver**, ignoring non-semver entries and falling back to the first listed when none parse.

### 3. 🟡 Non-string label/annotation values were silently dropped

A rendered `replicas: 3` (unquoted) unmarshals to `int` and vanished from `helm.resource.labels` while remaining visible under `helm.resource.manifest` — the two views disagreed. Scalar values are now coerced to their string form instead of dropped.

## Tests

- **Reverse link** (`resource_reverselink_test.go`): populated template via the chart path + no cache poisoning; direct link from `helm.template.resources`; null (not husk) for owner-less/`crds` resources.
- **Version resolution** (`fetch_test.go`): `latestChartVersion` semver ranking incl. prerelease/non-semver; `resolveChartInRepo` highest-semver selection, exact-version match, repo-relative URL resolution, and missing-chart/version errors — this path had **zero** unit coverage before.
- **Scalar coercion**: numeric/bool labels and annotations preserved as strings.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

## Deliberately deferred (from the same review)

- OCI: a non-concrete `--version` is appended as a literal tag, failing with an opaque registry error (LOW).
- `repository-config`/`repository-cache` options are parsed but not used by the hand-rolled fetch path (feature gap, not a bug).
