### PR TITLE
✨ github: discover a user scope's repositories

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -93,7 +93,7 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 		userId = conf.Options["owner"]
 	}
 	if userId != "" {
-		userAssets, err := user(runtime, userId, conn)
+		userAssets, err := user(runtime, userId, conn, targets)
 		if err != nil {
 			return nil, err
 		}
@@ -221,8 +221,9 @@ func getMqlGithubRepo(runtime *plugin.Runtime, repoName string) (*mqlGithubRepos
 	return res.(*mqlGithubRepository), nil
 }
 
-func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConnection) ([]*inventory.Asset, error) {
+func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConnection, targets []string) ([]*inventory.Asset, error) {
 	conf := conn.Asset().Connections[0]
+	reposFilter := NewReposFilter(conf)
 	assetList := []*inventory.Asset{}
 
 	user, err := getMqlGithubUser(runtime, userName)
@@ -238,7 +239,42 @@ func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConne
 		Labels:      make(map[string]string),
 		Connections: []*inventory.Config{cfg},
 	})
+
+	if discoverUserRepos(conf, targets) {
+		for i := range user.GetRepositories().Data {
+			repo := user.GetRepositories().Data[i].(*mqlGithubRepository)
+			if reposFilter.skipRepo(repo.Name.Data) {
+				continue
+			}
+			repoCfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+			repoCfg.Options["repository"] = repo.Name.Data
+			assetList = append(assetList, &inventory.Asset{
+				PlatformIds: []string{connection.NewGitHubRepoIdentifier(user.Login.Data, repo.Name.Data)},
+				Name:        user.Login.Data + "/" + repo.Name.Data,
+				Platform:    connection.NewGitHubRepoPlatform(user.Login.Data, repo.Name.Data),
+				Labels:      convert.DictToTypedMap[string](repo.CustomProperties.Data),
+				Connections: []*inventory.Config{repoCfg},
+			})
+
+			iacAssets, err := discoverRepoIac(conn, repo, targets)
+			if err != nil {
+				return nil, err
+			}
+			assetList = append(assetList, iacAssets...)
+		}
+	}
 	return assetList, nil
+}
+
+// discoverUserRepos reports whether a user-scoped connection fans out to the
+// account's repositories, mirroring the org path (a personal-account GitHub
+// App install scans through the user scope). It must stay false when an
+// explicit repository is configured: discover() also reaches the user path
+// through the owner fallback of single-repo scans, which must not fan out to
+// every repository the owner has.
+func discoverUserRepos(conf *inventory.Config, targets []string) bool {
+	return conf.Options["repository"] == "" &&
+		stringx.ContainsAnyOf(targets, connection.DiscoveryRepos, connection.DiscoveryAll, connection.DiscoveryAuto)
 }
 
 func getMqlGithubUser(runtime *plugin.Runtime, userName string) (*mqlGithubUser, error) {

--- a/providers/github/resources/discovery_test.go
+++ b/providers/github/resources/discovery_test.go
@@ -89,3 +89,49 @@ func TestHandleTargets(t *testing.T) {
 		assert.Empty(t, handleTargets([]string{}))
 	})
 }
+
+func TestDiscoverUserRepos(t *testing.T) {
+	conf := func(opts map[string]string) *inventory.Config {
+		return &inventory.Config{Options: opts}
+	}
+
+	t.Run("user scope with auto discovery fans out to the account's repos", func(t *testing.T) {
+		// the server sends discover=auto for GitHub integrations, including
+		// personal-account app installs (user scope)
+		assert.True(t, discoverUserRepos(
+			conf(map[string]string{"user": "some-user"}),
+			[]string{connection.DiscoveryAuto},
+		))
+	})
+
+	t.Run("repos and all targets fan out too", func(t *testing.T) {
+		assert.True(t, discoverUserRepos(
+			conf(map[string]string{"user": "some-user"}),
+			[]string{connection.DiscoveryRepos},
+		))
+		assert.True(t, discoverUserRepos(
+			conf(map[string]string{"user": "some-user"}),
+			[]string{connection.DiscoveryAll},
+		))
+	})
+
+	t.Run("an explicit repository never fans out", func(t *testing.T) {
+		// discover() reaches the user path via the owner fallback of
+		// single-repo scans — those must scan exactly the one repo
+		assert.False(t, discoverUserRepos(
+			conf(map[string]string{"owner": "some-user", "repository": "one-repo"}),
+			[]string{connection.DiscoveryAuto},
+		))
+	})
+
+	t.Run("no repo-ish discovery target means no fan-out", func(t *testing.T) {
+		assert.False(t, discoverUserRepos(
+			conf(map[string]string{"user": "some-user"}),
+			[]string{connection.DiscoveryUsers},
+		))
+		assert.False(t, discoverUserRepos(
+			conf(map[string]string{"user": "some-user"}),
+			nil,
+		))
+	})
+}


### PR DESCRIPTION
## Summary

The github provider's user discovery path emitted only the `github-user` asset itself, while the org path fans out to every repository. Personal-account GitHub App installs (mondoohq/server side: user-scoped scanning integrations) scan through the user scope, so they never scanned any repositories.

The user path now mirrors the org path:

- With a `repos`/`all`/`auto` discovery target, it iterates the account's repositories via `user.repositories` (`Repositories.ListByUser` — whatever the token can see), applies the `repos`/`repos-exclude` allow/deny filter, and emits one repo asset per match plus per-repo IaC discovery.
- Single-repo scans that reach the user path through the owner fallback keep scanning exactly the one configured repo — the fan-out is gated on no explicit `repository` option (`discoverUserRepos`, unit-tested).

## Testing

- `go test ./resources/ ./connection/` in `providers/github` passes.
- New unit tests for the fan-out gating: auto/repos/all targets fan out, explicit repository never does, non-repo targets don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)