### PR TITLE
🐛 network: fix parser panics and silent wrong-data in tls/dns/cert probes

### DIFF
--- a/providers/network/resources/certificates.go
+++ b/providers/network/resources/certificates.go
@@ -457,8 +457,8 @@ func (s *mqlCertificate) sanExtension() (*mqlPkixSanExtension, error) {
 	r, err := CreateResource(s.MqlRuntime, "pkix.sanExtension", map[string]*llx.RawData{
 		"extension":      llx.ResourceData(ext, "pkix.extension"),
 		"dnsNames":       llx.ArrayData(convert.SliceAnyToInterface(dnsNames), types.String),
-		"ipAddresses":    llx.ArrayData(convert.SliceAnyToInterface(emailAddresses), types.String),
-		"emailAddresses": llx.ArrayData(ipAddressesValues, types.String),
+		"ipAddresses":    llx.ArrayData(ipAddressesValues, types.String),
+		"emailAddresses": llx.ArrayData(convert.SliceAnyToInterface(emailAddresses), types.String),
 		"uris":           llx.ArrayData(uriValues, types.String),
 	})
 	if err != nil {

--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -90,6 +90,20 @@ func (d *mqlDns) params(fqdn string) (any, error) {
 	return convert.JsonToDict(records)
 }
 
+// dictTTL reads a DNS record's TTL out of a record map produced by
+// convert.JsonToDict (json.Marshal then Unmarshal of a dnsshake.DnsRecord).
+// The map key is therefore the json tag "ttl" (not the Go field name "TTL"),
+// and every JSON number decodes to float64, not int64. Reading "TTL" or
+// asserting .(int64) is why the TTL was silently dropped (and would panic if
+// the key were fixed without the type). Returns (0, false) when absent.
+func dictTTL(m map[string]any) (int64, bool) {
+	v, ok := m["ttl"].(float64)
+	if !ok {
+		return 0, false
+	}
+	return int64(v), true
+}
+
 func (d *mqlDns) records(params any) ([]any, error) {
 	// NOTE: mql does not cache the results of GetRecords since it has an input argument
 	// Iterations over map keys are not deterministic and therefore we need to sort the keys
@@ -113,10 +127,10 @@ func (d *mqlDns) records(params any) ([]any, error) {
 		}
 
 		var ttl *llx.RawData
-		if r["TTL"] == nil {
-			ttl = llx.NilData
+		if v, ok := dictTTL(r); ok {
+			ttl = llx.IntData(v)
 		} else {
-			ttl = llx.IntData(r["TTL"].(int64))
+			ttl = llx.NilData
 		}
 		o, err := CreateResource(d.MqlRuntime, "dns.record", map[string]*llx.RawData{
 			"name":  llx.StringData(r["name"].(string)),
@@ -176,8 +190,8 @@ func (d *mqlDns) mx(params any) ([]any, error) {
 		t = r["type"].(string)
 	}
 
-	if r["TTL"] != nil {
-		ttl = r["TTL"].(int64)
+	if v, ok := dictTTL(r); ok {
+		ttl = v
 	}
 
 	if r["rData"] != nil {
@@ -311,8 +325,8 @@ func (d *mqlDns) dnssec(params any) (*mqlDnsDnssecConfig, error) {
 			if record["class"] != nil {
 				class = record["class"].(string)
 			}
-			if record["TTL"] != nil {
-				ttl = record["TTL"].(int64)
+			if v, ok := dictTTL(record); ok {
+				ttl = v
 			}
 			if record["rData"] != nil {
 				rdata = record["rData"].([]any)

--- a/providers/network/resources/dns_internal_test.go
+++ b/providers/network/resources/dns_internal_test.go
@@ -90,3 +90,29 @@ func TestDmarcUris(t *testing.T) {
 	assert.Equal(t, []any{}, dmarcUris(""))
 	assert.Equal(t, []any{"mailto:a@x.com"}, dmarcUris("mailto:a@x.com"))
 }
+
+// TestDictTTL guards the JsonToDict key/type contract for a record's TTL: the
+// map comes from json.Marshal/Unmarshal of dnsshake.DnsRecord, so the key is the
+// json tag "ttl" (not "TTL") and the number is float64 (not int64). Reading the
+// wrong key silently dropped the TTL; asserting .(int64) would panic.
+func TestDictTTL(t *testing.T) {
+	t.Run("reads the lowercase json-tag key as float64", func(t *testing.T) {
+		got, ok := dictTTL(map[string]any{"ttl": float64(3600)})
+		assert.True(t, ok)
+		assert.Equal(t, int64(3600), got)
+	})
+	t.Run("uppercase TTL key is absent (the original bug)", func(t *testing.T) {
+		_, ok := dictTTL(map[string]any{"TTL": float64(3600)})
+		assert.False(t, ok)
+	})
+	t.Run("missing key", func(t *testing.T) {
+		_, ok := dictTTL(map[string]any{"name": "example.com."})
+		assert.False(t, ok)
+	})
+	t.Run("does not panic on an int64 value (wrong type)", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			_, ok := dictTTL(map[string]any{"ttl": int64(3600)})
+			assert.False(t, ok)
+		})
+	})
+}

--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -54,7 +54,12 @@ func New(fqdn string) (*DnsClient, error) {
 	_, err := os.Stat(resolveFile)
 	if err == nil {
 		rConfig, err := dns.ClientConfigFromFile(resolveFile)
-		if err == nil {
+		// Only adopt the host's resolv.conf if it actually lists a nameserver.
+		// A resolv.conf with only `search`/`options` lines parses without error
+		// but yields an empty Servers slice, and queryDnsType indexes Servers[0]
+		// unconditionally, which would panic. Keeping the default resolver avoids
+		// crashing the scan on such hosts.
+		if err == nil && len(rConfig.Servers) > 0 {
 			config = rConfig
 		}
 	}
@@ -279,9 +284,9 @@ func (d *DnsClient) queryDnsType(fqdn string, t string) (map[string]DnsRecord, e
 		case *dns.GID:
 			rec.RData = append(rec.RData, strconv.FormatInt(int64(v.Gid), 10))
 		case *dns.EUI48:
-			strconv.FormatInt(int64(v.Address), 10)
+			rec.RData = append(rec.RData, strconv.FormatInt(int64(v.Address), 10))
 		case *dns.EUI64:
-			strconv.FormatInt(int64(v.Address), 10)
+			rec.RData = append(rec.RData, strconv.FormatInt(int64(v.Address), 10))
 		case *dns.AVC:
 			rec.RData = append(rec.RData, strings.Join(v.Txt, ""))
 		default:

--- a/providers/network/resources/openpgp.go
+++ b/providers/network/resources/openpgp.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"encoding/hex"
+	"strconv"
 	"strings"
 	"time"
 
@@ -142,7 +143,10 @@ type mqlOpenpgpIdentityInternal struct {
 }
 
 func (r *mqlOpenpgpIdentity) id() (string, error) {
-	return "openpgp.identity/" + r.Fingerprint.Data + "/" + r.Name.Data, nil
+	// Use the full UserId (name + comment + email), not just the name: a key can
+	// carry several user IDs that share a name but differ by email/comment, and
+	// keying on Name alone collides so the resource cache drops all but the first.
+	return "openpgp.identity/" + r.Fingerprint.Data + "/" + r.Id.Data, nil
 }
 
 func (r *mqlOpenpgpIdentity) signatures() ([]any, error) {
@@ -203,7 +207,7 @@ func (r *mqlOpenpgpIdentity) signatures() ([]any, error) {
 			ts := llx.DurationToTime(diff)
 			keyExpirationTime = llx.TimeData(ts)
 		} else {
-			expirationTime = llx.NilData
+			keyExpirationTime = llx.NilData
 		}
 
 		o, err := CreateResource(r.MqlRuntime, "openpgp.signature", map[string]*llx.RawData{
@@ -230,5 +234,14 @@ func (r *mqlOpenpgpIdentity) signatures() ([]any, error) {
 }
 
 func (r *mqlOpenpgpSignature) id() (string, error) {
-	return "openpgp.identity/" + r.Fingerprint.Data + "/" + r.IdentityName.Data + "/" + r.Hash.Data, nil
+	// An identity carries several signatures (self-cert, revocation, third-party
+	// certifications) that commonly share the same hash algorithm, so the hash
+	// alone does not disambiguate them. Add the signature type and creation time
+	// so distinct signatures don't collide and get dropped by the resource cache.
+	created := ""
+	if r.CreationTime.Data != nil {
+		created = strconv.FormatInt(r.CreationTime.Data.Unix(), 10)
+	}
+	return "openpgp.signature/" + r.Fingerprint.Data + "/" + r.IdentityName.Data +
+		"/" + r.Hash.Data + "/" + r.SignatureType.Data + "/" + created, nil
 }

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -505,14 +505,22 @@ func (s *mqlTls) populateCertificates(socket *mqlSocket, domainName string) erro
 		return err
 	}
 
-	mqlCerts, _, err := parseCertificates(s.MqlRuntime, domainName, certs, map[string]*tlsshake.Revocation{})
+	// The handshake tester performs OCSP and records revocations keyed by
+	// string(cert.Signature); reuse that map so certificate.isRevoked/revokedAt
+	// reflect real revocation status instead of a hardcoded "not revoked".
+	var revocations map[string]*tlsshake.Revocation
+	if s.tester != nil {
+		revocations = s.tester.Findings.Revocations
+	}
+
+	mqlCerts, _, err := parseCertificates(s.MqlRuntime, domainName, certs, revocations)
 	if err != nil {
 		s.Certificates = plugin.TValue[[]any]{Error: err, State: plugin.StateIsSet}
 	} else {
 		s.Certificates = plugin.TValue[[]any]{Data: mqlCerts, State: plugin.StateIsSet}
 	}
 
-	mqlNonSniCerts, _, err := parseCertificates(s.MqlRuntime, domainName, nonSniCerts, map[string]*tlsshake.Revocation{})
+	mqlNonSniCerts, _, err := parseCertificates(s.MqlRuntime, domainName, nonSniCerts, revocations)
 	if err != nil {
 		s.NonSniCertificates = plugin.TValue[[]any]{Error: err, State: plugin.StateIsSet}
 	} else {

--- a/providers/network/resources/tls.go
+++ b/providers/network/resources/tls.go
@@ -508,8 +508,9 @@ func (s *mqlTls) populateCertificates(socket *mqlSocket, domainName string) erro
 	// The handshake tester performs OCSP and records revocations keyed by
 	// string(cert.Signature); reuse that map so certificate.isRevoked/revokedAt
 	// reflect real revocation status instead of a hardcoded "not revoked".
-	var revocations map[string]*tlsshake.Revocation
-	if s.tester != nil {
+	// Default to an empty (non-nil) map so parseCertificates never receives nil.
+	revocations := map[string]*tlsshake.Revocation{}
+	if s.tester != nil && s.tester.Findings.Revocations != nil {
 		revocations = s.tester.Findings.Revocations
 	}
 

--- a/providers/network/resources/tlsshake/tlsshake.go
+++ b/providers/network/resources/tlsshake/tlsshake.go
@@ -272,6 +272,11 @@ func (s *Tester) addError(msg string) {
 }
 
 func (s *Tester) parseAlert(data []byte, conf *ScanConfig) error {
+	// An Alert record body is 2 bytes (level + description). A hostile or broken
+	// server can send a shorter body; guard before indexing so we don't panic.
+	if len(data) < 2 {
+		return errors.New("malformed TLS/SSL alert (body too short)")
+	}
 	var severity string
 	switch data[0] {
 	case '\x01':
@@ -351,6 +356,12 @@ func hexdump(data []byte) string {
 func (s *Tester) parseServerHello(data []byte, version string, conf *ScanConfig) error {
 	idx := 0
 
+	// version(2) + random(32) + session-ID-length(1) are mandatory fixed fields.
+	// The whole body length is attacker-controlled, so bounds-check before every
+	// read; an unchecked index here panics and takes down the entire scan.
+	if len(data) < idx+35 {
+		return errors.New("malformed ServerHello (too short for random + session-ID length)")
+	}
 	idx += 2
 	random := data[idx : idx+32]
 	isHelloRetryRequest := bytes.Equal(random, helloRetryRequestRandom)
@@ -362,6 +373,10 @@ func (s *Tester) parseServerHello(data []byte, version string, conf *ScanConfig)
 	idx += 1
 	idx += sessionIDlen
 
+	// cipher(2) + compression(1) follow the (variable-length) session ID.
+	if idx+3 > len(data) {
+		return errors.New("malformed ServerHello (truncated before cipher suite)")
+	}
 	cipher, cipherOK := ALL_CIPHERS[string(data[idx:idx+2])]
 	idx += 2
 
@@ -380,9 +395,13 @@ func (s *Tester) parseServerHello(data []byte, version string, conf *ScanConfig)
 	}
 
 	var serverKeyShareGroup []byte
-	for allExtLen > 0 && idx < len(data) {
+	for allExtLen > 0 && idx+4 <= len(data) {
 		extType := string(data[idx : idx+2])
 		extLen := bytes2int(data[idx+2 : idx+4])
+		if idx+4+extLen > len(data) {
+			// extension length runs past the record; stop rather than panic
+			break
+		}
 		extData := data[idx+4 : idx+4+extLen]
 
 		allExtLen -= 4 + extLen
@@ -442,6 +461,9 @@ func (s *Tester) parseServerHello(data []byte, version string, conf *ScanConfig)
 }
 
 func (s *Tester) parseCertificate(data []byte, conf *ScanConfig) error {
+	if len(data) < 3 {
+		return errors.New("malformed certificate response, too little data read from stream to parse certificate")
+	}
 	certsLen := bytes3int(data[0:3])
 	if len(data) < certsLen+3 {
 		return errors.New("malformed certificate response, too little data read from stream to parse certificate")
@@ -450,9 +472,17 @@ func (s *Tester) parseCertificate(data []byte, conf *ScanConfig) error {
 	certs := []*x509.Certificate{}
 	i := 3
 	for i < 3+certsLen {
+		// each cert is prefixed by a 3-byte length; both the prefix and the cert
+		// body it describes are attacker-controlled and must stay within data.
+		if i+3 > len(data) {
+			return errors.New("malformed certificate response, truncated certificate length prefix")
+		}
 		certLen := bytes3int(data[i : i+3])
 		i += 3
 
+		if i+certLen > len(data) {
+			return errors.New("malformed certificate response, certificate length exceeds record")
+		}
 		rawCert := data[i : i+certLen]
 		i += certLen
 
@@ -511,15 +541,28 @@ func (s *Tester) parseCertificate(data []byte, conf *ScanConfig) error {
 //   - There are a few other responses that also signal that we are done
 //     processing handshake responses, like ServerHelloDone or Finished
 func (s *Tester) parseHandshake(data []byte, version string, conf *ScanConfig) (bool, int, error) {
+	// The 4-byte handshake header (type + 3-byte length) and the body it
+	// describes are attacker-controlled; a short record or an oversized length
+	// field must not panic the slice operations below.
+	if len(data) < 4 {
+		return true, 0, errors.New("malformed TLS/SSL handshake (header too short)")
+	}
 	handshakeType := data[0]
 	handshakeLen := bytes3int(data[1:4])
+	bodyEnd := 4 + handshakeLen
 
 	switch handshakeType {
 	case HANDSHAKE_TYPE_ServerHello:
-		err := s.parseServerHello(data[4:4+handshakeLen], version, conf)
+		if bodyEnd > len(data) {
+			return true, 0, errors.New("malformed TLS/SSL handshake (ServerHello body exceeds record)")
+		}
+		err := s.parseServerHello(data[4:bodyEnd], version, conf)
 		return false, handshakeLen, err
 	case HANDSHAKE_TYPE_Certificate:
-		return true, handshakeLen, s.parseCertificate(data[4:4+handshakeLen], conf)
+		if bodyEnd > len(data) {
+			return true, 0, errors.New("malformed TLS/SSL handshake (Certificate body exceeds record)")
+		}
+		return true, handshakeLen, s.parseCertificate(data[4:bodyEnd], conf)
 	case HANDSHAKE_TYPE_ServerKeyExchange:
 		return false, handshakeLen, nil
 	case HANDSHAKE_TYPE_ServerHelloDone:

--- a/providers/network/resources/tlsshake/tlsshake.go
+++ b/providers/network/resources/tlsshake/tlsshake.go
@@ -399,7 +399,12 @@ func (s *Tester) parseServerHello(data []byte, version string, conf *ScanConfig)
 		extType := string(data[idx : idx+2])
 		extLen := bytes2int(data[idx+2 : idx+4])
 		if idx+4+extLen > len(data) {
-			// extension length runs past the record; stop rather than panic
+			// extension length runs past the record; stop rather than panic,
+			// but surface the truncation so a malformed/misconfigured
+			// ServerHello isn't silently treated as fully parsed.
+			s.sync.Lock()
+			s.Findings.Errors = append(s.Findings.Errors, "malformed ServerHello: extension length runs past the record")
+			s.sync.Unlock()
 			break
 		}
 		extData := data[idx+4 : idx+4+extLen]

--- a/providers/network/resources/tlsshake/tlsshake_test.go
+++ b/providers/network/resources/tlsshake/tlsshake_test.go
@@ -66,3 +66,69 @@ func TestTlsshake_Tls13(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok)
 }
+
+// TestParsers_MalformedInputReturnsErrorNotPanic feeds truncated / oversized
+// records (what a broken or hostile TLS server can return to a scanner) to each
+// wire-format parser and asserts they return an error instead of panicking. A
+// panic in these worker goroutines is unrecoverable and crashes the whole scan.
+func TestParsers_MalformedInputReturnsErrorNotPanic(t *testing.T) {
+	conf := &ScanConfig{}
+	newTester := func() *Tester { return New("tcp", "example.com", "example.com", 443) }
+
+	t.Run("parseAlert 1-byte body", func(t *testing.T) {
+		s := newTester()
+		assert.NotPanics(t, func() {
+			assert.Error(t, s.parseAlert([]byte{0x02}, conf))
+		})
+	})
+
+	t.Run("parseHandshake header shorter than 4 bytes", func(t *testing.T) {
+		s := newTester()
+		assert.NotPanics(t, func() {
+			_, _, err := s.parseHandshake([]byte{0x02, 0x00}, "tls1.2", conf)
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("parseHandshake ServerHello length exceeds record", func(t *testing.T) {
+		s := newTester()
+		// type=ServerHello, declared length 0xffffff, but only the 4 header bytes
+		data := []byte{HANDSHAKE_TYPE_ServerHello, 0xff, 0xff, 0xff}
+		assert.NotPanics(t, func() {
+			_, _, err := s.parseHandshake(data, "tls1.2", conf)
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("parseServerHello shorter than fixed fields", func(t *testing.T) {
+		s := newTester()
+		assert.NotPanics(t, func() {
+			assert.Error(t, s.parseServerHello([]byte{0x03, 0x03}, "tls1.2", conf))
+		})
+	})
+
+	t.Run("parseServerHello sessionID length overruns buffer", func(t *testing.T) {
+		s := newTester()
+		data := make([]byte, 35) // version(2)+random(32)+sessionIDlen(1)
+		data[34] = 0xff          // sessionIDlen=255 pushes idx past the buffer
+		assert.NotPanics(t, func() {
+			assert.Error(t, s.parseServerHello(data, "tls1.2", conf))
+		})
+	})
+
+	t.Run("parseCertificate shorter than 3-byte length", func(t *testing.T) {
+		s := newTester()
+		assert.NotPanics(t, func() {
+			assert.Error(t, s.parseCertificate([]byte{0x00, 0x02}, conf))
+		})
+	})
+
+	t.Run("parseCertificate inner cert length exceeds record", func(t *testing.T) {
+		s := newTester()
+		// certsLen=2, total len=5 → the per-cert length prefix runs off the end
+		data := []byte{0x00, 0x00, 0x02, 0xff, 0xff}
+		assert.NotPanics(t, func() {
+			assert.Error(t, s.parseCertificate(data, conf))
+		})
+	})
+}


### PR DESCRIPTION
## Summary

A static bug-review of the `network` provider — which probes untrusted, often hostile network endpoints, so malformed/adversarial responses are its *normal* input — surfaced crash-on-input bugs in the hand-rolled protocol parsers plus several silent wrong-data defects in security-relevant fields. This PR fixes the high-confidence, self-contained ones with regression tests.

## Crashes (a panic in these goroutine-run parsers is unrecoverable → kills the whole scan)

- **openpgp nil-panic** (`openpgp.go`): a copy-paste typo (`expirationTime = llx.NilData` in the `keyExpirationTime` branch) left `keyExpirationTime` as a **Go-nil `*llx.RawData`** for any key with no key-expiration subpacket — i.e. any **never-expiring key** (extremely common). The generated setter dereferences it → panic. One-line fix (also restores `expiresIn` for the sig-expiry-only case).
- **tlsshake handshake parser** (`tlsshake/tlsshake.go`): `parseHandshake` (`data[1:4]`, `data[4:4+len]`), `parseServerHello` (`data[2:34]`, sessionID/cipher reads), `parseCertificate` (`data[0:3]` + inner per-cert length), and `parseAlert` (`data[1]`) indexed **attacker-controlled record bytes with no length checks** — a truncated or oversized record panics. Added bounds guards that return a malformed-response error.
- **dnsshake `Servers[0]` panic** (`dnsshake/dnsshake.go`): a host whose `/etc/resolv.conf` has only `search`/`options` (no `nameserver`) parses OK with an empty `Servers`, and `queryDnsType` indexes `Servers[0]`. Keep the default resolver unless resolv.conf actually lists one.

## Silent wrong-data (security-relevant)

- **TLS cert revocation discarded** (`tls.go`): the handshake tester performs OCSP and records revocations, but `parseCertificates` was called with an **empty** map, so `certificate.isRevoked` was always `false` and `revokedAt` always `0001-01-01`. A revoked leaf passed `all(isRevoked == false)`. Now wires the real `Findings.Revocations` through.
- **Certificate SAN swap** (`certificates.go`): `ipAddresses` and `emailAddresses` were crossed at creation — IP SANs surfaced under `emailAddresses` and vice versa. Unswapped.
- **`dns.record.ttl` always null** (`dns.go`): records flow through `JsonToDict` (marshal→unmarshal), so the key is the json tag `ttl` and the value is `float64`, but the code read `TTL` as `int64` — always null via the collection (and inconsistent with `reverse()`, which returned the real TTL). Added `dictTTL` to read the correct key/type at all three sites; also removes a latent `float64`-vs-`int64` panic.
- **dnsshake EUI48/EUI64** (`dnsshake/dnsshake.go`): both computed their rdata string then discarded it (never appended). Now appended.
- **openpgp `__id` collisions** (`openpgp.go`): `signature.id()` keyed on `fingerprint/identity/hash` (signatures on one identity commonly share a hash → cache dedup dropped all but the first); `identity.id()` used the non-unique `Name` instead of the full UserId. Both now use disambiguating keys.

## Tests
- `tlsshake`: `TestParsers_MalformedInputReturnsErrorNotPanic` feeds truncated/oversized records to each parser and asserts an error, not a panic.
- `dns`: `TestDictTTL` locks in the `JsonToDict` key/type contract (lowercase `ttl`, `float64`).

## Notes
- All changes are Go-only — no `.lr` schema change, no `.lr.versions` bump, no `permissions.json`.
- Deferred to a follow-up (need modeling/design decisions): the tlsshake cipher-enumeration reconnect-loop hang bound, multiple-`Set-Cookie` list modeling + empty-value cookie parsing, `negotiated*` legacy/mTLS degrade, `isVerified` chain validation, the HTTP response-body FD leak, and url.go IPv6/password-key handling.
