### PR TITLE
🐛 mistral: robust pagination, nullable numerics, richer API errors + tests

### DIFF
--- a/providers/mistral/connection/connection_test.go
+++ b/providers/mistral/connection/connection_test.go
@@ -1,0 +1,82 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
+)
+
+func TestTokenFromConfig(t *testing.T) {
+	passwordCred := vault.NewPasswordCredential("", "from-credential")
+	otherCred := &vault.Credential{Type: vault.CredentialType_json, Secret: []byte("ignored")}
+
+	tests := []struct {
+		name      string
+		apiKeyEnv string
+		keyEnv    string
+		conf      *inventory.Config
+		want      string
+	}{
+		{
+			name:      "MISTRAL_API_KEY env",
+			apiKeyEnv: "from-api-key-env",
+			conf:      &inventory.Config{},
+			want:      "from-api-key-env",
+		},
+		{
+			name:   "MISTRAL_KEY fallback when API key empty",
+			keyEnv: "from-key-env",
+			conf:   &inventory.Config{},
+			want:   "from-key-env",
+		},
+		{
+			name:      "option overrides env",
+			apiKeyEnv: "from-env",
+			conf:      &inventory.Config{Options: map[string]string{OptionToken: "from-option"}},
+			want:      "from-option",
+		},
+		{
+			name:      "credential overrides option and env",
+			apiKeyEnv: "from-env",
+			conf: &inventory.Config{
+				Options:     map[string]string{OptionToken: "from-option"},
+				Credentials: []*vault.Credential{passwordCred},
+			},
+			want: "from-credential",
+		},
+		{
+			name: "non-password credential is ignored",
+			conf: &inventory.Config{
+				Options:     map[string]string{OptionToken: "from-option"},
+				Credentials: []*vault.Credential{otherCred},
+			},
+			want: "from-option",
+		},
+		{
+			name:      "surrounding whitespace trimmed",
+			apiKeyEnv: "  spaced-token  ",
+			conf:      &inventory.Config{},
+			want:      "spaced-token",
+		},
+		{
+			name: "nothing configured yields empty",
+			conf: &inventory.Config{},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Neutralize any host env, then apply the case's values.
+			t.Setenv("MISTRAL_API_KEY", tc.apiKeyEnv)
+			t.Setenv("MISTRAL_KEY", tc.keyEnv)
+
+			assert.Equal(t, tc.want, tokenFromConfig(tc.conf))
+		})
+	}
+}

--- a/providers/mistral/internal/mistralai/client.go
+++ b/providers/mistral/internal/mistralai/client.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 )
 
@@ -107,58 +106,62 @@ func (c *Client) GetModel(ctx context.Context, modelID string) (*Model, error) {
 	return &model, nil
 }
 
