### PR TITLE
🎉 iru-13.0.1

### DIFF
--- a/providers/iru/config/config.go
+++ b/providers/iru/config/config.go
@@ -12,7 +12,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "iru",
 	ID:              "go.mondoo.com/mql/providers/iru",
-	Version:         "13.0.0",
+	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### iru (13.0.1)
- 🐛 iru: match the live Kandji API + add client tests (#9381)