### PR TITLE
✨ stackit: expose transport-crypto TLS fields for PQC readiness checks

### DIFF
--- a/providers/stackit/resources/dbaas_tls.go
+++ b/providers/stackit/resources/dbaas_tls.go
@@ -1,0 +1,106 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// Transport-crypto accessors for the Cloud-Foundry-broker DBaaS instances
+// (OpenSearch, Redis, RabbitMQ, LogMe). These services stash their TLS
+// configuration in the free-form `parameters` blob under stable keys
+// (`tls-protocols`, `tls-ciphers`, ...). We surface the TLS-relevant keys as
+// typed fields so post-quantum-cryptography readiness checks can grade the
+// negotiated protocol versions and cipher suites. The Flex engines (Postgres,
+// MongoDB, SQLServer) and MariaDB expose no transport-crypto parameters and so
+// have no such fields.
+
+// paramValue reads a single key out of a DBaaS instance's parameters blob,
+// returning nil when the blob is absent or not a map.
+func paramValue(parameters any, key string) any {
+	params, ok := parameters.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return params[key]
+}
+
+// tlsParamList extracts a string-list TLS parameter (e.g. tls-protocols,
+// tls-ciphers) and returns it as the []any list MQL expects. Both JSON arrays
+// and single comma-separated strings are accepted (see dictStrSlice); a missing
+// key yields an empty list.
+func tlsParamList(params *plugin.TValue[any], key string) ([]any, error) {
+	if params.Error != nil {
+		return nil, params.Error
+	}
+	return strSlice(dictStrSlice(paramValue(params.Data, key))), nil
+}
+
+// tlsParamString extracts a scalar-string TLS parameter (e.g. tls-ciphersuites,
+// fluentd-tls-min-version). A missing key yields "".
+func tlsParamString(params *plugin.TValue[any], key string) (string, error) {
+	if params.Error != nil {
+		return "", params.Error
+	}
+	return dictStr(paramValue(params.Data, key)), nil
+}
+
+// ---- OpenSearch ----
+
+func (r *mqlStackitOpenSearchInstance) tlsProtocols() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-protocols")
+}
+
+func (r *mqlStackitOpenSearchInstance) tlsCiphers() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-ciphers")
+}
+
+// ---- Redis ----
+
+func (r *mqlStackitRedisInstance) tlsProtocols() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-protocols")
+}
+
+func (r *mqlStackitRedisInstance) tlsCiphers() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-ciphers")
+}
+
+func (r *mqlStackitRedisInstance) tlsCiphersuites() (string, error) {
+	return tlsParamString(r.GetParameters(), "tls-ciphersuites")
+}
+
+// ---- RabbitMQ ----
+
+func (r *mqlStackitRabbitMqInstance) tlsProtocols() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-protocols")
+}
+
+func (r *mqlStackitRabbitMqInstance) tlsCiphers() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "tls-ciphers")
+}
+
+// ---- LogMe ----
+//
+// LogMe fronts a Fluentd ingestion listener and an embedded OpenSearch API,
+// each with its own TLS knobs, so the parameter keys are prefixed accordingly.
+
+func (r *mqlStackitLogMeInstance) fluentdTlsMinVersion() (string, error) {
+	return tlsParamString(r.GetParameters(), "fluentd-tls-min-version")
+}
+
+func (r *mqlStackitLogMeInstance) fluentdTlsMaxVersion() (string, error) {
+	return tlsParamString(r.GetParameters(), "fluentd-tls-max-version")
+}
+
+func (r *mqlStackitLogMeInstance) fluentdTlsCiphers() (string, error) {
+	return tlsParamString(r.GetParameters(), "fluentd-tls-ciphers")
+}
+
+func (r *mqlStackitLogMeInstance) opensearchTlsProtocols() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "opensearch-tls-protocols")
+}
+
+func (r *mqlStackitLogMeInstance) opensearchTlsCiphers() ([]any, error) {
+	return tlsParamList(r.GetParameters(), "opensearch-tls-ciphers")
+}

