### PR TITLE
✨ fex: add city and coordinates to NetworkRange geolocation

### DIFF
--- a/providers-sdk/v1/upstream/fex/fex.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex.pb.go
@@ -3126,7 +3126,13 @@ type NetworkRange struct {
 	// Optional. Autonomous system or organization name.
 	AsName string `protobuf:"bytes,3,opt,name=as_name,json=asName,proto3" json:"as_name,omitempty"`
 	// Optional. Two-letter ISO country code.
-	Country       string `protobuf:"bytes,4,opt,name=country,proto3" json:"country,omitempty"`
+	Country string `protobuf:"bytes,4,opt,name=country,proto3" json:"country,omitempty"`
+	// Optional. City name of the geolocation, e.g. "Council Bluffs".
+	City string `protobuf:"bytes,5,opt,name=city,proto3" json:"city,omitempty"`
+	// Optional. Latitude of the geolocation, in decimal degrees.
+	Latitude float64 `protobuf:"fixed64,6,opt,name=latitude,proto3" json:"latitude,omitempty"`
+	// Optional. Longitude of the geolocation, in decimal degrees.
+	Longitude     float64 `protobuf:"fixed64,7,opt,name=longitude,proto3" json:"longitude,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3187,6 +3193,27 @@ func (x *NetworkRange) GetCountry() string {
 		return x.Country
 	}
 	return ""
+}
+
+func (x *NetworkRange) GetCity() string {
+	if x != nil {
+		return x.City
+	}
+	return ""
+}
+
+func (x *NetworkRange) GetLatitude() float64 {
+	if x != nil {
+		return x.Latitude
+	}
+	return 0
+}
+
+func (x *NetworkRange) GetLongitude() float64 {
+	if x != nil {
+		return x.Longitude
+	}
+	return 0
 }
 
 // ThreatIntelIndicator captures an artifact — an IP, domain, URL, or file hash
@@ -4054,12 +4081,15 @@ const file_fex_proto_rawDesc = "" +
 	"\n" +
 	"expires_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12!\n" +
 	"\fname_servers\x18\x06 \x03(\tR\vnameServers\x12\x1a\n" +
-	"\bstatuses\x18\a \x03(\tR\bstatuses\"g\n" +
+	"\bstatuses\x18\a \x03(\tR\bstatuses\"\xb5\x01\n" +
 	"\fNetworkRange\x12\x12\n" +
 	"\x04cidr\x18\x01 \x01(\tR\x04cidr\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x12\x17\n" +
 	"\aas_name\x18\x03 \x01(\tR\x06asName\x12\x18\n" +
-	"\acountry\x18\x04 \x01(\tR\acountry\"\xd9\x01\n" +
+	"\acountry\x18\x04 \x01(\tR\acountry\x12\x12\n" +
+	"\x04city\x18\x05 \x01(\tR\x04city\x12\x1a\n" +
+	"\blatitude\x18\x06 \x01(\x01R\blatitude\x12\x1c\n" +
+	"\tlongitude\x18\a \x01(\x01R\tlongitude\"\xd9\x01\n" +
 	"\x14ThreatIntelIndicator\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value\x12\x1a\n" +

--- a/providers-sdk/v1/upstream/fex/fex.proto
+++ b/providers-sdk/v1/upstream/fex/fex.proto
@@ -606,6 +606,12 @@ message NetworkRange {
   string as_name = 3;
   // Optional. Two-letter ISO country code.
   string country = 4;
+  // Optional. City name of the geolocation, e.g. "Council Bluffs".
+  string city = 5;
+  // Optional. Latitude of the geolocation, in decimal degrees.
+  double latitude = 6;
+  // Optional. Longitude of the geolocation, in decimal degrees.
+  double longitude = 7;
 }
 
 // ThreatIntelIndicator captures an artifact — an IP, domain, URL, or file hash

--- a/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
@@ -2788,6 +2788,25 @@ func (m *NetworkRange) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Longitude != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Longitude))))
+		i--
+		dAtA[i] = 0x39
+	}
+	if m.Latitude != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(math.Float64bits(float64(m.Latitude))))
+		i--
+		dAtA[i] = 0x31
+	}
+	if len(m.City) > 0 {
+		i -= len(m.City)
+		copy(dAtA[i:], m.City)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.City)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.Country) > 0 {
 		i -= len(m.Country)
 		copy(dAtA[i:], m.Country)
@@ -4414,6 +4433,16 @@ func (m *NetworkRange) SizeVT() (n int) {
 	l = len(m.Country)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.City)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Latitude != 0 {
+		n += 9
+	}
+	if m.Longitude != 0 {
+		n += 9
 	}
 	n += len(m.unknownFields)
 	return n
@@ -12150,6 +12179,60 @@ func (m *NetworkRange) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Country = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field City", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.City = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Latitude", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Latitude = float64(math.Float64frombits(v))
+		case 7:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Longitude", wireType)
+			}
+			var v uint64
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			v = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
+			m.Longitude = float64(math.Float64frombits(v))
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])


### PR DESCRIPTION
`NetworkRange` evidence already records the **ASN**, **AS/organization name**, and **country** of an IP block. This adds the finer geolocation an IP-geo lookup commonly returns:

- `city` — city name (e.g. "Council Bluffs")
- `latitude` / `longitude` — decimal degrees

All optional and additive (fields 5–7). This lets a network evidence record *where* an address is located, not just its country and ASN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)