### PR TITLE
🐛 google-workspace: fix silent data loss in user aggregates, nested org units, and activity ids

### DIFF
--- a/providers/google-workspace/resources/connected_apps.go
+++ b/providers/google-workspace/resources/connected_apps.go
@@ -29,11 +29,13 @@ type connectedApp struct {
 }
 
 func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
-	// get all users
-	if g.Users.Error != nil {
-		return nil, g.Users.Error
+	// get all users. Resolve via GetUsers() so connectedApps works even when
+	// the caller never touched googleworkspace.users directly.
+	usersField := g.GetUsers()
+	if usersField.Error != nil {
+		return nil, usersField.Error
 	}
-	users := g.Users.Data
+	users := usersField.Data
 
 	// Phase 1: fan out Tokens.List for every user in parallel. Each user's
 	// tokens are independent API calls, so the previous serial loop was
@@ -95,7 +97,9 @@ func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
 				return nil, tk.Scopes.Error
 			}
 			for _, scope := range tk.Scopes.Data {
-				cApp.scopes = append(cApp.scopes, scope.(string))
+				if s, ok := scope.(string); ok {
+					cApp.scopes = append(cApp.scopes, s)
+				}
 			}
 
 			cApp.tokens = append(cApp.tokens, tk)

--- a/providers/google-workspace/resources/connected_apps.go
+++ b/providers/google-workspace/resources/connected_apps.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -99,6 +100,8 @@ func (g *mqlGoogleworkspace) connectedApps() ([]any, error) {
 			for _, scope := range tk.Scopes.Data {
 				if s, ok := scope.(string); ok {
 					cApp.scopes = append(cApp.scopes, s)
+				} else {
+					log.Warn().Str("clientId", clientID).Msgf("googleworkspace> unexpected scope type %T in connected-app token; dropping", scope)
 				}
 			}
 

--- a/providers/google-workspace/resources/endpoints.go
+++ b/providers/google-workspace/resources/endpoints.go
@@ -64,13 +64,24 @@ func (g *mqlGoogleworkspace) endpoints() ([]any, error) {
 }
 
 func newMqlGoogleWorkspaceEndpoint(runtime *plugin.Runtime, entry *cloudidentity.GoogleAppsCloudidentityDevicesV1Device) (any, error) {
-	androidAttrs, err := convert.JsonToDict(entry.AndroidSpecificAttributes)
-	if err != nil {
-		return nil, err
+	// Leave these as a true nil (rendered as null) when the device didn't
+	// report the attribute group. convert.JsonToDict on a nil pointer returns a
+	// non-nil empty map, which would surface as `{}` and defeat `x != null`
+	// audits (the .lr doc promises null on platforms that don't report it).
+	var err error
+	var androidAttrs any
+	if entry.AndroidSpecificAttributes != nil {
+		androidAttrs, err = convert.JsonToDict(entry.AndroidSpecificAttributes)
+		if err != nil {
+			return nil, err
+		}
 	}
-	endpointVerificationAttrs, err := convert.JsonToDict(entry.EndpointVerificationSpecificAttributes)
-	if err != nil {
-		return nil, err
+	var endpointVerificationAttrs any
+	if entry.EndpointVerificationSpecificAttributes != nil {
+		endpointVerificationAttrs, err = convert.JsonToDict(entry.EndpointVerificationSpecificAttributes)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	signals := parseEndpointAdditionalSignals(entry.EndpointVerificationSpecificAttributes)

--- a/providers/google-workspace/resources/google-workspace.go
+++ b/providers/google-workspace/resources/google-workspace.go
@@ -60,12 +60,15 @@ type mqlGoogleworkspaceInternal struct {
 
 func (g *mqlGoogleworkspace) userByEmail(email string) (*mqlGoogleworkspaceUser, error) {
 	g.usersByEmailOnce.Do(func() {
-		if g.Users.Error != nil {
-			g.usersByEmailErr = g.Users.Error
+		// Go through GetUsers() so the lazily-computed users field is resolved
+		// even when the caller never touched googleworkspace.users directly.
+		users := g.GetUsers()
+		if users.Error != nil {
+			g.usersByEmailErr = users.Error
 			return
 		}
-		m := make(map[string]*mqlGoogleworkspaceUser, len(g.Users.Data))
-		for _, u := range g.Users.Data {
+		m := make(map[string]*mqlGoogleworkspaceUser, len(users.Data))
+		for _, u := range users.Data {
 			user := u.(*mqlGoogleworkspaceUser)
 			if user.PrimaryEmail.Error != nil {
 				g.usersByEmailErr = user.PrimaryEmail.Error

--- a/providers/google-workspace/resources/helpers.go
+++ b/providers/google-workspace/resources/helpers.go
@@ -5,13 +5,16 @@ package resources
 
 // filterUsers returns the subset of the customer's users for which keep
 // reports true. It reuses the cached `users` field so every aggregate
-// accessor shares a single Users.List instead of re-fetching.
+// accessor shares a single Users.List instead of re-fetching. It resolves
+// that field via GetUsers() so the aggregate works even when the caller
+// never touched googleworkspace.users directly.
 func filterUsers(g *mqlGoogleworkspace, keep func(*mqlGoogleworkspaceUser) (bool, error)) ([]any, error) {
-	if g.Users.Error != nil {
-		return nil, g.Users.Error
+	users := g.GetUsers()
+	if users.Error != nil {
+		return nil, users.Error
 	}
 	res := []any{}
-	for _, u := range g.Users.Data {
+	for _, u := range users.Data {
 		user := u.(*mqlGoogleworkspaceUser)
 		ok, err := keep(user)
 		if err != nil {

--- a/providers/google-workspace/resources/orgunit.go
+++ b/providers/google-workspace/resources/orgunit.go
@@ -19,7 +19,11 @@ func (g *mqlGoogleworkspace) orgUnits() ([]any, error) {
 
 	res := []any{}
 
-	orgUnits, err := directoryService.Orgunits.List(conn.CustomerID()).Do()
+	// Type("all") returns the full org-unit subtree. The default ("children")
+	// returns only the immediate children of the root, silently omitting every
+	// nested org unit. The response carries no page token, so a single call
+	// returns the whole hierarchy.
+	orgUnits, err := directoryService.Orgunits.List(conn.CustomerID()).Type("all").Do()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -4,7 +4,9 @@
 package resources
 
 import (
+	"encoding/json"
 	"errors"
+	"hash/fnv"
 	"strconv"
 	"time"
 
@@ -138,19 +140,23 @@ func newMqlGoogleWorkspaceReportActivity(runtime *plugin.Runtime, entry *reports
 	}
 
 	var uniqueQualifier int64
-	var appName, eventTime string
+	var activityID string
 	if entry.Id != nil {
 		uniqueQualifier = entry.Id.UniqueQualifier
-		appName = entry.Id.ApplicationName
-		eventTime = entry.Id.Time
-	}
-
-	return CreateResource(runtime, "googleworkspace.report.activity", map[string]*llx.RawData{
 		// The cache key must include the application name and event time:
 		// uniqueQualifier is only a tiebreaker for events sharing a time (and is
 		// absent for most events), so keying on it alone aliases distinct
 		// activities. The public `id` field keeps the bare uniqueQualifier.
-		"__id":        llx.StringData(reportActivityID(appName, eventTime, uniqueQualifier)),
+		activityID = reportActivityID(entry.Id.ApplicationName, entry.Id.Time, uniqueQualifier)
+	} else {
+		// No id from the API (malformed/partial event): fall back to a content
+		// hash so nil-id activities get distinct, stable keys instead of all
+		// aliasing to a single cache entry.
+		activityID = "googleworkspace.report.activity/nil/" + hashActivity(entry)
+	}
+
+	return CreateResource(runtime, "googleworkspace.report.activity", map[string]*llx.RawData{
+		"__id":        llx.StringData(activityID),
 		"id":          llx.IntData(uniqueQualifier),
 		"ipAddress":   llx.StringData(entry.IpAddress),
 		"ownerDomain": llx.StringData(entry.OwnerDomain),
@@ -164,6 +170,20 @@ func newMqlGoogleWorkspaceReportActivity(runtime *plugin.Runtime, entry *reports
 // it in the Reports API.
 func reportActivityID(appName, eventTime string, uniqueQualifier int64) string {
 	return "googleworkspace.report.activity/" + appName + "/" + eventTime + "/" + strconv.FormatInt(uniqueQualifier, 10)
+}
+
+// hashActivity produces a stable 64-bit content hash of an activity, used as a
+// cache-key discriminator for the rare event that arrives without an id. It is
+// deterministic (same content -> same key across scans) so two distinct
+// nil-id activities don't alias each other.
+func hashActivity(entry *reports.Activity) string {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return ""
+	}
+	h := fnv.New64a()
+	h.Write(data)
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 func (g *mqlGoogleworkspaceReportUsers) id() (string, error) {

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -177,12 +177,15 @@ func reportActivityID(appName, eventTime string, uniqueQualifier int64) string {
 // deterministic (same content -> same key across scans) so two distinct
 // nil-id activities don't alias each other.
 func hashActivity(entry *reports.Activity) string {
-	data, err := json.Marshal(entry)
-	if err != nil {
-		return ""
-	}
 	h := fnv.New64a()
-	h.Write(data)
+	if data, err := json.Marshal(entry); err == nil {
+		h.Write(data)
+	} else {
+		// json.Marshal of this plain struct effectively never fails, but if it
+		// ever did we still hash the stable scalar fields so distinct events get
+		// distinct keys instead of all collapsing onto one empty discriminator.
+		h.Write([]byte(entry.Etag + "\x00" + entry.IpAddress + "\x00" + entry.OwnerDomain))
+	}
 	return strconv.FormatUint(h.Sum64(), 16)
 }
 

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -138,17 +138,32 @@ func newMqlGoogleWorkspaceReportActivity(runtime *plugin.Runtime, entry *reports
 	}
 
 	var uniqueQualifier int64
+	var appName, eventTime string
 	if entry.Id != nil {
 		uniqueQualifier = entry.Id.UniqueQualifier
+		appName = entry.Id.ApplicationName
+		eventTime = entry.Id.Time
 	}
 
 	return CreateResource(runtime, "googleworkspace.report.activity", map[string]*llx.RawData{
+		// The cache key must include the application name and event time:
+		// uniqueQualifier is only a tiebreaker for events sharing a time (and is
+		// absent for most events), so keying on it alone aliases distinct
+		// activities. The public `id` field keeps the bare uniqueQualifier.
+		"__id":        llx.StringData(reportActivityID(appName, eventTime, uniqueQualifier)),
 		"id":          llx.IntData(uniqueQualifier),
 		"ipAddress":   llx.StringData(entry.IpAddress),
 		"ownerDomain": llx.StringData(entry.OwnerDomain),
 		"actor":       llx.MapData(actor, types.Any),
 		"events":      llx.ArrayData(events, types.Any),
 	})
+}
+
+// reportActivityID builds a stable, unique cache key for a report activity from
+// the application name, event time, and unique qualifier that together identify
+// it in the Reports API.
+func reportActivityID(appName, eventTime string, uniqueQualifier int64) string {
+	return "googleworkspace.report.activity/" + appName + "/" + eventTime + "/" + strconv.FormatInt(uniqueQualifier, 10)
 }
 
 func (g *mqlGoogleworkspaceReportUsers) id() (string, error) {

--- a/providers/google-workspace/resources/reports_test.go
+++ b/providers/google-workspace/resources/reports_test.go
@@ -145,3 +145,14 @@ func TestReportActivityID(t *testing.T) {
 		reportActivityID("login", "2026-01-01T00:00:00Z", 42),
 	)
 }
+
+func TestHashActivity(t *testing.T) {
+	a := &reports.Activity{IpAddress: "1.2.3.4", OwnerDomain: "example.com"}
+	b := &reports.Activity{IpAddress: "5.6.7.8", OwnerDomain: "example.com"}
+
+	// Distinct nil-id activities get distinct discriminators.
+	require.NotEqual(t, hashActivity(a), hashActivity(b))
+	// Stable for identical content across calls.
+	require.Equal(t, hashActivity(a), hashActivity(&reports.Activity{IpAddress: "1.2.3.4", OwnerDomain: "example.com"}))
+	require.NotEmpty(t, hashActivity(a))
+}

--- a/providers/google-workspace/resources/reports_test.go
+++ b/providers/google-workspace/resources/reports_test.go
@@ -128,3 +128,20 @@ func TestParseUserReports_EmptyAndUnknownParams(t *testing.T) {
 	})
 	require.Nil(t, r.AppUsage.LastImapTime)
 }
+
+func TestReportActivityID(t *testing.T) {
+	// Distinct activities that share a unique qualifier (0 is the common
+	// "absent" value) must still get distinct cache keys via app + time.
+	a := reportActivityID("drive", "2026-01-01T00:00:00Z", 0)
+	b := reportActivityID("admin", "2026-01-01T00:00:00Z", 0)
+	c := reportActivityID("drive", "2026-01-02T00:00:00Z", 0)
+	require.NotEqual(t, a, b, "same qualifier across apps must not collide")
+	require.NotEqual(t, a, c, "same qualifier across times must not collide")
+
+	// Stable for identical inputs, and carries the composed parts.
+	require.Equal(t, a, reportActivityID("drive", "2026-01-01T00:00:00Z", 0))
+	require.Equal(t,
+		"googleworkspace.report.activity/login/2026-01-01T00:00:00Z/42",
+		reportActivityID("login", "2026-01-01T00:00:00Z", 42),
+	)
+}


### PR DESCRIPTION
## Summary

Static bug-review pass over the `google-workspace` provider surfaced several defects that returned **wrong data with no error** — the worst kind, since the wrong answer looks valid. This fixes the confirmed ones.

## Fixes

### HIGH — user aggregates silently return empty
`userByEmail`, `filterUsers` (backing `superAdmins` / `suspendedUsers` / `usersWithout2sv`), and `connectedApps` read `g.Users.Data` off the struct directly instead of resolving the field via `GetUsers()`. That field is only populated if something *else* in the same query already resolved `googleworkspace.users`. The sibling `userById` already does it correctly (with a comment explaining why); three call sites missed it.

Failure shapes (all return null/empty, no error):
- `groups { members { user { primaryEmail } } }` → every member's `user` is null
- `superAdmins` / `suspendedUsers` / `usersWithout2sv` → empty unless `.users` queried first
- `connectedApps` → empty app list on the same condition

`sync.Once` then caches the empty index for the resource's life. A policy asserting "no unexpected super admins" passes vacuously.

### HIGH — nested org units dropped
`orgUnits()` omitted the `type` parameter, so the Directory API defaulted to `"children"` (immediate children of the root only). Nested org units (grandchildren and deeper) were silently omitted. Now passes `Type("all")` for the full subtree (the response is not paginated, so one call suffices).

### MEDIUM — report.activity `__id` collision
The cache key was built from `uniqueQualifier` alone, which the SDK documents as *"Unique qualifier if multiple events have the same time"* — a per-timestamp tiebreaker that is absent (`0`) for most events and encodes neither the app nor the time. Both `report.apps.drive()` and `report.apps.admin()` mint this resource type, so distinct activities collided in the runtime cache and aliased to the first instance. The key now composes `applicationName` + `time` + `uniqueQualifier`; the public `id` field is unchanged.

### LOW — endpoint attribute dicts rendered as `{}` instead of null
`androidAttributes` / `endpointVerificationAttributes` used `JsonToDict` on a possibly-nil SDK pointer, which returns a non-nil empty map — so a non-Android / non-Endpoint-Verification device showed `{}`, defeating `x != null` audits and contradicting the schema doc. They now surface as null when the device didn't report them.

### LOW — bare type assertion could crash a scan
`connectedApps` asserted `scope.(string)` without comma-ok; a failed assert panics an executor goroutine and takes down the whole scan. Guarded.

## Testing
- `go test ./resources/` passes; added a unit test for the composed report-activity cache key.
- Pure-param change (`Type("all")`) and no new API calls, so `*.permissions.json` is unchanged and no codegen was needed.

## Deliberately deferred (need a live tenant / are judgment calls)
- Token `__id` depends on `tokens.list` populating `userKey` (documented field; wanted live confirmation before hardening).
- `connectedApps` aborts the whole batch if one user's `Tokens.List` errors (arguably intentional; mirrors the top-level `users` hard-fail).
- `Client()` re-runs the OAuth exchange per service constructor (perf/cleanliness only).