--- a/providers/stackit/resources/dbaas_tls_test.go
+++ b/providers/stackit/resources/dbaas_tls_test.go
@@ -1,0 +1,100 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestDictStr(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"string", "TLSv1.2", "TLSv1.2"},
+		{"empty string", "", ""},
+		{"nil", nil, ""},
+		{"wrong type int", 12, ""},
+		{"wrong type slice", []any{"TLSv1.2"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := dictStr(c.in); got != c.want {
+				t.Errorf("dictStr(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParamValue(t *testing.T) {
+	params := map[string]any{
+		"tls-protocols": []any{"TLSv1.2", "TLSv1.3"},
+		"tls-ciphers":   "TLS_AES_128",
+	}
+	cases := []struct {
+		name       string
+		parameters any
+		key        string
+		wantNil    bool
+	}{
+		{"present list key", params, "tls-protocols", false},
+		{"present string key", params, "tls-ciphers", false},
+		{"missing key", params, "does-not-exist", true},
+		{"parameters not a map", "not-a-map", "tls-protocols", true},
+		{"nil parameters", nil, "tls-protocols", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := paramValue(c.parameters, c.key)
+			if (got == nil) != c.wantNil {
+				t.Errorf("paramValue(%v, %q) = %v, wantNil=%v", c.parameters, c.key, got, c.wantNil)
+			}
+		})
+	}
+}
+
+// TestTlsParamCoercion covers the string-list normalization the accessors rely
+// on: a JSON array (RabbitMQ/OpenSearch shape) and a single string (the Redis
+// tls-protocols enum shape) must both yield a stable []any, and absent keys an
+// empty list. This is where a wrong-type assertion would silently drop a TLS
+// setting from a PQC check.
+func TestTlsParamCoercion(t *testing.T) {
+	cases := []struct {
+		name   string
+		params map[string]any
+		key    string
+		want   []string
+	}{
+		{
+			name:   "json array of protocols",
+			params: map[string]any{"tls-protocols": []any{"TLSv1.2", "TLSv1.3"}},
+			key:    "tls-protocols",
+			want:   []string{"TLSv1.2", "TLSv1.3"},
+		},
+		{
+			name:   "single string protocol (redis enum)",
+			params: map[string]any{"tls-protocols": "TLSv1.3"},
+			key:    "tls-protocols",
+			want:   []string{"TLSv1.3"},
+		},
+		{
+			name:   "missing key yields empty list",
+			params: map[string]any{},
+			key:    "tls-protocols",
+			want:   []string{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := strSlice(dictStrSlice(paramValue(c.params, c.key)))
+			if len(got) != len(c.want) {
+				t.Fatalf("coercion(%v) = %v, want %v", c.params, got, c.want)
+			}
+			for i := range got {
+				if got[i].(string) != c.want[i] {
+					t.Errorf("coercion[%d] = %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -1562,6 +1562,18 @@ private stackit.openSearch.instance @defaults("id name status planName") {
   // source-IP allow-list (`sgw_acl`) is empty or admits any address
   // (0.0.0.0/0 or ::/0), making the instance reachable from the internet.
   internetReachable() bool
+  // Enabled TLS protocol versions
+  //
+  // TLS protocol versions the instance's OpenSearch endpoint accepts,
+  // from the `tls-protocols` parameter (for example TLSv1.2 or TLSv1.3).
+  // Empty when the instance uses the service default. Use it to audit
+  // instances still accepting legacy TLS versions.
+  tlsProtocols() []string
+  // Enabled TLS cipher list
+  //
+  // Cipher suites the OpenSearch endpoint offers, from the `tls-ciphers`
+  // parameter. Empty when the instance uses the service default.
+  tlsCiphers() []string
 }
 
 // STACKIT MariaDB namespace
@@ -1674,6 +1686,24 @@ private stackit.redis.instance @defaults("id name status planName") {
   // source-IP allow-list (`sgw_acl`) is empty or admits any address
   // (0.0.0.0/0 or ::/0), making the instance reachable from the internet.
   internetReachable() bool
+  // Enabled TLS protocol versions
+  //
+  // TLS protocol versions the instance accepts, from the `tls-protocols`
+  // parameter (for example TLSv1.2 or TLSv1.3). Empty when the instance
+  // uses the engine default. Use it to audit instances still accepting
+  // legacy TLS versions.
+  tlsProtocols() []string
+  // Enabled TLS 1.2 cipher list
+  //
+  // Cipher suites offered for TLS 1.2 connections, from the `tls-ciphers`
+  // parameter. Empty when the instance uses the engine default.
+  tlsCiphers() []string
+  // Enabled TLS 1.3 cipher suites
+  //
+  // Colon-separated TLS 1.3 cipher suites the instance offers, from the
+  // `tls-ciphersuites` parameter. Empty when the instance uses the engine
+  // default.
+  tlsCiphersuites() string
 }
 
 // STACKIT RabbitMQ namespace
@@ -1731,6 +1761,18 @@ private stackit.rabbitMq.instance @defaults("id name status planName") {
   // source-IP allow-list (`sgw_acl`) is empty or admits any address
   // (0.0.0.0/0 or ::/0), making the instance reachable from the internet.
   internetReachable() bool
+  // Enabled TLS protocol versions
+  //
+  // TLS protocol versions the broker accepts, from the `tls-protocols`
+  // parameter (for example TLSv1.2 or TLSv1.3). Empty when the instance
+  // uses the broker default. Use it to audit brokers still accepting
+  // legacy TLS versions.
+  tlsProtocols() []string
+  // Enabled TLS cipher list
+  //
+  // Cipher suites the broker offers, from the `tls-ciphers` parameter.
+  // Empty when the instance uses the broker default.
+  tlsCiphers() []string
 }
 
 // STACKIT LogMe namespace
@@ -1786,6 +1828,36 @@ private stackit.logMe.instance @defaults("id name status planName") {
   // source-IP allow-list (`sgw_acl`) is empty or admits any address
   // (0.0.0.0/0 or ::/0), making the instance reachable from the internet.
   internetReachable() bool
+  // Minimum TLS version for the Fluentd log-ingestion endpoint
+  //
+  // Lowest TLS protocol version accepted by the Fluentd ingestion
+  // listener, from the `fluentd-tls-min-version` parameter (for example
+  // TLSv1.2). Empty when the instance uses the service default.
+  fluentdTlsMinVersion() string
+  // Maximum TLS version for the Fluentd log-ingestion endpoint
+  //
+  // Highest TLS protocol version accepted by the Fluentd ingestion
+  // listener, from the `fluentd-tls-max-version` parameter. Empty when
+  // the instance uses the service default.
+  fluentdTlsMaxVersion() string
+  // Fluentd endpoint TLS cipher list
+  //
+  // Cipher suites the Fluentd ingestion listener offers, from the
+  // `fluentd-tls-ciphers` parameter. Empty when the instance uses the
+  // service default.
+  fluentdTlsCiphers() string
+  // Enabled TLS protocol versions for the embedded OpenSearch endpoint
+  //
+  // TLS protocol versions accepted by the instance's OpenSearch API,
+  // from the `opensearch-tls-protocols` parameter (for example TLSv1.2
+  // or TLSv1.3). Empty when the instance uses the service default.
+  opensearchTlsProtocols() []string
+  // OpenSearch endpoint TLS cipher list
+  //
+  // Cipher suites the instance's OpenSearch API offers, from the
+  // `opensearch-tls-ciphers` parameter. Empty when the instance uses the
+  // service default.
+  opensearchTlsCiphers() []string
 }
 
 // STACKIT Secrets Manager namespace

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -1933,6 +1933,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.openSearch.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitOpenSearchInstance).GetInternetReachable()).ToDataRes(types.Bool)
 	},
+	"stackit.openSearch.instance.tlsProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitOpenSearchInstance).GetTlsProtocols()).ToDataRes(types.Array(types.String))
+	},
+	"stackit.openSearch.instance.tlsCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitOpenSearchInstance).GetTlsCiphers()).ToDataRes(types.Array(types.String))
+	},
 	"stackit.mariaDb.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitMariaDb).GetInstances()).ToDataRes(types.Array(types.Resource("stackit.mariaDb.instance")))
 	},
@@ -2011,6 +2017,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.redis.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitRedisInstance).GetInternetReachable()).ToDataRes(types.Bool)
 	},
