### PR TITLE
🐛 huggingface: follow list pagination, fix webhook cap + model author N+1

### DIFF
--- a/providers/huggingface/internal/huggingface-hub-go/api/api.go
+++ b/providers/huggingface/internal/huggingface-hub-go/api/api.go
@@ -434,10 +434,21 @@ func (a *API) ListWebhooks(ctx context.Context, opts *models.WebhookListOptions)
 		endpoint = fmt.Sprintf("%s?%s", endpoint, params.Encode())
 	}
 
+	// Follow cursor pagination like the other list endpoints. The settings
+	// endpoint may not paginate today, in which case the loop simply runs once
+	// (no Link header, so next is empty).
 	var webhookList models.WebhookList
-	err := a.request(ctx, http.MethodGet, endpoint, nil, &webhookList)
-	if err != nil {
-		return nil, err
+	next := endpoint
+	seen := map[string]bool{}
+	for next != "" && !seen[next] {
+		seen[next] = true
+		var page models.WebhookList
+		nextURL, err := a.getPaged(ctx, next, &page)
+		if err != nil {
+			return nil, err
+		}
+		webhookList = append(webhookList, page...)
+		next = nextURL
 	}
 	return []models.Webhook(webhookList), nil
 }

--- a/providers/huggingface/internal/huggingface-hub-go/api/api.go
+++ b/providers/huggingface/internal/huggingface-hub-go/api/api.go
@@ -50,10 +50,12 @@ func escapeRepoID(id string) string {
 	return url.PathEscape(id)
 }
 
