### PR TITLE
🐛 Fix spurious "parent connection not found" warnings during K8s scans

### DIFF
--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -303,19 +304,38 @@ func (r *RestartableProvider) Disconnect(req *pp.DisconnectReq) (*pp.DisconnectR
 	r.lock.Lock()
 	r.connectionGraph.markDisconnected(req.Connection)
 	collected := r.connectionGraph.garbageCollect()
+	// Check whether the requested connection survived GC (children keep it
+	// alive). Must be checked under the lock since another goroutine's
+	// Connect/Disconnect can mutate the graph concurrently.
+	requestedCollected := slices.Contains(collected, req.Connection)
+	keptByChildren := false
+	if !requestedCollected {
+		_, keptByChildren = r.connectionGraph.getNode(req.Connection)
+	}
 	r.lock.Unlock()
 
-	resp, err := r.plugin.Disconnect(req)
+	// Only disconnect the requested connection from the provider if GC
+	// actually collected it. When children still reference this connection
+	// (GC kept it in the graph), the Service-layer runtime must stay alive
+	// so children can share its resource cache. GC will disconnect it later
+	// once all children are done.
+	var resp *pp.DisconnectRes
+	var err error
+	if keptByChildren {
+		resp = &pp.DisconnectRes{}
+	} else {
+		resp, err = r.plugin.Disconnect(req)
+	}
 
 	for _, c := range collected {
 		if c == req.Connection {
 			continue
 		}
-		_, err := r.plugin.Disconnect(&pp.DisconnectReq{
+		_, disconnectErr := r.plugin.Disconnect(&pp.DisconnectReq{
 			Connection: c,
 		})
-		if err != nil {
-			log.Warn().Err(err).Uint32("connection", c).Msg("failed to disconnect garbage collected connection")
+		if disconnectErr != nil {
+			log.Warn().Err(disconnectErr).Uint32("connection", c).Msg("failed to disconnect garbage collected connection")
 		}
 	}
 

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -319,6 +319,9 @@ func (r *RestartableProvider) Disconnect(req *pp.DisconnectReq) (*pp.DisconnectR
 	// (GC kept it in the graph), the Service-layer runtime must stay alive
 	// so children can share its resource cache. GC will disconnect it later
 	// once all children are done.
+	//
+	// The else branch also covers double-disconnect (node absent from graph
+	// entirely); the plugin handles unknown connection IDs as a no-op.
 	var resp *pp.DisconnectRes
 	var err error
 	if keptByChildren {

--- a/providers/running_provider_test.go
+++ b/providers/running_provider_test.go
@@ -288,6 +288,124 @@ func TestRestartableProvider_ParentReconnectsAfterGC(t *testing.T) {
 	require.True(t, mock.alive(workloadBatch2))
 }
 
+// TestRestartableProvider_ParentDisconnectedWhileChildrenActive reproduces
+// the bug where a parent is disconnected while children still reference it.
+// GC keeps the parent in the graph (children hold it alive), but the
+// unconditional r.plugin.Disconnect call removes its Service-layer runtime.
+// A subsequent child then finds the parent in the graph (no reconnection),
+// but Service.AddRuntime fails to find the parent runtime → warning.
+func TestRestartableProvider_ParentDisconnectedWhileChildrenActive(t *testing.T) {
+	mock := newMockPlugin()
+	rp := &RestartableProvider{
+		plugin:          mock,
+		connectionGraph: newConnectionGraph(),
+	}
+
+	const (
+		nsConn = uint32(2)
+		child1 = uint32(10)
+		child2 = uint32(11)
+		child3 = uint32(12)
+	)
+
+	// Connect namespace.
+	_, err := rp.Connect(connectReqFor(nsConn, 0), nil)
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn))
+
+	// Connect first child (workload).
+	_, err = rp.Connect(connectReqFor(child1, nsConn), nil)
+	require.NoError(t, err)
+	require.True(t, mock.alive(child1))
+
+	// Disconnect namespace while child1 is still connected.
+	// GC should keep node nsConn (child1 references it).
+	// The Service-layer runtime for nsConn must stay alive.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: nsConn})
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn),
+		"parent runtime must stay alive while children reference it")
+
+	// Connect second child — parent is in graph, no reconnection needed.
+	// This MUST succeed because the parent runtime is still alive.
+	_, err = rp.Connect(connectReqFor(child2, nsConn), nil)
+	require.NoError(t, err, "child2 should connect with parent still alive in Service")
+
+	// Disconnect child1 — parent still needed by child2.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: child1})
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn), "parent still needed by child2")
+
+	// Disconnect child2 — parent no longer needed, should be GC'd.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: child2})
+	require.NoError(t, err)
+	require.False(t, mock.alive(nsConn), "parent should be GC'd when all children disconnect")
+
+	// A third child arrives after full GC — should reconnect via collectedNodes.
+	_, err = rp.Connect(connectReqFor(child3, nsConn), nil)
+	require.NoError(t, err, "child3 should connect after parent is re-reconnected from collectedNodes")
+	require.True(t, mock.alive(nsConn))
+}
+
+// TestRestartableProvider_OverlappingBatchesWithParentDisconnect simulates
+// the realistic scanner pattern where batches overlap: some children from
+// batch 1 are still connected when the parent is disconnected, and new
+// children from batch 2 arrive afterward.
+func TestRestartableProvider_OverlappingBatchesWithParentDisconnect(t *testing.T) {
+	mock := newMockPlugin()
+	rp := &RestartableProvider{
+		plugin:          mock,
+		connectionGraph: newConnectionGraph(),
+	}
+
+	const nsConn = uint32(2)
+
+	// Connect namespace.
+	_, err := rp.Connect(connectReqFor(nsConn, 0), nil)
+	require.NoError(t, err)
+
+	// Batch 1: connect children 10, 11, 12.
+	for _, id := range []uint32{10, 11, 12} {
+		_, err := rp.Connect(connectReqFor(id, nsConn), nil)
+		require.NoError(t, err)
+	}
+
+	// Scanner closes namespace (done scanning it as an asset).
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: nsConn})
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn), "parent kept alive by batch 1 children")
+
+	// Batch 1 children finish one by one.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: 10})
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn), "parent kept alive by children 11, 12")
+
+	// Batch 2 arrives while batch 1 isn't fully done yet.
+	for _, id := range []uint32{13, 14} {
+		_, err := rp.Connect(connectReqFor(id, nsConn), nil)
+		require.NoError(t, err, "batch 2 child %d should connect", id)
+	}
+
+	// Finish remaining batch 1 children.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: 11})
+	require.NoError(t, err)
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: 12})
+	require.NoError(t, err)
+	require.True(t, mock.alive(nsConn), "parent kept alive by batch 2 children")
+
+	// Finish batch 2.
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: 13})
+	require.NoError(t, err)
+	_, err = rp.Disconnect(&pp.DisconnectReq{Connection: 14})
+	require.NoError(t, err)
+	require.False(t, mock.alive(nsConn), "parent GC'd after all children disconnect")
+
+	// Batch 3 arrives after full GC — reconnection from collectedNodes.
+	_, err = rp.Connect(connectReqFor(15, nsConn), nil)
+	require.NoError(t, err, "batch 3 child should reconnect parent from collectedNodes")
+	require.True(t, mock.alive(nsConn))
+}
+
 // TestRestartableProvider_MultiNamespaceMultiBatch simulates a realistic
 // K8s cluster scan: 5 namespaces × 10 workloads each, processed in
 // batches of 15. This catches ordering-dependent bugs that single-pair

