### PR TITLE
🐛 together: fix cluster storage volume misattribution + null timestamps

### DIFF
--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -225,16 +225,13 @@ func (r *mqlTogether) clusters() ([]interface{}, error) {
 			"numCpuWorkers":        llx.IntData(c.NumCPUWorkers),
 			"oidcIssuer":           llx.StringData(c.OidcConfig.IssuerURL),
 			"oidcClientId":         llx.StringData(c.OidcConfig.ClientID),
-			"createdAt":            llx.TimeData(c.CreatedAt),
-			"reservationStartTime": llx.TimeData(c.ReservationStartTime),
-			"reservationEndTime":   llx.TimeData(c.ReservationEndTime),
+			"createdAt":            llx.TimeDataPtr(timeOrNil(c.CreatedAt)),
+			"reservationStartTime": llx.TimeDataPtr(timeOrNil(c.ReservationStartTime)),
+			"reservationEndTime":   llx.TimeDataPtr(timeOrNil(c.ReservationEndTime)),
 		})
 		if err != nil {
 			return nil, err
 		}
-		cluster := mqlCluster.(*mqlTogetherCluster)
-		cluster.clusterId = c.ClusterID
-		cluster.projectId = c.ProjectID
 		res = append(res, mqlCluster)
 	}
 
@@ -280,18 +277,17 @@ func (r *mqlTogether) secrets() ([]interface{}, error) {
 	return res, nil
 }
 