-func (a *API) request(ctx context.Context, method, endpoint string, body interface{}, result interface{}) error {
+// buildURL turns a relative API endpoint (optionally carrying a query string)
+// into the absolute URL under the "/api" base path.
+func (a *API) buildURL(endpoint string) (string, error) {
 	u, err := url.Parse(a.baseURL)
 	if err != nil {
-		return fmt.Errorf("invalid base URL: %w", err)
+		return "", fmt.Errorf("invalid base URL: %w", err)
 	}
 
 	pathPart := endpoint
@@ -69,6 +71,86 @@ func (a *API) request(ctx context.Context, method, endpoint string, body interfa
 		u.RawQuery = queryPart
 	}
 
+	return u.String(), nil
+}
+
+// parseNextLink extracts the URL marked rel="next" from an RFC 8288 Link
+// header. The HuggingFace list endpoints paginate by returning a cursor in
+// this header; an empty string means there is no further page.
+func parseNextLink(header string) string {
+	if header == "" {
+		return ""
+	}
+	for _, part := range strings.Split(header, ",") {
+		segments := strings.Split(part, ";")
+		if len(segments) < 2 {
+			continue
+		}
+		rawURL := strings.TrimSpace(segments[0])
+		if !strings.HasPrefix(rawURL, "<") || !strings.HasSuffix(rawURL, ">") {
+			continue
+		}
+		for _, param := range segments[1:] {
+			param = strings.TrimSpace(param)
+			if param == `rel="next"` || param == "rel=next" {
+				return rawURL[1 : len(rawURL)-1]
+			}
+		}
+	}
+	return ""
+}
+
+// getPaged performs a GET against a relative endpoint or an absolute URL (as
+// returned by parseNextLink), decodes the body into result, and returns the
+// URL of the next page (empty when the response has no rel="next" link).
+func (a *API) getPaged(ctx context.Context, endpointOrURL string, result interface{}) (string, error) {
+	rawURL := endpointOrURL
+	if !strings.HasPrefix(endpointOrURL, "http://") && !strings.HasPrefix(endpointOrURL, "https://") {
+		var err error
+		rawURL, err = a.buildURL(endpointOrURL)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	if a.token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.token)
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))
+		var apiErr models.Error
+		if err := json.Unmarshal(bodyBytes, &apiErr); err != nil {
+			return "", fmt.Errorf("request failed (status: %d)", resp.StatusCode)
+		}
+		return "", fmt.Errorf("API error: %s (status: %d)", apiErr.Error, resp.StatusCode)
+	}
+
+	if result != nil {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return "", fmt.Errorf("failed to decode response: %w", err)
+		}
+	}
+
+	return parseNextLink(resp.Header.Get("Link")), nil
+}
+
+func (a *API) request(ctx context.Context, method, endpoint string, body interface{}, result interface{}) error {
+	rawURL, err := a.buildURL(endpoint)
+	if err != nil {
+		return err
+	}
+
 	var bodyReader io.Reader
 	if body != nil {
 		jsonBody, err := json.Marshal(body)
@@ -78,7 +160,7 @@ func (a *API) request(ctx context.Context, method, endpoint string, body interfa
 		bodyReader = bytes.NewReader(jsonBody)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, bodyReader)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -177,9 +259,17 @@ func (a *API) ListModels(ctx context.Context, opts *models.ModelListOptions) (*m
 	}
 
 	var modelList models.ModelList
-	err := a.request(ctx, http.MethodGet, endpoint, nil, &modelList)
-	if err != nil {
-		return nil, err
+	next := endpoint
+	seen := map[string]bool{}
+	for next != "" && !seen[next] {
+		seen[next] = true
+		var page models.ModelList
+		nextURL, err := a.getPaged(ctx, next, &page)
+		if err != nil {
+			return nil, err
+		}
+		modelList.Models = append(modelList.Models, page.Models...)
+		next = nextURL
 	}
 	return &modelList, nil
 }
@@ -220,9 +310,17 @@ func (a *API) ListDatasets(ctx context.Context, opts *models.DatasetListOptions)
 	}
 
 	var datasetList models.DatasetList
-	err := a.request(ctx, http.MethodGet, endpoint, nil, &datasetList)
-	if err != nil {
-		return nil, err
+	next := endpoint
+	seen := map[string]bool{}
+	for next != "" && !seen[next] {
+		seen[next] = true
+		var page models.DatasetList
+		nextURL, err := a.getPaged(ctx, next, &page)
+		if err != nil {
+			return nil, err
+		}
+		datasetList.Datasets = append(datasetList.Datasets, page.Datasets...)
+		next = nextURL
 	}
 	return &datasetList, nil
 }
@@ -263,9 +361,17 @@ func (a *API) ListSpaces(ctx context.Context, opts *models.SpaceListOptions) (*m
 	}
 
 	var spaceList models.SpaceList
-	err := a.request(ctx, http.MethodGet, endpoint, nil, &spaceList)
-	if err != nil {
-		return nil, err
+	next := endpoint
+	seen := map[string]bool{}
+	for next != "" && !seen[next] {
+		seen[next] = true
+		var page models.SpaceList
+		nextURL, err := a.getPaged(ctx, next, &page)
+		if err != nil {
+			return nil, err
+		}
+		spaceList.Spaces = append(spaceList.Spaces, page.Spaces...)
+		next = nextURL
 	}
 	return &spaceList, nil
 }

--- a/providers/huggingface/internal/huggingface-hub-go/api/api_test.go
+++ b/providers/huggingface/internal/huggingface-hub-go/api/api_test.go
@@ -118,6 +118,31 @@ func TestListModelsStopsOnRepeatedCursor(t *testing.T) {
 	assert.Len(t, list.Models, 2)
 }
 
+// TestListWebhooksPagination proves webhooks follow the same cursor pagination
+// as the other list endpoints (the settings endpoint returns a bare array).
+func TestListWebhooksPagination(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/settings/webhooks", r.URL.Path)
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			w.Header().Set("Link", fmt.Sprintf(`<%s/api/settings/webhooks?cursor=page2>; rel="next"`, srv.URL))
+			_, _ = w.Write([]byte(`[{"id":"w1"},{"id":"w2"}]`))
+		case "page2":
+			_, _ = w.Write([]byte(`[{"id":"w3"}]`))
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer srv.Close()
+
+	a := NewAPI(srv.URL, srv.Client(), "")
+	hooks, err := a.ListWebhooks(context.Background(), models.NewWebhookListOptions())
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	assert.Equal(t, "w3", hooks[2].ID)
+}
+
 func TestListModelsPropagatesError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/providers/huggingface/internal/huggingface-hub-go/api/api_test.go
+++ b/providers/huggingface/internal/huggingface-hub-go/api/api_test.go
@@ -1,0 +1,134 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/huggingface/internal/huggingface-hub-go/models"
+)
+
+func TestParseNextLink(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"no next rel", `<https://hf.co/api/models?cursor=a>; rel="prev"`, ""},
+		{"single next", `<https://hf.co/api/models?cursor=a>; rel="next"`, "https://hf.co/api/models?cursor=a"},
+		{"next among many", `<https://hf.co/api/models?cursor=z>; rel="prev", <https://hf.co/api/models?cursor=a>; rel="next"`, "https://hf.co/api/models?cursor=a"},
+		{"unquoted rel", `<https://hf.co/next>; rel=next`, "https://hf.co/next"},
+		{"malformed no brackets", `https://hf.co/next; rel="next"`, ""},
+		{"malformed no rel param", `<https://hf.co/next>`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseNextLink(tt.header))
+		})
+	}
+}
+
+func TestEscapeRepoID(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B"},
+		{"gpt2", "gpt2"},
+		{"owner/name with space", "owner/name%20with%20space"},
+		{"owner/sub/name", "owner/sub%2Fname"}, // only the first "/" is a separator
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, escapeRepoID(tt.in))
+		})
+	}
+}
+
+func TestBuildURL(t *testing.T) {
+	a := NewAPI("https://huggingface.co", http.DefaultClient, "")
+
+	u, err := a.buildURL("models?author=acme&limit=1000")
+	require.NoError(t, err)
+	assert.Equal(t, "https://huggingface.co/api/models?author=acme&limit=1000", u)
+
+	u, err = a.buildURL("whoami-v2")
+	require.NoError(t, err)
+	assert.Equal(t, "https://huggingface.co/api/whoami-v2", u)
+}
+
+// TestListModelsPagination proves the list loop follows the rel="next" Link
+// header across pages instead of truncating at the first page.
+func TestListModelsPagination(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/models", r.URL.Path)
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			// First page: two models plus a link to the next page.
+			w.Header().Set("Link", fmt.Sprintf(`<%s/api/models?cursor=page2>; rel="next"`, srv.URL))
+			_, _ = w.Write([]byte(`[{"id":"acme/one"},{"id":"acme/two"}]`))
+		case "page2":
+			// Last page: one model, no Link header.
+			_, _ = w.Write([]byte(`[{"id":"acme/three"}]`))
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer srv.Close()
+
+	a := NewAPI(srv.URL, srv.Client(), "")
+	opts := models.NewModelListOptions()
+	opts.Author = "acme"
+
+	list, err := a.ListModels(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, list.Models, 3)
+	assert.Equal(t, "acme/one", list.Models[0].ID)
+	assert.Equal(t, "acme/three", list.Models[2].ID)
+}
+
+// TestListModelsStopsOnRepeatedCursor guards against an infinite loop if the
+// server ever returns a Link header pointing back at the same page.
+func TestListModelsStopsOnRepeatedCursor(t *testing.T) {
+	var srv *httptest.Server
+	calls := 0
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// Always point "next" at the same absolute URL.
+		w.Header().Set("Link", fmt.Sprintf(`<%s/api/models?cursor=loop>; rel="next"`, srv.URL))
+		_, _ = w.Write([]byte(`[{"id":"acme/one"}]`))
+	}))
+	defer srv.Close()
+
+	a := NewAPI(srv.URL, srv.Client(), "")
+	list, err := a.ListModels(context.Background(), models.NewModelListOptions())
+	require.NoError(t, err)
+	// First page ("models?...") then the repeated "cursor=loop" URL once; the
+	// third visit is a repeat and breaks the loop.
+	assert.Equal(t, 2, calls)
+	assert.Len(t, list.Models, 2)
+}
+
+func TestListModelsPropagatesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	a := NewAPI(srv.URL, srv.Client(), "")
+	_, err := a.ListModels(context.Background(), models.NewModelListOptions())
+	require.Error(t, err)
+	// Error string must carry the "(status: 403)" suffix the resource layer
+	// matches on to degrade gracefully.
+	assert.Contains(t, err.Error(), "(status: 403)")
+}

