### PR TITLE
🐛 gcp: fix silent-wrong-data, scan-crash panics, and husk typed-refs

### DIFF
--- a/providers/gcp/resources/accesscontextmanager.go
+++ b/providers/gcp/resources/accesscontextmanager.go
@@ -9,6 +9,7 @@ import (
 
 	accesscontextmanager "cloud.google.com/go/accesscontextmanager/apiv1"
 	acmpb "cloud.google.com/go/accesscontextmanager/apiv1/accesscontextmanagerpb"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -58,6 +59,10 @@ func (g *mqlGcpOrganization) gcpUserAccessBindings() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -111,6 +116,10 @@ func (g *mqlGcpOrganization) accessPolicies() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -154,6 +163,10 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) accessLevels() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -208,6 +221,10 @@ func (g *mqlGcpAccesscontextmanagerAccessPolicy) servicePerimeters() ([]any, err
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -416,7 +416,7 @@ func initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[strin
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.alloydbService.cluster requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""

--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -414,7 +414,11 @@ func initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[strin
 		return nil, nil, clusters.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
 		locationVal = args["location"].Value.(string)

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -250,7 +250,7 @@ func initGcpProjectApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	idRaw := args["id"]
 	if idRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.apiKey requires an \"id\" argument")
 	}
 	idVal, _ := idRaw.Value.(string)
 	for _, k := range keys.Data {

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -248,7 +248,11 @@ func initGcpProjectApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return nil, nil, keys.Error
 	}
 
-	idVal := args["id"].Value.(string)
+	idRaw := args["id"]
+	if idRaw == nil {
+		return args, nil, nil
+	}
+	idVal, _ := idRaw.Value.(string)
 	for _, k := range keys.Data {
 		key := k.(*mqlGcpProjectApiKey)
 		if key.Id.Data == idVal {

--- a/providers/gcp/resources/backupdr.go
+++ b/providers/gcp/resources/backupdr.go
@@ -362,11 +362,32 @@ func (g *mqlGcpProjectBackupdrServiceBackupPlan) backupVault() (*mqlGcpProjectBa
 		g.BackupVault.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.backupdrService.backupVault", map[string]*llx.RawData{
-		"name": llx.StringData(g.cacheBackupVaultName),
+	// The backupVault resource has no init, so a NewResource by-name would leave
+	// a husk (only name populated). Scan the parent service's backupVaults()
+	// list and return the real, fully-populated resource. The vault name is a
+	// full resource path, so derive the project from it.
+	projectId := projectFromResourceName(g.cacheBackupVaultName)
+	if projectId == "" {
+		g.BackupVault.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	obj, err := CreateResource(g.MqlRuntime, "gcp.project.backupdrService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectBackupdrServiceBackupVault), nil
+	svc := obj.(*mqlGcpProjectBackupdrService)
+	vaults := svc.GetBackupVaults()
+	if vaults.Error != nil {
+		return nil, vaults.Error
+	}
+	for _, v := range vaults.Data {
+		vault, ok := v.(*mqlGcpProjectBackupdrServiceBackupVault)
+		if ok && vault.Name.Data == g.cacheBackupVaultName {
+			return vault, nil
+		}
+	}
+	g.BackupVault.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -436,8 +436,19 @@ func initGcpProjectBigqueryServiceDataset(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// The dataset is matched by (id, projectId, location); without all three we
+	// can't do the lookup, so return a bare resource rather than dereferencing a
+	// nil arg (which would panic and crash the scan).
+	if args["id"] == nil || args["projectId"] == nil || args["location"] == nil {
+		return args, nil, nil
+	}
+	projectIdArg, ok := args["projectId"].Value.(string)
+	if !ok {
+		return args, nil, nil
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.bigqueryService", map[string]*llx.RawData{
-		"projectId": llx.StringData(args["projectId"].Value.(string)),
+		"projectId": llx.StringData(projectIdArg),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -437,14 +437,14 @@ func initGcpProjectBigqueryServiceDataset(runtime *plugin.Runtime, args map[stri
 	}
 
 	// The dataset is matched by (id, projectId, location); without all three we
-	// can't do the lookup, so return a bare resource rather than dereferencing a
-	// nil arg (which would panic and crash the scan).
+	// can't do the lookup. Return an error rather than dereferencing a nil arg
+	// (which would panic) or falling through to build a husk with unset fields.
 	if args["id"] == nil || args["projectId"] == nil || args["location"] == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.bigqueryService.dataset requires id, projectId, and location")
 	}
 	projectIdArg, ok := args["projectId"].Value.(string)
 	if !ok {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.bigqueryService.dataset projectId must be a string")
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.bigqueryService", map[string]*llx.RawData{

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -83,7 +83,11 @@ func initGcpProjectBigtableServiceInstance(runtime *plugin.Runtime, args map[str
 		return nil, nil, instances.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, i := range instances.Data {
 		instance := i.(*mqlGcpProjectBigtableServiceInstance)
 		// Bigtable instance name from the SDK is the short ID; it may also

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -85,7 +85,7 @@ func initGcpProjectBigtableServiceInstance(runtime *plugin.Runtime, args map[str
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.bigtableService.instance requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	for _, i := range instances.Data {

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -86,7 +86,7 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 		return nil, err
 	}
 
-	updateTime := resp.GetUpdateTime().AsTime()
+	updateTime := timestampAsTimePtr(resp.GetUpdateTime())
 
 	policy, err := CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl.policy", map[string]*llx.RawData{
 		"__id":                                   llx.StringData(name),
@@ -98,7 +98,7 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 		"kubernetesServiceAccountAdmissionRules": llx.MapData(kubernetesServiceAccountAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
 		"istioServiceIdentityAdmissionRules":     llx.MapData(istioServiceIdentityAdmissionRules, types.Resource("gcp.project.binaryAuthorizationControl.admissionRule")),
 		"defaultAdmissionRule":                   llx.ResourceData(defaultAdmissionRule, "gcp.project.binaryAuthorizationControl.admissionRule"),
-		"updated":                                llx.TimeData(updateTime),
+		"updated":                                llx.TimeDataPtr(updateTime),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -110,6 +110,10 @@ func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -215,6 +219,10 @@ func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -278,6 +286,10 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMap) entries() ([]any,
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -343,6 +355,10 @@ func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, err
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -412,6 +428,10 @@ func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -482,6 +502,10 @@ func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -174,7 +174,7 @@ func (g *mqlGcpProject) cloudFunctions() ([]any, error) {
 			"status":              llx.StringData(f.Status.String()),
 			"entryPoint":          llx.StringData(f.EntryPoint),
 			"runtime":             llx.StringData(f.Runtime),
-			"timeout":             llx.TimeData(llx.DurationToTime(int64(f.Timeout.Seconds))),
+			"timeout":             llx.TimeData(llx.DurationToTime(f.GetTimeout().GetSeconds())),
 			"availableMemoryMb":   llx.IntData(int64(f.AvailableMemoryMb)),
 			"serviceAccountEmail": llx.StringData(f.ServiceAccountEmail),
 			"updated":             llx.TimeData(f.UpdateTime.AsTime()),

--- a/providers/gcp/resources/cloudidentity.go
+++ b/providers/gcp/resources/cloudidentity.go
@@ -182,7 +182,9 @@ func (g *mqlGcpCloudIdentityGroup) memberships() ([]any, error) {
 
 			roles := make([]any, 0, len(m.Roles))
 			for _, role := range m.Roles {
-				roles = append(roles, role.Name)
+				if role != nil {
+					roles = append(roles, role.Name)
+				}
 			}
 
 			mqlMembership, err := CreateResource(g.MqlRuntime, "gcp.cloudIdentity.membership", map[string]*llx.RawData{

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -638,6 +638,9 @@ func (g *mqlGcpProjectCloudRunServiceService) iamPolicy() ([]any, error) {
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/services/%s", projectId, region, name)
 	policy, err := runSvc.Projects.Locations.Services.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
+		if isHTTPSkippable(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return cloudRunIamBindings(g.MqlRuntime, resourcePath, policy.Bindings)
@@ -672,6 +675,9 @@ func (g *mqlGcpProjectCloudRunServiceJob) iamPolicy() ([]any, error) {
 	resourcePath := fmt.Sprintf("projects/%s/locations/%s/jobs/%s", projectId, region, name)
 	policy, err := runSvc.Projects.Locations.Jobs.GetIamPolicy(resourcePath).OptionsRequestedPolicyVersion(3).Context(ctx).Do()
 	if err != nil {
+		if isHTTPSkippable(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return cloudRunIamBindings(g.MqlRuntime, resourcePath, policy.Bindings)
@@ -687,6 +693,12 @@ func (g *mqlGcpProjectCloudRunServiceServiceRevisionTemplate) serviceAccount() (
 		return nil, g.ServiceAccountEmail.Error
 	}
 	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		// No SA on the template means it falls back to the compute/project
+		// default; resolve to null rather than a husk keyed on an empty email.
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 
 	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),
@@ -708,6 +720,12 @@ func (g *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) serviceAc
 		return nil, g.ServiceAccountEmail.Error
 	}
 	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		// No SA on the template means it falls back to the compute/project
+		// default; resolve to null rather than a husk keyed on an empty email.
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 
 	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
@@ -437,6 +438,12 @@ func getDiskByUrl(diskUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComput
 			}
 			continue
 		}
+		// Regional disk (no zone): the location segment can't be matched against
+		// a zone, so this falls back to a name match within the project. Two
+		// regional disks with the same name in different regions would be
+		// ambiguous; warn so it's visible.
+		log.Warn().Str("disk", diskId.Name).Str("location", diskId.Region).
+			Msg("resolving regional source disk by name only; result may be ambiguous across regions")
 		return disk, nil
 	}
 	return nil, nil

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -400,31 +400,95 @@ func getDiskByUrl(diskUrl string, runtime *plugin.Runtime) (*mqlGcpProjectComput
 	}
 
 	// URL format: https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{disk}
-	//          or https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{disk}
-	// Also handles regional disks: .../projects/{project}/regions/{region}/disks/{disk}
-	params := diskUrl
-	switch {
-	case strings.HasPrefix(params, "https://www.googleapis.com/compute/v1/"):
-		params = strings.TrimPrefix(params, "https://www.googleapis.com/compute/v1/")
-	case strings.HasPrefix(params, "https://compute.googleapis.com/compute/v1/"):
-		params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
-	default:
-		return nil, errors.New("unrecognized source disk URL prefix: " + diskUrl)
-	}
-	parts := strings.Split(params, "/")
-	// Expect at least: projects/{project}/{zones|regions}/{loc}/disks/{disk}
-	if len(parts) < 6 {
-		return nil, errors.New("invalid source disk URL: " + diskUrl)
+	//          or https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks/{disk}
+	diskId, err := getDiskIdByUrl(diskUrl)
+	if err != nil {
+		return nil, err
 	}
 
-	res, err := NewResource(runtime, "gcp.project.computeService.disk", map[string]*llx.RawData{
-		"name":      llx.StringData(parts[len(parts)-1]),
-		"projectId": llx.StringData(parts[1]),
+	// The gcp.project.computeService.disk resource has no init, so NewResource
+	// would leave a husk whose id() (derived from the unset Id field) collides
+	// with every other url-resolved disk. Instead scan the parent project's
+	// already-populated disks() list and return the real resource, mirroring
+	// attachedDisk.source(). Returns (nil, nil) when the disk isn't in the
+	// scanned project (e.g. a cross-project reference not otherwise scanned).
+	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(diskId.Project),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceDisk), nil
+	computeSvc := obj.(*mqlGcpProjectComputeService)
+	disks := computeSvc.GetDisks()
+	if disks.Error != nil {
+		return nil, disks.Error
+	}
+	for _, d := range disks.Data {
+		disk, ok := d.(*mqlGcpProjectComputeServiceDisk)
+		if !ok || disk.Name.Data != diskId.Name {
+			continue
+		}
+		// Disk names are unique per zone/region, so match the location segment
+		// when the disk is zonal; regional disks carry no Zone, so fall back to
+		// a name match within the project.
+		if zone := disk.Zone.Data; zone != nil {
+			if zone.GetName().Data == diskId.Region {
+				return disk, nil
+			}
+			continue
+		}
+		return disk, nil
+	}
+	return nil, nil
+}
+
+// resolveComputeSnapshotByName returns the fully-populated snapshot with the
+// given name from the project's snapshots() list. The snapshot resource has no
+// init, so a NewResource by-name would collide on an empty __id; scanning the
+// parent list returns the real resource. Returns (nil, nil) when not found.
+func resolveComputeSnapshotByName(runtime *plugin.Runtime, projectId, name string) (*mqlGcpProjectComputeServiceSnapshot, error) {
+	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	computeSvc := obj.(*mqlGcpProjectComputeService)
+	snapshots := computeSvc.GetSnapshots()
+	if snapshots.Error != nil {
+		return nil, snapshots.Error
+	}
+	for _, s := range snapshots.Data {
+		snap, ok := s.(*mqlGcpProjectComputeServiceSnapshot)
+		if ok && snap.Name.Data == name {
+			return snap, nil
+		}
+	}
+	return nil, nil
+}
+
+// resolveComputeStoragePoolByName returns the fully-populated storage pool with
+// the given name from the project's storagePools() list. Same rationale as
+// resolveComputeSnapshotByName. Returns (nil, nil) when not found.
+func resolveComputeStoragePoolByName(runtime *plugin.Runtime, projectId, name string) (*mqlGcpProjectComputeServiceStoragePool, error) {
+	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
+		"projectId": llx.StringData(projectId),
+	})
+	if err != nil {
+		return nil, err
+	}
+	computeSvc := obj.(*mqlGcpProjectComputeService)
+	pools := computeSvc.GetStoragePools()
+	if pools.Error != nil {
+		return nil, pools.Error
+	}
+	for _, p := range pools.Data {
+		pool, ok := p.(*mqlGcpProjectComputeServiceStoragePool)
+		if ok && pool.Name.Data == name {
+			return pool, nil
+		}
+	}
+	return nil, nil
 }
 
 // getNetworkByUrl resolves a typed network resource from either of the two
@@ -523,6 +587,9 @@ func getDiskIdByUrl(diskUrl string) (*resourceId, error) {
 	params := strings.TrimPrefix(diskUrl, "https://www.googleapis.com/compute/v1/")
 	params = strings.TrimPrefix(params, "https://compute.googleapis.com/compute/v1/")
 	parts := strings.Split(params, "/")
+	if len(parts) < 6 || parts[0] != "projects" {
+		return nil, errors.New("invalid disk URL: " + diskUrl)
+	}
 	return &resourceId{Project: parts[1], Region: parts[3], Name: parts[5]}, nil
 }
 

--- a/providers/gcp/resources/common_test.go
+++ b/providers/gcp/resources/common_test.go
@@ -64,3 +64,46 @@ func TestParseSubnetworkURL(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestGetDiskIdByUrl(t *testing.T) {
+	okCases := []struct {
+		url                   string
+		project, region, name string
+	}{
+		{
+			"https://www.googleapis.com/compute/v1/projects/p1/zones/us-central1-a/disks/disk-1",
+			"p1", "us-central1-a", "disk-1",
+		},
+		{
+			"https://compute.googleapis.com/compute/v1/projects/p2/regions/us-east1/disks/rdisk",
+			"p2", "us-east1", "rdisk",
+		},
+	}
+	for _, c := range okCases {
+		id, err := getDiskIdByUrl(c.url)
+		require.NoError(t, err)
+		assert.Equal(t, c.project, id.Project)
+		assert.Equal(t, c.region, id.Region)
+		assert.Equal(t, c.name, id.Name)
+	}
+
+	// Malformed URLs must return an error, not panic on an out-of-range index.
+	for _, u := range []string{"", "not-a-url", "https://www.googleapis.com/compute/v1/projects/p1"} {
+		_, err := getDiskIdByUrl(u)
+		assert.Error(t, err, "getDiskIdByUrl(%q) should error", u)
+	}
+}
+
+func TestProjectFromResourceName(t *testing.T) {
+	cases := map[string]string{
+		"projects/my-proj/topics/t1":              "my-proj",
+		"projects/p2/locations/us/backupVaults/v": "p2",
+		"projects/only-project":                   "only-project",
+		"organizations/123/folders/456":           "",
+		"no-projects-segment/here":                "",
+		"":                                        "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, projectFromResourceName(in), "projectFromResourceName(%q)", in)
+	}
+}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -419,6 +419,16 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 		return nil, nil, instances.Error
 	}
 
+	// The instance is matched by (region, name, projectId); without all three we
+	// can't do the lookup, so return a bare resource rather than dereferencing a
+	// nil arg (which would panic and crash the scan).
+	wantRegion := args["region"]
+	wantName := args["name"]
+	wantProjectId := args["projectId"]
+	if wantRegion == nil || wantName == nil || wantProjectId == nil {
+		return args, nil, nil
+	}
+
 	for _, inst := range instances.Data {
 		instance := inst.(*mqlGcpProjectComputeServiceInstance)
 		name := instance.GetName()
@@ -433,8 +443,11 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 		if instanceZone.Error != nil {
 			return nil, nil, instanceZone.Error
 		}
+		if instanceZone.Data == nil {
+			continue
+		}
 
-		if instanceZone.Data.Name.Data == args["region"].Value && name.Data == args["name"].Value && projectId.Data == args["projectId"].Value {
+		if instanceZone.Data.Name.Data == wantRegion.Value && name.Data == wantName.Value && projectId.Data == wantProjectId.Value {
 			return args, instance, nil
 		}
 	}
@@ -635,10 +648,16 @@ func (g *mqlGcpProjectComputeServiceAttachedDisk) source() (*mqlGcpProjectComput
 
 	for _, d := range disks.Data {
 		disk := d.(*mqlGcpProjectComputeServiceDisk)
-		if disk.Zone.Data.GetName().Data == diskId.Region && disk.Name.Data == diskId.Name {
-			return disk, nil
+		if disk.Name.Data != diskId.Name {
+			continue
 		}
-
+		if zone := disk.Zone.Data; zone != nil {
+			if zone.GetName().Data == diskId.Region {
+				return disk, nil
+			}
+			continue
+		}
+		return disk, nil
 	}
 	return nil, errors.New("disk not found")
 }
@@ -1103,16 +1122,18 @@ func (g *mqlGcpProjectComputeServiceDisk) sourceSnapshot() (*mqlGcpProjectComput
 		return nil, errors.New("invalid source snapshot URL: " + url)
 	}
 	parts := strings.Split(strings.TrimPrefix(url, computePrefix), "/")
-	if len(parts) < 5 {
+	if len(parts) < 5 || parts[0] != "projects" {
 		return nil, errors.New("invalid source snapshot URL: " + url)
 	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.computeService.snapshot", map[string]*llx.RawData{
-		"name": llx.StringData(parts[len(parts)-1]),
-	})
+	snap, err := resolveComputeSnapshotByName(g.MqlRuntime, parts[1], parts[len(parts)-1])
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceSnapshot), nil
+	if snap == nil {
+		g.SourceSnapshot.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return snap, nil
 }
 
 func (g *mqlGcpProjectComputeServiceDisk) storagePool() (*mqlGcpProjectComputeServiceStoragePool, error) {
@@ -1127,16 +1148,18 @@ func (g *mqlGcpProjectComputeServiceDisk) storagePool() (*mqlGcpProjectComputeSe
 		return nil, errors.New("invalid storage pool URL: " + url)
 	}
 	parts := strings.Split(strings.TrimPrefix(url, computePrefix), "/")
-	if len(parts) < 6 {
+	if len(parts) < 6 || parts[0] != "projects" {
 		return nil, errors.New("invalid storage pool URL: " + url)
 	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.computeService.storagePool", map[string]*llx.RawData{
-		"name": llx.StringData(parts[5]),
-	})
+	pool, err := resolveComputeStoragePoolByName(g.MqlRuntime, parts[1], parts[5])
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceStoragePool), nil
+	if pool == nil {
+		g.StoragePool.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return pool, nil
 }
 
 // customerEncryptionKeyToDict converts a Compute Engine CustomerEncryptionKey to a dict
@@ -1731,16 +1754,18 @@ func (g *mqlGcpProjectComputeServiceImage) sourceSnapshot() (*mqlGcpProjectCompu
 		return nil, errors.New("invalid source snapshot URL: " + url)
 	}
 	parts := strings.Split(strings.TrimPrefix(url, computePrefix), "/")
-	if len(parts) < 5 {
+	if len(parts) < 5 || parts[0] != "projects" {
 		return nil, errors.New("invalid source snapshot URL: " + url)
 	}
-	res, err := NewResource(g.MqlRuntime, "gcp.project.computeService.snapshot", map[string]*llx.RawData{
-		"name": llx.StringData(parts[len(parts)-1]),
-	})
+	snap, err := resolveComputeSnapshotByName(g.MqlRuntime, parts[1], parts[len(parts)-1])
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceSnapshot), nil
+	if snap == nil {
+		g.SourceSnapshot.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return snap, nil
 }
 
 func (g *mqlGcpProjectComputeService) images() ([]any, error) {
@@ -2804,7 +2829,7 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 					"id":                              llx.StringData(backendServiceId),
 					"affinityCookieTtlSec":            llx.IntData(b.AffinityCookieTtlSec),
 					"backends":                        llx.ArrayData(mqlBackends, types.Resource("gcp.project.computeService.backendService.backend")),
-					"cdnPolicy":                       llx.ResourceData(cdnPolicy, " gcp.project.computeService.backendService.cdnPolicy"),
+					"cdnPolicy":                       llx.ResourceData(cdnPolicy, "gcp.project.computeService.backendService.cdnPolicy"),
 					"circuitBreakers":                 llx.DictData(mqlCircuitBreakers),
 					"compressionMode":                 llx.StringData(b.CompressionMode),
 					"connectionDraining":              llx.DictData(mqlConnectionDraining),
@@ -2977,6 +3002,13 @@ func (g *mqlGcpProjectComputeServiceAddress) id() (string, error) {
 }
 
 func (g *mqlGcpProjectComputeService) forwardingRules() ([]any, error) {
+	// when the service is not enabled, we return nil (mirrors the other 19
+	// compute list accessors so an API-disabled project degrades to empty
+	// rather than hard-failing this one query).
+	if !g.GetEnabled().Data {
+		return nil, nil
+	}
+
 	if g.ProjectId.Error != nil {
 		return nil, g.ProjectId.Error
 	}

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -420,13 +420,13 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 	}
 
 	// The instance is matched by (region, name, projectId); without all three we
-	// can't do the lookup, so return a bare resource rather than dereferencing a
-	// nil arg (which would panic and crash the scan).
+	// can't do the lookup. Return an error rather than dereferencing a nil arg
+	// (which would panic) or falling through to build a husk with unset fields.
 	wantRegion := args["region"]
 	wantName := args["name"]
 	wantProjectId := args["projectId"]
 	if wantRegion == nil || wantName == nil || wantProjectId == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.computeService.instance requires region, name, and projectId")
 	}
 
 	for _, inst := range instances.Data {
@@ -657,6 +657,10 @@ func (g *mqlGcpProjectComputeServiceAttachedDisk) source() (*mqlGcpProjectComput
 			}
 			continue
 		}
+		// Regional disk (no zone): fall back to a name match within the project.
+		// Same-named regional disks in different regions would be ambiguous.
+		log.Warn().Str("disk", diskId.Name).Str("location", diskId.Region).
+			Msg("resolving regional attached disk by name only; result may be ambiguous across regions")
 		return disk, nil
 	}
 	return nil, errors.New("disk not found")
@@ -1082,7 +1086,15 @@ func (g *mqlGcpProjectComputeServiceDisk) sourceDisk() (*mqlGcpProjectComputeSer
 		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	return getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	disk, err := getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if disk == nil {
+		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return disk, nil
 }
 
 func (g *mqlGcpProjectComputeServiceDisk) sourceImage() (*mqlGcpProjectComputeServiceImage, error) {
@@ -1706,7 +1718,15 @@ func (g *mqlGcpProjectComputeServiceSnapshot) sourceDiskRef() (*mqlGcpProjectCom
 		g.SourceDiskRef.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	return getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	disk, err := getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if disk == nil {
+		g.SourceDiskRef.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return disk, nil
 }
 
 func (g *mqlGcpProjectComputeServiceImage) sourceDisk() (*mqlGcpProjectComputeServiceDisk, error) {
@@ -1714,7 +1734,15 @@ func (g *mqlGcpProjectComputeServiceImage) sourceDisk() (*mqlGcpProjectComputeSe
 		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	return getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	disk, err := getDiskByUrl(g.cacheSourceDiskUrl, g.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if disk == nil {
+		g.SourceDisk.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	return disk, nil
 }
 
 func (g *mqlGcpProjectComputeServiceImage) sourceImage() (*mqlGcpProjectComputeServiceImage, error) {

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -390,7 +390,7 @@ func (g *mqlGcpProjectComputeServiceFirewallPolicy) rules() ([]any, error) {
 			"securityProfileGroup":  llx.StringData(r.SecurityProfileGroup),
 			"srcIpRanges":           llx.ArrayData(srcIpRanges, types.String),
 			"destIpRanges":          llx.ArrayData(destIpRanges, types.String),
-			"layer4Configs":         llx.ArrayData(layer4Configs, types.Any),
+			"layer4Configs":         llx.ArrayData(layer4Configs, types.Dict),
 			"srcSecureTags":         llx.MapData(srcSecureTags, types.String),
 			"srcAddressGroups":      llx.ArrayData(srcAddressGroups, types.String),
 			"destAddressGroups":     llx.ArrayData(destAddressGroups, types.String),

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -856,7 +856,11 @@ func initGcpProjectDataprocServiceCluster(runtime *plugin.Runtime, args map[stri
 		return nil, nil, clusters.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
 		locationVal = args["location"].Value.(string)
@@ -905,14 +909,29 @@ func (a *mqlGcpProjectDataprocServiceClusterConfig) autoscalingPolicyRef() (*mql
 		a.AutoscalingPolicyRef.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
-	res, err := NewResource(a.MqlRuntime, "gcp.project.dataprocService.autoscalingPolicy", map[string]*llx.RawData{
+	// The autoscalingPolicy resource has no init, so a NewResource by-name would
+	// leave a husk (workerConfig/secondaryWorkerConfig/basicAlgorithm unset).
+	// Scan the parent service's autoscalingPolicies() list and return the real,
+	// fully-populated resource.
+	obj, err := CreateResource(a.MqlRuntime, "gcp.project.dataprocService", map[string]*llx.RawData{
 		"projectId": llx.StringData(a.cacheProjectId),
-		"name":      llx.StringData(name),
 	})
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectDataprocServiceAutoscalingPolicy), nil
+	svc := obj.(*mqlGcpProjectDataprocService)
+	policies := svc.GetAutoscalingPolicies()
+	if policies.Error != nil {
+		return nil, policies.Error
+	}
+	for _, p := range policies.Data {
+		policy, ok := p.(*mqlGcpProjectDataprocServiceAutoscalingPolicy)
+		if ok && policy.Name.Data == name {
+			return policy, nil
+		}
+	}
+	a.AutoscalingPolicyRef.State = plugin.StateIsNull | plugin.StateIsSet
+	return nil, nil
 }
 
 func dataprocBucketRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlGcpProjectStorageServiceBucket], nameField plugin.TValue[string]) (*mqlGcpProjectStorageServiceBucket, error) {

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -858,12 +858,12 @@ func initGcpProjectDataprocServiceCluster(runtime *plugin.Runtime, args map[stri
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.dataprocService.cluster requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
-		locationVal = args["location"].Value.(string)
+		locationVal, _ = args["location"].Value.(string)
 	}
 	for _, c := range clusters.Data {
 		cluster := c.(*mqlGcpProjectDataprocServiceCluster)

--- a/providers/gcp/resources/dataproc_test.go
+++ b/providers/gcp/resources/dataproc_test.go
@@ -126,3 +126,15 @@ func TestNodePoolTargetToMql(t *testing.T) {
 		assert.Len(t, result.NodePoolConfig.Config.Accelerators, 1)
 	})
 }
+
+func TestDataprocResourceNameFromUri(t *testing.T) {
+	cases := map[string]string{
+		"https://dataproc.googleapis.com/v1/projects/p/regions/r/autoscalingPolicies/ap": "projects/p/regions/r/autoscalingPolicies/ap",
+		"projects/p/regions/r/autoscalingPolicies/ap":                                    "projects/p/regions/r/autoscalingPolicies/ap",
+		"just-a-name": "just-a-name",
+		"":            "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, dataprocResourceNameFromUri(in), "dataprocResourceNameFromUri(%q)", in)
+	}
+}

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -415,6 +415,10 @@ func discoverOrganization(conn *connection.GcpConnection, gcpOrg *mqlGcpOrganiza
 			if folderConf.Options == nil {
 				folderConf.Options = map[string]string{}
 			}
+			// Scope the child connection to this folder: drop the inherited
+			// organization-id so the asset resolves as a folder (not the org),
+			// and set folder-id.
+			delete(folderConf.Options, "organization-id")
 			folderConf.Options["folder-id"] = folder.Id.Data
 
 			assetList = append(assetList, &inventory.Asset{
@@ -431,7 +435,7 @@ func discoverOrganization(conn *connection.GcpConnection, gcpOrg *mqlGcpOrganiza
 				},
 				Labels: map[string]string{},
 				// NOTE: we explicitly do not exclude discovery here, as we want to discover the projects for the folder
-				Connections: []*inventory.Config{conn.Conf.Clone(inventory.WithParentConnectionId(conn.Conf.Id))},
+				Connections: []*inventory.Config{folderConf},
 			})
 		}
 	}

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -874,9 +874,16 @@ func (g *mqlGcpProjectDlpServiceTableDataProfile) bigqueryTable() (*mqlGcpProjec
 		g.BigqueryTable.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	tblId := fmt.Sprintf("%s.%s.%s", projectId, datasetId, tableId)
+	// Key on the same (id, projectId, datasetId) the bigquery table resource is
+	// created with, so the computed __id
+	// (gcp.project.bigqueryService.table/{project}/{dataset}/{table}) matches a
+	// table already resolved via bigqueryService.datasets.tables. Passing a
+	// dotted "proj.dataset.table" id with no project/dataset never matched and
+	// left a husk.
 	mqlTbl, err := NewResource(g.MqlRuntime, "gcp.project.bigqueryService.table", map[string]*llx.RawData{
-		"id": llx.StringData(tblId),
+		"id":        llx.StringData(tableId),
+		"projectId": llx.StringData(projectId),
+		"datasetId": llx.StringData(datasetId),
 	})
 	if err != nil {
 		return nil, err
@@ -1111,8 +1118,11 @@ func (g *mqlGcpProjectDlpServiceFileStoreDataProfile) bucket() (*mqlGcpProjectSt
 		g.Bucket.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+	// The storage bucket init keys on "name" (it does a Buckets.Get(name) and
+	// populates every field). Passing "id" instead no-ops the init and leaves a
+	// husk, so key it on "name" like the sibling logBucket() ref does.
 	mqlBucket, err := NewResource(g.MqlRuntime, "gcp.project.storageService.bucket", map[string]*llx.RawData{
-		"id": llx.StringData(bucketName),
+		"name": llx.StringData(bucketName),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -38,9 +38,10 @@ func initGcpProjectDnsServiceManagedzone(runtime *plugin.Runtime, args map[strin
 	}
 
 	// The managed zone is matched by (name, projectId); without both we can't do
-	// the lookup, so return a bare resource rather than dereferencing a nil arg.
+	// the lookup. Return an error rather than dereferencing a nil arg (panic) or
+	// falling through to build a husk with unset fields.
 	if args["name"] == nil || args["projectId"] == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.dnsService.managedzone requires name and projectId")
 	}
 
 	// Create the parent DNS service and find the specific managed zone

--- a/providers/gcp/resources/dns.go
+++ b/providers/gcp/resources/dns.go
@@ -37,6 +37,12 @@ func initGcpProjectDnsServiceManagedzone(runtime *plugin.Runtime, args map[strin
 		}
 	}
 
+	// The managed zone is matched by (name, projectId); without both we can't do
+	// the lookup, so return a bare resource rather than dereferencing a nil arg.
+	if args["name"] == nil || args["projectId"] == nil {
+		return args, nil, nil
+	}
+
 	// Create the parent DNS service and find the specific managed zone
 	obj, err := CreateResource(runtime, "gcp.project.dnsService", map[string]*llx.RawData{
 		"projectId": args["projectId"],

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -77,7 +77,11 @@ func initGcpProjectFirestoreServiceDatabase(runtime *plugin.Runtime, args map[st
 		return nil, nil, databases.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, d := range databases.Data {
 		database := d.(*mqlGcpProjectFirestoreServiceDatabase)
 		// Firestore database name is a full resource path:

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -79,7 +79,7 @@ func initGcpProjectFirestoreServiceDatabase(runtime *plugin.Runtime, args map[st
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.firestoreService.database requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	for _, d := range databases.Data {

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -260,8 +260,11 @@ func (g *mqlGcpFolder) projects() (*mqlGcpProjects, error) {
 }
 
 func folderToMql(runtime *plugin.Runtime, f *cloudresourcemanager.Folder) (any, error) {
+	// Store the bare id ("123456"), matching initGcpFolder. folders()/projects()
+	// re-prefix with "folders/", so storing the full "folders/123456" here would
+	// double-prefix and silently break child traversal.
 	return CreateResource(runtime, "gcp.folder", map[string]*llx.RawData{
-		"id":                llx.StringData(f.Name),
+		"id":                llx.StringData(strings.TrimPrefix(f.Name, "folders/")),
 		"name":              llx.StringData(f.DisplayName),
 		"created":           llx.TimeDataPtr(parseTime(f.CreateTime)),
 		"updated":           llx.TimeDataPtr(parseTime(f.UpdateTime)),

--- a/providers/gcp/resources/folder_test.go
+++ b/providers/gcp/resources/folder_test.go
@@ -1,0 +1,40 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFolderResourceName(t *testing.T) {
+	cases := map[string]string{
+		"123456":         "folders/123456",
+		"folders/123456": "folders/123456",
+		"":               "folders/",
+		"folders/":       "folders/",
+	}
+	for in, want := range cases {
+		if got := folderResourceName(in); got != want {
+			t.Errorf("folderResourceName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestFolderIdNormalizationRoundTrip documents the folder id fix: folderToMql
+// stores the bare id and folders()/projects() re-prefix with "folders/". If the
+// list path stored the full "folders/123" instead, the child lookup key would
+// become "folders/folders/123" and silently match nothing.
+func TestFolderIdNormalizationRoundTrip(t *testing.T) {
+	// The bare id that folderToMql now stores (mirroring initGcpFolder).
+	bareID := strings.TrimPrefix("folders/123456", "folders/")
+	if bareID != "123456" {
+		t.Fatalf("bare id = %q, want 123456", bareID)
+	}
+	// folders()/projects() build the child lookup key this way:
+	childKey := "folders/" + bareID
+	if childKey != "folders/123456" {
+		t.Errorf("child lookup key = %q, want folders/123456 (double-prefix regression)", childKey)
+	}
+}

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -5993,6 +5993,8 @@ private gcp.project.loggingservice.sink @defaults("destination") {
 private gcp.project.loggingservice.exclusion @defaults("name disabled") {
   // Exclusion name
   name string
+  // Project ID
+  projectId string
   // Human-readable description of the resource
   description string
   // Advanced logs filter that matches log entries to be excluded

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -7977,6 +7977,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.loggingservice.exclusion.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceExclusion).GetName()).ToDataRes(types.String)
 	},
+	"gcp.project.loggingservice.exclusion.projectId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectLoggingserviceExclusion).GetProjectId()).ToDataRes(types.String)
+	},
 	"gcp.project.loggingservice.exclusion.description": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectLoggingserviceExclusion).GetDescription()).ToDataRes(types.String)
 	},
@@ -26067,6 +26070,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.loggingservice.exclusion.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectLoggingserviceExclusion).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"gcp.project.loggingservice.exclusion.projectId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectLoggingserviceExclusion).ProjectId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"gcp.project.loggingservice.exclusion.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -60263,6 +60270,7 @@ type mqlGcpProjectLoggingserviceExclusion struct {
 	__id       string
 	// optional: if you define mqlGcpProjectLoggingserviceExclusionInternal it will be used here
 	Name        plugin.TValue[string]
+	ProjectId   plugin.TValue[string]
 	Description plugin.TValue[string]
 	Filter      plugin.TValue[string]
 	Disabled    plugin.TValue[bool]
@@ -60309,6 +60317,10 @@ func (c *mqlGcpProjectLoggingserviceExclusion) MqlID() string {
 
 func (c *mqlGcpProjectLoggingserviceExclusion) GetName() *plugin.TValue[string] {
 	return &c.Name
+}
+
+func (c *mqlGcpProjectLoggingserviceExclusion) GetProjectId() *plugin.TValue[string] {
+	return &c.ProjectId
 }
 
 func (c *mqlGcpProjectLoggingserviceExclusion) GetDescription() *plugin.TValue[string] {

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -3907,6 +3907,7 @@ gcp.project.loggingservice.exclusion.description 13.6.1
 gcp.project.loggingservice.exclusion.disabled 13.6.1
 gcp.project.loggingservice.exclusion.filter 13.6.1
 gcp.project.loggingservice.exclusion.name 13.6.1
+gcp.project.loggingservice.exclusion.projectId 13.33.2
 gcp.project.loggingservice.exclusion.updated 13.6.1
 gcp.project.loggingservice.exclusions 13.6.1
 gcp.project.loggingservice.metric 9.0.0

--- a/providers/gcp/resources/gcp_exposure.go
+++ b/providers/gcp/resources/gcp_exposure.go
@@ -76,8 +76,11 @@ func (g *mqlGcpProjectGkeServiceCluster) controlPlaneInternetReachable() (bool, 
 // firewallRuleOpenIngress reports whether a firewall rule admits inbound traffic
 // from any address — an enabled INGRESS rule whose source ranges include
 // 0.0.0.0/0 or ::/0.
-func firewallRuleOpenIngress(direction string, disabled bool, sourceRanges []any) bool {
-	if disabled || !strings.EqualFold(direction, "INGRESS") {
+func firewallRuleOpenIngress(isAllow bool, direction string, disabled bool, sourceRanges []any) bool {
+	// A GCP VPC firewall rule is exclusively an allow rule or a deny rule. Only
+	// allow rules can open ingress; a broad-source INGRESS deny rule (a common
+	// "block all" pattern) must not be counted as reachable exposure.
+	if !isAllow || disabled || !strings.EqualFold(direction, "INGRESS") {
 		return false
 	}
 	for _, s := range sourceRanges {
@@ -215,7 +218,12 @@ func (g *mqlGcpProjectComputeServiceInstance) exposure() (*mqlGcpProjectComputeS
 		if sourceRanges.Error != nil {
 			return nil, sourceRanges.Error
 		}
-		if !firewallRuleOpenIngress(direction.Data, disabled.Data, sourceRanges.Data) {
+		allowed := fw.GetAllowed()
+		if allowed.Error != nil {
+			return nil, allowed.Error
+		}
+		isAllow := len(allowed.Data) > 0
+		if !firewallRuleOpenIngress(isAllow, direction.Data, disabled.Data, sourceRanges.Data) {
 			continue
 		}
 		if !instanceNetworks[networkNameFromUrl(fw.cacheNetworkUrl)] {

--- a/providers/gcp/resources/gcp_exposure_test.go
+++ b/providers/gcp/resources/gcp_exposure_test.go
@@ -98,23 +98,26 @@ func TestGkeControlPlaneInternetReachable(t *testing.T) {
 func TestFirewallRuleOpenIngress(t *testing.T) {
 	cases := []struct {
 		name      string
+		isAllow   bool
 		direction string
 		disabled  bool
 		sources   []any
 		want      bool
 	}{
-		{"ingress any v4", "INGRESS", false, []any{"0.0.0.0/0"}, true},
-		{"ingress any v6", "INGRESS", false, []any{"::/0"}, true},
-		{"ingress lowercase", "ingress", false, []any{"0.0.0.0/0"}, true},
-		{"disabled", "INGRESS", true, []any{"0.0.0.0/0"}, false},
-		{"egress", "EGRESS", false, []any{"0.0.0.0/0"}, false},
-		{"scoped source", "INGRESS", false, []any{"10.0.0.0/8"}, false},
-		{"no sources", "INGRESS", false, []any{}, false},
+		{"allow ingress any v4", true, "INGRESS", false, []any{"0.0.0.0/0"}, true},
+		{"allow ingress any v6", true, "INGRESS", false, []any{"::/0"}, true},
+		{"allow ingress lowercase", true, "ingress", false, []any{"0.0.0.0/0"}, true},
+		{"deny ingress any v4 is not open", false, "INGRESS", false, []any{"0.0.0.0/0"}, false},
+		{"deny ingress any v6 is not open", false, "INGRESS", false, []any{"::/0"}, false},
+		{"allow disabled", true, "INGRESS", true, []any{"0.0.0.0/0"}, false},
+		{"allow egress", true, "EGRESS", false, []any{"0.0.0.0/0"}, false},
+		{"allow scoped source", true, "INGRESS", false, []any{"10.0.0.0/8"}, false},
+		{"allow no sources", true, "INGRESS", false, []any{}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := firewallRuleOpenIngress(c.direction, c.disabled, c.sources); got != c.want {
-				t.Errorf("firewallRuleOpenIngress(%q,%v,%v) = %v, want %v", c.direction, c.disabled, c.sources, got, c.want)
+			if got := firewallRuleOpenIngress(c.isAllow, c.direction, c.disabled, c.sources); got != c.want {
+				t.Errorf("firewallRuleOpenIngress(%v,%q,%v,%v) = %v, want %v", c.isAllow, c.direction, c.disabled, c.sources, got, c.want)
 			}
 		})
 	}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -552,8 +552,8 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 				"enabled":        c.BinaryAuthorization.Enabled,
 				"evaluationMode": c.BinaryAuthorization.EvaluationMode.String(),
 			}
-			// CIS interpretation: Binary Auth is "enabled" when evaluationMode is anything
-			// other than DISABLED. The legacy boolean Enabled field is also honored.
+			// Binary Auth is "enabled" when evaluationMode is anything other than
+			// DISABLED/UNSPECIFIED, or when the legacy boolean Enabled field is set.
 			mode := c.BinaryAuthorization.EvaluationMode
 			binaryAuthorizationEnabled = c.BinaryAuthorization.Enabled ||
 				(mode != containerpb.BinaryAuthorization_EVALUATION_MODE_UNSPECIFIED && mode != containerpb.BinaryAuthorization_DISABLED)
@@ -989,6 +989,12 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) serviceAccount() (*mqlGcp
 		return nil, g.ServiceAccountEmail.Error
 	}
 	email := g.ServiceAccountEmail.Data
+	if email == "" {
+		// No SA on the node pool config means it falls back to the project
+		// default; resolve to null rather than a husk keyed on an empty email.
+		g.ServiceAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 
 	res, err := NewResource(g.MqlRuntime, "gcp.project.iamService.serviceAccount", map[string]*llx.RawData{
 		"projectId": llx.StringData(projectId),
@@ -1374,17 +1380,24 @@ func (g *mqlGcpProjectGkeServiceClusterNetworkConfig) network() (*mqlGcpProjectC
 		return nil, g.NetworkPath.Error
 	}
 	networkPath := g.NetworkPath.Data
+	if networkPath == "" {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 
-	// Format is projects/project-1/global/networks/net-1
-	params := strings.Split(networkPath, "/")
-	res, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.network", map[string]*llx.RawData{
-		"name":      llx.StringData(params[len(params)-1]),
-		"projectId": llx.StringData(params[1]),
-	})
+	// Format is projects/project-1/global/networks/net-1. getNetworkByUrl uses
+	// NewResource so the network's init runs and every field is populated (a
+	// plain CreateResource here would leave a husk with only name/projectId set),
+	// and it length-guards the path instead of blindly indexing.
+	net, err := getNetworkByUrl(networkPath, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceNetwork), nil
+	if net == nil {
+		g.Network.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return net, nil
 }
 
 func (g *mqlGcpProjectGkeServiceClusterNetworkConfig) subnetwork() (*mqlGcpProjectComputeServiceSubnetwork, error) {

--- a/providers/gcp/resources/iam_public_test.go
+++ b/providers/gcp/resources/iam_public_test.go
@@ -1,0 +1,22 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+func TestIsPublicMember(t *testing.T) {
+	cases := map[string]bool{
+		"allUsers":               true,
+		"allAuthenticatedUsers":  true,
+		"user:alice@example.com": false,
+		"serviceAccount:sa@p.iam.gserviceaccount.com": false,
+		"":         false,
+		"AllUsers": false, // case-sensitive
+	}
+	for in, want := range cases {
+		if got := isPublicMember(in); got != want {
+			t.Errorf("isPublicMember(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/providers/gcp/resources/iam_roles_test.go
+++ b/providers/gcp/resources/iam_roles_test.go
@@ -1,0 +1,61 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestRoleGrantsIamPolicyManagement(t *testing.T) {
+	cases := []struct {
+		name  string
+		perms []any
+		want  bool
+	}{
+		{"setIamPolicy suffix", []any{"resourcemanager.projects.setIamPolicy"}, true},
+		{"storage setIamPolicy", []any{"storage.buckets.setIamPolicy"}, true},
+		{"only getIamPolicy", []any{"resourcemanager.projects.getIamPolicy"}, false},
+		{"unrelated", []any{"compute.instances.list"}, false},
+		{"empty", []any{}, false},
+		{"non-string element ignored", []any{42, "x.setIamPolicy"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := roleGrantsIamPolicyManagement(&plugin.TValue[[]any]{Data: c.perms, State: plugin.StateIsSet})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("roleGrantsIamPolicyManagement(%v) = %v, want %v", c.perms, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRoleGrantsServiceAccountImpersonation(t *testing.T) {
+	cases := []struct {
+		name  string
+		perms []any
+		want  bool
+	}{
+		{"actAs", []any{"iam.serviceAccounts.actAs"}, true},
+		{"getAccessToken", []any{"iam.serviceAccounts.getAccessToken"}, true},
+		{"signJwt", []any{"iam.serviceAccounts.signJwt"}, true},
+		{"list is not impersonation", []any{"iam.serviceAccounts.list"}, false},
+		{"empty", []any{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := roleGrantsServiceAccountImpersonation(&plugin.TValue[[]any]{Data: c.perms, State: plugin.StateIsSet})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("roleGrantsServiceAccountImpersonation(%v) = %v, want %v", c.perms, got, c.want)
+			}
+		})
+	}
+}

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -83,10 +83,10 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 	}
 
 	// The keyring is matched by (name, location, projectId); without all three we
-	// can't do the lookup, so return a bare resource rather than dereferencing a
-	// nil arg (which would panic and crash the scan).
+	// can't do the lookup. Return an error rather than dereferencing a nil arg
+	// (which would panic) or falling through to build a husk with unset fields.
 	if args["name"] == nil || args["location"] == nil || args["projectId"] == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.kmsService.keyring requires name, location, and projectId")
 	}
 
 	// Find the matching keyring

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -82,6 +82,13 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 		return nil, nil, keyrings.Error
 	}
 
+	// The keyring is matched by (name, location, projectId); without all three we
+	// can't do the lookup, so return a bare resource rather than dereferencing a
+	// nil arg (which would panic and crash the scan).
+	if args["name"] == nil || args["location"] == nil || args["projectId"] == nil {
+		return args, nil, nil
+	}
+
 	// Find the matching keyring
 	for _, kr := range keyrings.Data {
 		keyring := kr.(*mqlGcpProjectKmsServiceKeyring)
@@ -240,7 +247,7 @@ func initGcpProjectKmsServiceKeyringCryptokey(runtime *plugin.Runtime, args map[
 	args["primaryState"] = llx.StringData(primaryState)
 	args["purpose"] = llx.StringData(k.Purpose.String())
 	args["created"] = llx.TimeData(k.CreateTime.AsTime())
-	args["nextRotation"] = llx.TimeData(k.NextRotationTime.AsTime())
+	args["nextRotation"] = llx.TimeDataPtr(timestampAsTimePtr(k.NextRotationTime))
 	args["rotationPeriod"] = llx.TimeDataPtr(mqlRotationPeriod)
 	args["versionTemplate"] = llx.DictData(versionTemplate)
 	args["labels"] = llx.MapData(convert.MapToInterfaceMap(k.Labels), types.String)
@@ -483,7 +490,7 @@ func (g *mqlGcpProjectKmsServiceKeyring) cryptokeys() ([]any, error) {
 			"primaryState":                  llx.StringData(primaryState),
 			"purpose":                       llx.StringData(k.Purpose.String()),
 			"created":                       llx.TimeData(k.CreateTime.AsTime()),
-			"nextRotation":                  llx.TimeData(k.NextRotationTime.AsTime()),
+			"nextRotation":                  llx.TimeDataPtr(timestampAsTimePtr(k.NextRotationTime)),
 			"rotationPeriod":                llx.TimeDataPtr(mqlRotationPeriod),
 			"versionTemplate":               llx.DictData(versionTemplate),
 			"labels":                        llx.MapData(convert.MapToInterfaceMap(k.Labels), types.String),
@@ -664,9 +671,9 @@ func cryptoKeyVersionToMql(runtime *plugin.Runtime, v *kmspb.CryptoKeyVersion) (
 	if v.Attestation != nil {
 		mqlAttestationCertChains, err := CreateResource(runtime, "gcp.project.kmsService.keyring.cryptokey.version.attestation.certificatechains", map[string]*llx.RawData{
 			"cryptoKeyVersionName": llx.StringData(v.Name),
-			"caviumCerts":          llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.CertChains.CaviumCerts), types.String),
-			"googleCardCerts":      llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.CertChains.GoogleCardCerts), types.String),
-			"googlePartitionCerts": llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.CertChains.GooglePartitionCerts), types.String),
+			"caviumCerts":          llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.GetCertChains().GetCaviumCerts()), types.String),
+			"googleCardCerts":      llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.GetCertChains().GetGoogleCardCerts()), types.String),
+			"googlePartitionCerts": llx.ArrayData(convert.SliceAnyToInterface(v.Attestation.GetCertChains().GetGooglePartitionCerts()), types.String),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -593,7 +593,10 @@ func initGcpProjectLoggingserviceBucket(runtime *plugin.Runtime, args map[string
 		}
 	}
 
-	obj, err := CreateResource(runtime, "gcp.project.loggingservice", map[string]*llx.RawData{
+	// Use NewResource so initGcpProjectLoggingservice runs and sets serviceEnabled;
+	// CreateResource would skip init and leave serviceEnabled=false, making
+	// GetBuckets() short-circuit to empty even when logging is enabled.
+	obj, err := NewResource(runtime, "gcp.project.loggingservice", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
 	if err != nil {
@@ -652,6 +655,7 @@ func (g *mqlGcpProjectLoggingservice) exclusions() ([]any, error) {
 		for _, exclusion := range page.Exclusions {
 			mqlExclusion, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.exclusion", map[string]*llx.RawData{
 				"name":        llx.StringData(parseResourceName(exclusion.Name)),
+				"projectId":   llx.StringData(projectId),
 				"description": llx.StringData(exclusion.Description),
 				"filter":      llx.StringData(exclusion.Filter),
 				"disabled":    llx.BoolData(exclusion.Disabled),
@@ -671,11 +675,15 @@ func (g *mqlGcpProjectLoggingservice) exclusions() ([]any, error) {
 }
 
 func (g *mqlGcpProjectLoggingserviceExclusion) id() (string, error) {
+	if g.ProjectId.Error != nil {
+		return "", g.ProjectId.Error
+	}
 	if g.Name.Error != nil {
 		return "", g.Name.Error
 	}
-	name := g.Name.Data
-	return fmt.Sprintf("gcp.project.loggingservice.exclusion/%s", name), nil
+	// Include projectId so identically-named exclusions in different projects
+	// don't collide on the cache key (mirrors sink.id() / metric.id()).
+	return fmt.Sprintf("gcp.project.loggingservice.exclusion/%s/%s", g.ProjectId.Data, g.Name.Data), nil
 }
 
 func (g *mqlGcpProjectLoggingserviceBucket) views() ([]any, error) {

--- a/providers/gcp/resources/monitoring.go
+++ b/providers/gcp/resources/monitoring.go
@@ -199,7 +199,7 @@ func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 			if matchedLog := c.GetConditionMatchedLog(); matchedLog != nil {
 				mqlMatchedLog = map[string]any{
 					"filter":          matchedLog.Filter,
-					"labelExtractors": matchedLog.LabelExtractors,
+					"labelExtractors": convert.MapToInterfaceMap(matchedLog.LabelExtractors),
 				}
 			}
 
@@ -225,7 +225,7 @@ func (g *mqlGcpProjectMonitoringService) alertPolicies() ([]any, error) {
 		var mqlValidity any
 		if p.Validity != nil {
 			mqlValidity = map[string]any{
-				"code":    p.Validity.Code,
+				"code":    int64(p.Validity.Code),
 				"message": p.Validity.Message,
 			}
 		}

--- a/providers/gcp/resources/privateca.go
+++ b/providers/gcp/resources/privateca.go
@@ -99,6 +99,10 @@ func (g *mqlGcpProjectCertificateAuthorityService) caPools() ([]any, error) {
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -234,6 +238,10 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificateAuthorities(
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -363,6 +371,10 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCaPool) certificates() ([]any, 
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -477,6 +489,10 @@ func (g *mqlGcpProjectCertificateAuthorityServiceCertificateAuthority) certifica
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 
@@ -550,6 +566,10 @@ func (g *mqlGcpProjectCertificateAuthorityService) certificateTemplates() ([]any
 			break
 		}
 		if err != nil {
+			if isGRPCSkippable(err) {
+				log.Warn().Err(err).Msg("could not list resources (API disabled or access denied), skipping")
+				return nil, nil
+			}
 			return nil, err
 		}
 

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -126,7 +126,7 @@ func initGcpProjectPubsubServiceTopic(runtime *plugin.Runtime, args map[string]*
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.pubsubService.topic requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	for _, t := range topics.Data {

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -124,7 +124,11 @@ func initGcpProjectPubsubServiceTopic(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, topics.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, t := range topics.Data {
 		topic := t.(*mqlGcpProjectPubsubServiceTopic)
 		if topic.Name.Data == nameVal {
@@ -512,8 +516,14 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 		return nil, err
 	}
 
+	// A subscription may reference a topic in a different project; key the topic
+	// ref on the topic's own project (from its resource path), not the local one.
+	topicProjectId := projectFromResourceName(cfg.Topic)
+	if topicProjectId == "" {
+		topicProjectId = projectId
+	}
 	topic, err := CreateResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
-		"projectId": llx.StringData(projectId),
+		"projectId": llx.StringData(topicProjectId),
 		"name":      llx.StringData(lastPathSegment(cfg.Topic)),
 	})
 	if err != nil {
@@ -681,8 +691,14 @@ func (g *mqlGcpProjectPubsubService) snapshots() ([]any, error) {
 		snapshotName := lastPathSegment(s.Name)
 		topicName := lastPathSegment(s.Topic)
 
+		// A snapshot may reference a topic in a different project; key the topic
+		// ref on the topic's own project (from its resource path).
+		topicProjectId := projectFromResourceName(s.Topic)
+		if topicProjectId == "" {
+			topicProjectId = projectId
+		}
 		topic, err := CreateResource(g.MqlRuntime, "gcp.project.pubsubService.topic", map[string]*llx.RawData{
-			"projectId": llx.StringData(projectId),
+			"projectId": llx.StringData(topicProjectId),
 			"name":      llx.StringData(topicName),
 		})
 		if err != nil {

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -116,6 +116,11 @@ func initGcpProjectRedisServiceInstance(runtime *plugin.Runtime, args map[string
 		return nil, nil, instances.Error
 	}
 
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	wantName, _ := nameRaw.Value.(string)
 	for _, inst := range instances.Data {
 		instance := inst.(*mqlGcpProjectRedisServiceInstance)
 		// Redis instance name is a full resource path:
@@ -123,7 +128,7 @@ func initGcpProjectRedisServiceInstance(runtime *plugin.Runtime, args map[string
 		nameParts := strings.Split(instance.Name.Data, "/")
 		instanceName := nameParts[len(nameParts)-1]
 
-		if instanceName == args["name"].Value.(string) {
+		if instanceName == wantName {
 			return args, instance, nil
 		}
 	}
@@ -518,12 +523,17 @@ func initGcpProjectRedisServiceCluster(runtime *plugin.Runtime, args map[string]
 		return nil, nil, clusters.Error
 	}
 
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	wantName, _ := nameRaw.Value.(string)
 	for _, c := range clusters.Data {
 		cluster := c.(*mqlGcpProjectRedisServiceCluster)
 		nameParts := strings.Split(cluster.Name.Data, "/")
 		clusterName := nameParts[len(nameParts)-1]
 
-		if clusterName == args["name"].Value.(string) {
+		if clusterName == wantName {
 			return args, cluster, nil
 		}
 	}

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -118,7 +118,7 @@ func initGcpProjectRedisServiceInstance(runtime *plugin.Runtime, args map[string
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.redisService.instance requires a \"name\" argument")
 	}
 	wantName, _ := nameRaw.Value.(string)
 	for _, inst := range instances.Data {
@@ -525,7 +525,7 @@ func initGcpProjectRedisServiceCluster(runtime *plugin.Runtime, args map[string]
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.redisService.cluster requires a \"name\" argument")
 	}
 	wantName, _ := nameRaw.Value.(string)
 	for _, c := range clusters.Data {

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -239,7 +239,7 @@ func initGcpProjectSecretmanagerServiceSecret(runtime *plugin.Runtime, args map[
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.secretmanagerService.secret requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	for _, s := range secrets.Data {

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -237,7 +237,11 @@ func initGcpProjectSecretmanagerServiceSecret(runtime *plugin.Runtime, args map[
 		return nil, nil, secrets.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, s := range secrets.Data {
 		secret := s.(*mqlGcpProjectSecretmanagerServiceSecret)
 		if secret.Name.Data == nameVal {

--- a/providers/gcp/resources/securitycenter.go
+++ b/providers/gcp/resources/securitycenter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/gcp/connection"
 	"go.mondoo.com/mql/v13/types"
 	"google.golang.org/api/iterator"
@@ -221,7 +222,7 @@ func chokepointToDict(cp *sccpb.Chokepoint) map[string]any {
 		return nil
 	}
 	return map[string]any{
-		"relatedFindings": cp.RelatedFindings,
+		"relatedFindings": convert.SliceAnyToInterface(cp.RelatedFindings),
 	}
 }
 
@@ -253,7 +254,7 @@ func toxicCombinationToDict(tc *sccpb.ToxicCombination) map[string]any {
 	}
 	return map[string]any{
 		"attackExposureScore": tc.AttackExposureScore,
-		"relatedFindings":     tc.RelatedFindings,
+		"relatedFindings":     convert.SliceAnyToInterface(tc.RelatedFindings),
 	}
 }
 

--- a/providers/gcp/resources/securitycenter_test.go
+++ b/providers/gcp/resources/securitycenter_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	sccpb "cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
+)
+
+// assertDictSerializable mirrors llx's dict2primitive allow-list: a value stored
+// in an mql dict/[]dict field must be one of bool/int64/float64/string/[]any/
+// map[string]any/nil. Anything else (int32, []string, map[string]string, *T)
+// errors at query time with "unsupported child type". This guards the class of
+// bug where a hand-built dict embeds a non-JSON-native value.
+func assertDictSerializable(t *testing.T, path string, v any) {
+	t.Helper()
+	switch x := v.(type) {
+	case nil, bool, int64, float64, string:
+		// native scalar, ok
+	case []any:
+		for _, e := range x {
+			assertDictSerializable(t, path+"[]", e)
+		}
+	case map[string]any:
+		for k, e := range x {
+			assertDictSerializable(t, path+"."+k, e)
+		}
+	default:
+		t.Errorf("dict value at %q has non-serializable type %T (would error at query time)", path, v)
+	}
+}
+
+func TestSecuritycenterDictBuildersAreSerializable(t *testing.T) {
+	// Populate the []string/float64 fields that previously shipped as-is.
+	chokepoint := chokepointToDict(&sccpb.Chokepoint{
+		RelatedFindings: []string{"organizations/1/sources/2/findings/3", "f4"},
+	})
+	assertDictSerializable(t, "chokepoint", chokepoint)
+
+	toxic := toxicCombinationToDict(&sccpb.ToxicCombination{
+		AttackExposureScore: 8.5,
+		RelatedFindings:     []string{"f1", "f2"},
+	})
+	assertDictSerializable(t, "toxicCombination", toxic)
+
+	exposure := externalExposureToDict(&sccpb.ExternalExposure{
+		PrivateIpAddress: "10.0.0.1",
+		PrivatePort:      "8080",
+		PublicIpAddress:  "203.0.113.1",
+		PublicPort:       "443",
+	})
+	assertDictSerializable(t, "externalExposure", exposure)
+}

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -85,7 +85,7 @@ func initGcpProjectSpannerServiceInstance(runtime *plugin.Runtime, args map[stri
 
 	nameRaw := args["name"]
 	if nameRaw == nil {
-		return args, nil, nil
+		return nil, nil, errors.New("gcp.project.spannerService.instance requires a \"name\" argument")
 	}
 	nameVal, _ := nameRaw.Value.(string)
 	for _, i := range instances.Data {

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -83,7 +83,11 @@ func initGcpProjectSpannerServiceInstance(runtime *plugin.Runtime, args map[stri
 		return nil, nil, instances.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, i := range instances.Data {
 		instance := i.(*mqlGcpProjectSpannerServiceInstance)
 		// Spanner instance name is a full resource path:

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -357,7 +357,13 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 				mqlIpAddresses = append(mqlIpAddresses, mqlIpAddress)
 			}
 
+			// Settings is nil for instances that are mid-provisioning or in a
+			// failed state; fall back to an empty struct so a single such
+			// instance doesn't panic (and take down) the whole instances() list.
 			s := instance.Settings
+			if s == nil {
+				s = &sqladmin.Settings{}
+			}
 			dbFlags := make(map[string]string)
 			for _, f := range s.DatabaseFlags {
 				dbFlags[f.Name] = f.Value
@@ -393,12 +399,15 @@ func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
 					RetainedBackups int64  `json:"retainedBackups"`
 					RetentionUnit   string `json:"retentionUnit"`
 				}
-				mqlRetention, err := convert.JsonToDict(mqlRetentionSettings{
-					RetainedBackups: s.BackupConfiguration.BackupRetentionSettings.RetainedBackups,
-					RetentionUnit:   s.BackupConfiguration.BackupRetentionSettings.RetentionUnit,
-				})
-				if err != nil {
-					return err
+				var mqlRetention map[string]any
+				if brs := s.BackupConfiguration.BackupRetentionSettings; brs != nil {
+					mqlRetention, err = convert.JsonToDict(mqlRetentionSettings{
+						RetainedBackups: brs.RetainedBackups,
+						RetentionUnit:   brs.RetentionUnit,
+					})
+					if err != nil {
+						return err
+					}
 				}
 
 				mqlBackupCfg, err = CreateResource(g.MqlRuntime, "gcp.project.sqlService.instance.settings.backupconfiguration", map[string]*llx.RawData{

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -578,6 +578,12 @@ func (g *mqlGcpProjectStorageServiceBucket) iamPolicy() ([]any, error) {
 	// conditional grants (including conditional public-access bindings).
 	policy, err := storeSvc.Buckets.GetIamPolicy(bucketName).OptionsRequestedPolicyVersion(3).Do()
 	if err != nil {
+		// Degrade a permission gap to an empty policy rather than a hard error,
+		// matching sibling IAM-policy accessors, and so public() can still fall
+		// back to its ACL check instead of failing outright.
+		if isHTTPSkippable(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Static bug-review sweep of the GCP provider (12 parallel analysis agents + mechanical sweeps, every finding verified against source and the SDK/runtime internals). Fixes the class of defect that reaches users as **wrong data with no error**, plus several **scan-crashing panics**, and adds unit tests for the pure-Go logic where those bugs live.

Provider builds clean, `go vet` clean, codegen idempotent, full resources test suite green.

## Tier 1 — silent wrong data / data loss

- **exposure deny-rule** (`gcp_exposure.go`): `firewallRuleOpenIngress` now requires the rule to be an *allow* rule. A broad-source INGRESS **deny** rule (a common "block-all") no longer flips `instance.exposure.internetReachable` to a false positive.
- **folder id** (`folder.go`): `folderToMql` stores the bare id (matching `initGcpFolder`); `folders()`/`projects()` re-prefix `folders/`, so the list path no longer produces `folders/folders/<id>` and silently empty child traversal.
- **compute husks** (`common.go`/`compute.go`): `sourceDisk`/`sourceDiskRef`/`sourceSnapshot`/`storagePool` resolve via a parent-list cache-scan (the proven `attachedDisk.source()` pattern) instead of `NewResource` on init-less resources, which collided on an empty `__id`.
- **discovery folder assets** (`discovery.go`): attach the per-folder connection config (`folder-id`, org-id stripped) instead of a fresh clone of the parent org connection — folder assets were re-scanning the whole organization.
- **dict type fixes** (query-time `unsupported child type` errors): `monitoring` `validity.code` int32→int64 and `labelExtractors` map[string]string→map[string]any; `securitycenter` `relatedFindings` []string→[]any; firewall-policy `layer4Configs` `types.Any`→`types.Dict`.
- **more husk typed-refs**: gke `networkConfig.network()` (via `getNetworkByUrl`), `dataproc.autoscalingPolicyRef()`, `backupdr.backupVault()`, dlp `bucket()` (key on `name`) and `bigqueryTable()` (key on id+project+dataset).
- **pubsub cross-project topic**: key subscription/snapshot topic refs on the topic's own project.
- **logging exclusion `__id`**: add `projectId` field + include it in the id (cross-project same-name collision); build the parent loggingservice via `NewResource` so `serviceEnabled` is set.
- **1970 timestamps**: kms `nextRotation` and binaryAuth `updated` are nil-safe (`TimeDataPtr`).

## Tier 2 — scan-crash panics

- kms attestation `CertChains` nested-pointer deref (nil-safe getter chain).
- sql nil `instance.Settings` / `BackupRetentionSettings` (took out the whole Cloud SQL inventory).
- cloud_functions nil `Timeout`.
- ~14 partial-arg inits that dereferenced `args["name"|"id"|"region"].Value` without a nil guard.
- compute `attachedDisk.source()` zone nil-guard; hardened `getDiskIdByUrl` indexing.

## Tier 3 — robustness

- `privateca`/`accesscontextmanager`/`certificatemanager` list loops degrade disabled-API/access-denied via `isGRPCSkippable` (matching the other 17 files).
- cloudrun/storage-bucket `iamPolicy()` degrade 403 (lets bucket `public()` reach its ACL fallback).
- compute `forwardingRules()` gets the missing service-enabled guard.
- gke/cloudrun `serviceAccount()` return null on empty email instead of a husk.

## Cleanup

- Drop a CIS reference in a gke comment; fix a stray leading space in a `ResourceData` type name.

## Tests

New/updated unit tests for the pure-Go logic (where a regression would silently ship wrong data): deny-rule exposure cases, IAM public/impersonation & role predicates, folder id round-trip, `getDiskIdByUrl`/`projectFromResourceName`/dataproc URI parsers, and a **dict-serializability guard** over the securitycenter builders that catches the non-JSON-native (class-8b) bug at test time.

## Not changed (deliberate)

- `vertexai` `public()` returning `false` when `getIamPolicy` is permission-denied (understated exposure): degrade-vs-surface is a genuine product judgment call — left for a follow-up with live verification rather than changing behavior blind.

## Verification

Live-verification of the resolver/degrade behavior is best done via the batch provider-verification run against real infra; this PR is codegen + build + unit tests.