+	"stackit.redis.instance.tlsProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitRedisInstance).GetTlsProtocols()).ToDataRes(types.Array(types.String))
+	},
+	"stackit.redis.instance.tlsCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitRedisInstance).GetTlsCiphers()).ToDataRes(types.Array(types.String))
+	},
+	"stackit.redis.instance.tlsCiphersuites": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitRedisInstance).GetTlsCiphersuites()).ToDataRes(types.String)
+	},
 	"stackit.rabbitMq.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitRabbitMq).GetInstances()).ToDataRes(types.Array(types.Resource("stackit.rabbitMq.instance")))
 	},
@@ -2050,6 +2065,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.rabbitMq.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitRabbitMqInstance).GetInternetReachable()).ToDataRes(types.Bool)
 	},
+	"stackit.rabbitMq.instance.tlsProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitRabbitMqInstance).GetTlsProtocols()).ToDataRes(types.Array(types.String))
+	},
+	"stackit.rabbitMq.instance.tlsCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitRabbitMqInstance).GetTlsCiphers()).ToDataRes(types.Array(types.String))
+	},
 	"stackit.logMe.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitLogMe).GetInstances()).ToDataRes(types.Array(types.Resource("stackit.logMe.instance")))
 	},
@@ -2088,6 +2109,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"stackit.logMe.instance.internetReachable": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitLogMeInstance).GetInternetReachable()).ToDataRes(types.Bool)
+	},
+	"stackit.logMe.instance.fluentdTlsMinVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitLogMeInstance).GetFluentdTlsMinVersion()).ToDataRes(types.String)
+	},
+	"stackit.logMe.instance.fluentdTlsMaxVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitLogMeInstance).GetFluentdTlsMaxVersion()).ToDataRes(types.String)
+	},
+	"stackit.logMe.instance.fluentdTlsCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitLogMeInstance).GetFluentdTlsCiphers()).ToDataRes(types.String)
+	},
+	"stackit.logMe.instance.opensearchTlsProtocols": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitLogMeInstance).GetOpensearchTlsProtocols()).ToDataRes(types.Array(types.String))
+	},
+	"stackit.logMe.instance.opensearchTlsCiphers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitLogMeInstance).GetOpensearchTlsCiphers()).ToDataRes(types.Array(types.String))
 	},
 	"stackit.secretsManager.instances": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSecretsManager).GetInstances()).ToDataRes(types.Array(types.Resource("stackit.secretsManager.instance")))
