### PR TITLE
🎉 os-13.37.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.36.0",
+	Version: "13.37.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.37.0)
- ✨ os: add PostgreSQL on-disk config inspection (postgresql.conf/hba/ident) (#9360)
- ⭐ support Rootless Docker (#9352)