### PR TITLE
🐛 ollama: key models by name to fix digest __id collision + placeholder cross-ref data

### DIFF
--- a/providers/ollama/resources/ollama.go
+++ b/providers/ollama/resources/ollama.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ollama/ollama/api"
 	"go.mondoo.com/mql/v13/llx"
@@ -40,25 +39,7 @@ func (r *mqlOllama) models() ([]interface{}, error) {
 
 	res := make([]interface{}, 0, len(resp.Models))
 	for _, m := range resp.Models {
-		families := make([]interface{}, len(m.Details.Families))
-		for i, f := range m.Details.Families {
-			families[i] = f
-		}
-
-		mqlModel, err := CreateResource(r.MqlRuntime, "ollama.model", map[string]*llx.RawData{
-			"__id":              llx.StringData(m.Digest),
-			"name":              llx.StringData(m.Name),
-			"model":             llx.StringData(m.Model),
-			"modifiedAt":        llx.TimeData(m.ModifiedAt),
-			"size":              llx.IntData(m.Size),
-			"digest":            llx.StringData(m.Digest),
-			"format":            llx.StringData(m.Details.Format),
-			"family":            llx.StringData(m.Details.Family),
-			"families":          llx.ArrayData(families, types.String),
-			"parameterSize":     llx.StringData(m.Details.ParameterSize),
-			"quantizationLevel": llx.StringData(m.Details.QuantizationLevel),
-			"parentModel":       llx.StringData(m.Details.ParentModel),
-		})
+		mqlModel, err := CreateResource(r.MqlRuntime, "ollama.model", ollamaModelArgs(m))
 		if err != nil {
 			return nil, err
 		}
@@ -66,6 +47,69 @@ func (r *mqlOllama) models() ([]interface{}, error) {
 	}
 
 	return res, nil
+}
+
+// ollamaModelArgs builds the full set of resource args for an installed model.
+// The name is the stable, unique identifier a user selects by, so it is used as
+// the cache key. The digest is not unique: aliased tags (e.g. "llama3.1:latest"
+// and "llama3.1:8b") share one manifest digest, so keying on it would collapse
+// distinct models into a single cached resource.
+func ollamaModelArgs(m api.ListModelResponse) map[string]*llx.RawData {
+	families := make([]interface{}, len(m.Details.Families))
+	for i, f := range m.Details.Families {
+		families[i] = f
+	}
+
+	return map[string]*llx.RawData{
+		"__id":              llx.StringData(m.Name),
+		"name":              llx.StringData(m.Name),
+		"model":             llx.StringData(m.Model),
+		"modifiedAt":        llx.TimeData(m.ModifiedAt),
+		"size":              llx.IntData(m.Size),
+		"digest":            llx.StringData(m.Digest),
+		"format":            llx.StringData(m.Details.Format),
+		"family":            llx.StringData(m.Details.Family),
+		"families":          llx.ArrayData(families, types.String),
+		"parameterSize":     llx.StringData(m.Details.ParameterSize),
+		"quantizationLevel": llx.StringData(m.Details.QuantizationLevel),
+		"parentModel":       llx.StringData(m.Details.ParentModel),
+	}
+}
+
+// initOllamaModel resolves an installed model from just its name, so a
+// cross-reference like ollama.runningModel.model returns full, real metadata
+// (size, modifiedAt, digest, ...) rather than placeholder values. Models
+// created directly via ollama.models carry a digest and skip this path.
+func initOllamaModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if _, ok := args["digest"]; ok {
+		return args, nil, nil
+	}
+	nameRaw, ok := args["name"]
+	if !ok {
+		return args, nil, nil
+	}
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+
+	// Reuse an already-listed model instead of calling the API again.
+	if x, ok := runtime.Resources.Get("ollama.model\x00" + name); ok {
+		return nil, x, nil
+	}
+
+	conn := ollamaConn(runtime)
+	resp, err := conn.Client().List(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, m := range resp.Models {
+		if m.Name == name {
+			return ollamaModelArgs(m), nil, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("ollama model %q not found", name)
 }
 
 func (r *mqlOllama) runningModels() ([]interface{}, error) {
@@ -80,7 +124,7 @@ func (r *mqlOllama) runningModels() ([]interface{}, error) {
 	res := make([]interface{}, 0, len(resp.Models))
 	for _, m := range resp.Models {
 		mqlRunning, err := CreateResource(r.MqlRuntime, "ollama.runningModel", map[string]*llx.RawData{
-			"__id":          llx.StringData("running/" + m.Digest),
+			"__id":          llx.StringData("running/" + m.Name),
 			"name":          llx.StringData(m.Name),
 			"expiresAt":     llx.TimeData(m.ExpiresAt),
 			"sizeVram":      llx.IntData(m.SizeVRAM),
@@ -89,10 +133,6 @@ func (r *mqlOllama) runningModels() ([]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		rm := mqlRunning.(*mqlOllamaRunningModel)
-		rm.cacheDigest = m.Digest
-		rm.cacheDetails = m.Details
 
 		res = append(res, mqlRunning)
 	}
@@ -128,7 +168,7 @@ func (r *mqlOllamaModel) fetchShow() (*api.ShowResponse, error) {
 }
 
 func (r *mqlOllamaModel) id() (string, error) {
-	return r.Digest.Data, nil
+	return r.Name.Data, nil
 }
 
 func (r *mqlOllamaModel) license() (string, error) {
@@ -189,7 +229,7 @@ func (r *mqlOllamaModel) info() (*mqlOllamaModelInfo, error) {
 	datasets := getStringSlice(mi, "general.datasets")
 
 	res, err := CreateResource(r.MqlRuntime, "ollama.model.info", map[string]*llx.RawData{
-		"__id":              llx.StringData(r.Digest.Data + "/info"),
+		"__id":              llx.StringData(r.Name.Data + "/info"),
 		"architecture":      llx.StringData(arch),
 		"basename":          llx.StringData(getString(mi, "general.basename")),
 		"finetune":          llx.StringData(getString(mi, "general.finetune")),
@@ -265,34 +305,13 @@ func (r *mqlOllamaModelInfo) id() (string, error) {
 	return r.Architecture.Data + "/" + r.Basename.Data + "/" + r.SizeLabel.Data, nil
 }
 
-type mqlOllamaRunningModelInternal struct {
-	cacheDigest  string
-	cacheDetails api.ModelDetails
-}
-
 func (r *mqlOllamaRunningModel) id() (string, error) {
-	return "running/" + r.cacheDigest, nil
+	return "running/" + r.Name.Data, nil
 }
 
 func (r *mqlOllamaRunningModel) model() (*mqlOllamaModel, error) {
-	families := make([]interface{}, len(r.cacheDetails.Families))
-	for i, f := range r.cacheDetails.Families {
-		families[i] = f
-	}
-
 	res, err := NewResource(r.MqlRuntime, "ollama.model", map[string]*llx.RawData{
-		"__id":              llx.StringData(r.cacheDigest),
-		"name":              llx.StringData(r.GetName().Data),
-		"model":             llx.StringData(r.GetName().Data),
-		"modifiedAt":        llx.TimeData(time.Time{}),
-		"size":              llx.IntData(0),
-		"digest":            llx.StringData(r.cacheDigest),
-		"format":            llx.StringData(r.cacheDetails.Format),
-		"family":            llx.StringData(r.cacheDetails.Family),
-		"families":          llx.ArrayData(families, types.String),
-		"parameterSize":     llx.StringData(r.cacheDetails.ParameterSize),
-		"quantizationLevel": llx.StringData(r.cacheDetails.QuantizationLevel),
-		"parentModel":       llx.StringData(r.cacheDetails.ParentModel),
+		"name": llx.StringData(r.GetName().Data),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/ollama/resources/ollama.go
+++ b/providers/ollama/resources/ollama.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -81,16 +82,17 @@ func ollamaModelArgs(m api.ListModelResponse) map[string]*llx.RawData {
 // (size, modifiedAt, digest, ...) rather than placeholder values. Models
 // created directly via ollama.models carry a digest and skip this path.
 func initOllamaModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	// Created directly with full metadata (carries a digest); nothing to resolve.
 	if _, ok := args["digest"]; ok {
 		return args, nil, nil
 	}
 	nameRaw, ok := args["name"]
 	if !ok {
-		return args, nil, nil
+		return nil, nil, errors.New("ollama.model init requires a name or digest")
 	}
 	name, ok := nameRaw.Value.(string)
 	if !ok || name == "" {
-		return args, nil, nil
+		return nil, nil, errors.New("ollama.model init requires a non-empty name")
 	}
 
 	// Reuse an already-listed model instead of calling the API again.

--- a/providers/ollama/resources/ollama.lr.go
+++ b/providers/ollama/resources/ollama.lr.go
@@ -31,7 +31,7 @@ func init() {
 			Create: createOllama,
 		},
 		"ollama.model": {
-			// to override args, implement: initOllamaModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOllamaModel,
 			Create: createOllamaModel,
 		},
 		"ollama.model.info": {
@@ -876,7 +876,7 @@ func (c *mqlOllamaModelInfo) GetTokenizerModel() *plugin.TValue[string] {
 type mqlOllamaRunningModel struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlOllamaRunningModelInternal
+	// optional: if you define mqlOllamaRunningModelInternal it will be used here
 	Name          plugin.TValue[string]
 	Model         plugin.TValue[*mqlOllamaModel]
 	ExpiresAt     plugin.TValue[*time.Time]

--- a/providers/ollama/resources/ollama_test.go
+++ b/providers/ollama/resources/ollama_test.go
@@ -1,0 +1,67 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetString(t *testing.T) {
+	m := map[string]any{
+		"general.architecture": "llama",
+		"general.parameter":    float64(42),
+		"general.nil":          nil,
+	}
+	assert.Equal(t, "llama", getString(m, "general.architecture"))
+	assert.Equal(t, "", getString(m, "missing"), "missing key returns empty string")
+	assert.Equal(t, "", getString(m, "general.parameter"), "non-string value returns empty string")
+	assert.Equal(t, "", getString(m, "general.nil"), "nil value returns empty string")
+}
+
+func TestGetInt(t *testing.T) {
+	// JSON numbers decode into map[string]any as float64, which is the real
+	// wire type from the ollama client; int64 is covered for completeness.
+	m := map[string]any{
+		"float": float64(8030261248),
+		"int64": int64(4096),
+		"str":   "128",
+		"nil":   nil,
+	}
+	assert.Equal(t, int64(8030261248), getInt(m, "float"), "large float64 preserved without precision loss")
+	assert.Equal(t, int64(4096), getInt(m, "int64"))
+	assert.Equal(t, int64(0), getInt(m, "missing"), "missing key returns zero")
+	assert.Equal(t, int64(0), getInt(m, "str"), "non-numeric value returns zero")
+	assert.Equal(t, int64(0), getInt(m, "nil"), "nil value returns zero")
+}
+
+func TestGetArchInt(t *testing.T) {
+	m := map[string]any{
+		"llama.context_length":       float64(131072),
+		"llama.attention.head_count": float64(32),
+		"qwen2.embedding_length":     float64(3584),
+	}
+	assert.Equal(t, int64(131072), getArchInt(m, "llama", "context_length"))
+	assert.Equal(t, int64(32), getArchInt(m, "llama", "attention.head_count"))
+	assert.Equal(t, int64(3584), getArchInt(m, "qwen2", "embedding_length"))
+	assert.Equal(t, int64(0), getArchInt(m, "llama", "embedding_length"), "wrong arch prefix returns zero")
+	assert.Equal(t, int64(0), getArchInt(m, "", "context_length"), "empty arch returns zero, not a panic")
+}
+
+func TestGetStringSlice(t *testing.T) {
+	m := map[string]any{
+		"general.languages": []any{"en", "de", "fr"},
+		"mixed":             []any{"en", float64(1), "de"},
+		"scalar":            "en",
+		"nil":               nil,
+		"empty":             []any{},
+	}
+	assert.Equal(t, []interface{}{"en", "de", "fr"}, getStringSlice(m, "general.languages"))
+	assert.Equal(t, []interface{}{"en", "de"}, getStringSlice(m, "mixed"), "non-string elements are skipped")
+	assert.Equal(t, []interface{}{}, getStringSlice(m, "scalar"), "scalar (non-array) value yields empty slice")
+	assert.Equal(t, []interface{}{}, getStringSlice(m, "missing"), "missing key yields empty slice")
+	assert.Equal(t, []interface{}{}, getStringSlice(m, "nil"), "nil value yields empty slice")
+	assert.Equal(t, []interface{}{}, getStringSlice(m, "empty"))
+}


### PR DESCRIPTION
## Problem

Two silent-data-loss bugs in the ollama provider, both rooted in using the model **digest** as the cache `__id`.

### 1. `__id` collision on shared digest (HIGH)

`ollama.model` keyed on `m.Digest`, `ollama.runningModel` on `"running/"+m.Digest`, and `ollama.model.info` on `digest+"/info"`. Ollama assigns the **same manifest digest** to aliased tags — installing `llama3.1` gives you both `llama3.1:latest` and `llama3.1:8b` as distinct entries that share one ID (visible in `ollama list`).

Because `CreateResource` returns the already-cached resource on an `__id` hit, two distinct installed models collapsed onto one cache key: `ollama.models { name }` listed the same model twice and dropped the other — wrong data, no error.

**Fix:** key on `m.Name`, the stable unique identifier a user selects by. This also fixes `ollama.model.info` for free, since its `__id` derives from the parent model's name.

### 2. `runningModel.model()` returned placeholder `size`/`modifiedAt` (MEDIUM)

The installed-model cross-reference was built with `size: 0` and `modifiedAt: time.Time{}` placeholders (there was no `initOllamaModel`, so `NewResource` just stored the fakes). Running `ollama.runningModels { model { size } }` without also evaluating `ollama.models` in the same query returned `0` instead of the real on-disk size.

**Fix:** replace the hand-built husk with an `initOllamaModel` that resolves the model by name via `client.List()`, reusing an already-listed model from the resource cache when present (so no extra API call in the common case). The cross-reference now always yields real metadata.

## Tests

Added table tests for the pure-Go GGUF metadata parsers (`getString`, `getInt`, `getArchInt`, `getStringSlice`) — these are the null/type-normalization helpers where a regression would silently zero out fields. Coverage includes the `float64` wire type (the real decode type from the ollama client), missing/nil keys, and scalar-instead-of-array values.

## Verification

- `make providers/build/ollama` — builds clean
- `go vet ./...` + `go test ./...` — pass
- Generated `.lr.go` diff is only the `Init` wiring + removal of the now-unused running-model Internal struct

Found via `/provider-bug-review`. No schema/field changes, so no `.lr.versions` bump.