-type mqlTogetherClusterInternal struct {
-	clusterId string
-	projectId string
-}
-
-func (r *mqlTogetherCluster) storageVolumes() ([]interface{}, error) {
+func (r *mqlTogether) clusterStorageVolumes() ([]interface{}, error) {
 	conn := togetherConn(r.MqlRuntime)
 	client := conn.Client()
 
+	// The storage volume API is project-scoped, not cluster-scoped: the list
+	// endpoint accepts only a project filter and the returned volumes carry no
+	// cluster reference, so they belong to the account's project and are shared
+	// across its clusters.
 	params := together.BetaClusterStorageListParams{}
-	if r.projectId != "" {
-		params.ProjectID = together.Opt(r.projectId)
+	if project := conn.Project(); project != "" {
+		params.ProjectID = together.Opt(project)
 	}
 
 	resp, err := client.Beta.Clusters.Storage.List(context.Background(), params)
@@ -308,7 +304,7 @@ func (r *mqlTogetherCluster) storageVolumes() ([]interface{}, error) {
 	res := make([]interface{}, 0, len(resp.Volumes))
 	for _, v := range resp.Volumes {
 		mqlVol, err := CreateResource(r.MqlRuntime, "together.clusterStorageVolume", map[string]*llx.RawData{
-			"__id":       llx.StringData(r.clusterId + "/" + v.VolumeID),
+			"__id":       llx.StringData(v.VolumeID),
 			"volumeId":   llx.StringData(v.VolumeID),
 			"volumeName": llx.StringData(v.VolumeName),
 			"sizeTib":    llx.IntData(v.SizeTib),
@@ -364,8 +360,8 @@ func (r *mqlTogether) deployments() ([]interface{}, error) {
 			"minReplicas":              llx.IntData(d.MinReplicas),
 			"maxReplicas":              llx.IntData(d.MaxReplicas),
 			"environmentVariableNames": llx.ArrayData(envVarNames, types.String),
-			"createdAt":                llx.TimeData(d.CreatedAt),
-			"updatedAt":                llx.TimeData(d.UpdatedAt),
+			"createdAt":                llx.TimeDataPtr(timeOrNil(d.CreatedAt)),
+			"updatedAt":                llx.TimeDataPtr(timeOrNil(d.UpdatedAt)),
 		})
 		if err != nil {
 			return nil, err
@@ -405,9 +401,9 @@ func (r *mqlTogether) batches() ([]interface{}, error) {
 			"progress":      llx.FloatData(b.Progress),
 			"fileSizeBytes": llx.IntData(b.FileSizeBytes),
 			"userId":        llx.StringData(b.UserID),
-			"createdAt":     llx.TimeData(b.CreatedAt),
-			"completedAt":   llx.TimeData(b.CompletedAt),
-			"jobDeadline":   llx.TimeData(b.JobDeadline),
+			"createdAt":     llx.TimeDataPtr(timeOrNil(b.CreatedAt)),
+			"completedAt":   llx.TimeDataPtr(timeOrNil(b.CompletedAt)),
+			"jobDeadline":   llx.TimeDataPtr(timeOrNil(b.JobDeadline)),
 		})
 		if err != nil {
 			return nil, err
@@ -441,8 +437,8 @@ func (r *mqlTogether) evals() ([]interface{}, error) {
 			"type":       llx.StringData(string(e.Type)),
 			"status":     llx.StringData(string(e.Status)),
 			"ownerId":    llx.StringData(e.OwnerID),
-			"createdAt":  llx.TimeData(e.CreatedAt),
-			"updatedAt":  llx.TimeData(e.UpdatedAt),
+			"createdAt":  llx.TimeDataPtr(timeOrNil(e.CreatedAt)),
+			"updatedAt":  llx.TimeDataPtr(timeOrNil(e.UpdatedAt)),
 		})
 		if err != nil {
 			return nil, err
@@ -623,6 +619,18 @@ func (r *mqlTogetherEval) id() (string, error) {
 
 func (r *mqlTogetherVolume) id() (string, error) {
 	return r.Id.Data, nil
+}
+
+// timeOrNil maps a zero time.Time to nil so absent SDK timestamps render as
+// null instead of the year-1 zero value. The Together SDK returns optional
+// timestamps as zero-valued time.Time (not pointers), so a job that has not
+// completed or a cluster with no reservation window would otherwise surface
+// 0001-01-01T00:00:00Z.
+func timeOrNil(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
 }
 
 func parseTimeStr(s string) *time.Time {

--- a/providers/together/resources/together.go
+++ b/providers/together/resources/together.go
@@ -232,6 +232,9 @@ func (r *mqlTogether) clusters() ([]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		cluster := mqlCluster.(*mqlTogetherCluster)
+		cluster.clusterId = c.ClusterID
+		cluster.projectId = c.ProjectID
 		res = append(res, mqlCluster)
 	}
 
@@ -279,14 +282,32 @@ func (r *mqlTogether) secrets() ([]interface{}, error) {
 
 func (r *mqlTogether) clusterStorageVolumes() ([]interface{}, error) {
 	conn := togetherConn(r.MqlRuntime)
-	client := conn.Client()
+	return listClusterStorageVolumes(r.MqlRuntime, conn.Client(), conn.Project(), "")
+}
 
-	// The storage volume API is project-scoped, not cluster-scoped: the list
-	// endpoint accepts only a project filter and the returned volumes carry no
-	// cluster reference, so they belong to the account's project and are shared
-	// across its clusters.
+type mqlTogetherClusterInternal struct {
+	clusterId string
+	projectId string
+}
+
+// storageVolumes is deprecated in favor of the top-level
+// together.clusterStorageVolumes. The Together storage API is project-scoped
+// and returns no cluster association, so this lists the cluster's project-wide
+// volumes rather than volumes owned by this specific cluster. Retained for
+// backward compatibility with its original project filter and __id.
+func (r *mqlTogetherCluster) storageVolumes() ([]interface{}, error) {
+	conn := togetherConn(r.MqlRuntime)
+	return listClusterStorageVolumes(r.MqlRuntime, conn.Client(), r.projectId, r.clusterId+"/")
+}
+
+// listClusterStorageVolumes lists project-scoped cluster storage volumes. The
+// list endpoint accepts only a project filter and the returned volumes carry no
+// cluster reference, so they belong to the account's project and are shared
+// across its clusters. idPrefix is prepended to each volume's __id to preserve
+// the deprecated per-cluster accessor's cache keys.
+func listClusterStorageVolumes(runtime *plugin.Runtime, client *together.Client, project, idPrefix string) ([]interface{}, error) {
 	params := together.BetaClusterStorageListParams{}
-	if project := conn.Project(); project != "" {
+	if project != "" {
 		params.ProjectID = together.Opt(project)
 	}
 
@@ -303,8 +324,8 @@ func (r *mqlTogether) clusterStorageVolumes() ([]interface{}, error) {
 
 	res := make([]interface{}, 0, len(resp.Volumes))
 	for _, v := range resp.Volumes {
-		mqlVol, err := CreateResource(r.MqlRuntime, "together.clusterStorageVolume", map[string]*llx.RawData{
-			"__id":       llx.StringData(v.VolumeID),
+		mqlVol, err := CreateResource(runtime, "together.clusterStorageVolume", map[string]*llx.RawData{
+			"__id":       llx.StringData(idPrefix + v.VolumeID),
 			"volumeId":   llx.StringData(v.VolumeID),
 			"volumeName": llx.StringData(v.VolumeName),
 			"sizeTib":    llx.IntData(v.SizeTib),

--- a/providers/together/resources/together.lr
+++ b/providers/together/resources/together.lr
@@ -231,6 +231,13 @@ together.cluster @defaults("name gpuType numGpus region status") @maturity("prev
   reservationStartTime time
   // Reservation end time
   reservationEndTime time
+  // Storage volumes reachable from this cluster
+  //
+  // Deprecated in favor of the top-level together.clusterStorageVolumes.
+  // The Together storage API is project-scoped and returns no cluster
+  // association, so the volumes listed here are the account's project-wide
+  // volumes rather than volumes owned by this specific cluster.
+  storageVolumes() @maturity("deprecated") []together.clusterStorageVolume
 }
 
 // Together AI managed secret

--- a/providers/together/resources/together.lr
+++ b/providers/together/resources/together.lr
@@ -10,9 +10,10 @@ option go_package = "go.mondoo.com/mql/v13/providers/together/resources"
 // auditing an account's inference and training footprint. Reachable
 // through it are the available models catalog, fine-tuning jobs,
 // dedicated endpoint deployments, container deployments, uploaded
-// files, GPU compute clusters, managed secrets, batch inference jobs,
-// evaluation jobs, and persistent volumes. The project the account is
-// scoped to is reported by the organization field.
+// files, GPU compute clusters, cluster storage volumes, managed
+// secrets, batch inference jobs, evaluation jobs, and persistent
+// volumes. The project the account is scoped to is reported by the
+// organization field.
 together @defaults("organization") @maturity("preview") {
   // Project identifier the account connection is scoped to
   organization() string
@@ -28,6 +29,8 @@ together @defaults("organization") @maturity("preview") {
   files() []together.file
   // GPU compute clusters
   clusters() []together.cluster
+  // Shared storage volumes for GPU compute clusters
+  clusterStorageVolumes() []together.clusterStorageVolume
   // Managed secrets for deployments
   secrets() []together.secret
   // Batch inference jobs
@@ -228,8 +231,6 @@ together.cluster @defaults("name gpuType numGpus region status") @maturity("prev
   reservationStartTime time
   // Reservation end time
   reservationEndTime time
-  // Persistent storage volumes attached to this cluster
-  storageVolumes() []together.clusterStorageVolume
 }
 
 // Together AI managed secret
@@ -257,12 +258,13 @@ together.secret @defaults("id name") @maturity("preview") {
 
 // Together AI cluster storage volume
 //
-// Persistent storage volume attached to a Together AI GPU cluster.
-// Volumes back model checkpoints, datasets, and scratch space for
-// cluster workloads, so tracking their capacity and lifecycle state
-// matters for both cost and availability. The `sizeTib` field reports
-// provisioned capacity in TiB, and `status` reports where the volume
-// sits in its provisioning and binding lifecycle.
+// Shared storage volume available to a Together AI account's GPU compute
+// clusters, scoped to the connection's project rather than owned by a
+// single cluster. Volumes back model checkpoints, datasets, and scratch
+// space for cluster workloads, so tracking their capacity and lifecycle
+// state matters for both cost and availability. The `sizeTib` field
+// reports provisioned capacity in TiB, and `status` reports where the
+// volume sits in its provisioning and binding lifecycle.
 private together.clusterStorageVolume @defaults("volumeName sizeTib status") @maturity("preview") {
   // Volume identifier
   volumeId string

--- a/providers/together/resources/together.lr.go
+++ b/providers/together/resources/together.lr.go
@@ -363,6 +363,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"together.cluster.reservationEndTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherCluster).GetReservationEndTime()).ToDataRes(types.Time)
 	},
+	"together.cluster.storageVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogetherCluster).GetStorageVolumes()).ToDataRes(types.Array(types.Resource("together.clusterStorageVolume")))
+	},
 	"together.secret.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherSecret).GetId()).ToDataRes(types.String)
 	},
@@ -845,6 +848,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"together.cluster.reservationEndTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTogetherCluster).ReservationEndTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"together.cluster.storageVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogetherCluster).StorageVolumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"together.secret.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1750,7 +1757,7 @@ func (c *mqlTogetherFile) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlTogetherCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlTogetherClusterInternal it will be used here
+	mqlTogetherClusterInternal
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	ClusterType          plugin.TValue[string]
@@ -1768,6 +1775,7 @@ type mqlTogetherCluster struct {
 	CreatedAt            plugin.TValue[*time.Time]
 	ReservationStartTime plugin.TValue[*time.Time]
 	ReservationEndTime   plugin.TValue[*time.Time]
+	StorageVolumes       plugin.TValue[[]any]
 }
 
 // createTogetherCluster creates a new instance of this resource
@@ -1873,6 +1881,22 @@ func (c *mqlTogetherCluster) GetReservationStartTime() *plugin.TValue[*time.Time
 
 func (c *mqlTogetherCluster) GetReservationEndTime() *plugin.TValue[*time.Time] {
 	return &c.ReservationEndTime
+}
+
+func (c *mqlTogetherCluster) GetStorageVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.StorageVolumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("together.cluster", c.__id, "storageVolumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.storageVolumes()
+	})
 }
 
 // mqlTogetherSecret for the together.secret resource

--- a/providers/together/resources/together.lr.go
+++ b/providers/together/resources/together.lr.go
@@ -174,6 +174,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"together.clusters": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogether).GetClusters()).ToDataRes(types.Array(types.Resource("together.cluster")))
 	},
+	"together.clusterStorageVolumes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlTogether).GetClusterStorageVolumes()).ToDataRes(types.Array(types.Resource("together.clusterStorageVolume")))
+	},
 	"together.secrets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogether).GetSecrets()).ToDataRes(types.Array(types.Resource("together.secret")))
 	},
@@ -359,9 +362,6 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"together.cluster.reservationEndTime": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherCluster).GetReservationEndTime()).ToDataRes(types.Time)
-	},
-	"together.cluster.storageVolumes": func(r plugin.Resource) *plugin.DataRes {
-		return (r.(*mqlTogetherCluster).GetStorageVolumes()).ToDataRes(types.Array(types.Resource("together.clusterStorageVolume")))
 	},
 	"together.secret.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlTogetherSecret).GetId()).ToDataRes(types.String)
@@ -573,6 +573,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"together.clusters": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTogether).Clusters, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"together.clusterStorageVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlTogether).ClusterStorageVolumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"together.secrets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -841,10 +845,6 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"together.cluster.reservationEndTime": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlTogetherCluster).ReservationEndTime, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
-		return
-	},
-	"together.cluster.storageVolumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
-		r.(*mqlTogetherCluster).StorageVolumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"together.secret.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1124,17 +1124,18 @@ type mqlTogether struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlTogetherInternal it will be used here
-	Organization plugin.TValue[string]
-	Models       plugin.TValue[[]any]
-	FineTunes    plugin.TValue[[]any]
-	Endpoints    plugin.TValue[[]any]
-	Deployments  plugin.TValue[[]any]
-	Files        plugin.TValue[[]any]
-	Clusters     plugin.TValue[[]any]
-	Secrets      plugin.TValue[[]any]
-	Batches      plugin.TValue[[]any]
-	Evals        plugin.TValue[[]any]
-	Volumes      plugin.TValue[[]any]
+	Organization          plugin.TValue[string]
+	Models                plugin.TValue[[]any]
+	FineTunes             plugin.TValue[[]any]
+	Endpoints             plugin.TValue[[]any]
+	Deployments           plugin.TValue[[]any]
+	Files                 plugin.TValue[[]any]
+	Clusters              plugin.TValue[[]any]
+	ClusterStorageVolumes plugin.TValue[[]any]
+	Secrets               plugin.TValue[[]any]
+	Batches               plugin.TValue[[]any]
+	Evals                 plugin.TValue[[]any]
+	Volumes               plugin.TValue[[]any]
 }
 
 // createTogether creates a new instance of this resource
@@ -1273,6 +1274,22 @@ func (c *mqlTogether) GetClusters() *plugin.TValue[[]any] {
 		}
 
 		return c.clusters()
+	})
+}
+
+func (c *mqlTogether) GetClusterStorageVolumes() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ClusterStorageVolumes, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("together", c.__id, "clusterStorageVolumes")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.clusterStorageVolumes()
 	})
 }
 