--- a/providers/huggingface/internal/huggingface-hub-go/models/models_test.go
+++ b/providers/huggingface/internal/huggingface-hub-go/models/models_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The HuggingFace API returns "gated" either as a bool (false) or as a string
+// ("auto"/"manual"); both must decode without error.
+func TestGatedValueUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		gated   bool
+		mode    string
+		wantErr bool
+	}{
+		{"bool false", `false`, false, "false", false},
+		{"bool true", `true`, true, "true", false},
+		{"string auto", `"auto"`, true, "auto", false},
+		{"string manual", `"manual"`, true, "manual", false},
+		{"string false", `"false"`, false, "false", false},
+		{"string empty", `""`, false, "", false},
+		{"unexpected number", `5`, false, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g GatedValue
+			err := json.Unmarshal([]byte(tt.json), &g)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.gated, g.IsGated)
+			assert.Equal(t, tt.mode, g.Mode)
+		})
+	}
+}
+
+func TestModelListUnmarshal(t *testing.T) {
+	// Bare array form (the normal list response).
+	var arr ModelList
+	require.NoError(t, json.Unmarshal([]byte(`[{"id":"a/1"},{"id":"a/2"}]`), &arr))
+	require.Len(t, arr.Models, 2)
+	assert.Equal(t, "a/1", arr.Models[0].ID)
+
+	// Object-wrapped form.
+	var obj ModelList
+	require.NoError(t, json.Unmarshal([]byte(`{"models":[{"id":"a/1"}]}`), &obj))
+	require.Len(t, obj.Models, 1)
+
+	// A "gated" string inside a list entry must not break array decoding.
+	var gated ModelList
+	require.NoError(t, json.Unmarshal([]byte(`[{"id":"a/1","gated":"manual"}]`), &gated))
+	require.Len(t, gated.Models, 1)
+	assert.True(t, gated.Models[0].Gated.IsGated)
+}
+
+func TestDatasetAndSpaceListUnmarshal(t *testing.T) {
+	var dl DatasetList
+	require.NoError(t, json.Unmarshal([]byte(`[{"id":"a/d1"}]`), &dl))
+	require.Len(t, dl.Datasets, 1)
+
+	var sl SpaceList
+	require.NoError(t, json.Unmarshal([]byte(`[{"id":"a/s1"}]`), &sl))
+	require.Len(t, sl.Spaces, 1)
+}
+
+func TestWebhookListUnmarshal(t *testing.T) {
+	// Bare array form.
+	var arr WebhookList
+	require.NoError(t, json.Unmarshal([]byte(`[{"id":"w1"},{"id":"w2"}]`), &arr))
+	require.Len(t, arr, 2)
+
+	// Object-wrapped form.
+	var obj WebhookList
+	require.NoError(t, json.Unmarshal([]byte(`{"webhooks":[{"id":"w1"}]}`), &obj))
+	require.Len(t, obj, 1)
+	assert.Equal(t, "w1", obj[0].ID)
+}

