### PR TITLE
🐛 stackit: fix backup-sourced volume ref + 2 more bug-review findings

### DIFF
--- a/providers/stackit/resources/albwaf.go
+++ b/providers/stackit/resources/albwaf.go
@@ -115,6 +115,12 @@ func (r *mqlStackitAlbWaf) managedRuleSet() (*mqlStackitAlbManagedRuleSet, error
 		"name": llx.StringData(r.ManagedRuleSetName.Data),
 	})
 	if err != nil {
+		// Degrade the auto-traversal from the parent WAF: a token that can list
+		// WAFs but lacks GetManagedRuleSet, or a set that was deleted (404),
+		// should read as null rather than fail the whole query.
+		if isAccessDenied(err) || isNotFound(err) {
+			return markNull[mqlStackitAlbManagedRuleSet](&r.ManagedRuleSet)
+		}
 		return nil, err
 	}
 	return res.(*mqlStackitAlbManagedRuleSet), nil
@@ -128,6 +134,12 @@ func (r *mqlStackitAlbWaf) customRuleGroup() (*mqlStackitAlbCustomRuleGroup, err
 		"name": llx.StringData(r.CustomRuleGroupName.Data),
 	})
 	if err != nil {
+		// Degrade the auto-traversal from the parent WAF: a token that can list
+		// WAFs but lacks GetCustomRuleGroup, or a group that was deleted (404),
+		// should read as null rather than fail the whole query.
+		if isAccessDenied(err) || isNotFound(err) {
+			return markNull[mqlStackitAlbCustomRuleGroup](&r.CustomRuleGroup)
+		}
 		return nil, err
 	}
 	return res.(*mqlStackitAlbCustomRuleGroup), nil

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -748,6 +748,9 @@ func initStackitOpenSearchInstance(runtime *plugin.Runtime, args map[string]*llx
 	if err != nil {
 		return nil, nil, err
 	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.openSearch.instance with id %q not found", id)
+	}
 	lop := inst.GetLastOperation()
 	res, err := CreateResource(runtime, "stackit.openSearch.instance", map[string]*llx.RawData{
 		"id":                 llx.StringData(inst.GetInstanceId()),
@@ -784,6 +787,9 @@ func initStackitMariaDbInstance(runtime *plugin.Runtime, args map[string]*llx.Ra
 	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
 	if err != nil {
 		return nil, nil, err
+	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.mariaDb.instance with id %q not found", id)
 	}
 	lop := inst.GetLastOperation()
 	res, err := CreateResource(runtime, "stackit.mariaDb.instance", map[string]*llx.RawData{
@@ -822,6 +828,9 @@ func initStackitRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.redis.instance with id %q not found", id)
+	}
 	lop := inst.GetLastOperation()
 	res, err := CreateResource(runtime, "stackit.redis.instance", map[string]*llx.RawData{
 		"id":                 llx.StringData(inst.GetInstanceId()),
@@ -859,6 +868,9 @@ func initStackitRabbitMqInstance(runtime *plugin.Runtime, args map[string]*llx.R
 	if err != nil {
 		return nil, nil, err
 	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.rabbitMq.instance with id %q not found", id)
+	}
 	lop := inst.GetLastOperation()
 	res, err := CreateResource(runtime, "stackit.rabbitMq.instance", map[string]*llx.RawData{
 		"id":                 llx.StringData(inst.GetInstanceId()),
@@ -895,6 +907,9 @@ func initStackitSecretsManagerInstance(runtime *plugin.Runtime, args map[string]
 	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), id)
 	if err != nil {
 		return nil, nil, err
+	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.secretsManager.instance with id %q not found", id)
 	}
 	res, err := CreateResource(runtime, "stackit.secretsManager.instance", map[string]*llx.RawData{
 		"id":                 llx.StringData(inst.GetId()),
@@ -1008,6 +1023,9 @@ func initStackitLogMeInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
 	if err != nil {
 		return nil, nil, err
+	}
+	if inst == nil {
+		return nil, nil, fmt.Errorf("stackit.logMe.instance with id %q not found", id)
 	}
 	lop := inst.GetLastOperation()
 	res, err := CreateResource(runtime, "stackit.logMe.instance", map[string]*llx.RawData{

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -273,18 +273,28 @@ func (r *mqlStackit) volumes() ([]any, error) {
 	return out, nil
 }
 
+// classifyVolumeSource maps a volume's source type onto the correct
+// typed-reference field. VolumeSource.Type is one of image, volume, snapshot,
+// or backup. Snapshots and backups are distinct STACKIT resources, so their
+// UUIDs must not be conflated: a backup UUID surfaced as sourceSnapshotId would
+// resolve against the snapshot API and 404. A "volume" clone source (and any
+// unknown type) has no modeled field and yields all-empty IDs.
+func classifyVolumeSource(sourceType, sourceID string) (imageID, snapshotID, backupID string) {
+	switch sourceType {
+	case "image":
+		imageID = sourceID
+	case "snapshot":
+		snapshotID = sourceID
+	case "backup":
+		backupID = sourceID
+	}
+	return
+}
+
 func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, error) {
-	var (
-		imageID    string
-		snapshotID string
-	)
+	var imageID, snapshotID, backupID string
 	if src, ok := v.GetSourceOk(); ok {
-		switch src.GetType() {
-		case "image":
-			imageID = src.GetId()
-		case "snapshot", "backup":
-			snapshotID = src.GetId()
-		}
+		imageID, snapshotID, backupID = classifyVolumeSource(src.GetType(), src.GetId())
 	}
 	serverID := v.GetServerId()
 
@@ -311,6 +321,7 @@ func buildVolume(runtime *plugin.Runtime, v *iaas.Volume) (plugin.Resource, erro
 		"bootable":             llx.BoolData(v.GetBootable()),
 		"imageId":              llx.StringData(imageID),
 		"sourceSnapshotId":     llx.StringData(snapshotID),
+		"sourceBackupId":       llx.StringData(backupID),
 		"serverId":             llx.StringData(serverID),
 		"encrypted":            llx.BoolData(v.GetEncrypted()),
 		"encryptionKeyId":      llx.StringData(kekKeyID),
@@ -384,6 +395,19 @@ func (r *mqlStackitVolume) sourceSnapshot() (*mqlStackitSnapshot, error) {
 		return nil, err
 	}
 	return res.(*mqlStackitSnapshot), nil
+}
+
+func (r *mqlStackitVolume) sourceBackup() (*mqlStackitBackup, error) {
+	if r.SourceBackupId.Data == "" {
+		return markNull[mqlStackitBackup](&r.SourceBackup)
+	}
+	res, err := NewResource(r.MqlRuntime, "stackit.backup", map[string]*llx.RawData{
+		"id": llx.StringData(r.SourceBackupId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlStackitBackup), nil
 }
 
 // ------------------------- snapshots -------------------------

--- a/providers/stackit/resources/iaas_test.go
+++ b/providers/stackit/resources/iaas_test.go
@@ -28,3 +28,28 @@ func TestProtocolLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyVolumeSource(t *testing.T) {
+	const id = "11111111-2222-3333-4444-555555555555"
+	cases := []struct {
+		name                              string
+		sourceType                        string
+		wantImage, wantSnapshot, wantBkup string
+	}{
+		{"image source", "image", id, "", ""},
+		{"snapshot source", "snapshot", "", id, ""},
+		{"backup source stays a backup, not a snapshot", "backup", "", "", id},
+		{"volume clone maps to nothing", "volume", "", "", ""},
+		{"unknown type maps to nothing", "something-new", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotImage, gotSnapshot, gotBackup := classifyVolumeSource(tc.sourceType, id)
+			if gotImage != tc.wantImage || gotSnapshot != tc.wantSnapshot || gotBackup != tc.wantBkup {
+				t.Fatalf("classifyVolumeSource(%q, id) = (%q, %q, %q), want (%q, %q, %q)",
+					tc.sourceType, gotImage, gotSnapshot, gotBackup,
+					tc.wantImage, tc.wantSnapshot, tc.wantBkup)
+			}
+		})
+	}
+}

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -211,8 +211,8 @@ private stackit.server @defaults("id name status machineType") {
 // `id` (for example `stackit.volume(id: "...")`). Reports the volume's
 // size in GiB, lifecycle status, and availability zone, whether it is
 // encrypted at rest and which key-encryption key wraps its data key, the
-// image or snapshot it was created from, and the server it is attached
-// to. Use it to audit unattached, unencrypted, or oversized volumes.
+// image, snapshot, or backup it was created from, and the server it is
+// attached to. Use it to audit unattached, unencrypted, or oversized volumes.
 private stackit.volume @defaults("id name size status") {
   init(id? string)
   // Volume UUID
@@ -239,6 +239,10 @@ private stackit.volume @defaults("id name size status") {
   sourceSnapshotId string
   // Snapshot the volume was created from (nullable)
   sourceSnapshot() stackit.snapshot
+  // Source backup UUID (empty if not backup-based)
+  sourceBackupId string
+  // Backup the volume was created from (nullable)
+  sourceBackup() stackit.backup
   // Server the volume is attached to (nullable)
   server() stackit.server
   // Attached server UUID (empty if detached)

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -781,6 +781,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.volume.sourceSnapshot": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetSourceSnapshot()).ToDataRes(types.Resource("stackit.snapshot"))
 	},
+	"stackit.volume.sourceBackupId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetSourceBackupId()).ToDataRes(types.String)
+	},
+	"stackit.volume.sourceBackup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitVolume).GetSourceBackup()).ToDataRes(types.Resource("stackit.backup"))
+	},
 	"stackit.volume.server": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitVolume).GetServer()).ToDataRes(types.Resource("stackit.server"))
 	},
@@ -3107,6 +3113,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.volume.sourceSnapshot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitVolume).SourceSnapshot, ok = plugin.RawToTValue[*mqlStackitSnapshot](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.sourceBackupId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).SourceBackupId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"stackit.volume.sourceBackup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitVolume).SourceBackup, ok = plugin.RawToTValue[*mqlStackitBackup](v.Value, v.Error)
 		return
 	},
 	"stackit.volume.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -7142,6 +7156,8 @@ type mqlStackitVolume struct {
 	Image                plugin.TValue[*mqlStackitImage]
 	SourceSnapshotId     plugin.TValue[string]
 	SourceSnapshot       plugin.TValue[*mqlStackitSnapshot]
+	SourceBackupId       plugin.TValue[string]
+	SourceBackup         plugin.TValue[*mqlStackitBackup]
 	Server               plugin.TValue[*mqlStackitServer]
 	ServerId             plugin.TValue[string]
 	Encrypted            plugin.TValue[bool]
@@ -7258,6 +7274,26 @@ func (c *mqlStackitVolume) GetSourceSnapshot() *plugin.TValue[*mqlStackitSnapsho
 		}
 
 		return c.sourceSnapshot()
+	})
+}
+
+func (c *mqlStackitVolume) GetSourceBackupId() *plugin.TValue[string] {
+	return &c.SourceBackupId
+}
+
+func (c *mqlStackitVolume) GetSourceBackup() *plugin.TValue[*mqlStackitBackup] {
+	return plugin.GetOrCompute[*mqlStackitBackup](&c.SourceBackup, func() (*mqlStackitBackup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("stackit.volume", c.__id, "sourceBackup")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlStackitBackup), nil
+			}
+		}
+
+		return c.sourceBackup()
 	})
 }
 

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -760,8 +760,8 @@ stackit.volume.performanceClass 13.0.0
 stackit.volume.server 13.0.0
 stackit.volume.serverId 13.0.0
 stackit.volume.size 13.0.0
-stackit.volume.sourceBackup 13.4.2
-stackit.volume.sourceBackupId 13.4.2
+stackit.volume.sourceBackup 13.4.3
+stackit.volume.sourceBackupId 13.4.3
 stackit.volume.sourceSnapshot 13.4.2
 stackit.volume.sourceSnapshotId 13.0.0
 stackit.volume.status 13.0.0

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -760,6 +760,8 @@ stackit.volume.performanceClass 13.0.0
 stackit.volume.server 13.0.0
 stackit.volume.serverId 13.0.0
 stackit.volume.size 13.0.0
+stackit.volume.sourceBackup 13.4.2
+stackit.volume.sourceBackupId 13.4.2
 stackit.volume.sourceSnapshot 13.4.2
 stackit.volume.sourceSnapshotId 13.0.0
 stackit.volume.status 13.0.0


### PR DESCRIPTION
## Summary

Three fixes surfaced by a static bug-review of the `stackit` provider. All are low-severity; the first is the most user-impactful (wrong data + a hard error), the other two are robustness/consistency fixes.

### 1. Backup-restored volumes mislabeled their source as a snapshot (wrong data + failing typed ref)
`VolumeSource.Type` is one of `image`, `volume`, `snapshot`, or `backup`, and STACKIT models `stackit.snapshot` and `stackit.backup` as **separate** resources. `buildVolume` folded `backup` into `sourceSnapshotId`, so a backup-sourced volume:
- stored a **backup UUID in `sourceSnapshotId`** (mislabeled), and
- made `volume.sourceSnapshot` resolve that backup UUID against the snapshot API → **404, hard error** on `stackit.volumes { sourceSnapshot { … } }`.

Fixed by splitting the source classification into a pure `classifyVolumeSource` helper, adding a `sourceBackupId string` field + `sourceBackup() stackit.backup` typed edge, and mapping only `snapshot` → `sourceSnapshotId`. (`volume` clone sources remain unmodeled, as before.) A `classifyVolumeSource` table test covers all source types.

### 2. WAF typed-ref auto-traversal hard-failed on 403/404 (error propagation)
`stackit.alb.waf.managedRuleSet()` / `customRuleGroup()` resolve via `NewResource`, whose init issues a separate `GetManagedRuleSet`/`GetCustomRuleGroup` and propagated the raw error — so a token scoped for `List/GetWAF` but lacking `GetManagedRuleSet` (or a deleted referenced set → 404) failed the **entire** query. Every sibling fetcher (`groups()`/`customRules()`) already degrades. The two accessors now degrade to null on access-denied / not-found for the parent→child auto-traversal, matching the provider convention.

### 3. CF-broker instance inits could panic on a null response body (robustness)
The five Cloud-Foundry-broker inits (opensearch/mariadb/redis/rabbitmq/logme) plus secretsmanager dereferenced the `*Instance` returned by `GetInstanceExecute` without a nil guard. A `200`-with-`null` body → `(nil, nil)` would panic (`inst.GetLastOperation()` / `inst.GetId()`) and crash the whole scan. Added a not-found guard for parity with the Flex paths' nil-safe `GetItemOk()` handling.

## Notes
- New schema fields are versioned at `13.4.2` (next patch after the shipped `13.4.1`), joining the existing unreleased `13.4.2` entries. No provider `Version` bump.
- No `permissions.json` change — no new API calls.

## Testing
- `go test ./resources/` (stackit) passes, including the new `TestClassifyVolumeSource`.
- `make providers/build/stackit` builds cleanly; codegen is in sync.
