### PR TITLE
🧹 mikrotik: harden connection cache + close pure-Go test gaps

### DIFF
--- a/providers/mikrotik/connection/connection.go
+++ b/providers/mikrotik/connection/connection.go
@@ -25,6 +25,14 @@ const (
 	DefaultAPISSLPort = "8729"
 )
 
+// rosClient is the subset of *routeros.Client the connection depends on.
+// Depending on the interface (rather than the concrete type) lets tests drive
+// Print/PrintOptional with a fake reply source; *routeros.Client satisfies it.
+type rosClient interface {
+	Run(sentences ...string) (*routeros.Reply, error)
+	Close() error
+}
+
 type MikrotikConnection struct {
 	plugin.Connection
 	Conf  *inventory.Config
@@ -33,7 +41,7 @@ type MikrotikConnection struct {
 	// client is the underlying RouterOS API client. The RouterOS API
 	// multiplexes a single TCP connection, so concurrent commands must be
 	// serialized; mu guards every Run call.
-	client *routeros.Client
+	client rosClient
 	mu     sync.Mutex
 
 	// printCache memoizes `<menu>/print` results for the lifetime of the
@@ -132,9 +140,10 @@ func (c *MikrotikConnection) Run(sentences ...string) (*routeros.Reply, error) {
 // Print runs a `<menu>/print` command and returns each reply sentence as a
 // map of attribute names to values. For example Print("/interface") issues
 // `/interface/print` and returns one map per interface. Results are memoized
-// per menu for the connection's lifetime (see printCache), and each map is
-// copied out of the routeros reply so callers can never mutate the library's
-// internal sentence state.
+// per menu for the connection's lifetime (see printCache). Each call returns
+// an independent copy of the cached rows, so a caller mutating a returned map
+// can corrupt neither the cache nor the routeros library's internal sentence
+// state, and repeated callers always observe the original device values.
 func (c *MikrotikConnection) Print(menu string) ([]map[string]string, error) {
 	// Hold cacheMu across the fetch (not just the read and the write): this
 	// makes concurrent callers for the same menu wait for the first fetch and
@@ -149,21 +158,31 @@ func (c *MikrotikConnection) Print(menu string) ([]map[string]string, error) {
 	if c.printCache == nil {
 		c.printCache = map[string][]map[string]string{}
 	}
-	if cached, ok := c.printCache[menu]; ok {
-		return cached, nil
+
+	cached, ok := c.printCache[menu]
+	if !ok {
+		reply, err := c.Run(menu + "/print")
+		if err != nil {
+			return nil, err
+		}
+		cached = make([]map[string]string, 0, len(reply.Re))
+		for _, re := range reply.Re {
+			cached = append(cached, maps.Clone(re.Map))
+		}
+		c.printCache[menu] = cached
 	}
 
-	reply, err := c.Run(menu + "/print")
-	if err != nil {
-		return nil, err
-	}
+	return cloneRows(cached), nil
+}
 
-	out := make([]map[string]string, 0, len(reply.Re))
-	for _, re := range reply.Re {
-		out = append(out, maps.Clone(re.Map))
+// cloneRows returns a deep copy of a slice of attribute maps so callers can
+// freely read or mutate the result without touching the shared print cache.
+func cloneRows(rows []map[string]string) []map[string]string {
+	out := make([]map[string]string, len(rows))
+	for i, row := range rows {
+		out[i] = maps.Clone(row)
 	}
-	c.printCache[menu] = out
-	return out, nil
+	return out
 }
 
 // PrintOptional behaves like Print but treats a menu the device does not

--- a/providers/mikrotik/connection/connection_test.go
+++ b/providers/mikrotik/connection/connection_test.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/go-routeros/routeros/v3"
+	"github.com/go-routeros/routeros/v3/proto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsUnknownCommandErr(t *testing.T) {
@@ -19,4 +22,121 @@ func TestIsUnknownCommandErr(t *testing.T) {
 	assert.False(t, isUnknownCommandErr(nil))
 	assert.False(t, isUnknownCommandErr(errors.New("connection refused")))
 	assert.False(t, isUnknownCommandErr(errors.New("permission denied")))
+}
+
+// fakeClient is a rosClient that serves canned replies/errors per command and
+// counts how many times Run is invoked, so tests can assert cache behavior.
+type fakeClient struct {
+	replies map[string]*routeros.Reply
+	errs    map[string]error
+	runs    map[string]int
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		replies: map[string]*routeros.Reply{},
+		errs:    map[string]error{},
+		runs:    map[string]int{},
+	}
+}
+
+func (f *fakeClient) Run(sentences ...string) (*routeros.Reply, error) {
+	cmd := sentences[0]
+	f.runs[cmd]++
+	if err, ok := f.errs[cmd]; ok {
+		return nil, err
+	}
+	return f.replies[cmd], nil
+}
+
+func (f *fakeClient) Close() error { return nil }
+
+// reply builds a routeros.Reply whose sentences carry the given attribute maps.
+func reply(rows ...map[string]string) *routeros.Reply {
+	r := &routeros.Reply{}
+	for _, row := range rows {
+		r.Re = append(r.Re, &proto.Sentence{Map: row})
+	}
+	return r
+}
+
+func TestPrintCachesPerMenu(t *testing.T) {
+	fake := newFakeClient()
+	fake.replies["/interface/print"] = reply(
+		map[string]string{"name": "ether1"},
+		map[string]string{"name": "ether2"},
+	)
+	conn := &MikrotikConnection{client: fake}
+
+	first, err := conn.Print("/interface")
+	require.NoError(t, err)
+	assert.Len(t, first, 2)
+	assert.Equal(t, "ether1", first[0]["name"])
+
+	// second call for the same menu must hit the cache, not the device
+	second, err := conn.Print("/interface")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, fake.runs["/interface/print"], "menu should only be fetched once")
+}
+
+func TestPrintCopiesRowsOutOfLibraryState(t *testing.T) {
+	fake := newFakeClient()
+	fake.replies["/ip/pool/print"] = reply(map[string]string{"name": "dhcp-pool"})
+	conn := &MikrotikConnection{client: fake}
+
+	rows, err := conn.Print("/ip/pool")
+	require.NoError(t, err)
+	// a caller mutating the returned map must not corrupt the cached copy
+	rows[0]["name"] = "tampered"
+
+	again, err := conn.Print("/ip/pool")
+	require.NoError(t, err)
+	assert.Equal(t, "dhcp-pool", again[0]["name"], "cache must be isolated from caller mutation")
+}
+
+func TestPrintPropagatesError(t *testing.T) {
+	fake := newFakeClient()
+	fake.errs["/user/print"] = errors.New("permission denied")
+	conn := &MikrotikConnection{client: fake}
+
+	_, err := conn.Print("/user")
+	assert.Error(t, err)
+	// a failed fetch must not be cached, so a retry re-issues the command
+	_, _ = conn.Print("/user")
+	assert.Equal(t, 2, fake.runs["/user/print"], "errors must not be cached")
+}
+
+func TestPrintOptionalDegradesOnUnknownCommand(t *testing.T) {
+	fake := newFakeClient()
+	fake.errs["/interface/wifi/print"] = errors.New("no such command prefix")
+	conn := &MikrotikConnection{client: fake}
+
+	rows, err := conn.PrintOptional("/interface/wifi")
+	require.NoError(t, err, "an unsupported menu must degrade to empty, not error")
+	assert.Empty(t, rows)
+}
+
+func TestPrintOptionalPropagatesRealError(t *testing.T) {
+	fake := newFakeClient()
+	fake.errs["/interface/wifi/print"] = errors.New("permission denied")
+	conn := &MikrotikConnection{client: fake}
+
+	_, err := conn.PrintOptional("/interface/wifi")
+	assert.Error(t, err, "a genuine failure must still surface")
+}
+
+func TestPrintOne(t *testing.T) {
+	fake := newFakeClient()
+	fake.replies["/system/identity/print"] = reply(map[string]string{"name": "router-a"})
+	fake.replies["/snmp/print"] = reply() // no records
+	conn := &MikrotikConnection{client: fake}
+
+	row, err := conn.PrintOne("/system/identity")
+	require.NoError(t, err)
+	assert.Equal(t, "router-a", row["name"])
+
+	empty, err := conn.PrintOne("/snmp")
+	require.NoError(t, err)
+	assert.Empty(t, empty, "a menu with no records yields an empty map, not nil access")
 }

--- a/providers/mikrotik/resources/mikrotik_test.go
+++ b/providers/mikrotik/resources/mikrotik_test.go
@@ -114,3 +114,12 @@ func TestSplitList(t *testing.T) {
 	assert.Equal(t, []any{"a", "b", "c"}, splitList("a, b ,c"))
 	assert.Equal(t, []any{"a", "b"}, splitList("a,,b,"))
 }
+
+func TestMasterInterfaceName(t *testing.T) {
+	// RouterOS reports "none" for physical radios with no parent interface;
+	// that sentinel must normalize to empty so the masterInterface accessor
+	// returns null instead of trying to resolve an interface named "none".
+	assert.Equal(t, "", masterInterfaceName("none"))
+	assert.Equal(t, "", masterInterfaceName(""))
+	assert.Equal(t, "wifi1", masterInterfaceName("wifi1"))
+}


### PR DESCRIPTION
Test-hardening pass from a static bug review of the mikrotik provider. The review found no high/critical bugs; this PR closes the pure-Go test-coverage gaps it identified and fixes one latent bug the new tests surfaced.

## Changes

**Testability seam (non-breaking).** Introduce a small `rosClient` interface (`Run`, `Close`) over `*routeros.Client` and store that on the connection instead of the concrete type. The concrete client already satisfies it, so no call sites change — but a fake client can now drive `Print`/`PrintOptional`, which no device-less test could reach before.

**Latent aliasing bug fixed.** `Print` memoizes each menu's rows and previously returned the *same* cached maps to every caller. The `maps.Clone` on fetch protected the routeros library's internal sentence state, but not the cache itself: a caller mutating a returned row map would corrupt the shared cache for all subsequent callers of that menu. No current caller mutates returned rows, so this was latent — but the docstring promised an isolation it did not deliver. `Print` now returns an independent deep copy per call, and the comment is corrected.

**New unit tests** for the pure-Go logic the review flagged as untested:
- per-menu memoization (repeated `Print` = one device round-trip)
- cache isolation from caller mutation (the regression test for the fix above)
- failed fetches are not cached (retry re-issues the command)
- `PrintOptional` degrades to empty on "no such command" but propagates genuine errors
- `PrintOne` returns the first row, and an empty map (not a nil-access) when a menu has no records
- `masterInterfaceName` — the one previously untested resource helper ("none" sentinel normalizes to "")

## Not included (and why)
- **Interface traffic/error counters** (whether a plain `/interface/print` returns `rx-byte`/`tx-byte`/… on every RouterOS family) is runtime-data-dependent and belongs in live verification, not a static change.
- **`mikrotik.ip.dns.servers` typed as `string`** while sibling comma-lists use `[]string` is a shipped field; changing its type would be customer-breaking, so it is left as-is.
- The composite `__id` fallbacks (used only when a print reply omits `.id`, which the RouterOS API never does) are effectively dead defensive code and need no change.

## Testing
`go test ./connection/... ./resources/... ./provider/...` — all pass. `make providers/build/mikrotik` succeeds with no generated-code changes (no schema was touched).
