### PR TITLE
✨ os: detect WizOS (Alpine-derivative) and wire apk packages

### DIFF
--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -110,6 +110,20 @@ var wolfi = &PlatformResolver{
 	},
 }
 
+// WizOS is an Alpine-lineage distro (ID_LIKE=alpine) that ships its own
+// ID=wizos in /etc/os-release and uses apk. It is resolved before alpine so
+// its exact-name match wins over alpine's /etc/alpine-release fallback.
+var wizos = &PlatformResolver{
+	Name:     "wizos",
+	IsFamily: false,
+	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
+		if pf.Name == "wizos" {
+			return true, nil
+		}
+		return false, nil
+	},
+}
+
 var arch = &PlatformResolver{
 	Name:     "arch",
 	IsFamily: false,
@@ -1298,7 +1312,7 @@ var eulerFamily = &PlatformResolver{
 var linuxFamily = &PlatformResolver{
 	Name:     inventory.FAMILY_LINUX,
 	IsFamily: true,
-	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
+	Children: []*PlatformResolver{archFamily, redhatFamily, debianFamily, suseFamily, eulerFamily, bottlerocket, amazonlinux, wizos, alpine, wolfi, nixos, gentoo, busybox, photon, windriver, lede, openwrt, plcnext, mageia, azurelinux, flatcar, cirros, defaultLinux},
 	Detect: func(r *PlatformResolver, pf *inventory.Platform, conn shared.Connection) (bool, error) {
 		detected := false
 		osrd := NewOSReleaseDetector(conn)

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -743,6 +743,17 @@ func TestWolfiLinuxDetector(t *testing.T) {
 	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
 }
 
+func TestWizOSLinuxDetector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-wizos.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "wizos", di.Name, "os name should be identified")
+	assert.Equal(t, "WizOS", di.Title, "os title should be identified")
+	assert.Equal(t, "1.0", di.Version, "os version should be identified")
+	assert.Equal(t, "x86_64", di.Arch, "os arch should be identified")
+	assert.Equal(t, []string{"linux", "unix", "os"}, di.Family)
+}
+
 func TestBusyboxLinuxDetector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-busybox.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/device_type_test.go
+++ b/providers/os/detector/device_type_test.go
@@ -522,6 +522,8 @@ func TestDetectDeviceType_LinuxNoSignals_DefaultServer(t *testing.T) {
 		{"azure linux", "azurelinux", "Microsoft Azure Linux", []string{"linux", "unix", "os"}},
 		// detect-wolfi.toml
 		{"wolfi", "wolfi", "Wolfi", []string{"linux", "unix", "os"}},
+		// detect-wizos.toml
+		{"wizos", "wizos", "WizOS", []string{"linux", "unix", "os"}},
 		// detect-buildroot.toml
 		{"buildroot", "buildroot", "Buildroot 2019.02.9", []string{"linux", "unix", "os"}},
 	}

--- a/providers/os/detector/testdata/detect-wizos.toml
+++ b/providers/os/detector/testdata/detect-wizos.toml
@@ -1,0 +1,18 @@
+[commands."uname -s"]
+stdout = "Linux"
+
+[commands."uname -m"]
+stdout = "x86_64"
+
+[commands."uname -r"]
+stdout = "6.6.0"
+
+[files."/etc/os-release"]
+content = """
+ID=wizos
+ID_LIKE=alpine
+NAME="WizOS"
+PRETTY_NAME="WizOS"
+VERSION_ID="1.0"
+HOME_URL="https://www.wiz.io/wizos"
+"""

--- a/providers/os/resources/packages/packages.go
+++ b/providers/os/resources/packages/packages.go
@@ -129,7 +129,7 @@ func ResolveSystemPkgManagers(conn shared.Connection) ([]OperatingSystemPkgManag
 		}
 	case asset.Platform.IsFamily("suse"): // suse handling
 		pms = append(pms, &SusePkgManager{RpmPkgManager{conn: conn, platform: asset.Platform}})
-	case asset.Platform.Name == "alpine" || asset.Platform.Name == "wolfi": // alpine & wolfi share apk
+	case asset.Platform.Name == "alpine" || asset.Platform.Name == "wolfi" || asset.Platform.Name == "wizos": // alpine, wolfi & wizos share apk
 		pms = append(pms, &AlpinePkgManager{conn: conn, platform: asset.Platform})
 	case asset.Platform.Name == "macos": // macos family
 		pms = append(pms, &MacOSPkgManager{conn: conn, platform: asset.Platform})

--- a/providers/os/resources/services/manager.go
+++ b/providers/os/resources/services/manager.go
@@ -182,7 +182,7 @@ func ResolveManager(conn shared.Connection) (OSServiceManager, error) {
 		osm = &OpenBsdRcctlServiceManager{conn: conn}
 	case asset.Platform.Name == "windows":
 		osm = &WindowsServiceManager{conn: conn}
-	case asset.Platform.Name == "alpine":
+	case asset.Platform.Name == "alpine" || asset.Platform.Name == "wizos": // wizos is Alpine-based and uses OpenRC
 		osm = &OpenrcServiceManager{conn: conn}
 	case asset.Platform.Name == "gentoo":
 		osm = &OpenrcServiceManager{conn: conn}


### PR DESCRIPTION
## What

Adds platform detection for **WizOS**, a hardened, Alpine-lineage container distribution from Wiz. It ships its own os-release identity (`ID=wizos`, `ID_LIKE=alpine`) and uses `apk`.

## Changes

- **`detector_all.go`** — new `wizos` leaf resolver under `linuxFamily`, matched by exact os-release `ID` (same pattern as `wolfi`). Registered **before** `alpine` so its exact-name match wins over alpine's `/etc/alpine-release` marker-file fallback (an Alpine derivative may also ship that file). `wizos` matches only `pf.Name == "wizos"`, so it can never steal genuine Alpine assets.
- **`packages.go`** — `wizos` added to the apk package-manager case alongside `alpine`/`wolfi`, so package inventory works.
- **Tests** — `detect-wizos.toml` mock fixture, `TestWizOSLinuxDetector`, and a `device_type` table entry.

## Result

A WizOS asset now resolves to platform `wizos` with family `["linux","unix","os"]` and gets apk package detection, instead of falling through to `generic-linux` with no package manager.

## Verification

```
go test ./providers/os/detector/ ./providers/os/resources/packages/   # ok
```

`ID=wizos` / `ID_LIKE=alpine` and apk usage were confirmed with the maintainer; the images are behind Wiz's customer-preview registry so they can't be pulled here for a live scan.
