### PR TITLE
🐛 claude: fix null allowed_inference_geos decoding to [""] + pure-Go tests

### DIFF
--- a/providers/claude/connection/admin.go
+++ b/providers/claude/connection/admin.go
@@ -105,6 +105,14 @@ type AdminDataResidency struct {
 type FlexibleStringSlice []string
 
 func (f *FlexibleStringSlice) UnmarshalJSON(data []byte) error {
+	// A JSON null (e.g. "allowed_inference_geos": null for an unrestricted
+	// workspace) must decode to an empty slice, not [""]. json.Unmarshal of
+	// null into a string is a no-op that returns no error, so without this
+	// guard the string branch below would win and yield a bogus [""].
+	if string(data) == "null" {
+		*f = nil
+		return nil
+	}
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		*f = []string{s}

--- a/providers/claude/connection/admin_test.go
+++ b/providers/claude/connection/admin_test.go
@@ -1,0 +1,177 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexibleStringSlice_UnmarshalJSON(t *testing.T) {
+	// Decoded via a struct field so the test exercises the same code path
+	// encoding/json uses for AdminDataResidency.AllowedInferenceGeos.
+	type wrap struct {
+		Geos FlexibleStringSlice `json:"geos"`
+	}
+
+	tests := []struct {
+		name string
+		json string
+		want []string
+	}{
+		{"array", `{"geos": ["us", "eu"]}`, []string{"us", "eu"}},
+		{"single string", `{"geos": "us"}`, []string{"us"}},
+		{"empty array", `{"geos": []}`, []string{}},
+		// Regression: a JSON null (an unrestricted workspace) must decode to an
+		// empty slice, never [""]. json.Unmarshal of null into a string is a
+		// no-op that returns no error, so without an explicit guard the string
+		// branch wins and produces a bogus one-element slice.
+		{"null", `{"geos": null}`, nil},
+		{"absent", `{}`, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w wrap
+			require.NoError(t, json.Unmarshal([]byte(tt.json), &w))
+			assert.Equal(t, tt.want, []string(w.Geos))
+		})
+	}
+}
+
+func TestAdminRateLimit_LimitValue(t *testing.T) {
+	rl := &AdminRateLimit{
+		Limits: []AdminRateLimiter{
+			{Type: "requests_per_minute", Value: 1000},
+			{Type: "output_tokens_per_minute", Value: 50000},
+		},
+	}
+
+	assert.Equal(t, int64(1000), rl.LimitValue("requests_per_minute"))
+	assert.Equal(t, int64(50000), rl.LimitValue("output_tokens_per_minute"))
+	// Missing limiter types report 0 rather than panicking.
+	assert.Equal(t, int64(0), rl.LimitValue("input_tokens_per_minute_cache_aware"))
+	assert.Equal(t, int64(0), rl.LimitValue(""))
+}
+
+// item is a minimal payload used by the pagination tests.
+type item struct {
+	ID string `json:"id"`
+}
+
+func TestPaginate_AfterIDCursor(t *testing.T) {
+	var seenCursors []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenCursors = append(seenCursors, r.URL.Query().Get("after_id"))
+		// Every request must carry the limit and the correct path.
+		assert.Equal(t, "100", r.URL.Query().Get("limit"))
+		assert.Equal(t, "/v1/things", r.URL.Path)
+
+		var resp paginatedResponse[item]
+		switch r.URL.Query().Get("after_id") {
+		case "":
+			resp = paginatedResponse[item]{Data: []item{{"a"}, {"b"}}, HasMore: true, LastID: "b"}
+		case "b":
+			resp = paginatedResponse[item]{Data: []item{{"c"}}, HasMore: false, LastID: "c"}
+		default:
+			t.Fatalf("unexpected after_id cursor %q", r.URL.Query().Get("after_id"))
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	c := NewAdminClient("test-key", srv.URL)
+	got, err := paginate[item](context.Background(), c, "/v1/things")
+	require.NoError(t, err)
+
+	assert.Equal(t, []item{{"a"}, {"b"}, {"c"}}, got)
+	// First page has no cursor; the second page must forward last_id from page one.
+	assert.Equal(t, []string{"", "b"}, seenCursors)
+}
+
+func TestPaginate_StopsWhenHasMoreFalse(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		resp := paginatedResponse[item]{Data: []item{{"only"}}, HasMore: false, LastID: "only"}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	c := NewAdminClient("test-key", srv.URL)
+	got, err := paginate[item](context.Background(), c, "/v1/things")
+	require.NoError(t, err)
+
+	assert.Equal(t, []item{{"only"}}, got)
+	assert.Equal(t, 1, calls, "must not request a second page when has_more is false")
+}
+
+func TestPaginatePageToken_NextPageCursor(t *testing.T) {
+	var seenPages []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPages = append(seenPages, r.URL.Query().Get("page"))
+
+		next := "page-2"
+		var resp pageTokenResponse[item]
+		switch r.URL.Query().Get("page") {
+		case "":
+			resp = pageTokenResponse[item]{Data: []item{{"a"}}, HasMore: true, NextPage: &next}
+		case "page-2":
+			resp = pageTokenResponse[item]{Data: []item{{"b"}}, HasMore: false, NextPage: nil}
+		default:
+			t.Fatalf("unexpected page cursor %q", r.URL.Query().Get("page"))
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	c := NewAdminClient("test-key", srv.URL)
+	// A base path that already carries a query string, to exercise the
+	// "?"-vs-"&" separator logic.
+	got, err := paginatePageToken[item](context.Background(), c, "/v1/report?bucket_width=1d")
+	require.NoError(t, err)
+
+	assert.Equal(t, []item{{"a"}, {"b"}}, got)
+	assert.Equal(t, []string{"", "page-2"}, seenPages)
+}
+
+func TestPaginatePageToken_StopsOnEmptyNextPage(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		empty := ""
+		resp := pageTokenResponse[item]{Data: []item{{"a"}}, HasMore: true, NextPage: &empty}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	c := NewAdminClient("test-key", srv.URL)
+	got, err := paginatePageToken[item](context.Background(), c, "/v1/report")
+	require.NoError(t, err)
+
+	assert.Equal(t, []item{{"a"}}, got)
+	assert.Equal(t, 1, calls, "an empty next_page string must terminate pagination")
+}
+
+func TestDoRequest_ErrorStatusPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Auth headers must be set on every request.
+		assert.Equal(t, "test-key", r.Header.Get("x-api-key"))
+		assert.Equal(t, adminAPIVersion, r.Header.Get("anthropic-version"))
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	c := NewAdminClient("test-key", srv.URL)
+	_, err := c.get(context.Background(), "/v1/things")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}

--- a/providers/claude/connection/connection.go
+++ b/providers/claude/connection/connection.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -91,6 +92,11 @@ func NewClaudeConnection(id uint32, asset *inventory.Asset, conf *inventory.Conf
 		if err == nil {
 			conn.orgID = org.ID
 			conn.orgName = org.Name
+		} else {
+			// Without an org identity, asset detection falls back to the
+			// generic host platform and discovery finds no workspaces. Surface
+			// the reason instead of silently coming up empty.
+			log.Warn().Err(err).Msg("claude: could not resolve organization from admin token; workspace discovery will be skipped")
 		}
 	}
 

--- a/providers/claude/go.mod
+++ b/providers/claude/go.mod
@@ -6,6 +6,7 @@ go 1.26.5
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.58.0
+	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.30.0
 )
@@ -78,7 +79,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
-	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect

--- a/providers/claude/resources/helpers_test.go
+++ b/providers/claude/resources/helpers_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFamily(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{"claude-opus-4-6", "opus"},
+		{"claude-sonnet-5", "sonnet"},
+		{"claude-haiku-4-5-20251001", "haiku"},
+		{"claude-3-5-sonnet-20241022", "sonnet"},
+		{"some-unknown-model", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseFamily(tt.id))
+		})
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	// An empty string is a valid "not set" value and must yield the zero time
+	// with no error, so a missing timestamp never fails the whole list call.
+	zero, err := parseTime("")
+	require.NoError(t, err)
+	assert.True(t, zero.IsZero())
+
+	got, err := parseTime("2026-01-02T15:04:05Z")
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC), got.UTC())
+
+	_, err = parseTime("not-a-timestamp")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Two bug fixes from a static bug review of the `claude` provider, plus unit tests for the provider's pure-Go logic (previously only the platform catalog was tested).

