### PR TITLE
🐛 openai: null never-used project apiKey lastUsedAt + document 30-day audit window

### DIFF
--- a/providers/openai/connection/connection_test.go
+++ b/providers/openai/connection/connection_test.go
@@ -1,0 +1,71 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAdminToken(t *testing.T) {
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{"sk-admin-abc123", true},
+		{"sk-proj-abc123", false},
+		{"sk-abc123", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, isAdminToken(tc.token), tc.token)
+	}
+}
+
+func TestFetchAccountInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantOrgID string
+		wantName  string
+	}{
+		{
+			name:      "single org",
+			body:      `{"orgs":{"data":[{"id":"org-1","name":"Acme","is_default":true}]}}`,
+			wantOrgID: "org-1",
+			wantName:  "Acme",
+		},
+		{
+			name:      "prefers the default org over the first",
+			body:      `{"orgs":{"data":[{"id":"org-1","name":"First","is_default":false},{"id":"org-2","name":"Default","is_default":true}]}}`,
+			wantOrgID: "org-2",
+			wantName:  "Default",
+		},
+		{
+			name:      "falls back to the first org when none is default",
+			body:      `{"orgs":{"data":[{"id":"org-1","name":"First","is_default":false},{"id":"org-2","name":"Second","is_default":false}]}}`,
+			wantOrgID: "org-1",
+			wantName:  "First",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/v1/me", r.URL.Path)
+				assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			info, err := fetchAccountInfo(srv.URL, "test-token")
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOrgID, info.OrgID)
+			assert.Equal(t, tc.wantName, info.OrgName)
+		})
+	}
+}

--- a/providers/openai/resources/openai.lr
+++ b/providers/openai/resources/openai.lr
@@ -33,7 +33,7 @@ openai @defaults("organization") @maturity("preview") {
   users() []openai.organizationUser
   // Pending invites (requires admin API key)
   invites() []openai.invite
-  // Audit log entries (requires admin API key)
+  // Audit log entries from the last 30 days (requires admin API key)
   auditLogs() []openai.auditLog
 }
 
@@ -317,9 +317,9 @@ openai.invite @defaults("id email status") @maturity("preview") {
 // organization, such as API key creation, project updates, login events,
 // and role changes. Query these entries to monitor security-relevant
 // activity, detect unauthorized changes, and support compliance
-// requirements. The `type` field identifies the recorded event and
-// `actorType` distinguishes whether a user session or an API key
-// performed it.
+// requirements. The collection covers the last 30 days of activity. The
+// `type` field identifies the recorded event and `actorType` distinguishes
+// whether a user session or an API key performed it.
 openai.auditLog @defaults("id type effectiveAt") @maturity("preview") {
   // Log entry identifier
   id string

--- a/providers/openai/resources/openai_project.go
+++ b/providers/openai/resources/openai_project.go
@@ -67,7 +67,12 @@ func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 	for iter.Next() {
 		k := iter.Current()
 		created := unixToTime(k.CreatedAt)
-		lastUsed := unixToTime(k.LastUsedAt)
+
+		var lastUsedAt *time.Time
+		if k.LastUsedAt != 0 {
+			t := unixToTime(k.LastUsedAt)
+			lastUsedAt = &t
+		}
 
 		ownerType := k.Owner.Type
 		var ownerName, ownerId string
@@ -86,7 +91,7 @@ func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 			"name":          llx.StringData(k.Name),
 			"redactedValue": llx.StringData(k.RedactedValue),
 			"createdAt":     llx.TimeData(created),
-			"lastUsedAt":    llx.TimeData(lastUsed),
+			"lastUsedAt":    llx.TimeDataPtr(lastUsedAt),
 			"ownerType":     llx.StringData(ownerType),
 			"ownerName":     llx.StringData(ownerName),
 			"ownerId":       llx.StringData(ownerId),

--- a/providers/openai/resources/openai_test.go
+++ b/providers/openai/resources/openai_test.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestUnixToTime(t *testing.T) {
+	// A zero unix timestamp is how the OpenAI API surfaces a null/absent time
+	// (e.g. a never-used API key). It must map to the Go zero time so callers
+	// can detect it and emit null instead of a year-1 timestamp.
+	assert.True(t, unixToTime(0).IsZero())
+
+	ts := int64(1719878400) // 2024-07-02T00:00:00Z
+	got := unixToTime(ts)
+	assert.False(t, got.IsZero())
+	assert.Equal(t, ts, got.Unix())
+}
+
+func newTestModel(id string) *mqlOpenaiModel {
+	return &mqlOpenaiModel{Id: plugin.TValue[string]{Data: id}}
+}
+
+func TestOpenaiModelIsFineTuned(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"gpt-4o", false},
+		{"o3-mini", false},
+		{"ft:gpt-4o-mini:my-org:custom:abc123", true},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got, err := newTestModel(tc.id).isFineTuned()
+		assert.NoError(t, err)
+		assert.Equal(t, tc.want, got, tc.id)
+	}
+}
+
+func TestOpenaiModelBaseModel(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{"gpt-4o", ""}, // base model, not fine-tuned
+		{"ft:gpt-4o-mini:my-org:custom:abc123", "gpt-4o-mini"}, // full fine-tuned form
+		{"ft:gpt-3.5-turbo:acme::xyz", "gpt-3.5-turbo"},        // base name unaffected by later colons
+		{"ft:", ""}, // degenerate, no base
+	}
+	for _, tc := range tests {
+		got, err := newTestModel(tc.id).baseModel()
+		assert.NoError(t, err)
+		assert.Equal(t, tc.want, got, tc.id)
+	}
+}