@@ -4781,6 +4817,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitOpenSearchInstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"stackit.openSearch.instance.tlsProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitOpenSearchInstance).TlsProtocols, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.openSearch.instance.tlsCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitOpenSearchInstance).TlsCiphers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"stackit.mariaDb.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitMariaDb).__id, ok = v.Value.(string)
 		return
@@ -4901,6 +4945,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitRedisInstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"stackit.redis.instance.tlsProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitRedisInstance).TlsProtocols, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.redis.instance.tlsCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitRedisInstance).TlsCiphers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.redis.instance.tlsCiphersuites": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitRedisInstance).TlsCiphersuites, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
 	"stackit.rabbitMq.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitRabbitMq).__id, ok = v.Value.(string)
 		return
@@ -4961,6 +5017,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlStackitRabbitMqInstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"stackit.rabbitMq.instance.tlsProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitRabbitMqInstance).TlsProtocols, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.rabbitMq.instance.tlsCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitRabbitMqInstance).TlsCiphers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"stackit.logMe.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitLogMe).__id, ok = v.Value.(string)
 		return
@@ -5019,6 +5083,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.logMe.instance.internetReachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitLogMeInstance).InternetReachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.logMe.instance.fluentdTlsMinVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitLogMeInstance).FluentdTlsMinVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.logMe.instance.fluentdTlsMaxVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitLogMeInstance).FluentdTlsMaxVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.logMe.instance.fluentdTlsCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitLogMeInstance).FluentdTlsCiphers, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.logMe.instance.opensearchTlsProtocols": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitLogMeInstance).OpensearchTlsProtocols, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.logMe.instance.opensearchTlsCiphers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitLogMeInstance).OpensearchTlsCiphers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"stackit.secretsManager.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11422,6 +11506,8 @@ type mqlStackitOpenSearchInstance struct {
 	ImageUrl           plugin.TValue[string]
 	Parameters         plugin.TValue[any]
 	InternetReachable  plugin.TValue[bool]
+	TlsProtocols       plugin.TValue[[]any]
+	TlsCiphers         plugin.TValue[[]any]
 }
 
 // createStackitOpenSearchInstance creates a new instance of this resource
