### PR TITLE
🐛 redfish: fix secure-boot silent-false, OEM merge, and add pure-Go tests

### DIFF
--- a/providers/redfish/connection/connection.go
+++ b/providers/redfish/connection/connection.go
@@ -34,6 +34,8 @@ type RedfishConnection struct {
 	managersOnce sync.Once
 	managers     []*schemas.Manager
 	managersErr  error
+
+	idOnce sync.Once
 }
 
 // Systems returns the compute systems exposed by the service, fetched once and
@@ -131,35 +133,34 @@ func (c *RedfishConnection) Close() {
 // Identifier derives a stable platform ID from the first system or manager
 // UUID, falling back to the host when neither is available.
 func (c *RedfishConnection) Identifier() (string, error) {
-	if c.id != "" {
-		return c.id, nil
-	}
-
-	uid := ""
-	if systems, err := c.Systems(); err == nil {
-		for _, s := range systems {
-			if s.UUID != "" {
-				uid = s.UUID
-				break
-			}
-		}
-	}
-	if uid == "" {
-		if managers, err := c.Managers(); err == nil {
-			for _, m := range managers {
-				if m.UUID != "" {
-					uid = m.UUID
+	// idOnce guards the read-compute-write of c.id so concurrent callers cannot
+	// race, and ensures the Systems/Managers lookups run at most once even when
+	// they yield no UUID and we fall back to the host.
+	c.idOnce.Do(func() {
+		uid := ""
+		if systems, err := c.Systems(); err == nil {
+			for _, s := range systems {
+				if s.UUID != "" {
+					uid = s.UUID
 					break
 				}
 			}
 		}
-	}
-	if uid == "" {
-		uid = c.Conf.Host
-	}
+		if uid == "" {
+			if managers, err := c.Managers(); err == nil {
+				for _, m := range managers {
+					if m.UUID != "" {
+						uid = m.UUID
+						break
+					}
+				}
+			}
+		}
+		if uid == "" {
+			uid = c.Conf.Host
+		}
 
-	// c.id is cached after the first call, so the Systems/Managers lookups above
-	// run at most once even when they yield no UUID and we fall back to the host.
-	c.id = "//platformid.api.mondoo.app/runtime/redfish/uuid/" + uid
+		c.id = "//platformid.api.mondoo.app/runtime/redfish/uuid/" + uid
+	})
 	return c.id, nil
 }

--- a/providers/redfish/connection/vendor_test.go
+++ b/providers/redfish/connection/vendor_test.go
@@ -1,0 +1,33 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import "testing"
+
+func TestDetectVendor(t *testing.T) {
+	tests := []struct {
+		name         string
+		manufacturer string
+		wantPlatform string
+	}{
+		{"hpe", "HPE", "bmc-hpe-ilo"},
+		{"hpe lowercase", "hpe", "bmc-hpe-ilo"},
+		{"hewlett packard", "Hewlett Packard Enterprise", "bmc-hpe-ilo"},
+		{"dell", "Dell Inc.", "bmc-dell-idrac"},
+		{"dell mixed case", "DELL", "bmc-dell-idrac"},
+		{"supermicro one word", "Supermicro", "bmc-supermicro"},
+		{"supermicro two words", "Super Micro Computer, Inc.", "bmc-supermicro"},
+		{"unknown vendor", "Lenovo", "bmc-redfish"},
+		{"empty", "", "bmc-redfish"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectVendor(tt.manufacturer)
+			if got.Platform != tt.wantPlatform {
+				t.Errorf("DetectVendor(%q).Platform = %q, want %q", tt.manufacturer, got.Platform, tt.wantPlatform)
+			}
+		})
+	}
+}

--- a/providers/redfish/provider/provider_test.go
+++ b/providers/redfish/provider/provider_test.go
@@ -1,0 +1,79 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/redfish/connection"
+)
+
+func TestParseCLI(t *testing.T) {
+	s := Init()
+
+	t.Run("user, host and explicit port", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "redfish",
+			Args:      []string{"admin@10.0.0.5:8443"},
+			Flags:     map[string]*llx.Primitive{"password": llx.StringPrimitive("secret")},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := res.Asset.Connections[0]
+		if conf.Host != "10.0.0.5" {
+			t.Errorf("host = %q, want 10.0.0.5", conf.Host)
+		}
+		if conf.Port != 8443 {
+			t.Errorf("port = %d, want 8443", conf.Port)
+		}
+		if len(conf.Credentials) != 1 || conf.Credentials[0].User != "admin" {
+			t.Errorf("expected credential for user admin, got %+v", conf.Credentials)
+		}
+	})
+
+	t.Run("defaults to port 443", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "redfish",
+			Args:      []string{"admin@bmc.example.com"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := res.Asset.Connections[0].Port; got != connection.DefaultPort {
+			t.Errorf("port = %d, want %d", got, connection.DefaultPort)
+		}
+	})
+
+	t.Run("insecure flag", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "redfish",
+			Args:      []string{"admin@host"},
+			Flags:     map[string]*llx.Primitive{"insecure": llx.BoolPrimitive(true)},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Asset.Connections[0].Options["insecure"] != "true" {
+			t.Errorf("expected insecure=true option, got %v", res.Asset.Connections[0].Options)
+		}
+	})
+
+	t.Run("rejects invalid port", func(t *testing.T) {
+		if _, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "redfish",
+			Args:      []string{"admin@host:0"},
+		}); err == nil {
+			t.Error("expected error for port 0, got nil")
+		}
+		if _, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "redfish",
+			Args:      []string{"admin@host:99999"},
+		}); err == nil {
+			t.Error("expected error for out-of-range port, got nil")
+		}
+	})
+}