-func (c *Client) ListFineTuningJobs(ctx context.Context) ([]FineTuningJob, error) {
-	var all []FineTuningJob
-	page := 0
-	for {
-		var resp FineTuningJobList
-		endpoint := fmt.Sprintf("/v1/fine_tuning/jobs?page=%d&page_size=%d", page, defaultPageSize)
+// pagedList is the envelope every offset-paginated Mistral list endpoint
+// returns. Total and HasMore are pointers so a missing field ("null" or
+// absent) is distinguishable from a real zero/false.
+type pagedList[T any] struct {
+	Data    []T    `json:"data"`
+	Object  string `json:"object"`
+	Total   *int   `json:"total"`
+	HasMore *bool  `json:"has_more"`
+}
+
+// listPaged walks every page of an offset-paginated endpoint and returns the
+// concatenated results. Termination prefers the strongest signal the API
+// actually provides, so it stays correct whether or not a given endpoint
+// returns has_more/total, and even if the server caps page_size below what we
+// request:
+//  1. an empty page means there is nothing left;
+//  2. an explicit has_more:false means the server says it is done;
+//  3. otherwise, if a total is reported, stop once we have collected it;
+//  4. with no pagination metadata at all, a short page is the last page.
+func listPaged[T any](ctx context.Context, c *Client, path string) ([]T, error) {
+	var all []T
+	for page := 0; ; page++ {
+		var resp pagedList[T]
+		endpoint := fmt.Sprintf("%s?page=%d&page_size=%d", path, page, defaultPageSize)
 		if err := c.request(ctx, http.MethodGet, endpoint, &resp); err != nil {
 			return nil, err
 		}
 		all = append(all, resp.Data...)
-		if len(all) >= resp.Total || len(resp.Data) == 0 {
-			break
+
+		switch {
+		case len(resp.Data) == 0:
+			return all, nil
+		case resp.HasMore != nil:
+			if !*resp.HasMore {
+				return all, nil
+			}
+		case resp.Total != nil:
+			if len(all) >= *resp.Total {
+				return all, nil
+			}
+		case len(resp.Data) < defaultPageSize:
+			return all, nil
 		}
-		page++
 	}
-	return all, nil
+}
+
+func (c *Client) ListFineTuningJobs(ctx context.Context) ([]FineTuningJob, error) {
+	return listPaged[FineTuningJob](ctx, c, "/v1/fine_tuning/jobs")
 }
 
 func (c *Client) ListFiles(ctx context.Context) ([]File, error) {
-	var all []File
-	page := 0
-	for {
-		var resp FileList
-		endpoint := "/v1/files?page=" + strconv.Itoa(page) + "&page_size=" + strconv.Itoa(defaultPageSize)
-		if err := c.request(ctx, http.MethodGet, endpoint, &resp); err != nil {
-			return nil, err
-		}
-		all = append(all, resp.Data...)
-		if resp.Total == nil || len(all) >= *resp.Total || len(resp.Data) == 0 {
-			break
-		}
-		page++
-	}
-	return all, nil
+	return listPaged[File](ctx, c, "/v1/files")
 }
 
 func (c *Client) ListBatchJobs(ctx context.Context) ([]BatchJob, error) {
-	var all []BatchJob
-	page := 0
-	for {
-		var resp BatchJobList
-		endpoint := fmt.Sprintf("/v1/batch/jobs?page=%d&page_size=%d", page, defaultPageSize)
-		if err := c.request(ctx, http.MethodGet, endpoint, &resp); err != nil {
-			return nil, err
-		}
-		all = append(all, resp.Data...)
-		if len(all) >= resp.Total || len(resp.Data) == 0 {
-			break
-		}
-		page++
-	}
-	return all, nil
+	return listPaged[BatchJob](ctx, c, "/v1/batch/jobs")
 }
 
 func IsAccessDenied(err error) bool {

--- a/providers/mistral/internal/mistralai/client_test.go
+++ b/providers/mistral/internal/mistralai/client_test.go
@@ -1,0 +1,197 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package mistralai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pagedServer serves File objects split into pages. It optionally sets
+// has_more and/or total on the envelope so each pagination-termination path can
+// be exercised independently. perPage controls how many items a single page
+// returns, which lets us simulate a server that caps page_size below the
+// requested value.
+type pagedServer struct {
+	total       int  // total items available
+	perPage     int  // items returned per page (server-side cap)
+	sendHasMore bool // include has_more in the envelope
+	sendTotal   bool // include total in the envelope
+	requests    int  // number of pages actually requested
+}
+
+func (s *pagedServer) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.requests++
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		require.NoError(t, err)
+
+		start := page * s.perPage
+		data := []File{}
+		for i := start; i < start+s.perPage && i < s.total; i++ {
+			data = append(data, File{ID: fmt.Sprintf("file-%d", i)})
+		}
+
+		env := map[string]any{"object": "list", "data": data}
+		if s.sendTotal {
+			env["total"] = s.total
+		}
+		if s.sendHasMore {
+			env["has_more"] = start+len(data) < s.total
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(env))
+	}
+}
+
+func newTestClient(t *testing.T, h http.Handler) *Client {
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return NewClient("test-token", WithBaseURL(srv.URL))
+}
+
+func TestListPaged(t *testing.T) {
+	tests := []struct {
+		name        string
+		total       int
+		perPage     int
+		sendHasMore bool
+		sendTotal   bool
+		wantItems   int
+		wantPages   int
+	}{
+		{
+			name:  "has_more drives multi-page collection",
+			total: 230, perPage: defaultPageSize,
+			sendHasMore: true, sendTotal: false,
+			wantItems: 230, wantPages: 3,
+		},
+		{
+			name:  "total drives multi-page collection when has_more absent",
+			total: 230, perPage: defaultPageSize,
+			sendTotal: true,
+			wantItems: 230, wantPages: 3,
+		},
+		{
+			name:  "short page terminates when no metadata present",
+			total: 40, perPage: defaultPageSize,
+			wantItems: 40, wantPages: 1,
+		},
+		{
+			name:  "full page then empty page terminates without metadata",
+			total: defaultPageSize, perPage: defaultPageSize,
+			wantItems: defaultPageSize, wantPages: 2,
+		},
+		{
+			// A server that caps page_size below the request must NOT be cut
+			// short by the short-page heuristic while total is authoritative.
+			name:  "server-side page_size cap does not truncate when total is present",
+			total: 120, perPage: 50,
+			sendTotal: true,
+			wantItems: 120, wantPages: 3,
+		},
+		{
+			name:  "empty result set",
+			total: 0, perPage: defaultPageSize,
+			sendTotal: true,
+			wantItems: 0, wantPages: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &pagedServer{
+				total: tc.total, perPage: tc.perPage,
+				sendHasMore: tc.sendHasMore, sendTotal: tc.sendTotal,
+			}
+			c := newTestClient(t, srv.handler(t))
+
+			files, err := c.ListFiles(context.Background())
+			require.NoError(t, err)
+			assert.Len(t, files, tc.wantItems)
+			assert.Equal(t, tc.wantPages, srv.requests, "page request count")
+
+			// IDs must be contiguous and de-duplicated across pages.
+			for i, f := range files {
+				assert.Equal(t, fmt.Sprintf("file-%d", i), f.ID)
+			}
+		})
+	}
+}
+
+func TestListPaged_ErrorPropagates(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+
+	_, err := c.ListFiles(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestRequest_DetailStyleErrorSurfaces(t *testing.T) {
+	// A 422 validation error uses "detail", not "message". The old code left
+	// the surfaced error empty; it must now carry the detail payload.
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"page_size too large"}`))
+	}))
+
+	_, err := c.ListModels(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, "page_size too large", err.Error())
+
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, apiErr.StatusCode)
+}
+
+func TestRequest_NonJSONErrorBody(t *testing.T) {
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+
+	_, err := c.ListModels(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+	assert.Contains(t, err.Error(), "upstream unavailable")
+}
+
+func TestAPIErrorError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  APIError
+		want string
+	}{
+		{"message wins", APIError{Message: "nope", StatusCode: 400}, "nope"},
+		{"detail string", APIError{Detail: json.RawMessage(`"bad field"`), StatusCode: 422}, "bad field"},
+		{"detail array raw", APIError{Detail: json.RawMessage(`[{"msg":"x"}]`), StatusCode: 422}, `[{"msg":"x"}]`},
+		{"status fallback", APIError{StatusCode: 500}, "mistral API error (status 500)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.err.Error())
+		})
+	}
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	assert.True(t, IsAccessDenied(&APIError{StatusCode: 401}))
+	assert.True(t, IsAccessDenied(&APIError{StatusCode: 403}))
+	assert.False(t, IsAccessDenied(&APIError{StatusCode: 500}))
+	assert.False(t, IsAccessDenied(fmt.Errorf("plain error")))
+	assert.False(t, IsAccessDenied(nil))
+}

--- a/providers/mistral/internal/mistralai/types.go
+++ b/providers/mistral/internal/mistralai/types.go
@@ -3,6 +3,11 @@
 
 package mistralai
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 type ModelList struct {
 	Object string  `json:"object"`
 	Data   []Model `json:"data"`
@@ -39,12 +44,6 @@ type ModelCapabilities struct {
 	Moderation         bool `json:"moderation"`
 	Audio              bool `json:"audio"`
 	AudioTranscription bool `json:"audio_transcription"`
-}
-
-type FineTuningJobList struct {
-	Data   []FineTuningJob `json:"data"`
-	Object string          `json:"object"`
-	Total  int             `json:"total"`
 }
 
 type FineTuningJob struct {
@@ -93,12 +92,6 @@ type WandbIntegration struct {
 	URL     *string `json:"url"`
 }
 
-type FileList struct {
-	Data   []File `json:"data"`
-	Object string `json:"object"`
-	Total  *int   `json:"total"`
-}
-
 type File struct {
 	ID         string  `json:"id"`
 	Object     string  `json:"object"`
@@ -110,12 +103,6 @@ type File struct {
 	Source     string  `json:"source"`
 	NumLines   *int64  `json:"num_lines"`
 	MimeType   *string `json:"mimetype"`
-}
-
-type BatchJobList struct {
-	Data   []BatchJob `json:"data"`
-	Object string     `json:"object"`
-	Total  int        `json:"total"`
 }
 
 type BatchJob struct {
@@ -144,10 +131,25 @@ type BatchError struct {
 }
 
 type APIError struct {
-	Message    string `json:"message"`
-	StatusCode int    `json:"-"`
+	Message string `json:"message"`
+	// Detail carries validation-style error payloads (HTTP 422), which Mistral
+	// returns under "detail" instead of "message" (either a string or an array
+	// of objects). Kept raw so Error() can surface something meaningful rather
+	// than an empty string.
+	Detail     json.RawMessage `json:"detail"`
+	StatusCode int             `json:"-"`
 }
 
 func (e *APIError) Error() string {
-	return e.Message
+	if e.Message != "" {
+		return e.Message
+	}
+	if len(e.Detail) > 0 {
+		var s string
+		if err := json.Unmarshal(e.Detail, &s); err == nil {
+			return s
+		}
+		return string(e.Detail)
+	}
+	return fmt.Sprintf("mistral API error (status %d)", e.StatusCode)
 }

--- a/providers/mistral/resources/mistral.go
+++ b/providers/mistral/resources/mistral.go
@@ -20,6 +20,15 @@ func mistralConn(runtime *plugin.Runtime) *connection.MistralConnection {
 	return runtime.Connection.(*connection.MistralConnection)
 }
 
+// floatDataPtr maps a *float64 to MQL data, preserving null for an unset value.
+// llx ships IntDataPtr/BoolDataPtr/StringDataPtr but no float equivalent.
+func floatDataPtr(f *float64) *llx.RawData {
+	if f == nil {
+		return llx.NilData
+	}
+	return llx.FloatData(*f)
+}
+
 func (r *mqlMistral) id() (string, error) {
 	return "mistral", nil
 }
@@ -139,10 +148,6 @@ func (r *mqlMistral) fineTuningJobs() ([]interface{}, error) {
 		if j.Suffix != nil {
 			suffix = *j.Suffix
 		}
-		var trainedTokens int64
-		if j.TrainedTokens != nil {
-			trainedTokens = *j.TrainedTokens
-		}
 
 		trainingFiles := make([]interface{}, 0, len(j.TrainingFiles))
 		for _, f := range j.TrainingFiles {
@@ -153,25 +158,12 @@ func (r *mqlMistral) fineTuningJobs() ([]interface{}, error) {
 			validationFiles = append(validationFiles, f)
 		}
 
-		var trainingSteps int64
-		if j.Hyperparameters.TrainingSteps != nil {
-			trainingSteps = *j.Hyperparameters.TrainingSteps
-		}
-		var epochs float64
-		if j.Hyperparameters.Epochs != nil {
-			epochs = *j.Hyperparameters.Epochs
-		}
-
-		var expectedDuration int64
-		var cost float64
-		var costCurrency string
+		var expectedDuration *int64
+		var cost *float64
+		costCurrency := ""
 		if j.Metadata != nil {
-			if j.Metadata.ExpectedDurationSeconds != nil {
-				expectedDuration = *j.Metadata.ExpectedDurationSeconds
-			}
-			if j.Metadata.Cost != nil {
-				cost = *j.Metadata.Cost
-			}
+			expectedDuration = j.Metadata.ExpectedDurationSeconds
+			cost = j.Metadata.Cost
 			if j.Metadata.CostCurrency != nil {
 				costCurrency = *j.Metadata.CostCurrency
 			}
@@ -187,15 +179,15 @@ func (r *mqlMistral) fineTuningJobs() ([]interface{}, error) {
 			"autoStart":               llx.BoolData(j.AutoStart),
 			"trainingFiles":           llx.ArrayData(trainingFiles, types.String),
 			"validationFiles":         llx.ArrayData(validationFiles, types.String),
-			"trainedTokens":           llx.IntData(trainedTokens),
+			"trainedTokens":           llx.IntDataPtr(j.TrainedTokens),
 			"createdAt":               llx.TimeDataPtr(createdAt),
 			"modifiedAt":              llx.TimeDataPtr(modifiedAt),
 			"jobType":                 llx.StringData(j.JobType),
-			"trainingSteps":           llx.IntData(trainingSteps),
+			"trainingSteps":           llx.IntDataPtr(j.Hyperparameters.TrainingSteps),
 			"learningRate":            llx.FloatData(j.Hyperparameters.LearningRate),
-			"epochs":                  llx.FloatData(epochs),
-			"expectedDurationSeconds": llx.IntData(expectedDuration),
-			"cost":                    llx.FloatData(cost),
+			"epochs":                  floatDataPtr(j.Hyperparameters.Epochs),
+			"expectedDurationSeconds": llx.IntDataPtr(expectedDuration),
+			"cost":                    floatDataPtr(cost),
 			"costCurrency":            llx.StringData(costCurrency),
 		})
 		if err != nil {
@@ -223,10 +215,6 @@ func (r *mqlMistral) files() ([]interface{}, error) {
 	for _, f := range files {
 		createdAt := timeFromUnix(f.CreatedAt)
 
-		var numLines int64
-		if f.NumLines != nil {
-			numLines = *f.NumLines
-		}
 		mimeType := ""
 		if f.MimeType != nil {
 			mimeType = *f.MimeType
@@ -241,7 +229,7 @@ func (r *mqlMistral) files() ([]interface{}, error) {
 			"createdAt":  llx.TimeDataPtr(createdAt),
 			"sampleType": llx.StringData(f.SampleType),
 			"source":     llx.StringData(f.Source),
-			"numLines":   llx.IntData(numLines),
+			"numLines":   llx.IntDataPtr(f.NumLines),
 			"mimeType":   llx.StringData(mimeType),
 		})
 		if err != nil {
@@ -343,6 +331,11 @@ var mistralFamilies = []struct {
 	{"mistral", "Mistral"},
 }
 
+// matchFamily maps a model identifier to its architecture family by substring.
+// This is a best-effort heuristic: a fine-tuned model whose user-chosen suffix
+// happens to contain a family token (e.g. "my-embed-tuner" rooted on
+// mistral-large) can be misclassified. The order of mistralFamilies resolves
+// the ambiguous base-model cases most-specific first.
 func matchFamily(id string) string {
 	lower := strings.ToLower(id)
 	for _, f := range mistralFamilies {
@@ -353,37 +346,45 @@ func matchFamily(id string) string {
 	return ""
 }
 
-func (r *mqlMistralModel) family() (string, error) {
-	if f := matchFamily(r.Id.Data); f != "" {
-		return f, nil
+// familyFromNames resolves a family from the model id, falling back to the root
+// base model id for fine-tuned models.
+func familyFromNames(id, root string) string {
+	if f := matchFamily(id); f != "" {
+		return f
 	}
-	if root := r.Root.Data; root != "" {
+	if root != "" {
 		if f := matchFamily(root); f != "" {
-			return f, nil
+			return f
 		}
 	}
-	return "", nil
+	return ""
 }
 
-func (r *mqlMistralModel) parameterSize() (string, error) {
-	id := r.Id.Data
+// parseParameterSize extracts a normalized parameter count (e.g. "7B",
+// "8x22B") from the model id, falling back to the root base model id for
+// fine-tuned models. Returns "" when no size token is present.
+func parseParameterSize(id, root string) string {
 	m := mistralParamSizeRe.FindStringSubmatch(id)
-	if m == nil {
-		// Try root model for fine-tuned models
-		root := r.Root.Data
-		if root != "" {
-			m = mistralParamSizeRe.FindStringSubmatch(root)
-		}
+	if m == nil && root != "" {
+		m = mistralParamSizeRe.FindStringSubmatch(root)
 	}
 	if m == nil {
-		return "", nil
+		return ""
 	}
 	size := m[1]
 	last := size[len(size)-1]
 	if last >= 'a' && last <= 'z' {
 		size = size[:len(size)-1] + strings.ToUpper(string(last))
 	}
-	return size, nil
+	return size
+}
+
+func (r *mqlMistralModel) family() (string, error) {
+	return familyFromNames(r.Id.Data, r.Root.Data), nil
+}
+
+func (r *mqlMistralModel) parameterSize() (string, error) {
+	return parseParameterSize(r.Id.Data, r.Root.Data), nil
 }
 
 func (r *mqlMistralFineTuningJob) id() (string, error) {

--- a/providers/mistral/resources/mistral_test.go
+++ b/providers/mistral/resources/mistral_test.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/types"
+)
+
+func TestFamilyFromNames(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		root string
+		want string
+	}{
+		{"base mistral", "mistral-large-latest", "", "Mistral"},
+		{"open mistral nemo prefers Nemo over Mistral", "open-mistral-nemo", "", "Nemo"},
+		{"codestral before mistral", "codestral-2405", "", "Codestral"},
+		{"mixtral not mistral", "open-mixtral-8x22b", "", "Mixtral"},
+		{"pixtral", "pixtral-12b-2409", "", "Pixtral"},
+		{"ministral", "ministral-8b-latest", "", "Ministral"},
+		{"magistral", "magistral-medium-latest", "", "Magistral"},
+		{"mathstral", "mathstral-7b", "", "Mathstral"},
+		{"devstral", "devstral-small-2505", "", "Devstral"},
+		{"embed", "mistral-embed", "", "Embed"},
+		{"moderation", "mistral-moderation-latest", "", "Moderation"},
+		{"case-insensitive", "MISTRAL-LARGE", "", "Mistral"},
+		{"unknown returns empty", "gpt-4o", "", ""},
+		{"fine-tuned falls back to root", "ft:abc123", "codestral-2405", "Codestral"},
+		{"id wins over root", "mixtral-8x7b", "mistral-large", "Mixtral"},
+		{"empty root not consulted", "unknown-model", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, familyFromNames(tc.id, tc.root))
+		})
+	}
+}
+
+func TestParseParameterSize(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		root string
+		want string
+	}{
+		{"simple b suffix", "ministral-8b-latest", "", "8B"},
+		{"mixture of experts", "open-mixtral-8x22b", "", "8x22B"},
+		{"small moe", "open-mixtral-8x7b", "", "8x7B"},
+		{"7b", "open-mistral-7b", "", "7B"},
+		{"decimal size", "some-model-3.8b-instruct", "", "3.8B"},
+		{"already uppercase unit", "some-model-7B", "", "7B"},
+		{"m suffix", "tiny-500m-model", "", "500M"},
+		{"no size token", "mistral-large-latest", "", ""},
+		{"date is not a size", "codestral-2405", "", ""},
+		{"fine-tuned falls back to root", "ft:custom", "open-mistral-7b", "7B"},
+		{"id size wins over root", "my-13b-tune", "open-mistral-7b", "13B"},
+		{"empty when neither matches", "custom", "base", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseParameterSize(tc.id, tc.root))
+		})
+	}
+}
+
+func TestTimeFromUnix(t *testing.T) {
+	assert.Nil(t, timeFromUnix(0), "zero timestamp maps to null")
+
+	got := timeFromUnix(1700000000)
+	if assert.NotNil(t, got) {
+		assert.True(t, got.Equal(time.Unix(1700000000, 0)))
+	}
+}
+
+func TestTimeFromUnixPtr(t *testing.T) {
+	assert.Nil(t, timeFromUnixPtr(nil), "nil maps to null")
+
+	zero := int64(0)
+	assert.Nil(t, timeFromUnixPtr(&zero), "zero maps to null")
+
+	ts := int64(1700000000)
+	got := timeFromUnixPtr(&ts)
+	if assert.NotNil(t, got) {
+		assert.True(t, got.Equal(time.Unix(ts, 0)))
+	}
+}
+
+func TestFloatDataPtr(t *testing.T) {
+	assert.Same(t, llx.NilData, floatDataPtr(nil), "nil float maps to MQL null")
+
+	v := 0.0
+	got := floatDataPtr(&v)
+	assert.Equal(t, types.Float, got.Type)
+	assert.Equal(t, 0.0, got.Value, "a real zero is preserved, not treated as null")
+
+	v = 0.7
+	got = floatDataPtr(&v)
+	assert.Equal(t, 0.7, got.Value)
+}


### PR DESCRIPTION
## What

Fixes from a static bug review of the `mistral` provider (review findings 3–6), plus unit tests for the provider's pure-Go logic (which previously had none beyond the platform-catalog test).

### #3 — Pagination silently truncated to one page (silent data loss)
`ListFineTuningJobs` and `ListBatchJobs` terminated on `len(all) >= resp.Total` where `Total` was a plain `int`. When the API omits `total`, it deserializes to `0`, `len(all) >= 0` is always true, and the loop stops after the first 100 results with no error. `ListFiles` used a `*int` but still stopped after page 0 on a missing total, and none of the three used the API's `has_more` signal.

The three duplicated loops are now one generic `listPaged[T]` whose termination prefers the strongest signal the endpoint actually returns:
1. an empty page → done;
2. explicit `has_more: false` → done;
3. else a reported `total` reached → done;
4. else a short page (fewer than `page_size`) → done.

This stays correct whether or not an endpoint returns `has_more`/`total`, and no longer truncates when a server caps `page_size` below the requested value.

### #4 — Optional numeric fields lost their null (wrong data)
`trainedTokens`, `trainingSteps`, `epochs`, `expectedDurationSeconds`, `cost`, and file `numLines` were flattened from their SDK pointer types to a Go zero value, so "unset" became an indistinguishable `0` (e.g. a job with unknown cost reported `$0.00`). They now flow through `*DataPtr` helpers so an unset value stays MQL `null`. A small local `floatDataPtr` fills the gap where `llx` has no `FloatDataPtr`.

### #6 — Validation errors surfaced blank (robustness)
Mistral returns HTTP 422 validation errors under `detail` (a string or array), not `message`, so `APIError.Error()` returned an empty string. `APIError` now decodes `detail` and falls back to a status-coded message, so an error is never blank.

### #5 — Family matcher (minor)
Documented the substring-match false-positive risk (a fine-tuned model whose suffix contains a family token can be misclassified) and extracted the id/root parsing into pure `familyFromNames` / `parseParameterSize` helpers.

## Tests
New coverage for the pure-Go logic where wrong-data bugs hide:
- **Pagination** (`httptest`): `has_more`-driven, `total`-driven, short-page, full-page-then-empty, server-side `page_size` cap, empty set, and error propagation.
- **Error handling**: `detail`-style 422, non-JSON error body, `APIError.Error()` variants, `IsAccessDenied`.
- **Parsers**: `familyFromNames` (ordering + fallback + false-positive cases), `parseParameterSize`.
- **Helpers**: `timeFromUnix`/`timeFromUnixPtr` zero handling, `floatDataPtr` null-vs-real-zero, `tokenFromConfig` precedence.

## Notes
- No `.lr` schema changes, so no `.lr.versions` or provider-version bump.
- Review findings #1 (`deprecation` RFC3339-only parse) and #2 (`defaultModelTemperature` nil→0) are deferred: #1 needs the live API's actual date format confirmed, and #2 is the same class as #4 but was out of the requested scope.
