### PR TITLE
🧹 Reduce memory pressure and CPU cost in `AssetExplorer` during large scans

### DIFF
--- a/discovery/asset_explorer.go
+++ b/discovery/asset_explorer.go
@@ -71,6 +71,11 @@ type AssetExplorer struct {
 
 	allAssets []*TrackedAsset
 
+	// seenPlatformIDs records every platform ID encountered during discovery
+	// and connection. Enables O(1) child-dedup checks without scanning allAssets,
+	// and remains valid after closed assets have their data released.
+	seenPlatformIDs map[string]struct{}
+
 	upstream      *upstream.UpstreamConfig
 	recording     llx.Recording
 	features      []byte
@@ -108,8 +113,9 @@ func NewAssetExplorer(ctx context.Context, cfg AssetExplorerConfig) (*AssetExplo
 		// ones like TerraformResolveVars) into every asset connection, unioned with
 		// the local cli/config.Features global. Without this, connection-level
 		// features present only on the context never reach the provider.
-		features:      []byte(mql.GetFeatures(ctx)),
-		runtimeLabels: runtimeLabels,
+		features:        []byte(mql.GetFeatures(ctx)),
+		runtimeLabels:   runtimeLabels,
+		seenPlatformIDs: make(map[string]struct{}),
 	}
 
 	for _, rootAsset := range invAssets {
@@ -139,6 +145,9 @@ func NewAssetExplorer(ctx context.Context, cfg AssetExplorerConfig) (*AssetExplo
 
 		e.allAssets = append(e.allAssets, tracked)
 		e.rootAssets = append(e.rootAssets, resolvedRootAsset)
+		for _, id := range resolvedRootAsset.PlatformIds {
+			e.seenPlatformIDs[id] = struct{}{}
+		}
 
 		// Discover immediate children from the root's connection inventory
 		e.discoverChildren(tracked)
@@ -224,6 +233,9 @@ func (e *AssetExplorer) Connect(asset *TrackedAsset) (*TrackedAsset, error) {
 		if e.dedup(asset) {
 			return nil, fmt.Errorf("asset %q: %w", asset.Asset.GetName(), ErrDuplicateAsset)
 		}
+		for _, id := range asset.Asset.PlatformIds {
+			e.seenPlatformIDs[id] = struct{}{}
+		}
 	}
 
 	e.discoverChildren(asset)
@@ -302,7 +314,7 @@ func (e *AssetExplorer) discoverChildren(parent *TrackedAsset) {
 
 	for _, childAsset := range inv.Spec.Assets {
 		// Skip children whose platform IDs are already tracked (simple dedup)
-		if len(childAsset.PlatformIds) > 0 && e.findByPlatformIDs(childAsset.PlatformIds) != nil {
+		if len(childAsset.PlatformIds) > 0 && e.hasPlatformID(childAsset.PlatformIds) {
 			continue
 		}
 
@@ -313,6 +325,9 @@ func (e *AssetExplorer) discoverChildren(parent *TrackedAsset) {
 		}
 		e.allAssets = append(e.allAssets, child)
 		parent.Children = append(parent.Children, child)
+		for _, id := range childAsset.PlatformIds {
+			e.seenPlatformIDs[id] = struct{}{}
+		}
 	}
 }
 
@@ -374,17 +389,16 @@ func (e *AssetExplorer) isKnown(asset *TrackedAsset) bool {
 	return slices.Contains(e.allAssets, asset)
 }
 
-// findByPlatformIDs returns the first tracked asset that has any of the given
-// platform IDs. Must be called with e.mu held.
-func (e *AssetExplorer) findByPlatformIDs(ids []string) *TrackedAsset {
-	for _, a := range e.allAssets {
-		for _, id := range ids {
-			if slices.Contains(a.Asset.PlatformIds, id) {
-				return a
-			}
+// hasPlatformID returns true if any of the given platform IDs have already
+// been seen (discovered or connected). Uses the seenPlatformIDs index for
+// O(1) lookups instead of scanning allAssets. Must be called with e.mu held.
+func (e *AssetExplorer) hasPlatformID(ids []string) bool {
+	for _, id := range ids {
+		if _, ok := e.seenPlatformIDs[id]; ok {
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
 // findRootAsset walks up the parent chain to find the root asset for

--- a/discovery/asset_explorer.go
+++ b/discovery/asset_explorer.go
@@ -231,9 +231,10 @@ func (e *AssetExplorer) Connect(asset *TrackedAsset) (*TrackedAsset, error) {
 	return asset, nil
 }
 
-// CloseAsset disposes the connection for a specific asset. The caller is
-// responsible for closing all connections, including gateway assets that
-// were connected just to discover children.
+// CloseAsset disposes the connection for a specific asset and breaks
+// inter-asset reference chains so the GC can reclaim memory from completed
+// subtrees. The caller is responsible for closing all connections, including
+// gateway assets that were connected just to discover children.
 func (e *AssetExplorer) CloseAsset(asset *TrackedAsset) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -251,6 +252,13 @@ func (e *AssetExplorer) CloseAsset(asset *TrackedAsset) error {
 	}
 	asset.Runtime = nil
 	asset.State = AssetClosed
+
+	// Break bidirectional reference chains between TrackedAsset nodes so
+	// completed subtrees become GC-eligible without waiting for the entire
+	// scan to finish. seenPlatformIDs preserves dedup state independently.
+	asset.Children = nil
+	asset.Parent = nil
+
 	return nil
 }
 
@@ -342,7 +350,7 @@ func (e *AssetExplorer) dedup(asset *TrackedAsset) bool {
 		if existing == asset || existing.State != AssetConnected {
 			continue
 		}
-		if len(existing.Asset.PlatformIds) == 0 {
+		if existing.Asset == nil || len(existing.Asset.PlatformIds) == 0 {
 			continue
 		}
 		if slicesx.IsSubsetOf(existing.Asset.PlatformIds, asset.Asset.PlatformIds) {
@@ -353,6 +361,8 @@ func (e *AssetExplorer) dedup(asset *TrackedAsset) bool {
 			}
 			existing.Runtime = nil
 			existing.State = AssetClosed
+			existing.Children = nil
+			existing.Parent = nil
 		}
 	}
 	return false

--- a/discovery/asset_explorer_test.go
+++ b/discovery/asset_explorer_test.go
@@ -81,17 +81,29 @@ func TestAssetExplorerConnected(t *testing.T) {
 
 func TestAssetExplorerCloseAsset(t *testing.T) {
 	t.Run("close connected asset", func(t *testing.T) {
-		asset := &TrackedAsset{
-			Asset: &inventory.Asset{Name: "root"},
+		child := &TrackedAsset{
+			Asset: &inventory.Asset{Name: "child"},
+			State: AssetDiscovered,
+		}
+		parent := &TrackedAsset{
+			Asset: &inventory.Asset{Name: "parent"},
 			State: AssetConnected,
+		}
+		asset := &TrackedAsset{
+			Asset:    &inventory.Asset{Name: "root"},
+			State:    AssetConnected,
+			Parent:   parent,
+			Children: []*TrackedAsset{child},
 			// Runtime is nil in tests since we don't have a real provider
 		}
-		e := newTestExplorer(asset)
+		e := newTestExplorer(asset, parent, child)
 
 		err := e.CloseAsset(asset)
 		require.NoError(t, err)
 		assert.Equal(t, AssetClosed, asset.State)
 		assert.Nil(t, asset.Runtime)
+		assert.Nil(t, asset.Children, "Children should be nil'd to break reference chains")
+		assert.Nil(t, asset.Parent, "Parent should be nil'd to break reference chains")
 	})
 
 	t.Run("close discovered asset fails", func(t *testing.T) {
@@ -203,9 +215,14 @@ func TestAssetExplorerDedup(t *testing.T) {
 	})
 
 	t.Run("existing asset that is subset of new gets evicted", func(t *testing.T) {
+		child := &TrackedAsset{
+			Asset: &inventory.Asset{Name: "leaf"},
+			State: AssetDiscovered,
+		}
 		existing := &TrackedAsset{
-			Asset: &inventory.Asset{Name: "small", PlatformIds: []string{"id/1"}},
-			State: AssetConnected,
+			Asset:    &inventory.Asset{Name: "small", PlatformIds: []string{"id/1"}},
+			State:    AssetConnected,
+			Children: []*TrackedAsset{child},
 		}
 		newAsset := &TrackedAsset{
 			Asset: &inventory.Asset{Name: "big", PlatformIds: []string{"id/1", "id/2"}},
@@ -216,6 +233,8 @@ func TestAssetExplorerDedup(t *testing.T) {
 		e.dedup(newAsset)
 
 		assert.Equal(t, AssetClosed, existing.State)
+		assert.Nil(t, existing.Children, "evicted asset Children should be nil'd")
+		assert.Nil(t, existing.Parent, "evicted asset Parent should be nil'd")
 		assert.Equal(t, AssetConnected, newAsset.State)
 	})
 

--- a/discovery/asset_explorer_test.go
+++ b/discovery/asset_explorer_test.go
@@ -38,8 +38,17 @@ func TestMergeConnectionFeatures(t *testing.T) {
 }
 
 func newTestExplorer(assets ...*TrackedAsset) *AssetExplorer {
+	seen := make(map[string]struct{})
+	for _, a := range assets {
+		if a.Asset != nil {
+			for _, id := range a.Asset.PlatformIds {
+				seen[id] = struct{}{}
+			}
+		}
+	}
 	return &AssetExplorer{
-		allAssets: assets,
+		allAssets:       assets,
+		seenPlatformIDs: seen,
 	}
 }
 
@@ -266,6 +275,20 @@ func TestAssetExplorerDedup(t *testing.T) {
 
 		assert.Equal(t, AssetConnected, a.State)
 	})
+}
+
+func TestAssetExplorerHasPlatformID(t *testing.T) {
+	a := &TrackedAsset{
+		Asset: &inventory.Asset{Name: "a", PlatformIds: []string{"id/1", "id/2"}},
+		State: AssetConnected,
+	}
+	e := newTestExplorer(a)
+
+	assert.True(t, e.hasPlatformID([]string{"id/1"}))
+	assert.True(t, e.hasPlatformID([]string{"id/2"}))
+	assert.True(t, e.hasPlatformID([]string{"id/3", "id/1"}))
+	assert.False(t, e.hasPlatformID([]string{"id/3"}))
+	assert.False(t, e.hasPlatformID(nil))
 }
 
 func TestAssetExplorerErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

Reduce memory pressure and CPU cost in `AssetExplorer` during large K8s scans (~4000+ assets), addressing OOM kills observed in production with 1GB memory limits.

- **Break reference chains on close/eviction**: `CloseAsset` and dedup eviction now nil out `Children`/`Parent` pointers, so completed subtrees become GC-eligible immediately instead of staying reachable through `allAssets` for the entire scan duration. Adds a nil guard on `existing.Asset` in the dedup eviction loop to handle assets whose data was already released by the scan pipeline.
- **Replace O(n^2) platform ID dedup with O(1) map lookup**: `findByPlatformIDs` linearly scanned `allAssets` for every platform ID of every child — millions of string comparisons at scale. Replaced with `seenPlatformIDs map[string]struct{}` populated at discovery/connect time and queried via `hasPlatformID`. The map is append-only and independent of asset lifecycle, which also avoids the need for nil guards that the old slice scan would require after reference chain breaking.

## Test plan

- [x] Existing `TestAssetExplorerCloseAsset` enhanced with Parent/Children fields and nil assertions
- [x] Existing dedup eviction test enhanced with child references and nil assertions
- [x] New `TestAssetExplorerHasPlatformID` covering hit, miss, multi-ID, and nil cases
- [x] `newTestExplorer` populates `seenPlatformIDs` from asset PlatformIds
- [x] All discovery package tests pass