--- a/providers/redfish/resources/oem_test.go
+++ b/providers/redfish/resources/oem_test.go
@@ -1,0 +1,104 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseHpeManagerLicense(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantType  string
+		wantLabel string
+		wantFound bool
+	}{
+		{
+			name:      "current Hpe block",
+			raw:       `{"Hpe":{"License":{"LicenseType":"Perpetual","LicenseString":"iLO Advanced"}}}`,
+			wantType:  "Perpetual",
+			wantLabel: "iLO Advanced",
+			wantFound: true,
+		},
+		{
+			name:      "legacy Hp block",
+			raw:       `{"Hp":{"License":{"LicenseType":"Evaluation","LicenseString":"iLO Standard"}}}`,
+			wantType:  "Evaluation",
+			wantLabel: "iLO Standard",
+			wantFound: true,
+		},
+		{
+			name:      "prefers Hpe over Hp when both present",
+			raw:       `{"Hpe":{"License":{"LicenseType":"Perpetual","LicenseString":"iLO Advanced"}},"Hp":{"License":{"LicenseType":"Evaluation","LicenseString":"iLO Standard"}}}`,
+			wantType:  "Perpetual",
+			wantLabel: "iLO Advanced",
+			wantFound: true,
+		},
+		{name: "empty raw", raw: ``, wantFound: false},
+		{name: "no HPE key", raw: `{"Dell":{}}`, wantFound: false},
+		{name: "malformed json", raw: `{not json`, wantFound: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotLabel, gotFound := parseHpeManagerLicense(json.RawMessage(tt.raw))
+			if gotFound != tt.wantFound {
+				t.Fatalf("found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if gotType != tt.wantType || gotLabel != tt.wantLabel {
+				t.Errorf("got (%q, %q), want (%q, %q)", gotType, gotLabel, tt.wantType, tt.wantLabel)
+			}
+		})
+	}
+}
+
+func TestParseDellSystemOem(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantGen   string
+		wantID    int64
+		wantBios  string
+		wantFound bool
+	}{
+		{
+			name:      "full block",
+			raw:       `{"Dell":{"DellSystem":{"SystemGeneration":"15G","SystemID":1234,"BIOSReleaseDate":"03/01/2024"}}}`,
+			wantGen:   "15G",
+			wantID:    1234,
+			wantBios:  "03/01/2024",
+			wantFound: true,
+		},
+		{
+			name:      "id only, no generation",
+			raw:       `{"Dell":{"DellSystem":{"SystemID":42}}}`,
+			wantID:    42,
+			wantFound: true,
+		},
+		{
+			name:      "generation only",
+			raw:       `{"Dell":{"DellSystem":{"SystemGeneration":"16G"}}}`,
+			wantGen:   "16G",
+			wantFound: true,
+		},
+		{name: "empty raw", raw: ``, wantFound: false},
+		{name: "empty dell system", raw: `{"Dell":{"DellSystem":{}}}`, wantFound: false},
+		{name: "non-dell", raw: `{"Hpe":{}}`, wantFound: false},
+		{name: "malformed json", raw: `{`, wantFound: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGen, gotID, gotBios, gotFound := parseDellSystemOem(json.RawMessage(tt.raw))
+			if gotFound != tt.wantFound {
+				t.Fatalf("found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if gotGen != tt.wantGen || gotID != tt.wantID || gotBios != tt.wantBios {
+				t.Errorf("got (%q, %d, %q), want (%q, %d, %q)", gotGen, gotID, gotBios, tt.wantGen, tt.wantID, tt.wantBios)
+			}
+		})
+	}
+}

