### PR TITLE
🐛 aws: fix data race in aws.iam.role.getRoleDetails memoization

### DIFF
--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -1792,12 +1792,10 @@ type mqlAwsIamRoleInternal struct {
 // getRoleDetails fetches and memoizes the full role via GetRole. The account-wide
 // ListRoles call that roles() uses to enumerate never populates RoleLastUsed, so
 // lastUsedAt and lastUsedRegion have to come from GetRole. The result is cached
-// so both fields share a single API call, and the call is only made when one of
-// those fields is actually queried.
+// so both fields share a single API call, and the call is only made when one
+// of those fields is actually queried. The two getters can be evaluated
+// concurrently, so lock unconditionally rather than double-checking the flag.
 func (a *mqlAwsIamRole) getRoleDetails() (*iam.GetRoleOutput, error) {
-	if a.roleFetched {
-		return a.cachedRole, nil
-	}
 	a.roleLock.Lock()
 	defer a.roleLock.Unlock()
 	if a.roleFetched {


### PR DESCRIPTION
Follow-up to #9393.

## Problem

`getRoleDetails()` memoizes the `GetRole` response using a double-checked-locking pattern, but the first `if a.roleFetched` read is performed **outside** the mutex:

```go
func (a *mqlAwsIamRole) getRoleDetails() (*iam.GetRoleOutput, error) {
    if a.roleFetched {              // unsynchronized read
        return a.cachedRole, nil
    }
    a.roleLock.Lock()
    ...
    a.roleFetched = true            // write under lock
}
```

`aws.iam.role.lastUsedAt` and `aws.iam.role.lastUsedRegion` both call `getRoleDetails()` and can be evaluated concurrently for the same role, so that unlocked read of `roleFetched` / `cachedRole` can run concurrently with the locked writes. Under the Go memory model that is a data race (an unsynchronized read racing a write), i.e. the kind of access `go test -race` reports.

## Fix

Take the lock on entry and check the flag once under it. `getRoleDetails()` only issues a network `GetRole` on the first call and returns the cached value afterwards, so unconditional locking adds negligible cost and removes the unsynchronized access by construction.

## Verification

- Fix is correct by construction: every access to the shared `roleFetched` / `cachedRole` fields now happens while holding `roleLock`.
- Provider compiles: `go build ./main.go` (exit 0).
- Not run under `go test -race` — there is no existing test that concurrently exercises both getters on a single role.