@@ -11508,6 +11594,18 @@ func (c *mqlStackitOpenSearchInstance) GetParameters() *plugin.TValue[any] {
 func (c *mqlStackitOpenSearchInstance) GetInternetReachable() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
 		return c.internetReachable()
+	})
+}
+
+func (c *mqlStackitOpenSearchInstance) GetTlsProtocols() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsProtocols, func() ([]any, error) {
+		return c.tlsProtocols()
+	})
+}
+
+func (c *mqlStackitOpenSearchInstance) GetTlsCiphers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsCiphers, func() ([]any, error) {
+		return c.tlsCiphers()
 	})
 }
 
@@ -11756,6 +11854,9 @@ type mqlStackitRedisInstance struct {
 	ImageUrl           plugin.TValue[string]
 	Parameters         plugin.TValue[any]
 	InternetReachable  plugin.TValue[bool]
+	TlsProtocols       plugin.TValue[[]any]
+	TlsCiphers         plugin.TValue[[]any]
+	TlsCiphersuites    plugin.TValue[string]
 }
 
 // createStackitRedisInstance creates a new instance of this resource
@@ -11845,6 +11946,24 @@ func (c *mqlStackitRedisInstance) GetInternetReachable() *plugin.TValue[bool] {
 	})
 }
 
+func (c *mqlStackitRedisInstance) GetTlsProtocols() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsProtocols, func() ([]any, error) {
+		return c.tlsProtocols()
+	})
+}
+
+func (c *mqlStackitRedisInstance) GetTlsCiphers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsCiphers, func() ([]any, error) {
+		return c.tlsCiphers()
+	})
+}
+
+func (c *mqlStackitRedisInstance) GetTlsCiphersuites() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.TlsCiphersuites, func() (string, error) {
+		return c.tlsCiphersuites()
+	})
+}
+
 // mqlStackitRabbitMq for the stackit.rabbitMq resource
 type mqlStackitRabbitMq struct {
 	MqlRuntime *plugin.Runtime
@@ -11923,6 +12042,8 @@ type mqlStackitRabbitMqInstance struct {
 	ImageUrl           plugin.TValue[string]
 	Parameters         plugin.TValue[any]
 	InternetReachable  plugin.TValue[bool]
+	TlsProtocols       plugin.TValue[[]any]
+	TlsCiphers         plugin.TValue[[]any]
 }
 
 // createStackitRabbitMqInstance creates a new instance of this resource
@@ -12012,6 +12133,18 @@ func (c *mqlStackitRabbitMqInstance) GetInternetReachable() *plugin.TValue[bool]
 	})
 }
 
+func (c *mqlStackitRabbitMqInstance) GetTlsProtocols() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsProtocols, func() ([]any, error) {
+		return c.tlsProtocols()
+	})
+}
+
+func (c *mqlStackitRabbitMqInstance) GetTlsCiphers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.TlsCiphers, func() ([]any, error) {
+		return c.tlsCiphers()
+	})
+}
+
 // mqlStackitLogMe for the stackit.logMe resource
 type mqlStackitLogMe struct {
 	MqlRuntime *plugin.Runtime
@@ -12073,18 +12206,23 @@ type mqlStackitLogMeInstance struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlStackitLogMeInstanceInternal it will be used here
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	Status             plugin.TValue[string]
-	PlanName           plugin.TValue[string]
-	PlanId             plugin.TValue[string]
-	OfferingName       plugin.TValue[string]
-	CfOrganizationGuid plugin.TValue[string]
-	CfSpaceGuid        plugin.TValue[string]
-	DashboardUrl       plugin.TValue[string]
-	ImageUrl           plugin.TValue[string]
-	Parameters         plugin.TValue[any]
-	InternetReachable  plugin.TValue[bool]
+	Id                     plugin.TValue[string]
+	Name                   plugin.TValue[string]
+	Status                 plugin.TValue[string]
+	PlanName               plugin.TValue[string]
+	PlanId                 plugin.TValue[string]
+	OfferingName           plugin.TValue[string]
+	CfOrganizationGuid     plugin.TValue[string]
+	CfSpaceGuid            plugin.TValue[string]
+	DashboardUrl           plugin.TValue[string]
+	ImageUrl               plugin.TValue[string]
+	Parameters             plugin.TValue[any]
+	InternetReachable      plugin.TValue[bool]
+	FluentdTlsMinVersion   plugin.TValue[string]
+	FluentdTlsMaxVersion   plugin.TValue[string]
+	FluentdTlsCiphers      plugin.TValue[string]
+	OpensearchTlsProtocols plugin.TValue[[]any]
+	OpensearchTlsCiphers   plugin.TValue[[]any]
 }
 
 // createStackitLogMeInstance creates a new instance of this resource