--- a/providers/redfish/resources/redfish.go
+++ b/providers/redfish/resources/redfish.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -40,24 +41,18 @@ func (r *mqlRedfish) systems() ([]any, error) {
 
 	res := make([]any, 0, len(systems))
 	for _, s := range systems {
-		secureBoot := false
-		if sb, err := s.SecureBoot(); err == nil && sb != nil {
-			secureBoot = sb.SecureBootEnable
-		}
-
 		o, err := CreateResource(r.MqlRuntime, "redfish.system", map[string]*llx.RawData{
-			"__id":              llx.StringData(s.ODataID),
-			"uuid":              llx.StringData(s.UUID),
-			"name":              llx.StringData(s.Name),
-			"manufacturer":      llx.StringData(s.Manufacturer),
-			"model":             llx.StringData(s.Model),
-			"serialNumber":      llx.StringData(s.SerialNumber),
-			"sku":               llx.StringData(s.SKU),
-			"biosVersion":       llx.StringData(s.BiosVersion),
-			"hostName":          llx.StringData(s.HostName),
-			"powerState":        llx.StringData(string(s.PowerState)),
-			"systemType":        llx.StringData(string(s.SystemType)),
-			"secureBootEnabled": llx.BoolData(secureBoot),
+			"__id":         llx.StringData(s.ODataID),
+			"uuid":         llx.StringData(s.UUID),
+			"name":         llx.StringData(s.Name),
+			"manufacturer": llx.StringData(s.Manufacturer),
+			"model":        llx.StringData(s.Model),
+			"serialNumber": llx.StringData(s.SerialNumber),
+			"sku":          llx.StringData(s.SKU),
+			"biosVersion":  llx.StringData(s.BiosVersion),
+			"hostName":     llx.StringData(s.HostName),
+			"powerState":   llx.StringData(string(s.PowerState)),
+			"systemType":   llx.StringData(string(s.SystemType)),
 		})
 		if err != nil {
 			return nil, err
@@ -195,9 +190,26 @@ type mqlRedfishSystemInternal struct {
 	sys *schemas.ComputerSystem
 }
 
+// secureBootEnabled reports whether UEFI Secure Boot is enabled. It is null
+// when the system exposes no Secure Boot resource or the controller cannot
+// report its state, so an unsupported or unreachable system is not conflated
+// with one where Secure Boot is switched off.
+func (r *mqlRedfishSystem) secureBootEnabled() (bool, error) {
+	if r.sys == nil {
+		r.SecureBootEnabled.State = plugin.StateIsNull | plugin.StateIsSet
+		return false, nil
+	}
+	sb, err := r.sys.SecureBoot()
+	if err != nil || sb == nil {
+		r.SecureBootEnabled.State = plugin.StateIsNull | plugin.StateIsSet
+		return false, nil
+	}
+	return sb.SecureBootEnable, nil
+}
+
 func (r *mqlRedfishSystem) processors() ([]any, error) {
 	if r.sys == nil {
-		return nil, nil
+		return nil, errors.New("redfish.system is missing its source system reference")
 	}
 	processors, err := r.sys.Processors()
 	if err != nil {
@@ -227,7 +239,7 @@ func (r *mqlRedfishSystem) processors() ([]any, error) {
 
 func (r *mqlRedfishSystem) memory() ([]any, error) {
 	if r.sys == nil {
-		return nil, nil
+		return nil, errors.New("redfish.system is missing its source system reference")
 	}
 	memory, err := r.sys.Memory()
 	if err != nil {
@@ -257,7 +269,7 @@ func (r *mqlRedfishSystem) memory() ([]any, error) {
 
 func (r *mqlRedfishSystem) ethernetInterfaces() ([]any, error) {
 	if r.sys == nil {
-		return nil, nil
+		return nil, errors.New("redfish.system is missing its source system reference")
 	}
 	interfaces, err := r.sys.EthernetInterfaces()
 	if err != nil {
@@ -333,6 +345,28 @@ type hpeLicenseWrap struct {
 	} `json:"License"`
 }
 
+// parseHpeManagerLicense extracts the iLO license from a manager's OEM block.
+// Older iLO firmware nests the data under "Hp" rather than "Hpe"; found is
+// false when the block is empty, unparseable, or carries no HPE license.
+func parseHpeManagerLicense(raw json.RawMessage) (licenseType, licenseLabel string, found bool) {
+	if len(raw) == 0 {
+		return "", "", false
+	}
+	var oem hpeManagerOem
+	if err := json.Unmarshal(raw, &oem); err != nil {
+		log.Debug().Err(err).Msg("redfish: could not parse HPE manager OEM block")
+		return "", "", false
+	}
+	wrap := oem.Hpe
+	if wrap == nil {
+		wrap = oem.Hp
+	}
+	if wrap == nil {
+		return "", "", false
+	}
+	return wrap.License.LicenseType, wrap.License.LicenseString, true
+}
+
 // mqlRedfishHpeInternal caches the parsed HPE OEM license data.
 type mqlRedfishHpeInternal struct {
 	once               sync.Once
@@ -352,23 +386,12 @@ func (r *mqlRedfishHpe) load() {
 			return
 		}
 		for _, m := range managers {
-			if len(m.OEM) == 0 {
+			licenseType, licenseLabel, found := parseHpeManagerLicense(m.OEM)
+			if !found {
 				continue
 			}
-			var oem hpeManagerOem
-			if err := json.Unmarshal(m.OEM, &oem); err != nil {
-				log.Debug().Err(err).Msg("redfish: could not parse HPE manager OEM block")
-				continue
-			}
-			wrap := oem.Hpe
-			if wrap == nil {
-				wrap = oem.Hp
-			}
-			if wrap == nil {
-				continue
-			}
-			r.cachedLicenseType = wrap.License.LicenseType
-			r.cachedLicenseLabel = wrap.License.LicenseString
+			r.cachedLicenseType = licenseType
+			r.cachedLicenseLabel = licenseLabel
 			return
 		}
 	})
@@ -395,6 +418,25 @@ type dellSystemOem struct {
 	} `json:"Dell"`
 }
 
+// parseDellSystemOem extracts the Dell system data from a system's OEM block.
+// found is false when the block is empty, unparseable, or carries no Dell
+// system generation or numeric ID (the fields that identify Dell hardware).
+func parseDellSystemOem(raw json.RawMessage) (generation string, systemID int64, biosReleaseDate string, found bool) {
+	if len(raw) == 0 {
+		return "", 0, "", false
+	}
+	var oem dellSystemOem
+	if err := json.Unmarshal(raw, &oem); err != nil {
+		log.Debug().Err(err).Msg("redfish: could not parse Dell system OEM block")
+		return "", 0, "", false
+	}
+	d := oem.Dell.DellSystem
+	if d.SystemGeneration == "" && d.SystemID == 0 {
+		return "", 0, "", false
+	}
+	return d.SystemGeneration, d.SystemID, d.BIOSReleaseDate, true
+}
+
 // mqlRedfishDellInternal caches the parsed Dell OEM system data.
 type mqlRedfishDellInternal struct {
 	once                  sync.Once
@@ -415,20 +457,13 @@ func (r *mqlRedfishDell) load() {
 			return
 		}
 		for _, s := range systems {
-			if len(s.OEM) == 0 {
+			generation, systemID, biosReleaseDate, found := parseDellSystemOem(s.OEM)
+			if !found {
 				continue
 			}
-			var oem dellSystemOem
-			if err := json.Unmarshal(s.OEM, &oem); err != nil {
-				log.Debug().Err(err).Msg("redfish: could not parse Dell system OEM block")
-				continue
-			}
-			if oem.Dell.DellSystem.SystemGeneration == "" && oem.Dell.DellSystem.SystemID == 0 {
-				continue
-			}
-			r.cachedGeneration = oem.Dell.DellSystem.SystemGeneration
-			r.cachedSystemID = oem.Dell.DellSystem.SystemID
-			r.cachedBiosReleaseDate = oem.Dell.DellSystem.BIOSReleaseDate
+			r.cachedGeneration = generation
+			r.cachedSystemID = systemID
+			r.cachedBiosReleaseDate = biosReleaseDate
 			return
 		}
 	})
@@ -469,28 +504,36 @@ func (r *mqlRedfishSupermicro) load() {
 			log.Warn().Err(err).Msg("redfish: could not list managers for Supermicro OEM detection")
 			return
 		}
+		// License data and system-lockdown state can live on different managers,
+		// so accumulate each independently rather than stopping at the first
+		// manager that carries either one.
+		gotLicenses := false
+		gotLockdown := false
 		for _, m := range managers {
 			smcManager, err := smc.FromManager(m)
 			if err != nil {
 				continue
 			}
 
-			found := false
-			if lm, err := smcManager.LicenseManager(); err == nil && lm != nil {
-				if ql, err := lm.QueryLicense(); err == nil && ql != nil {
-					licenses := make([]any, 0, len(ql.Licenses))
-					for _, license := range ql.Licenses {
-						licenses = append(licenses, license)
+			if !gotLicenses {
+				if lm, err := smcManager.LicenseManager(); err == nil && lm != nil {
+					if ql, err := lm.QueryLicense(); err == nil && ql != nil {
+						licenses := make([]any, 0, len(ql.Licenses))
+						for _, license := range ql.Licenses {
+							licenses = append(licenses, license)
+						}
+						r.cachedLicenses = licenses
+						gotLicenses = true
 					}
-					r.cachedLicenses = licenses
-					found = true
 				}
 			}
-			if sl, err := smcManager.SysLockdown(); err == nil && sl != nil {
-				r.cachedLockdown = sl.Enabled
-				found = true
+			if !gotLockdown {
+				if sl, err := smcManager.SysLockdown(); err == nil && sl != nil {
+					r.cachedLockdown = sl.Enabled
+					gotLockdown = true
+				}
 			}
-			if found {
+			if gotLicenses && gotLockdown {
 				return
 			}
 		}

--- a/providers/redfish/resources/redfish.lr
+++ b/providers/redfish/resources/redfish.lr
@@ -52,7 +52,11 @@ redfish.system @defaults("model powerState") {
   // Kind of system, such as Physical, Virtual, OS, or PhysicallyPartitioned
   systemType string
   // Whether UEFI Secure Boot is enabled
-  secureBootEnabled bool
+  //
+  // Null when the system does not expose a Secure Boot resource or the
+  // controller cannot report its state, so an audit can tell an unsupported
+  // or unreachable system apart from one where Secure Boot is switched off.
+  secureBootEnabled() bool
   // Installed processors
   processors() []redfish.processor
   // Installed memory modules

--- a/providers/redfish/resources/redfish.lr.go
+++ b/providers/redfish/resources/redfish.lr.go
@@ -984,7 +984,9 @@ func (c *mqlRedfishSystem) GetSystemType() *plugin.TValue[string] {
 }
 
 func (c *mqlRedfishSystem) GetSecureBootEnabled() *plugin.TValue[bool] {
-	return &c.SecureBootEnabled
+	return plugin.GetOrCompute[bool](&c.SecureBootEnabled, func() (bool, error) {
+		return c.secureBootEnabled()
+	})
 }
 
 func (c *mqlRedfishSystem) GetProcessors() *plugin.TValue[[]any] {


### PR DESCRIPTION
## What

Fixes from a static bug review of the `redfish` provider. These are defects that reach users as **wrong data with no error** (the worst kind), plus gaps in unit-test coverage of the provider's pure-Go logic.

### Fixes

- **`secureBootEnabled` silently reported `false` on error/unsupported.** `SecureBoot()` is a separate HTTP GET; on any failure (unsupported resource, permission, transient error) the code swallowed the error and set the field to `false`, indistinguishable from a genuinely-disabled system. In an out-of-band security audit (`redfish.systems.where(secureBootEnabled == false)`) that produces false findings and masks unknown state. It is now a **computed field that resolves to `null`** when the state can't be determined, so an audit can tell "unsupported/unreachable" apart from "switched off". This also aligns with the project rule *"never hardcode default values for fields the API doesn't return."*

- **`processors`/`memory`/`ethernetInterfaces` returned an empty list (not an error)** when the cached source system was missing. Unreachable today, but it would become silent data loss if a lazy `init` for `redfish.system` were ever added. They now return an explicit error.

- **Supermicro OEM detection stopped at the first manager** that carried *either* license or lockdown data, dropping the other when they live on different managers. It now accumulates each independently.

- **`Identifier()` did a lock-free read-compute-write of `c.id`.** Guarded with a `sync.Once` (matching the existing `systemsOnce`/`managersOnce` pattern).

### Tests

Extracted the HPE and Dell OEM parsing into pure functions and added table-driven unit tests for them (including the legacy `Hp`-vs-`Hpe` fallback and the Dell empty-block guard), plus tests for `DetectVendor` (vendor substring matching) and `ParseCLI` (URL/port parsing, defaults, invalid-port rejection). Previously only the platform catalog had test coverage.

## Verified clean during review (no change needed)

- **Pagination** — gofish follows `Members@odata.nextLink` via `GetCollectionObjects` → `CollectListGeneric`, so no collection truncates.
- **`networkProtocol()` dict** — sub-structs are value types, `ProtocolEnabled` is a plain `bool`, and `Port *uint` goes through `uintPtrToAny`, so the dict is fully JSON-native.
- **`supermicro.licenses()`** — `QueryLicense.Licenses` is `[]string`, so the `[]any` holds strings.
- **No range-variable pointer capture** — all SDK collection methods return `[]*T`.
- **`__id` values** are all real, globally-unique `ODataID`s.

## Test plan

- `go test ./...` in `providers/redfish/` — all pass.
- `make providers/build/redfish` — succeeds; no drift in generated `resources.json` (the field's schema representation is unchanged, only its resolution moved from stored to computed).