### PR DESCRIPTION
## What

Two correctness fixes from a static bug review of the `openai` provider, plus unit tests for previously-untested pure-Go logic.

### 1. Never-used project API keys reported `0001-01-01` instead of null (MEDIUM)

`openai.project.apiKey.lastUsedAt` was built with `llx.TimeData(unixToTime(k.LastUsedAt))`. The OpenAI API returns `last_used_at: null` (decoded by the SDK to `0`) for a key that has never been used, and `unixToTime(0)` returns the Go zero time. `llx.TimeData` encodes that as a genuine year-1 timestamp (`0001-01-01T00:00:00Z`), **not** null — the null sentinel is a separate value.

Impact: unused API keys are exactly what a stale-credential audit inspects, so:
- a `lastUsedAt == null` check silently matched nothing, and
- the reporter displayed a nonsense year-1 date.

The organization-user path (`apiKeyLastUsedAt`, one file over) already guards this correctly; this change makes the project-key path match by emitting null via `llx.TimeDataPtr`.

### 2. `openai.auditLogs` 30-day window was silent (MEDIUM)

The accessor hardcodes a 30-day `EffectiveAt` lower bound, but neither the field doc nor the resource description mentioned it, so a query for older activity silently returned an incomplete-but-valid-looking result set. The `.lr` docs now state the 30-day coverage. (Widening or parameterizing the window is a reasonable follow-up but changes runtime behavior, so it's out of scope here.)

## Tests

Adds unit tests for the pure-Go logic that had no coverage (only a platform-catalog test existed):

- `unixToTime` zero / non-zero contract — the root cause of #1
- model ID parsing: `isFineTuned` and `baseModel` colon-splitting
- `isAdminToken` prefix detection
- `fetchAccountInfo` default-org selection (via `httptest`): single org, prefers default over first, falls back to first when none default

```
ok  go.mondoo.com/mql/v13/providers/openai/connection
ok  go.mondoo.com/mql/v13/providers/openai/resources
```

## Notes

- No schema/version change: #1 keeps `lastUsedAt time` (value semantics unchanged, only the null vs zero encoding is corrected); #2 is doc-only. `openai.lr.versions` regenerates unchanged.
- A third review finding — an admin key vs project key connection populates only one client, so the other resource group silently returns empty — is **not** included here. Verifying whether an OpenAI admin key can reach standard project endpoints requires live infrastructure, so it's deferred to a separate live-verification pass rather than guessed at.
