### PR TITLE
🐛 providers: declare static platform catalogs for iru, portainer, redfish

### DIFF
--- a/providers/iru/config/config.go
+++ b/providers/iru/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/iru/connection"
 	"go.mondoo.com/mql/v13/providers/iru/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/iru",
 	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "iru",

--- a/providers/iru/connection/connection.go
+++ b/providers/iru/connection/connection.go
@@ -138,14 +138,11 @@ func (c *IruConnection) Asset() *inventory.Asset { return c.asset }
 
 // PlatformInfo returns the asset platform metadata for an Iru tenant.
 func (c *IruConnection) PlatformInfo() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "iru",
-		Title:                 "Iru",
-		Family:                []string{"iru"},
-		Kind:                  "api",
-		Runtime:               "iru",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"saas", "iru"},
 	}
+	PlatformByName("iru").Apply(p)
+	return p
 }
 
 // Identifier returns the stable platform ID for the tenant, derived from

--- a/providers/iru/connection/platforms.go
+++ b/providers/iru/connection/platforms.go
@@ -1,0 +1,24 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "iru",
+		Title:   "Iru",
+		Family:  []string{"iru"},
+		Kind:    []string{"api"},
+		Runtime: []string{"iru"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/iru/connection/platforms_test.go
+++ b/providers/iru/connection/platforms_test.go
@@ -1,0 +1,25 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}

--- a/providers/iru/go.mod
+++ b/providers/iru/go.mod
@@ -6,6 +6,7 @@ go 1.26.5
 
 require (
 	github.com/rs/zerolog v1.35.1
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.0.0-00010101000000-000000000000
 )
 