@@ -1733,7 +1750,7 @@ func (c *mqlTogetherFile) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlTogetherCluster struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	mqlTogetherClusterInternal
+	// optional: if you define mqlTogetherClusterInternal it will be used here
 	Id                   plugin.TValue[string]
 	Name                 plugin.TValue[string]
 	ClusterType          plugin.TValue[string]
@@ -1751,7 +1768,6 @@ type mqlTogetherCluster struct {
 	CreatedAt            plugin.TValue[*time.Time]
 	ReservationStartTime plugin.TValue[*time.Time]
 	ReservationEndTime   plugin.TValue[*time.Time]
-	StorageVolumes       plugin.TValue[[]any]
 }
 
 // createTogetherCluster creates a new instance of this resource
@@ -1857,22 +1873,6 @@ func (c *mqlTogetherCluster) GetReservationStartTime() *plugin.TValue[*time.Time
 
 func (c *mqlTogetherCluster) GetReservationEndTime() *plugin.TValue[*time.Time] {
 	return &c.ReservationEndTime
-}
-
-func (c *mqlTogetherCluster) GetStorageVolumes() *plugin.TValue[[]any] {
-	return plugin.GetOrCompute[[]any](&c.StorageVolumes, func() ([]any, error) {
-		if c.MqlRuntime.HasRecording {
-			d, err := c.MqlRuntime.FieldResourceFromRecording("together.cluster", c.__id, "storageVolumes")
-			if err != nil {
-				return nil, err
-			}
-			if d != nil {
-				return d.Value.([]any), nil
-			}
-		}
-
-		return c.storageVolumes()
-	})
 }
 
 // mqlTogetherSecret for the together.secret resource

--- a/providers/together/resources/together.lr.versions
+++ b/providers/together/resources/together.lr.versions
@@ -35,6 +35,7 @@ together.cluster.region 13.0.0
 together.cluster.reservationEndTime 13.0.0
 together.cluster.reservationStartTime 13.0.0
 together.cluster.status 13.0.0
+together.cluster.storageVolumes 13.0.0
 together.clusterStorageVolume 13.0.0
 together.clusterStorageVolume.sizeTib 13.0.0
 together.clusterStorageVolume.status 13.0.0

--- a/providers/together/resources/together.lr.versions
+++ b/providers/together/resources/together.lr.versions
@@ -35,12 +35,12 @@ together.cluster.region 13.0.0
 together.cluster.reservationEndTime 13.0.0
 together.cluster.reservationStartTime 13.0.0
 together.cluster.status 13.0.0
-together.cluster.storageVolumes 13.0.0
 together.clusterStorageVolume 13.0.0
 together.clusterStorageVolume.sizeTib 13.0.0
 together.clusterStorageVolume.status 13.0.0
 together.clusterStorageVolume.volumeId 13.0.0
 together.clusterStorageVolume.volumeName 13.0.0
+together.clusterStorageVolumes 13.0.9
 together.clusters 13.0.0
 together.deployment 13.0.0
 together.deployment.cpu 13.0.0

--- a/providers/together/resources/together_test.go
+++ b/providers/together/resources/together_test.go
@@ -4,9 +4,12 @@
 package resources
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	together "github.com/togethercomputer/together-go"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
@@ -90,4 +93,68 @@ func TestModelDescription(t *testing.T) {
 	got, err := m.description()
 	assert.NoError(t, err)
 	assert.Equal(t, "Llama 3.3 70B Instruct Turbo", got)
+}
+
+func TestParseTimeStr(t *testing.T) {
+	t.Run("empty string returns nil", func(t *testing.T) {
+		assert.Nil(t, parseTimeStr(""))
+	})
+
+	t.Run("unparseable string returns nil", func(t *testing.T) {
+		assert.Nil(t, parseTimeStr("not-a-timestamp"))
+		assert.Nil(t, parseTimeStr("1719878400")) // unix epoch is not an accepted layout
+	})
+
+	want := time.Date(2026, 6, 20, 15, 4, 5, 0, time.UTC)
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{"RFC3339", "2026-06-20T15:04:05Z", want},
+		{"RFC3339Nano", "2026-06-20T15:04:05.000000000Z", want},
+		{"no timezone", "2026-06-20T15:04:05", want},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTimeStr(tt.input)
+			if assert.NotNil(t, got) {
+				assert.True(t, got.Equal(tt.want), "got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeOrNil(t *testing.T) {
+	t.Run("zero time returns nil", func(t *testing.T) {
+		assert.Nil(t, timeOrNil(time.Time{}))
+	})
+
+	t.Run("set time returns pointer", func(t *testing.T) {
+		want := time.Date(2026, 6, 20, 15, 4, 5, 0, time.UTC)
+		got := timeOrNil(want)
+		if assert.NotNil(t, got) {
+			assert.True(t, got.Equal(want))
+		}
+	})
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"401 unauthorized", &together.Error{StatusCode: 401}, true},
+		{"403 forbidden", &together.Error{StatusCode: 403}, true},
+		{"404 not found", &together.Error{StatusCode: 404}, false},
+		{"500 server error", &together.Error{StatusCode: 500}, false},
+		{"non-API error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isAccessDenied(tt.err))
+		})
+	}
 }


