### PR TITLE
🐛 aws: populate aws.iam.role.lastUsedAt/lastUsedRegion via GetRole

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2573,9 +2573,9 @@ private aws.iam.role @defaults("arn name") {
   // AWS account IDs outside this account that the trust policy allows to assume the role
   assumableByExternalAccounts() []string
   // Time when the role was last used to make an AWS request
-  lastUsedAt time
+  lastUsedAt() time
   // Region in which the role was last used
-  lastUsedRegion string
+  lastUsedRegion() string
   // Maximum session duration in seconds for the role (3600-43200)
   maxSessionDuration int
   // ARN of the permissions boundary policy attached to the role

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -88127,7 +88127,7 @@ func (c *mqlAwsIamPolicyversion) GetCreatedAt() *plugin.TValue[*time.Time] {
 type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsIamRoleInternal it will be used here
+	mqlAwsIamRoleInternal
 	Arn                         plugin.TValue[string]
 	Id                          plugin.TValue[string]
 	Name                        plugin.TValue[string]
@@ -88245,11 +88245,15 @@ func (c *mqlAwsIamRole) GetAssumableByExternalAccounts() *plugin.TValue[[]any] {
 }
 
 func (c *mqlAwsIamRole) GetLastUsedAt() *plugin.TValue[*time.Time] {
-	return &c.LastUsedAt
+	return plugin.GetOrCompute[*time.Time](&c.LastUsedAt, func() (*time.Time, error) {
+		return c.lastUsedAt()
+	})
 }
 
 func (c *mqlAwsIamRole) GetLastUsedRegion() *plugin.TValue[string] {
-	return &c.LastUsedRegion
+	return plugin.GetOrCompute[string](&c.LastUsedRegion, func() (string, error) {
+		return c.lastUsedRegion()
+	})
 }
 
 func (c *mqlAwsIamRole) GetMaxSessionDuration() *plugin.TValue[int64] {

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -659,13 +659,6 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 				json.Unmarshal([]byte(policyDocument), &policyDocumentMap)
 			}
 
-			var lastUsedAt *time.Time
-			var lastUsedRegion string
-			if role.RoleLastUsed != nil {
-				lastUsedAt = role.RoleLastUsed.LastUsedDate
-				lastUsedRegion = convert.ToValue(role.RoleLastUsed.Region)
-			}
-
 			var permBoundaryArn string
 			if role.PermissionsBoundary != nil {
 				permBoundaryArn = convert.ToValue(role.PermissionsBoundary.PermissionsBoundaryArn)
@@ -680,8 +673,6 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 					"tags":                     llx.MapData(iamTagsToMap(role.Tags), types.String),
 					"createdAt":                llx.TimeDataPtr(role.CreateDate),
 					"assumeRolePolicyDocument": llx.MapData(policyDocumentMap, types.Any),
-					"lastUsedAt":               llx.TimeDataPtr(lastUsedAt),
-					"lastUsedRegion":           llx.StringData(lastUsedRegion),
 					"maxSessionDuration":       llx.IntDataDefault(role.MaxSessionDuration, 3600),
 					"permissionsBoundaryArn":   llx.StringData(permBoundaryArn),
 					"path":                     llx.StringDataPtr(role.Path),
@@ -1790,6 +1781,63 @@ func (a *mqlAwsIamRole) permissionsBoundary() (*mqlAwsIamPolicy, error) {
 		return nil, err
 	}
 	return mqlPolicy.(*mqlAwsIamPolicy), nil
+}
+
+type mqlAwsIamRoleInternal struct {
+	cachedRole  *iam.GetRoleOutput
+	roleFetched bool
+	roleLock    sync.Mutex
+}
+
+// getRoleDetails fetches and memoizes the full role via GetRole. The account-wide
+// ListRoles call that roles() uses to enumerate never populates RoleLastUsed, so
+// lastUsedAt and lastUsedRegion have to come from GetRole. The result is cached
+// so both fields share a single API call, and the call is only made when one of
+// those fields is actually queried.
+func (a *mqlAwsIamRole) getRoleDetails() (*iam.GetRoleOutput, error) {
+	if a.roleFetched {
+		return a.cachedRole, nil
+	}
+	a.roleLock.Lock()
+	defer a.roleLock.Unlock()
+	if a.roleFetched {
+		return a.cachedRole, nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	roleName := a.Name.Data
+	resp, err := svc.GetRole(ctx, &iam.GetRoleInput{RoleName: &roleName})
+	if err != nil {
+		return nil, err
+	}
+	a.cachedRole = resp
+	a.roleFetched = true
+	return resp, nil
+}
+
+func (a *mqlAwsIamRole) lastUsedAt() (*time.Time, error) {
+	resp, err := a.getRoleDetails()
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Role == nil || resp.Role.RoleLastUsed == nil {
+		return nil, nil
+	}
+	return resp.Role.RoleLastUsed.LastUsedDate, nil
+}
+
+func (a *mqlAwsIamRole) lastUsedRegion() (string, error) {
+	resp, err := a.getRoleDetails()
+	if err != nil {
+		return "", err
+	}
+	if resp == nil || resp.Role == nil || resp.Role.RoleLastUsed == nil {
+		return "", nil
+	}
+	return convert.ToValue(resp.Role.RoleLastUsed.Region), nil
 }
 
 func (a *mqlAwsIamRole) attachedPolicies() ([]any, error) {


### PR DESCRIPTION
## Problem

`aws.iam.role.lastUsedAt` and `aws.iam.role.lastUsedRegion` are **always `null`/`""` for every role**, so any policy relying on role last-used activity (e.g. flagging roles unused for more than N days) is silently broken.

Root cause: `aws.iam.roles` enumerates roles with the IAM `ListRoles` API, and `ListRoles` **does not populate the `RoleLastUsed` field** — it is only returned by `GetRole`. The mapping in `roles()` (`if role.RoleLastUsed != nil { … }`) was therefore always skipped.

Reproduction (any account with at least one used role):

```
ListRoles → role.RoleLastUsed == nil          # lastUsedAt/lastUsedRegion end up null/""
GetRole   → role.RoleLastUsed.LastUsedDate set # the real value
```

## Fix

Make `lastUsedAt` and `lastUsedRegion` **computed fields** backed by a memoized `GetRole`, mirroring the existing `aws.kms.key.lastUsedAt` lazy-getter pattern:

- `resources/aws.lr`: `lastUsedAt time` → `lastUsedAt() time`; `lastUsedRegion string` → `lastUsedRegion() string`.
- `resources/aws_iam.go`: drop the dead `RoleLastUsed` block from `roles()`; add a `mqlAwsIamRoleInternal` cache plus a memoized `getRoleDetails()` helper and the two getters.
- Regenerated `resources/aws.lr.go`.

The `GetRole` call is only issued when one of these two fields is actually queried, and both fields share a single cached response, so enumerating roles for other fields still costs one `ListRoles` page as before. No new IAM permission is required (`iam:GetRole` is already used by `permissionsBoundary()` / the role init path).

## Verification

Built and installed the provider, scanned a live AWS account:

- Before: `lastUsedAt` was `null` for all roles.
- After: `lastUsedAt`/`lastUsedRegion` match the values returned by `aws iam get-role` exactly, including `null` for never-used roles.
- A "role used within the last 90 days" check now evaluates per-role and correctly identifies the single stale role in the test account instead of collapsing to a scalar.