@@ -35,6 +36,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.48.0 // indirect
@@ -69,6 +71,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -97,6 +100,7 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/portainer/config/config.go
+++ b/providers/portainer/config/config.go
@@ -17,6 +17,7 @@ var Config = plugin.Provider{
 	Version:         "13.1.3",
 	Maturity:        resources.MaturityExperimental,
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "portainer",

--- a/providers/portainer/connection/platform.go
+++ b/providers/portainer/connection/platform.go
@@ -7,7 +7,33 @@ import (
 	"strconv"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// Platforms is the static catalog of platforms this provider can emit.
+var Platforms = []*plugin.PlatformInfo{
+	{
+		Name:    "portainer-server",
+		Title:   "Portainer Server",
+		Family:  []string{"portainer"},
+		Kind:    []string{"api"},
+		Runtime: []string{"portainer"},
+	},
+	{
+		Name:    "portainer-environment",
+		Title:   "Portainer Environment",
+		Family:  []string{"portainer"},
+		Kind:    []string{"api"},
+		Runtime: []string{"portainer"},
+	},
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}
 
 // Discovery targets
 const (
@@ -132,25 +158,22 @@ func MembershipRole(r int64) string {
 }
 
 func InstancePlatform() *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "portainer-server",
-		Family:                []string{"portainer"},
-		Kind:                  "api",
-		Runtime:               "portainer",
-		Title:                 "Portainer Server",
+	p := &inventory.Platform{
 		TechnologyUrlSegments: []string{"virtualization", "portainer", "instance"},
 	}
+	PlatformByName("portainer-server").Apply(p)
+	return p
 }
 
 func EnvironmentPlatform(envType int64) *inventory.Platform {
-	return &inventory.Platform{
-		Name:                  "portainer-environment",
-		Family:                []string{"portainer"},
-		Kind:                  "api",
-		Runtime:               "portainer",
+	p := &inventory.Platform{
+		// The specific endpoint type is only known at runtime, so set the
+		// concrete title here; Apply preserves an already-set title.
 		Title:                 "Portainer Environment (" + EnvironmentType(envType) + ")",
 		TechnologyUrlSegments: []string{"virtualization", "portainer", "environment"},
 	}
+	PlatformByName("portainer-environment").Apply(p)
+	return p
 }
 
 func NewInstancePlatformID(instanceID string) string {

--- a/providers/portainer/connection/platforms_test.go
+++ b/providers/portainer/connection/platforms_test.go
@@ -1,0 +1,35 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}
+
+// The runtime platform builders must emit platforms the catalog declares.
+func TestRuntimePlatformsConsistent(t *testing.T) {
+	assert.True(t, PlatformByName("portainer-server").Consistent(InstancePlatform()))
+
+	env := EnvironmentPlatform(5) // kubernetes
+	assert.True(t, PlatformByName("portainer-environment").Consistent(env))
+	// The dynamic title survives Apply.
+	assert.Equal(t, "Portainer Environment (kubernetes)", env.Title)
+}

--- a/providers/redfish/config/config.go
+++ b/providers/redfish/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/redfish/connection"
 	"go.mondoo.com/mql/v13/providers/redfish/provider"
 )
 
@@ -14,6 +15,7 @@ var Config = plugin.Provider{
 	ID:              "go.mondoo.com/mql/providers/redfish",
 	Version:         "13.0.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
+	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
 			Name:  "redfish",

--- a/providers/redfish/connection/platforms.go
+++ b/providers/redfish/connection/platforms.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+
+// Platforms is the static catalog of platforms this provider can emit. It is
+// derived from the vendor registry so a new supported vendor only needs a
+// single entry in vendors (plus the generic fallback).
+var Platforms = platformCatalog()
+
+func platformCatalog() []*plugin.PlatformInfo {
+	all := append(append([]Vendor{}, vendors...), genericVendor)
+	out := make([]*plugin.PlatformInfo, len(all))
+	for i, v := range all {
+		out[i] = &plugin.PlatformInfo{
+			Name:    v.Platform,
+			Title:   v.Name,
+			Family:  []string{"redfish", "bmc"},
+			Kind:    []string{"api"},
+			Runtime: []string{"redfish"},
+		}
+	}
+	return out
+}
+
+var platformsByName = plugin.PlatformsByName(Platforms)
+
+// PlatformByName returns the catalog entry for the given platform name.
+func PlatformByName(name string) *plugin.PlatformInfo {
+	return platformsByName[name]
+}

--- a/providers/redfish/connection/platforms_test.go
+++ b/providers/redfish/connection/platforms_test.go
@@ -1,0 +1,34 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestPlatformCatalog(t *testing.T) {
+	require.NotEmpty(t, Platforms)
+	for _, pi := range Platforms {
+		require.NotEmpty(t, pi.Name)
+		assert.Same(t, pi, PlatformByName(pi.Name), pi.Name)
+
+		p := &inventory.Platform{}
+		pi.Apply(p)
+		assert.True(t, pi.Consistent(p), pi.Name)
+		assert.Equal(t, pi.Title, p.Title, pi.Name)
+	}
+}
+
+// Every detectable vendor (and the generic fallback) must be present in the
+// static catalog, so the platform stamped on an asset is always declared.
+func TestCatalogCoversVendors(t *testing.T) {
+	for _, v := range vendors {
+		assert.NotNil(t, PlatformByName(v.Platform), v.Platform)
+	}
+	assert.NotNil(t, PlatformByName(genericVendor.Platform), genericVendor.Platform)
+}

--- a/providers/redfish/go.mod
+++ b/providers/redfish/go.mod
@@ -7,6 +7,7 @@ go 1.26.5
 require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stmcginnis/gofish v0.23.0
+	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.30.0
 )
 
@@ -36,6 +37,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20241215232642-bb51bb14a506 // indirect
 	github.com/cockroachdb/redact v1.1.8 // indirect
 	github.com/cyphar/filepath-securejoin v0.7.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/getsentry/sentry-go v0.48.0 // indirect
@@ -70,6 +72,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
@@ -97,6 +100,7 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/providers/redfish/provider/provider.go
+++ b/providers/redfish/provider/provider.go
@@ -161,13 +161,9 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.RedfishConnect
 	asset.Name = conn.Conf.Host
 
 	asset.Platform = &inventory.Platform{
-		Name:                  vendor.Platform,
-		Family:                []string{"redfish", "bmc"},
-		Kind:                  "api",
-		Runtime:               "redfish",
-		Title:                 vendor.Name,
 		TechnologyUrlSegments: []string{"network", "redfish"},
 	}
+	connection.PlatformByName(vendor.Platform).Apply(asset.Platform)
 
 	identifier, err := conn.Identifier()
 	if err != nil {


### PR DESCRIPTION
## What

Three providers stamp a platform onto every asset they discover at connect time, but never declared those platforms in their `config.go` `Platforms` field:

| Provider | Runtime platform(s) stamped on assets | Static `config.Platforms` |
|---|---|---|
| `iru` | `iru` | ❌ missing → ✅ |
| `portainer` | `portainer-server`, `portainer-environment` | ❌ missing → ✅ |
| `redfish` | `bmc-hpe-ilo`, `bmc-dell-idrac`, `bmc-supermicro`, `bmc-redfish` | ❌ missing → ✅ |

Because the static declaration was absent, each provider's generated `dist/<p>.json` shipped **with no `Platforms` key**. Anything that reads the static manifest instead of connecting live — provider docs, the website platform matrix, and `scripts/list-platforms.sh` — silently omitted these providers. (This started from the question "why doesn't `list-platforms.sh` include iru?")

## How

Adopt the established `connection.Platforms` catalog idiom already used by every other provider (jamf, github, okta, claude, ...):

- New `connection/platforms.go` — a static `[]*plugin.PlatformInfo` catalog + `PlatformByName`.
- Runtime platform now built via `PlatformByName(name).Apply(p)`, making the catalog the single source of truth. Dynamic bits (portainer's environment-type title) are preserved because `Apply` only fills an empty title.
- `Platforms: connection.Platforms` wired into each `config.go`.
- **redfish** derives its catalog from the existing `vendors` registry, so adding a new supported BMC vendor stays covered automatically with no second edit.
- Added `platforms_test.go` catalog-consistency tests (mirrors the repo convention), plus drift guards asserting every runtime-emitted platform is present in the catalog.

## Audit

I audited **all** providers for the same mismatch (runtime platform set anywhere in `connection/` or `provider/`, but no static `config.Platforms`). These three were the only ones. `core` is the built-in meta-provider and correctly declares none.

## Verification

Rebuilt each `dist/<p>.json` and confirmed `Platforms` is now populated and that `list-platforms.sh` emits every entry:

```
iru
portainer-server
portainer-environment
bmc-hpe-ilo
bmc-dell-idrac
bmc-supermicro
bmc-redfish
```

`go test ./connection/...` passes for all three. No provider `Version` bumps; `dist/` is a build artifact (gitignored), so no generated JSON is committed. `go.mod` testify promotions are `go mod tidy`-clean.