@@ -12171,6 +12309,36 @@ func (c *mqlStackitLogMeInstance) GetParameters() *plugin.TValue[any] {
 func (c *mqlStackitLogMeInstance) GetInternetReachable() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.InternetReachable, func() (bool, error) {
 		return c.internetReachable()
+	})
+}
+
+func (c *mqlStackitLogMeInstance) GetFluentdTlsMinVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.FluentdTlsMinVersion, func() (string, error) {
+		return c.fluentdTlsMinVersion()
+	})
+}
+
+func (c *mqlStackitLogMeInstance) GetFluentdTlsMaxVersion() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.FluentdTlsMaxVersion, func() (string, error) {
+		return c.fluentdTlsMaxVersion()
+	})
+}
+
+func (c *mqlStackitLogMeInstance) GetFluentdTlsCiphers() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.FluentdTlsCiphers, func() (string, error) {
+		return c.fluentdTlsCiphers()
+	})
+}
+
+func (c *mqlStackitLogMeInstance) GetOpensearchTlsProtocols() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OpensearchTlsProtocols, func() ([]any, error) {
+		return c.opensearchTlsProtocols()
+	})
+}
+
+func (c *mqlStackitLogMeInstance) GetOpensearchTlsCiphers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.OpensearchTlsCiphers, func() ([]any, error) {
+		return c.opensearchTlsCiphers()
 	})
 }
 

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -231,11 +231,16 @@ stackit.logMe.instance 13.0.1
 stackit.logMe.instance.cfOrganizationGuid 13.0.1
 stackit.logMe.instance.cfSpaceGuid 13.0.1
 stackit.logMe.instance.dashboardUrl 13.0.1
+stackit.logMe.instance.fluentdTlsCiphers 13.4.2
+stackit.logMe.instance.fluentdTlsMaxVersion 13.4.2
+stackit.logMe.instance.fluentdTlsMinVersion 13.4.2
 stackit.logMe.instance.id 13.0.1
 stackit.logMe.instance.imageUrl 13.0.1
 stackit.logMe.instance.internetReachable 13.0.6
 stackit.logMe.instance.name 13.0.1
 stackit.logMe.instance.offeringName 13.0.1
+stackit.logMe.instance.opensearchTlsCiphers 13.4.2
+stackit.logMe.instance.opensearchTlsProtocols 13.4.2
 stackit.logMe.instance.parameters 13.0.1
 stackit.logMe.instance.planId 13.0.1
 stackit.logMe.instance.planName 13.0.1
@@ -377,6 +382,8 @@ stackit.openSearch.instance.parameters 13.0.0
 stackit.openSearch.instance.planId 13.0.0
 stackit.openSearch.instance.planName 13.0.0
 stackit.openSearch.instance.status 13.0.0
+stackit.openSearch.instance.tlsCiphers 13.4.2
+stackit.openSearch.instance.tlsProtocols 13.4.2
 stackit.openSearch.instances 13.0.0
 stackit.postgresFlex 13.0.0
 stackit.postgresFlex.instance 13.0.0
@@ -420,6 +427,8 @@ stackit.rabbitMq.instance.parameters 13.0.0
 stackit.rabbitMq.instance.planId 13.0.0
 stackit.rabbitMq.instance.planName 13.0.0
 stackit.rabbitMq.instance.status 13.0.0