### PR DESCRIPTION
## What

Two correctness fixes in the `together` provider (surfaced by a static bug review), plus unit tests for the provider's pure-Go logic.

### 1. Cluster storage volumes were misattributed across clusters

`together.cluster.storageVolumes` modeled cluster storage as a per-cluster child, but the Together storage API is **project-scoped**: `BetaClusterStorageService.List` accepts only a `ProjectID` filter, and the returned `ClusterStorage` items carry no cluster reference at all (fields are `VolumeID`, `VolumeName`, `SizeTib`, `Status`). Every cluster in a multi-cluster project therefore returned the project's **entire** volume set, each falsely attributed to a different cluster via a synthetic `clusterId/volumeId` `__id`.

**Fix:** added a top-level, project-scoped `together.clusterStorageVolumes` (keyed on the volume ID) as the correct model. The old `together.cluster.storageVolumes` is **kept and marked `@maturity("deprecated")`** — not removed — so existing consumers don't break; it retains its original project filter and `clusterId/volumeId` `__id` and now delegates to a shared `listClusterStorageVolumes` helper. Single-cluster projects were unaffected either way (which is why this survived smoke testing).

```
# deprecated: same volumes duplicated under every cluster
together.clusters { name storageVolumes { volumeName } }

# recommended: one project-scoped collection
together.clusterStorageVolumes { volumeName sizeTib status }
```