## Fixes

### 1. `null` `allowed_inference_geos` decoded to `[""]` (wrong data)

`FlexibleStringSlice.UnmarshalJSON` tries a string first, then an array. `json.Unmarshal` of a JSON `null` into a string is a **no-op that returns no error**, so the string branch won and produced a one-element slice containing an empty string.

A workspace with `"allowed_inference_geos": null` (the natural "no geo restriction" shape) therefore surfaced as `claude.organization.workspace.allowedInferenceGeos == [""]` — length 1 — instead of `[]`. A policy like `allowedInferenceGeos.length == 0` (interpret as unrestricted) was silently defeated, and `allowedInferenceGeos.contains("")` became true. Now `null` decodes to an empty slice. Verified behavior:

| input | before | after |
|---|---|---|
| `["us","eu"]` | `["us","eu"]` | `["us","eu"]` |
| `"us"` | `["us"]` | `["us"]` |
| `null` | `[""]` ❌ | `[]` ✅ |

### 2. Organization lookup error swallowed at connect time

If `GetOrganization` failed while building the connection, the error was discarded. With no org identity, asset detection falls back to the generic host platform and discovery returns **zero workspaces** — with no explanation. It now logs a warning so the empty result is attributable.

## Tests

Adds coverage for the pure-Go logic where wrong-data bugs hide, none of which was previously tested:

- `FlexibleStringSlice` decoding — array / single string / empty array / **null** (regression for fix #1) / absent
- Both pagination loops — `after_id` cursor and page-token — including cursor forwarding across pages and correct termination on `has_more: false` / empty `next_page`
- `AdminRateLimit.LimitValue` found / missing
- HTTP error-status propagation and auth-header presence
- `parseFamily` and `parseTime` (incl. empty-string → zero time)

## Verification

- `go test ./connection/... ./resources/...` passes
- `go build ./...` and `go vet` clean