--- a/providers/runtime.go
+++ b/providers/runtime.go
@@ -256,6 +256,19 @@ func (r *Runtime) setProviderConnection(c *plugin.ConnectRes, err error) {
 	r.mu.Unlock()
 }
 
+// crossProviderAsset returns a clone of the main provider's asset with
+// ParentConnectionId cleared. Parent-child resource cache sharing only
+// applies within the same provider; passing the original parent ID to an
+// unrelated provider triggers a spurious "parent connection not found"
+// warning because that provider never had the parent's runtime.
+func (r *Runtime) crossProviderAsset() *inventory.Asset {
+	asset := r.Provider.Connection.Asset.CloneVT()
+	if len(asset.Connections) > 0 {
+		asset.Connections[0].ParentConnectionId = 0
+	}
+	return asset
+}
+
 func (r *Runtime) addProvider(id string) (*ConnectedProvider, error) {
 	// TODO: we need to detect only the shared running providers
 	running, err := r.coordinator.GetRunningProvider(id, r.AutoUpdate)
@@ -385,7 +398,7 @@ func (r *Runtime) Connect(req *plugin.ConnectReq) error {
 		return err
 	}
 	if postProvider.ID != r.Provider.Instance.ID {
-		req.Asset = r.Provider.Connection.Asset
+		req.Asset = r.crossProviderAsset()
 		err = r.UseProvider(postProvider.ID)
 		if err != nil {
 			return err
@@ -972,7 +985,7 @@ func (r *Runtime) lookupResourceProvider(resource string) (*ConnectedProvider, *
 	res.Connection, res.ConnectionError = res.Instance.Plugin.Connect(&plugin.ConnectReq{
 		Features: r.features,
 		Upstream: r.UpstreamConfig,
-		Asset:    r.Provider.Connection.Asset,
+		Asset:    r.crossProviderAsset(),
 	}, nil)
 	if res.ConnectionError != nil {
 		return nil, nil, res.ConnectionError
@@ -1112,7 +1125,7 @@ func (r *Runtime) lookupFieldProvider(resource string, field string) (*Connected
 	res.Connection, res.ConnectionError = res.Instance.Plugin.Connect(&plugin.ConnectReq{
 		Features: r.features,
 		Upstream: r.UpstreamConfig,
-		Asset:    r.Provider.Connection.Asset,
+		Asset:    r.crossProviderAsset(),
 	}, nil)
 	if res.ConnectionError != nil {
 		return nil, nil, nil, res.ConnectionError


### PR DESCRIPTION
When a K8s workload's MQL query references a resource from another provider (core, network, OS), lookupResourceProvider and lookupFieldProvider trigger a cross-provider Plugin.Connect. These calls were passing the workload's asset with ParentConnectionId still set to the K8s namespace's connection ID. But the target provider's Service.runtimes never had that namespace connection — it only existed in the K8s provider — so GetRuntime(parentId) always failed, producing a "parent connection not found" warning for every cross-provider connect.

On a real cluster scan this produced ~1,600 warnings (2 per workload when both core and network providers were involved). No data was lost — the warning explicitly proceeds without cache sharing — and cross-provider cache sharing was never meaningful (different providers cache different resource types), so the performance impact was zero.

Fix: strip ParentConnectionId when connecting to a different provider. New crossProviderAsset() clones the asset and zeros the parent ID, applied to lookupResourceProvider, lookupFieldProvider, and the provider-switch path in Runtime.Connect.

Additionally, fix a GC race in RestartableProvider.Disconnect: when a parent connection is disconnected but children still reference it, GC correctly keeps it in the connection graph, but the old code unconditionally called plugin.Disconnect on the Service layer, destroying the runtime. Now defers the Service-layer disconnect when children keep the parent alive, so a late-arriving child can still share the parent's resource cache.

Resolves #9068