### 2. Absent timestamps rendered as year 1 instead of null

The Together SDK (Stainless-generated) returns optional timestamps as zero-valued `time.Time`, not pointers. Several fields were passed straight to `llx.TimeData`, so an absent value surfaced as `0001-01-01T00:00:00Z` — a valid non-null time — instead of null. Affected: `batch.completedAt` / `batch.jobDeadline` (in-progress jobs), `cluster.reservationStartTime` / `cluster.reservationEndTime` (on-demand clusters), and the `eval` / `deployment` created/updated times.

**Fix:** added a `timeOrNil` helper (mirroring the existing `parseTimeStr` nil convention) and applied it to every non-`api:"required"` value-typed timestamp. `together.batches.where(completedAt == null)` now works.

### 3. Test coverage for pure-Go logic

Added unit tests for `parseTimeStr` (multi-layout parser, silent nil on unparseable input), `isAccessDenied` (401/403 degrade classifier), and the new `timeOrNil`. None had direct coverage, and a regression in any of them silently corrupts data.

## Notes

- `together.clusterStorageVolumes` is versioned `13.0.9` (next patch after the shipped `13.0.8`); the deprecated `together.cluster.storageVolumes` keeps its original `13.0.0` version. No `config.go` version bump.

## Testing

- `go build ./...` — clean
- `go test ./resources/...` — pass (new and existing tests)
- `go vet ./resources/...` — clean
- `gofmt` — clean
