### PR TITLE
🎉 aws-13.50.2

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.50.1",
+	Version:         "13.50.2",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.50.2)
- 🐛 aws: fix data race in aws.iam.role.getRoleDetails memoization (#9395)
- 🐛 aws: populate aws.iam.role.lastUsedAt/lastUsedRegion via GetRole (#9393)