+stackit.rabbitMq.instance.tlsCiphers 13.4.2
+stackit.rabbitMq.instance.tlsProtocols 13.4.2
 stackit.rabbitMq.instances 13.0.0
 stackit.redis 13.0.0
 stackit.redis.instance 13.0.0
@@ -435,6 +444,9 @@ stackit.redis.instance.parameters 13.0.0
 stackit.redis.instance.planId 13.0.0
 stackit.redis.instance.planName 13.0.0
 stackit.redis.instance.status 13.0.0
+stackit.redis.instance.tlsCiphers 13.4.2
+stackit.redis.instance.tlsCiphersuites 13.4.2
+stackit.redis.instance.tlsProtocols 13.4.2
 stackit.redis.instances 13.0.0
 stackit.region 13.0.0
 stackit.secretsManager 13.0.0

--- a/providers/stackit/resources/stackit_exposure.go
+++ b/providers/stackit/resources/stackit_exposure.go
@@ -162,6 +162,15 @@ func dictStrSlice(v any) []string {
 	}
 }
 
+// dictStr reads a single string value out of a dict, returning "" when the
+// value is missing or not a string.
+func dictStr(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
 // dictBool reads a bool-ish value out of a dict. STACKIT parameter blobs encode
 // booleans as actual bools or as the strings "true"/"false".
 func dictBool(v any) bool {


### PR DESCRIPTION
## What

Adds typed **transport-crypto (TLS) fields** to the STACKIT Cloud-Foundry-broker DBaaS instances that actually carry that data, so the post-quantum-cryptography readiness policy has a gradeable surface on STACKIT (issue #9386).

| Resource | New fields |
|---|---|
| `stackit.openSearch.instance` | `tlsProtocols`, `tlsCiphers` |
| `stackit.redis.instance` | `tlsProtocols`, `tlsCiphers`, `tlsCiphersuites` |
| `stackit.rabbitMq.instance` | `tlsProtocols`, `tlsCiphers` |
| `stackit.logMe.instance` | `fluentdTlsMinVersion`, `fluentdTlsMaxVersion`, `fluentdTlsCiphers`, `opensearchTlsProtocols`, `opensearchTlsCiphers` |

## How

These are **computed accessors** that read the already-fetched `parameters` blob by its stable keys (`tls-protocols`, `tls-ciphers`, `fluentd-tls-min-version`, ...) — the same pattern as the existing `internetReachable()`. Consequences:

- **No new API calls** and no new IAM permissions (`permissions.json` unchanged); both the `instances()` list path and `instance(id:)` init path get the fields for free.
- `dictStrSlice` normalizes redis's single-string `tls-protocols` enum and the others' JSON arrays into one consistent list, so a policy can query all four resources uniformly.
- A field is empty/null when the instance runs on the service default (the key is absent from `parameters`).

Example:

```mql
stackit.redis.instances.where( tlsProtocols.contains("TLSv1.1") )
stackit.openSearch.instances { name tlsProtocols tlsCiphers }
```

## Scope — what this issue asked for that the SDK can't back

The issue lists ~12 resources; only these four expose transport-crypto in the pinned STACKIT SDK. The rest are **not satisfiable without new SDK/API surface** and are intentionally left out (see the issue comment for the per-resource detail):

- **postgresFlex / mongoDbFlex / sqlServerFlex** — Flex engines expose only an opaque `options` map with no TLS keys (sqlserver has only at-rest KEK `Encryption`).
- **mariaDb** — its `InstanceParameters` model carries no TLS fields.
- **objectStorage.bucket** — bucket model has no policy/TLS surface and there's no `GetBucketPolicy`; an `enforceTlsOnly` signal would require an S3-compatible client.
- **ske.cluster** — the cluster model exposes no cert/TLS fields; a control-plane signal would require fetching and x509-parsing the kubeconfig CA.

## Testing

- `go test ./resources/` passes; added `dbaas_tls_test.go` covering the dict coercion (JSON-array vs single-string vs missing-key) where a wrong-type assertion would silently drop a TLS setting.
- Live verification against real STACKIT infra is deferred to a batch provider-verification run.

Toward #9386.
