### PR TITLE
fix(network): default http.get to HTTPS for unschemed targets

### DIFF
--- a/providers/network/provider/provider.go
+++ b/providers/network/provider/provider.go
@@ -75,8 +75,9 @@ func parseTarget(target string) (string, int, string, string, error) {
 	// the assumptions that users have when they use other resources (like TLS).
 	// For example: `host google.com` and command `tls.versions` is a user
 	// indicating that they want the TLS config of https://google.com of course.
-	// However, we also want to use HTTP:80 when we do `http.get` requests,
-	// because that is the default way this is handled in the web (for now).
+	// The same holds for `http.get`, which defaults an unschemed target to
+	// HTTPS (see initHttpGet) so a bare `host google.com` inspects the HTTPS
+	// endpoint rather than plain :80.
 	//
 	// Thus: the scheme becomes empty "" and the port is set to 0. Every resource
 	// needs to figure out what that means to it.

--- a/providers/network/resources/http.go
+++ b/providers/network/resources/http.go
@@ -58,14 +58,7 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 
 		scheme := conn.Conf.Runtime
 		if scheme == "" {
-			// At this point we are in best effort territory. Which means we will
-			// go HTTP unless port 443 is specified. Users can always provide a
-			// scheme to be prescriptive.
-			if conn.Conf.Port == 443 {
-				scheme = "https"
-			} else {
-				scheme = "http"
-			}
+			scheme = defaultHTTPScheme(conn.Conf.Port)
 		}
 		url, err := NewResource(runtime, "url", map[string]*llx.RawData{
 			"host":   llx.StringData(conn.Conf.Host),
@@ -84,6 +77,23 @@ func initHttpGet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[str
 	}
 
 	return args, nil, nil
+}
+
+// defaultHTTPScheme picks the URL scheme for http.get when the target carried no
+// explicit scheme (a bare `host <domain>`). It defaults to HTTPS — the modern
+// web default and consistent with the tls resource, which assumes 443 for a bare
+// target — so scanning a bare domain exercises the HTTPS endpoint, where the
+// hardening headers policies check (HSTS, CSP, cookie flags) actually live,
+// instead of plain :80. Only an explicit non-TLS port falls back to HTTP, so
+// `http.get` on `example.com:8080` still speaks HTTP. Users can always prefix a
+// scheme to be prescriptive.
+func defaultHTTPScheme(port int32) string {
+	switch port {
+	case 0, 443:
+		return "https"
+	default:
+		return "http"
+	}
 }
 
 func (x *mqlHttpGet) id() (string, error) {

--- a/providers/network/resources/http_internal_test.go
+++ b/providers/network/resources/http_internal_test.go
@@ -22,6 +22,27 @@ func (timeoutErr) Error() string   { return "i/o timeout" }
 func (timeoutErr) Timeout() bool   { return true }
 func (timeoutErr) Temporary() bool { return true }
 
+func TestDefaultHTTPScheme(t *testing.T) {
+	tests := []struct {
+		name string
+		port int32
+		want string
+	}{
+		// A bare `host <domain>` (no scheme, no port) now inspects HTTPS, so the
+		// tls and http policies both target the same endpoint.
+		{"bare domain, no port", 0, "https"},
+		{"standard https port", 443, "https"},
+		// An explicit http port stays plain HTTP.
+		{"explicit http port", 80, "http"},
+		{"non-standard port", 8080, "http"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, defaultHTTPScheme(tt.port))
+		})
+	}
+}
+
 func TestHttpNotReachable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/providers/network/resources/http_test.go
+++ b/providers/network/resources/http_test.go
@@ -1,0 +1,51 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/network/connection"
+	"go.mondoo.com/mql/v13/providers/network/resources"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// TestResource_HttpGetTargetScheme verifies which endpoint http.get derives from
+// the connection when no URL is given: a bare `host <domain>` (no scheme, no
+// port) now resolves to HTTPS, matching the tls resource, so both policies
+// inspect the same endpoint. An explicit non-TLS port still resolves to HTTP.
+func TestResource_HttpGetTargetScheme(t *testing.T) {
+	testCases := []struct {
+		name       string
+		host       string
+		port       int32
+		wantPrefix string
+	}{
+		{"bare domain defaults to https", "mondoo.com", 0, "https://mondoo.com"},
+		{"explicit 443 is https", "mondoo.com", 443, "https://mondoo.com"},
+		{"explicit http port stays http", "mondoo.com", 80, "http://mondoo.com"},
+		{"non-standard port stays http", "mondoo.com", 8080, "http://mondoo.com:8080"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := &plugin.Runtime{Resources: &syncx.Map[plugin.Resource]{}}
+			conf := &inventory.Config{Host: tc.host, Port: tc.port}
+			runtime.Connection = connection.NewHostConnection(1, &inventory.Asset{}, conf)
+
+			// Building the resource derives the target URL from the connection
+			// (initHttpGet) without performing the request, so the id carries the
+			// endpoint http.get would hit.
+			get, err := resources.NewResource(runtime, "http.get", map[string]*llx.RawData{})
+			require.NoError(t, err)
+			require.Truef(t, strings.HasPrefix(get.MqlID(), tc.wantPrefix),
+				"http.get id = %q, want prefix %q", get.MqlID(), tc.wantPrefix)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a target is given without a scheme (a bare `host <domain>`), the network provider leaves the scheme empty and the port `0`, and each resource decides what that means (see `parseTarget`). The `tls` resource assumes **443**, but `http.get` previously fell back to plain **HTTP:80**.

That split meant scanning a bare domain inspected `:80` for HTTP header hardening — HSTS, CSP, `X-Frame-Options`, cookie flags — headers that only meaningfully exist over HTTPS. Callers had to force a `:443` suffix on the target to get useful results, which in turn prevents running the tls/http/dns/email policies against one shared target.

## Change

`http.get` now defaults an unschemed target to **HTTPS**, matching the `tls` resource:

| Target | Scheme |
|---|---|
| `host example.com` (bare, port 0) | **https** |
| `host example.com:443` | https |
| `host example.com:80` | http |
| `host example.com:8080` | http |
| explicit `http://…` / `https://…` | as given |

Only an explicit non-TLS port falls back to HTTP, so `http.get` on `example.com:8080` is unchanged. The scheme selection is extracted into a small `defaultHTTPScheme(port)` helper.

## Why it's safe

- Behavior for explicitly-schemed targets and explicit non-standard ports is unchanged.
- The asset platform id (`runtime/network/host/<host>`) does not include the port, so nothing about asset identity changes.

## Tests

- `TestDefaultHTTPScheme` — the helper across bare/443/80/8080.
- `TestResource_HttpGetTargetScheme` — builds a real `http.get` resource on a bare-domain `HostConnection` and asserts the derived URL is `https://mondoo.com` (and stays `http://` for explicit non-TLS ports).

Full `resources/` + `provider/` suites and `go vet` pass.

## Note

This is a deliberate default-behavior change to a shared provider: a bare `host <domain>` + `http.get.body` now hits `:443` instead of `:80`. Users who want plain HTTP can prefix `http://` or pass `:80`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)