--- a/providers/huggingface/resources/huggingface.go
+++ b/providers/huggingface/resources/huggingface.go
@@ -242,7 +242,12 @@ func (r *mqlHuggingface) spaces() ([]any, error) {
 func (r *mqlHuggingface) webhooks() ([]any, error) {
 	client := hfConn(r.MqlRuntime).Client()
 
-	webhookList, err := client.ListWebhooks(context.Background(), nil)
+	// Match the high page size used by the other collections so accounts with
+	// many webhooks are not silently truncated to the 20-item default.
+	opts := hfmodels.NewWebhookListOptions()
+	opts.Limit = 1000
+
+	webhookList, err := client.ListWebhooks(context.Background(), opts)
 	if isAccessDenied(err) {
 		return []any{}, nil
 	}
@@ -424,11 +429,11 @@ func initHuggingfaceModel(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	idRaw, ok := args["id"]
 	if !ok || idRaw == nil || idRaw.Value == nil {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("huggingface.model requires an 'id' (for example \"owner/model\")")
 	}
 	modelID, ok := idRaw.Value.(string)
 	if !ok || modelID == "" {
-		return args, nil, nil
+		return nil, nil, fmt.Errorf("huggingface.model 'id' must be a non-empty string")
 	}
 
 	modelID, err := normalizeModelID(modelID)
@@ -495,6 +500,11 @@ func (r *mqlHuggingfaceModel) id() (string, error) {
 func (r *mqlHuggingfaceModel) author() (string, error) {
 	if r.listAuthor != "" {
 		return r.listAuthor, nil
+	}
+	// The author is the owner segment of the "owner/name" ID; derive it
+	// directly to avoid a per-model detail fetch (the list API omits author).
+	if parts := strings.SplitN(r.Id.Data, "/", 2); len(parts) == 2 {
+		return parts[0], nil
 	}
 	detail, err := r.fetchDetail()
 	if err != nil {
@@ -645,8 +655,12 @@ func normalizeModelID(input string) (string, error) {
 			return "", fmt.Errorf("invalid model URL: %w", err)
 		}
 		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-		if len(parts) < 2 {
-			return "", fmt.Errorf("model URL must contain owner/model path: %s", input)
+		if len(parts) == 0 || parts[0] == "" {
+			return "", fmt.Errorf("model URL must contain a model path: %s", input)
+		}
+		// Canonical models (e.g. "gpt2") have no owner segment.
+		if len(parts) == 1 {
+			return parts[0], nil
 		}
 		return parts[0] + "/" + parts[1], nil
 	}

--- a/providers/huggingface/resources/huggingface_test.go
+++ b/providers/huggingface/resources/huggingface_test.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeModelID(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"plain owner/model", "meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B", false},
+		{"plain canonical", "gpt2", "gpt2", false},
+		{"url owner/model", "https://huggingface.co/meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-8B", false},
+		{"url with trailing path", "https://huggingface.co/meta-llama/Llama-3.1-8B/tree/main", "meta-llama/Llama-3.1-8B", false},
+		{"url canonical single segment", "https://huggingface.co/gpt2", "gpt2", false},
+		{"url trailing slash", "https://huggingface.co/gpt2/", "gpt2", false},
+		{"url no path", "https://huggingface.co", "", true},
+		{"url root only", "https://huggingface.co/", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeModelID(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseHFTime(t *testing.T) {
+	// RFC3339Nano (the common form, with and without fractional seconds).
+	got := parseHFTime("2024-01-02T03:04:05.123456789Z")
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(time.Date(2024, 1, 2, 3, 4, 5, 123456789, time.UTC)))
+
+	got = parseHFTime("2024-01-02T03:04:05Z")
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)))
+
+	// Millisecond "Z" form handled by the fallback layout.
+	got = parseHFTime("2024-01-02T03:04:05.000Z")
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)))
+
+	// Empty and unparseable inputs yield nil (null time), never a panic.
+	assert.Nil(t, parseHFTime(""))
+	assert.Nil(t, parseHFTime("not-a-timestamp"))
+}
+
+func TestStringsToInterface(t *testing.T) {
+	assert.Equal(t, []any{}, stringsToInterface(nil))
+	assert.Equal(t, []any{"a", "b"}, stringsToInterface([]string{"a", "b"}))
+}


### PR DESCRIPTION
## What

Fixes a set of silent-data-loss and correctness bugs in the `huggingface` provider surfaced by a static bug review, and adds unit coverage for the provider's pure-Go logic (previously only the platform catalog was tested).

## Why

The hand-rolled HuggingFace Hub client (`internal/huggingface-hub-go/`) never inspected the RFC 8288 `Link` header, so **every list endpoint silently returned only the first page**. The impact was masked behind large page sizes, but a namespace/org with enough repositories would lose data with no error — the worst kind of bug, because the wrong answer looks valid.

## Fixes

| Sev | Fix |
|-----|-----|
| Medium | **List pagination.** Follow the `Link: rel="next"` header. `request()` now shares a `buildURL` helper with a new paginating `getPaged`, and `ListModels`/`ListDatasets`/`ListSpaces` loop until exhausted. Previously truncated at the 1000-item page size. |
| Medium | **Webhook cap.** `webhooks()` passed `nil` options and inherited the 20-item default while every other collection used 1000. A namespace with >20 webhooks was truncated. Now uses 1000 to match. |
| Low (perf) | **`author()` N+1.** The list API omits `author`, so each model's `author` accessor fired one `GetModelDetail` call. The owner is now derived from the `owner/name` id with no network call. |
| Low | **`normalizeModelID`** now accepts canonical single-segment model URLs (e.g. `https://huggingface.co/gpt2`), which previously errored. |
| Low | **`initHuggingfaceModel`** returns an error on a missing/empty `id` instead of falling through to a blank-husk resource with unset fields. |

A visited-URL guard in each list loop prevents an infinite loop if the server ever returns a `next` link pointing back at the same page.

## Tests

New unit tests for the pure-Go logic where wrong-data bugs hide:

- `parseNextLink` (Link-header parsing), `escapeRepoID`, `buildURL`
- **End-to-end multi-page `ListModels`** via `httptest` — proves the loop follows `next` across pages
- The repeated-cursor infinite-loop guard
- Error-suffix propagation (`(status: 403)` must survive for the resource layer's access-denied degrade)
- `GatedValue` polymorphic bool/string unmarshal and the `*List` array-vs-object unmarshalers
- `parseHFTime` (dual-format + nil-on-failure) and `normalizeModelID`

## Verification

- `go build ./...` clean
- `go test ./internal/... ./resources/... ./connection/...` — all pass
- `go vet` clean
- No `.lr` changes, so no codegen / `.lr.versions` / version bump

## Note

The webhook-cap fix is defensive: the `settings/webhooks` endpoint may ignore the `limit` param entirely (in which case the old code was not truncating), but raising it to 1000 removes the asymmetry and any truncation risk regardless. Worth confirming against a live account with >20 webhooks.
