### PR TITLE
🐛 proxmox: fix firewall-rule cache collision, apt update detection, and container mount backup default

### DIFF
--- a/providers/proxmox/connection/guest_agent.go
+++ b/providers/proxmox/connection/guest_agent.go
@@ -127,9 +127,15 @@ func (c *PveConnection) GetUpdates(node string, vmid int, osInfo *OsInfo) ([]Upd
 }
 
 func (c *PveConnection) getAptUpdates(node string, vmid int) ([]UpdateInfo, error) {
-	result, err := c.QGAExec(node, vmid, []string{"sh", "-c", "apt list --installed 2>/dev/null"})
+	// `apt list --upgradable` is the only apt mode that reports pending
+	// upgrades; `--installed` lists every installed package with no upgrade
+	// annotation, so it can never surface an actual update.
+	result, err := c.QGAExec(node, vmid, []string{"sh", "-c", "apt list --upgradable 2>/dev/null"})
 	if err != nil {
-		return nil, fmt.Errorf("apt list --installed failed: %w", err)
+		if errors.Is(err, ErrQGANotRunning) {
+			return []UpdateInfo{}, nil
+		}
+		return nil, fmt.Errorf("apt list --upgradable failed: %w", err)
 	}
 	return ParseAptOutput(result.Stdout), nil
 }
@@ -199,31 +205,32 @@ func ParseWindowsHotfixes(raw string) []UpdateInfo {
 	return updates
 }
 
-// ParseAptOutput parses "apt list --installed 2>/dev/null".
+// ParseAptOutput parses "apt list --upgradable 2>/dev/null". Each line has the
+// shape `pkg/repo,repo new-version arch [upgradable from: installed-version]`,
+// so every reported package is a pending upgrade — the version column is the
+// candidate (new) version and the bracket carries the currently-installed one.
 func ParseAptOutput(raw string) []UpdateInfo {
 	var updates []UpdateInfo
 	for _, line := range strings.Split(raw, "\n") {
-		if line == "" || strings.HasPrefix(line, "Listing") {
+		line = strings.TrimSpace(line)
+		// Only "... [upgradable from: X]" lines are real upgrades; this also
+		// skips the "Listing..." header and any stray output.
+		const marker = "upgradable from: "
+		idx := strings.Index(line, marker)
+		if idx < 0 {
 			continue
 		}
 		parts := strings.Fields(line)
-		if len(parts) < 4 {
+		if len(parts) < 2 {
 			continue
 		}
-		pkgName := strings.SplitN(parts[0], "/", 2)[0]
-		installedVersion := parts[1]
-
-		upgradable := strings.Contains(line, "upgradable to:")
-		newVersion := ""
-		if upgradable {
-			idx := strings.Index(line, "upgradable to: ")
-			if idx >= 0 {
-				newVersion = strings.Trim(line[idx+len("upgradable to: "):], "]")
-			}
-		}
+		repoField := parts[0]
+		pkgName := strings.SplitN(repoField, "/", 2)[0]
+		newVersion := parts[1]
+		installedVersion := strings.Trim(line[idx+len(marker):], "]")
 
 		severity := "enhancement"
-		if strings.Contains(parts[0], "security") {
+		if strings.Contains(repoField, "security") {
 			severity = "security"
 		}
 
@@ -231,7 +238,7 @@ func ParseAptOutput(raw string) []UpdateInfo {
 			Name:             pkgName,
 			InstalledVersion: installedVersion,
 			NewVersion:       newVersion,
-			Upgradable:       upgradable,
+			Upgradable:       true,
 			Severity:         severity,
 		})
 	}

--- a/providers/proxmox/connection/guest_agent.go
+++ b/providers/proxmox/connection/guest_agent.go
@@ -146,6 +146,9 @@ func (c *PveConnection) getDnfUpdates(node string, vmid int) ([]UpdateInfo, erro
 	// returning a Go error — so any non-nil err is a real failure.
 	result, err := c.QGAExec(node, vmid, []string{"dnf", "check-update", "--quiet"})
 	if err != nil {
+		if errors.Is(err, ErrQGANotRunning) {
+			return []UpdateInfo{}, nil
+		}
 		return nil, fmt.Errorf("dnf check-update failed: %w", err)
 	}
 	return ParseDnfOutput(result.Stdout), nil

--- a/providers/proxmox/connection/parsers_test.go
+++ b/providers/proxmox/connection/parsers_test.go
@@ -7,37 +7,18 @@ import (
 	"testing"
 )
 
-func TestParseAptOutput_InstalledOnly(t *testing.T) {
-	input := `Listing...
-adduser/now 3.118ubuntu5 all [installed,automatic]
-apt/jammy-updates,jammy-security,now 2.4.11 amd64 [installed]
-base-files/jammy-updates,now 12ubuntu4.4 amd64 [installed]
-`
-	updates := ParseAptOutput(input)
-	if len(updates) != 3 {
-		t.Fatalf("expected 3 packages, got %d", len(updates))
-	}
-	for _, u := range updates {
-		if u.Upgradable {
-			t.Errorf("package %s should not be upgradable", u.Name)
-		}
-	}
-	if updates[0].Name != "adduser" {
-		t.Errorf("expected package name 'adduser', got %q", updates[0].Name)
-	}
-	if updates[0].InstalledVersion != "3.118ubuntu5" {
-		t.Errorf("expected version '3.118ubuntu5', got %q", updates[0].InstalledVersion)
-	}
-}
+// Inputs mirror real `apt list --upgradable` output: every line is a pending
+// upgrade, the version column is the candidate (new) version, and the bracket
+// carries the installed version as `[upgradable from: X]`.
 
-func TestParseAptOutput_WithUpgradable(t *testing.T) {
+func TestParseAptOutput_Upgradable(t *testing.T) {
 	input := `Listing...
-curl/jammy-updates,jammy-security,now 7.81.0-1ubuntu1.14 amd64 [installed,upgradable to: 7.81.0-1ubuntu1.16]
-vim/jammy,now 2:8.2.3995-1ubuntu2 amd64 [installed]
+curl/jammy-updates,jammy-security 7.81.0-1ubuntu1.16 amd64 [upgradable from: 7.81.0-1ubuntu1.14]
+libc6/jammy-updates 2.35-0ubuntu3.6 amd64 [upgradable from: 2.35-0ubuntu3.5]
 `
 	updates := ParseAptOutput(input)
 	if len(updates) != 2 {
-		t.Fatalf("expected 2 packages, got %d", len(updates))
+		t.Fatalf("expected 2 upgradable packages, got %d", len(updates))
 	}
 
 	curl := updates[0]
@@ -50,16 +31,14 @@ vim/jammy,now 2:8.2.3995-1ubuntu2 amd64 [installed]
 	if curl.NewVersion != "7.81.0-1ubuntu1.16" {
 		t.Errorf("expected new version '7.81.0-1ubuntu1.16', got %q", curl.NewVersion)
 	}
-
-	vim := updates[1]
-	if vim.Upgradable {
-		t.Error("vim should not be upgradable")
+	if curl.InstalledVersion != "7.81.0-1ubuntu1.14" {
+		t.Errorf("expected installed version '7.81.0-1ubuntu1.14', got %q", curl.InstalledVersion)
 	}
 }
 
 func TestParseAptOutput_SecuritySource(t *testing.T) {
 	input := `Listing...
-openssl/jammy-updates,jammy-security,now 3.0.2-0ubuntu1.12 amd64 [installed]
+openssl/jammy-security 3.0.2-0ubuntu1.12 amd64 [upgradable from: 3.0.2-0ubuntu1.10]
 `
 	updates := ParseAptOutput(input)
 	if len(updates) != 1 {
@@ -67,6 +46,15 @@ openssl/jammy-updates,jammy-security,now 3.0.2-0ubuntu1.12 amd64 [installed]
 	}
 	if updates[0].Severity != "security" {
 		t.Errorf("expected severity 'security', got %q", updates[0].Severity)
+	}
+}
+
+// A system with no pending upgrades prints only the "Listing..." header —
+// which must yield zero updates, not a phantom row.
+func TestParseAptOutput_NoUpgrades(t *testing.T) {
+	updates := ParseAptOutput("Listing...\n")
+	if len(updates) != 0 {
+		t.Errorf("expected 0 packages when nothing is upgradable, got %d", len(updates))
 	}
 }
 

--- a/providers/proxmox/resources/cache_keys_test.go
+++ b/providers/proxmox/resources/cache_keys_test.go
@@ -103,6 +103,14 @@ func firewallAliasKey(scope, name string) string {
 	return "proxmox.firewall.alias/" + scope + "/" + name
 }
 
+// firewall.rule has no natural scalar id, so its __id is scope + the rule
+// tuple. Scope MUST be part of the key: it's an Internal-struct field set
+// after CreateResource, so it can't come from id() (which would run with an
+// empty scope) — the __id is built explicitly at the call site instead.
+func firewallRuleKey(scope string, pos int, typ, action, source, dest string) string {
+	return fmt.Sprintf("proxmox.firewall.rule/%s/%d/%s/%s/%s/%s", scope, pos, typ, action, source, dest)
+}
+
 // TestVMSnapshotAndContainerSnapshotKeysDoNotCollide guards the bug
 // motivating this refactor: VM and container snapshots share the
 // proxmox.vm.snapshot resource type, so without a scope prefix a VM
@@ -155,6 +163,8 @@ func TestCacheKeysIncludeParentContext(t *testing.T) {
 		{"firewall.ipset.entry", firewallIpsetEntryKey("vm/100/allow", "10.0.0.0/24"), "vm/100/allow"},
 		{"firewall.alias (cluster)", firewallAliasKey("cluster", "office"), "cluster"},
 		{"firewall.alias (ct)", firewallAliasKey("ct/200", "internal"), "ct/200"},
+		{"firewall.rule (vm)", firewallRuleKey("vm/100", 0, "in", "ACCEPT", "", ""), "vm/100"},
+		{"firewall.rule (ct)", firewallRuleKey("ct/200", 0, "in", "ACCEPT", "", ""), "ct/200"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -188,6 +198,16 @@ func TestCacheKeysDistinctAcrossParents(t *testing.T) {
 		{"firewall.ipset across scopes", firewallIpsetKey("cluster", "blocklist"), firewallIpsetKey("vm/100", "blocklist")},
 		{"firewall.ipset.entry across parent ipsets", firewallIpsetEntryKey("vm/100/allow", "10.0.0.0/24"), firewallIpsetEntryKey("vm/101/allow", "10.0.0.0/24")},
 		{"firewall.alias across scopes", firewallAliasKey("cluster", "office"), firewallAliasKey("vm/100", "office")},
+		// The C1 regression: two rules with an identical pos/type/action/
+		// source/dest tuple on different guests must NOT collide. With an empty
+		// scope segment (the bug) both were "proxmox.firewall.rule//0/in/ACCEPT//"
+		// and the second aliased the first.
+		{"firewall.rule identical tuple across VMs",
+			firewallRuleKey("vm/100", 0, "in", "ACCEPT", "", ""),
+			firewallRuleKey("vm/101", 0, "in", "ACCEPT", "", "")},
+		{"firewall.rule identical tuple vm vs ct",
+			firewallRuleKey("vm/100", 0, "in", "ACCEPT", "", ""),
+			firewallRuleKey("ct/100", 0, "in", "ACCEPT", "", "")},
 	}
 	for _, tt := range pairs {
 		t.Run(tt.name, func(t *testing.T) {
@@ -236,5 +256,10 @@ func TestCacheKeyHelpersMatchProductionFormat(t *testing.T) {
 		if !containsSubstring(fwGo, expected) {
 			t.Errorf("firewall.go is missing the __id format %s", expected)
 		}
+	}
+	// firewall.rule builds its __id at the CreateResource site in helpers.go.
+	helpersGo := mustReadFile(t, "helpers.go")
+	if !containsSubstring(helpersGo, `"proxmox.firewall.rule/%s/%d/%s/%s/%s/%s"`) {
+		t.Error("helpers.go is missing the firewall.rule __id format")
 	}
 }

--- a/providers/proxmox/resources/helpers.go
+++ b/providers/proxmox/resources/helpers.go
@@ -82,6 +82,13 @@ func firewallRulesToResources(runtime *plugin.Runtime, rules []connection.Firewa
 	list := make([]any, len(rules))
 	for i, rule := range rules {
 		res, err := CreateResource(runtime, "proxmox.firewall.rule", map[string]*llx.RawData{
+			// Set __id explicitly: `scope` is an Internal-struct field assigned
+			// after CreateResource returns, but the cache key is computed inside
+			// CreateResource. Deriving it from id() there would bake an empty
+			// scope segment, so two identical rules in different scopes (e.g.
+			// vm/100 and vm/101) would collide and alias to the first.
+			"__id": llx.StringData(fmt.Sprintf("proxmox.firewall.rule/%s/%d/%s/%s/%s/%s",
+				scope, rule.Pos, rule.Type, rule.Action, rule.Source, rule.Dest)),
 			"pos":     llx.IntData(int64(rule.Pos)),
 			"type":    llx.StringData(rule.Type),
 			"action":  llx.StringData(rule.Action),
@@ -266,7 +273,10 @@ func parseContainerNetworkConfig(id, val string) map[string]*llx.RawData {
 func parseContainerMountPoint(id, val string) map[string]*llx.RawData {
 	storage, mountPath := "", ""
 	size := int64(0)
-	backup := true
+	// In PVE only rootfs is backed up by default; additional mount points
+	// (mp0..mp254) are EXCLUDED from vzdump unless backup=1 is set explicitly.
+	// (This differs from QEMU disks, where a drive is included unless backup=0.)
+	backup := id == "rootfs"
 	replicate := true
 	readonly := false
 	aclEnabled := false

--- a/providers/proxmox/resources/vm_parser_test.go
+++ b/providers/proxmox/resources/vm_parser_test.go
@@ -213,6 +213,33 @@ func TestParseContainerMountPoint_ExtraMount(t *testing.T) {
 	}
 }
 
+// An additional mount point with no explicit backup= must default to
+// backup=false: PVE excludes mp0..mp254 from vzdump unless backup=1 is set.
+// rootfs is the only mount point backed up by default.
+func TestParseContainerMountPoint_ExtraMountDefaultsNoBackup(t *testing.T) {
+	mp := parseContainerMountPoint("mp0", "local-lvm:subvol-200-disk-1,size=8G,mp=/data")
+	if getBool(mp, "backup") {
+		t.Error("expected backup=false for an additional mount point with no explicit backup flag")
+	}
+
+	// Explicit backup=1 still opts the extra mount into backups.
+	mp = parseContainerMountPoint("mp1", "local-lvm:subvol-200-disk-2,size=8G,mp=/data2,backup=1")
+	if !getBool(mp, "backup") {
+		t.Error("expected backup=true when backup=1 is set explicitly")
+	}
+
+	// rootfs stays backed up by default...
+	mp = parseContainerMountPoint("rootfs", "local-lvm:subvol-200-disk-0,size=8G")
+	if !getBool(mp, "backup") {
+		t.Error("expected backup=true by default for rootfs")
+	}
+	// ...but honors an explicit backup=0.
+	mp = parseContainerMountPoint("rootfs", "local-lvm:subvol-200-disk-0,size=8G,backup=0")
+	if getBool(mp, "backup") {
+		t.Error("expected backup=false when rootfs sets backup=0 explicitly")
+	}
+}
+
 func TestLooksLikeMAC(t *testing.T) {
 	if !looksLikeMAC("AA:BB:CC:DD:EE:FF") {
 		t.Error("expected true for valid MAC")


### PR DESCRIPTION
## Summary

A static bug-review pass over the `proxmox` provider surfaced several defects that returned **wrong data with no error**. This PR fixes the three confirmed data-correctness bugs; each ships with a regression test.

## Fixes

### CRITICAL — firewall rules collide in the resource cache
`firewallRulesToResources` created each `proxmox.firewall.rule` **without** an explicit `__id` and assigned the `scope` Internal-struct field *after* `CreateResource` returned. But the cache key is computed *inside* `CreateResource` via `id()`, which reads `scope` — so every rule's key was baked with an **empty scope segment** (`proxmox.firewall.rule//<pos>/<type>/<action>/<source>/<dest>`). Two rules sharing a `pos/type/action/source/dest` tuple in different scopes — cloned VMs (`vm/100` and `vm/101`), or a default `in DROP` replicated across cluster/nodes/guests — collided, and `CreateResource` returned the first, discarding the second. A firewall audit (`allowsPublicIngress`, `group()`, port checks) was then handed the wrong rule. Fixed by passing `__id` explicitly, matching the sibling `ipset`/`alias`/`options` creators.

### HIGH — `vm.updates` never reports pending updates on Debian/Ubuntu
`getAptUpdates` ran `apt list --installed` (which lists every installed package with no upgrade annotation) and the parser flagged upgrades via `"upgradable to:"` — a token apt never emits. The real marker, only produced by `apt list --upgradable`, is `"upgradable from:"`. So on any running Debian/Ubuntu guest `vm.updates` returned the full installed inventory with `upgradable=false` on every row, and an audit like `updates.where(upgradable && severity=="security").none` passed vacuously on every VM. Switched to `apt list --upgradable`, parse `"upgradable from:"` (version column is the candidate/new version, bracket carries the installed one), and degrade `ErrQGANotRunning` like the Windows path.

The existing `TestParseAptOutput_WithUpgradable` masked this by feeding a fabricated `[installed,upgradable to: X]` line that neither apt mode produces — the tests were rewritten against real `apt list --upgradable` output.

### MEDIUM — container additional mount points wrongly reported as backed up
`parseContainerMountPoint` defaulted `backup=true`. In PVE, additional LXC mount points (`mp0`..`mp254`) are **excluded** from vzdump unless `backup=1` is set explicitly; only `rootfs` is backed up by default. (The identical default in `parseVMDiskConfig` is correct — QEMU drives are included unless `backup=0` — it was just copied to containers where the semantics differ.) Now defaults to `id == "rootfs"`, with explicit `backup=` still honored.

## Testing
- `go test ./resources/ ./connection/` passes.
- Added: a real-`apt list --upgradable` parse test (incl. a no-upgrades header-only case), a cross-scope firewall-rule `__id` distinctness test (identical tuple on `vm/100` vs `vm/101` vs `ct/100`), a `helpers.go` production-format guard, and an additional-mount-point backup-default test.
- No `.lr`/schema or `*.permissions.json` changes.

## Deliberately deferred (follow-ups)
From the same review, a broader **access-denied consistency** cluster: only `user.tfaFactors` and `disk.smart` degrade 401/403/404 via `IsAccessDeniedOrNotFound`; the ~30 other per-guest/per-node accessors either propagate the raw error (one unreadable guest sinks the whole `vms { disks {...} }` query for a scoped token) or, for the scalar `cfgStr`/`cfgBool` helpers, swallow it and return `false`/`""` (a config-fetch error makes `vm.protection` read `false`). These want a focused refactor of their own. Also deferred: the firewall-rule `enable` absent-key default (needs live confirmation of PVE's response shape) and the init dangling-ref husk on typed refs.
