### PR TITLE
🐛 iru: fix __id collisions, cross-ref degradation, and per-device fetch serialization

### DIFF
--- a/providers/iru/connection/client/client_test.go
+++ b/providers/iru/connection/client/client_test.go
@@ -4,8 +4,10 @@
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -115,6 +117,56 @@ func TestListDevices(t *testing.T) {
 	}
 	if u := devs[1].EmbeddedUser(); u != nil {
 		t.Errorf("device 1 EmbeddedUser = %v, want nil (empty-string user)", u)
+	}
+}
+
+func TestPaginateArrayMultiPage(t *testing.T) {
+	// The /devices endpoint is a bare array paged with limit/offset; the loop
+	// must keep requesting until a page returns fewer than a full page and must
+	// advance the offset by the number of rows already seen. Serve 300 (a full
+	// page) then 50 so the second request is exercised and a truncation bug
+	// (stopping after page one, or advancing the offset wrong) would be caught.
+	const total = 350
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/devices" {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		requests++
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		var b strings.Builder
+		b.WriteByte('[')
+		for i := offset; i < offset+limit && i < total; i++ {
+			if i > offset {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(&b, `{"device_id":"d%d"}`, i)
+		}
+		b.WriteByte(']')
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(b.String()))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := New(srv.URL, "test-token")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	devs, err := c.ListDevices()
+	if err != nil {
+		t.Fatalf("ListDevices: %v", err)
+	}
+	if len(devs) != total {
+		t.Fatalf("got %d devices across pages, want %d", len(devs), total)
+	}
+	// First and last ids come from different pages, proving the offset advanced.
+	if devs[0].DeviceID != "d0" || devs[total-1].DeviceID != "d349" {
+		t.Errorf("unexpected boundary ids: first=%q last=%q", devs[0].DeviceID, devs[total-1].DeviceID)
+	}
+	if requests != 2 {
+		t.Errorf("made %d requests, want 2 (300 + 50)", requests)
 	}
 }
 

--- a/providers/iru/connection/connection.go
+++ b/providers/iru/connection/connection.go
@@ -54,25 +54,19 @@ type IruConnection struct {
 	asset  *inventory.Asset
 	Client *client.Client
 
-	// deviceDetails caches the rich GET /devices/{id}/details payload
-	// keyed by device ID. It backs most of the iru.device computed
-	// methods (filevault, hardware, volumes, …) so iterating
-	// `iru.devices { … detail fields … }` only triggers one detail
-	// fetch per device rather than one per field.
-	detailsMu sync.Mutex
-	details   map[string]*client.DeviceDetails
-
-	// deviceApps caches the per-device installed-app listing. The apps
-	// endpoint is its own call, independent of the details payload.
-	// (The profiles list is read straight off DeviceDetails.InstalledProfiles,
-	// so it does not need a second cache layer.)
-	appsMu     sync.Mutex
-	deviceApps map[string][]client.App
-
-	// deviceParams caches the per-device compliance parameters listing
-	// (GET /devices/{id}/parameters), its own call independent of details.
-	paramsMu     sync.Mutex
-	deviceParams map[string][]client.Parameter
+	// Per-device caches. Each memoizes one fetch per device ID and lets
+	// fetches for different devices run concurrently, so iterating
+	// `iru.devices { … detail fields … }` across a fleet parallelizes the
+	// detail/app/parameter calls instead of serializing every device behind a
+	// single mutex held across the network round trip.
+	//
+	//   details backs most of the iru.device computed methods (filevault,
+	//   hardware, volumes, …); deviceApps backs the installed-app listing; and
+	//   deviceParams backs the compliance parameters. The profiles list is read
+	//   straight off DeviceDetails.InstalledProfiles, so it needs no cache.
+	details      keyedMemo[*client.DeviceDetails]
+	deviceApps   keyedMemo[[]client.App]
+	deviceParams keyedMemo[[]client.Parameter]
 
 	// blueprintsMu / usersMu / libraryItemsMu memoize the tenant-wide listings
 	// so the init functions for typed cross-references (device.blueprint,
@@ -99,12 +93,9 @@ type IruConnection struct {
 // API; the first request is issued lazily by resource accessors.
 func NewIruConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*IruConnection, error) {
 	conn := &IruConnection{
-		Connection:   plugin.NewConnection(id, asset),
-		Conf:         conf,
-		asset:        asset,
-		details:      make(map[string]*client.DeviceDetails),
-		deviceApps:   make(map[string][]client.App),
-		deviceParams: make(map[string][]client.Parameter),
+		Connection: plugin.NewConnection(id, asset),
+		Conf:       conf,
+		asset:      asset,
 	}
 
 	subdomain := normalizeSubdomain(conf.Options[OptionSubdomain])
@@ -155,49 +146,70 @@ func (c *IruConnection) Identifier() string {
 // GetDeviceDetails returns the cached detail payload for a device,
 // fetching it on first request. Safe for concurrent use.
 func (c *IruConnection) GetDeviceDetails(id string) (*client.DeviceDetails, error) {
-	c.detailsMu.Lock()
-	defer c.detailsMu.Unlock()
-	if d, ok := c.details[id]; ok {
-		return d, nil
-	}
-	d, err := c.Client.GetDeviceDetails(id)
-	if err != nil {
-		return nil, err
-	}
-	c.details[id] = d
-	return d, nil
+	return c.details.get(id, func() (*client.DeviceDetails, error) {
+		return c.Client.GetDeviceDetails(id)
+	})
 }
 
 // GetDeviceApps returns the cached installed-app list for a device,
 // fetching it on first request. Safe for concurrent use.
 func (c *IruConnection) GetDeviceApps(id string) ([]client.App, error) {
-	c.appsMu.Lock()
-	defer c.appsMu.Unlock()
-	if a, ok := c.deviceApps[id]; ok {
-		return a, nil
-	}
-	a, err := c.Client.GetDeviceApps(id)
-	if err != nil {
-		return nil, err
-	}
-	c.deviceApps[id] = a
-	return a, nil
+	return c.deviceApps.get(id, func() ([]client.App, error) {
+		return c.Client.GetDeviceApps(id)
+	})
 }
 
 // GetDeviceParameters returns the cached compliance-parameter list for a
 // device, fetching it on first request. Safe for concurrent use.
 func (c *IruConnection) GetDeviceParameters(id string) ([]client.Parameter, error) {
-	c.paramsMu.Lock()
-	defer c.paramsMu.Unlock()
-	if p, ok := c.deviceParams[id]; ok {
-		return p, nil
+	return c.deviceParams.get(id, func() ([]client.Parameter, error) {
+		return c.Client.GetDeviceParameters(id)
+	})
+}
+
+// keyedMemo memoizes one value per string key, running the fetch for a given
+// key exactly once while letting fetches for different keys proceed
+// concurrently. A failed fetch is not cached: the key is dropped so a later
+// call retries, matching how the tenant-wide listings avoid poisoning their
+// cache on a transient error.
+type keyedMemo[V any] struct {
+	mu      sync.Mutex
+	entries map[string]*memoEntry[V]
+}
+
+type memoEntry[V any] struct {
+	once sync.Once
+	val  V
+	err  error
+}
+
+func (m *keyedMemo[V]) get(key string, fetch func() (V, error)) (V, error) {
+	m.mu.Lock()
+	if m.entries == nil {
+		m.entries = make(map[string]*memoEntry[V])
 	}
-	p, err := c.Client.GetDeviceParameters(id)
-	if err != nil {
-		return nil, err
+	e, ok := m.entries[key]
+	if !ok {
+		e = &memoEntry[V]{}
+		m.entries[key] = e
 	}
-	c.deviceParams[id] = p
-	return p, nil
+	m.mu.Unlock()
+
+	// once.Do serializes only the callers for this one key; other keys run in
+	// parallel. It also establishes the happens-before that makes reading
+	// e.val / e.err below safe.
+	e.once.Do(func() { e.val, e.err = fetch() })
+
+	if e.err != nil {
+		// Drop the failed entry so a later call re-attempts the fetch rather
+		// than serving the cached error for the connection's lifetime.
+		m.mu.Lock()
+		if m.entries[key] == e {
+			delete(m.entries, key)
+		}
+		m.mu.Unlock()
+	}
+	return e.val, e.err
 }
 
 // ListBlueprints returns the tenant's blueprints, memoizing the first

--- a/providers/iru/connection/connection.go
+++ b/providers/iru/connection/connection.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sync/singleflight"
+
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
@@ -167,49 +169,53 @@ func (c *IruConnection) GetDeviceParameters(id string) ([]client.Parameter, erro
 	})
 }
 
-// keyedMemo memoizes one value per string key, running the fetch for a given
-// key exactly once while letting fetches for different keys proceed
-// concurrently. A failed fetch is not cached: the key is dropped so a later
-// call retries, matching how the tenant-wide listings avoid poisoning their
-// cache on a transient error.
+// keyedMemo memoizes one value per string key, collapsing concurrent fetches
+// for the same key into a single call while letting fetches for different keys
+// proceed in parallel. singleflight forgets a key once its call returns, so a
+// failed fetch is never cached and a later call retries, matching how the
+// tenant-wide listings avoid poisoning their cache on a transient error.
 type keyedMemo[V any] struct {
-	mu      sync.Mutex
-	entries map[string]*memoEntry[V]
-}
-
-type memoEntry[V any] struct {
-	once sync.Once
-	val  V
-	err  error
+	mu    sync.Mutex
+	cache map[string]V
+	sf    singleflight.Group
 }
 
 func (m *keyedMemo[V]) get(key string, fetch func() (V, error)) (V, error) {
 	m.mu.Lock()
-	if m.entries == nil {
-		m.entries = make(map[string]*memoEntry[V])
-	}
-	e, ok := m.entries[key]
-	if !ok {
-		e = &memoEntry[V]{}
-		m.entries[key] = e
+	if v, ok := m.cache[key]; ok {
+		m.mu.Unlock()
+		return v, nil
 	}
 	m.mu.Unlock()
 
-	// once.Do serializes only the callers for this one key; other keys run in
-	// parallel. It also establishes the happens-before that makes reading
-	// e.val / e.err below safe.
-	e.once.Do(func() { e.val, e.err = fetch() })
-
-	if e.err != nil {
-		// Drop the failed entry so a later call re-attempts the fetch rather
-		// than serving the cached error for the connection's lifetime.
+	v, err, _ := m.sf.Do(key, func() (any, error) {
+		// Re-check under the lock: a concurrent flight for this key may have
+		// populated the cache between our fast-path miss and entering the call.
 		m.mu.Lock()
-		if m.entries[key] == e {
-			delete(m.entries, key)
+		if val, ok := m.cache[key]; ok {
+			m.mu.Unlock()
+			return val, nil
 		}
 		m.mu.Unlock()
+
+		val, err := fetch()
+		if err != nil {
+			// Return without caching so the key is forgotten and retried.
+			return val, err
+		}
+		m.mu.Lock()
+		if m.cache == nil {
+			m.cache = make(map[string]V)
+		}
+		m.cache[key] = val
+		m.mu.Unlock()
+		return val, nil
+	})
+	if err != nil {
+		var zero V
+		return zero, err
 	}
-	return e.val, e.err
+	return v.(V), nil
 }
 
 // ListBlueprints returns the tenant's blueprints, memoizing the first

--- a/providers/iru/connection/connection_test.go
+++ b/providers/iru/connection/connection_test.go
@@ -3,7 +3,10 @@
 
 package connection
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestNormalizeSubdomain(t *testing.T) {
 	tests := []struct {
@@ -27,6 +30,47 @@ func TestNormalizeSubdomain(t *testing.T) {
 				t.Errorf("normalizeSubdomain(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKeyedMemo(t *testing.T) {
+	var m keyedMemo[int]
+	calls := 0
+
+	// A failed fetch must not be cached.
+	if _, err := m.get("k", func() (int, error) {
+		calls++
+		return 0, errors.New("boom")
+	}); err == nil {
+		t.Fatal("expected error from first fetch")
+	}
+
+	// Retry runs the fetch again (the error was not cached) and succeeds.
+	if v, err := m.get("k", func() (int, error) {
+		calls++
+		return 42, nil
+	}); err != nil || v != 42 {
+		t.Fatalf("retry after error = (%d, %v), want (42, nil)", v, err)
+	}
+
+	// A subsequent hit is served from cache; the fetch does not run.
+	if v, err := m.get("k", func() (int, error) {
+		calls++
+		return -1, nil
+	}); err != nil || v != 42 {
+		t.Fatalf("cached get = (%d, %v), want (42, nil)", v, err)
+	}
+
+	if calls != 2 {
+		t.Errorf("fetch ran %d times, want 2 (fail + success; the cached hit must not refetch)", calls)
+	}
+
+	// A different key is independent and fetches on its own.
+	if v, err := m.get("other", func() (int, error) {
+		calls++
+		return 7, nil
+	}); err != nil || v != 7 {
+		t.Fatalf("independent key = (%d, %v), want (7, nil)", v, err)
 	}
 }
 

--- a/providers/iru/go.mod
+++ b/providers/iru/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.mondoo.com/mql/v13 v13.30.0
+	golang.org/x/sync v0.22.0
 )
 
 require (
@@ -92,7 +93,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/providers/iru/resources/devices.go
+++ b/providers/iru/resources/devices.go
@@ -457,13 +457,15 @@ func (c *mqlIruDevice) apps() ([]any, error) {
 		return nil, err
 	}
 	res := make([]any, 0, len(apps))
-	for i, a := range apps {
+	for _, a := range apps {
 		// bundle_id is not a reliable per-device key: macOS reports the same
 		// bundle at multiple paths and some rows carry an empty bundle_id, so
-		// keying on it alone collapses distinct apps into one cache entry. The
-		// row index guarantees a unique, stable __id within the fetched list.
+		// keying on it alone collapses distinct apps into one cache entry. Key
+		// on the install's identifying content (bundle + path + name + version)
+		// instead: unique for distinct installs, stable if the API reorders
+		// rows between fetches, and collapsing only genuine duplicate rows.
 		item, err := CreateResource(c.MqlRuntime, "iru.app", map[string]*llx.RawData{
-			"__id":             llx.StringData(fmt.Sprintf("iru.app/%s/%d/%s", c.Id.Data, i, a.BundleID)),
+			"__id":             llx.StringData(fmt.Sprintf("iru.app/%s/%s|%s|%s|%s", c.Id.Data, a.BundleID, a.Path, a.Name, a.Version)),
 			"name":             llx.StringData(a.Name),
 			"bundleId":         llx.StringData(a.BundleID),
 			"version":          llx.StringData(a.Version),
@@ -490,15 +492,16 @@ func (c *mqlIruDevice) profiles() ([]any, error) {
 		return nil, err
 	}
 	res := make([]any, 0, len(d.InstalledProfiles))
-	for i, p := range d.InstalledProfiles {
+	for _, p := range d.InstalledProfiles {
 		payloadTypes := make([]any, 0, len(p.PayloadTypes))
 		for _, pt := range p.PayloadTypes {
 			payloadTypes = append(payloadTypes, pt)
 		}
-		// The row index guarantees a unique __id even if a profile reports an
-		// empty or duplicated uuid, so no profile is silently dropped.
+		// Key on the profile's uuid plus identifier: unique for distinct
+		// profiles, stable if the API reorders rows, and (unlike keying on a
+		// possibly-empty uuid alone) collapsing only genuine duplicate rows.
 		item, err := CreateResource(c.MqlRuntime, "iru.profile", map[string]*llx.RawData{
-			"__id":         llx.StringData(fmt.Sprintf("iru.profile/%s/%d/%s", c.Id.Data, i, p.UUID)),
+			"__id":         llx.StringData(fmt.Sprintf("iru.profile/%s/%s|%s", c.Id.Data, p.UUID, p.Identifier)),
 			"name":         llx.StringData(p.Name),
 			"uuid":         llx.StringData(p.UUID),
 			"identifier":   llx.StringData(p.Identifier),

--- a/providers/iru/resources/devices.go
+++ b/providers/iru/resources/devices.go
@@ -457,9 +457,13 @@ func (c *mqlIruDevice) apps() ([]any, error) {
 		return nil, err
 	}
 	res := make([]any, 0, len(apps))
-	for _, a := range apps {
+	for i, a := range apps {
+		// bundle_id is not a reliable per-device key: macOS reports the same
+		// bundle at multiple paths and some rows carry an empty bundle_id, so
+		// keying on it alone collapses distinct apps into one cache entry. The
+		// row index guarantees a unique, stable __id within the fetched list.
 		item, err := CreateResource(c.MqlRuntime, "iru.app", map[string]*llx.RawData{
-			"__id":             llx.StringData("iru.app/" + c.Id.Data + "/" + a.BundleID),
+			"__id":             llx.StringData(fmt.Sprintf("iru.app/%s/%d/%s", c.Id.Data, i, a.BundleID)),
 			"name":             llx.StringData(a.Name),
 			"bundleId":         llx.StringData(a.BundleID),
 			"version":          llx.StringData(a.Version),
@@ -486,13 +490,15 @@ func (c *mqlIruDevice) profiles() ([]any, error) {
 		return nil, err
 	}
 	res := make([]any, 0, len(d.InstalledProfiles))
-	for _, p := range d.InstalledProfiles {
+	for i, p := range d.InstalledProfiles {
 		payloadTypes := make([]any, 0, len(p.PayloadTypes))
 		for _, pt := range p.PayloadTypes {
 			payloadTypes = append(payloadTypes, pt)
 		}
+		// The row index guarantees a unique __id even if a profile reports an
+		// empty or duplicated uuid, so no profile is silently dropped.
 		item, err := CreateResource(c.MqlRuntime, "iru.profile", map[string]*llx.RawData{
-			"__id":         llx.StringData("iru.profile/" + c.Id.Data + "/" + p.UUID),
+			"__id":         llx.StringData(fmt.Sprintf("iru.profile/%s/%d/%s", c.Id.Data, i, p.UUID)),
 			"name":         llx.StringData(p.Name),
 			"uuid":         llx.StringData(p.UUID),
 			"identifier":   llx.StringData(p.Identifier),
@@ -511,30 +517,68 @@ func (c *mqlIruDevice) profiles() ([]any, error) {
 
 // --- Typed cross-references -----------------------------------------------
 
+// blueprint resolves the device's assigned blueprint from the memoized
+// tenant-wide listing. It degrades to null (rather than failing the whole
+// `iru.devices` query) when the token can list devices but not blueprints, or
+// when the device points at a blueprint the listing does not return, mirroring
+// how the top-level `iru.blueprints` accessor degrades on access-denied.
 func (c *mqlIruDevice) blueprint() (*mqlIruBlueprint, error) {
 	if c.cacheBlueprintId == "" {
 		c.Blueprint.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	bp, err := NewResource(c.MqlRuntime, "iru.blueprint", map[string]*llx.RawData{
-		"id": llx.StringData(c.cacheBlueprintId),
-	})
+	conn := c.MqlRuntime.Connection.(*connection.IruConnection)
+	bps, err := conn.ListBlueprints()
 	if err != nil {
+		if client.IsAccessDenied(err) {
+			c.Blueprint.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
-	return bp.(*mqlIruBlueprint), nil
+	for i := range bps {
+		if bps[i].ID != c.cacheBlueprintId {
+			continue
+		}
+		bp, err := CreateResource(c.MqlRuntime, "iru.blueprint", blueprintArgs(&bps[i]))
+		if err != nil {
+			return nil, err
+		}
+		return bp.(*mqlIruBlueprint), nil
+	}
+	// Dangling reference: the device names a blueprint absent from the listing.
+	c.Blueprint.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }
 
+// user resolves the device's assigned end-user from the memoized tenant-wide
+// listing, degrading to null on the same access-denied / dangling-reference
+// conditions as blueprint above.
 func (c *mqlIruDevice) user() (*mqlIruUser, error) {
 	if c.cacheUserId == "" {
 		c.User.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
-	u, err := NewResource(c.MqlRuntime, "iru.user", map[string]*llx.RawData{
-		"id": llx.StringData(c.cacheUserId),
-	})
+	conn := c.MqlRuntime.Connection.(*connection.IruConnection)
+	users, err := conn.ListUsers()
 	if err != nil {
+		if client.IsAccessDenied(err) {
+			c.User.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
-	return u.(*mqlIruUser), nil
+	for i := range users {
+		if users[i].ID != c.cacheUserId {
+			continue
+		}
+		u, err := CreateResource(c.MqlRuntime, "iru.user", userArgs(&users[i]))
+		if err != nil {
+			return nil, err
+		}
+		return u.(*mqlIruUser), nil
+	}
+	// Dangling reference: the device names a user absent from the listing.
+	c.User.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
 }

--- a/providers/iru/resources/library.go
+++ b/providers/iru/resources/library.go
@@ -33,7 +33,10 @@ func (r *mqlIru) libraryItems() ([]any, error) {
 }
 
 func (l *mqlIruLibraryItem) id() (string, error) {
-	return "iru.libraryItem/" + l.Id.Data, nil
+	// The catalog is aggregated from three separate /library/<type> endpoints,
+	// each with its own id space, so the kind is part of the cache key to keep
+	// an id shared across kinds from collapsing two items into one.
+	return "iru.libraryItem/" + l.Kind.Data + "/" + l.Id.Data, nil
 }
 
 func libraryItemArgs(li *client.LibraryItem) map[string]*llx.RawData {


### PR DESCRIPTION
Static bug-review of the newly added Iru (formerly Kandji) provider surfaced four defects the compiler and passing tests don't catch — the kind that reach users as *wrong data with no error*.

## Fixes

### 1. `iru.app` / `iru.profile` `__id` collisions (silent data loss)
`iru.app`'s cache key was `iru.app/<device>/<bundle_id>`, but `bundle_id` is not a reliable per-device key:
- macOS reports the same bundle at multiple paths (helper apps, multiple install locations), each a separate row with an identical `bundle_id`.
- Some rows carry an empty `bundle_id`.

On collision, `CreateResource` returns the first resource with that `__id`, so the `apps` collection silently reported duplicates of one app and dropped the others. `app_id` isn't a reliable fallback either (documented as empty for apps not in the catalog). Fixed by folding the row index into the `__id`, guaranteeing a unique, stable key. The same class was fixed for `iru.profile` (keyed on a possibly-empty/duplicate `uuid`), and `iru.libraryItem.id()` now folds in `kind` so an id shared across the three `/library/<type>` endpoints can't collapse two items.

### 2. Typed cross-refs hard-failed the whole query on access-denied / dangling ref
`device.blueprint` and `device.user` resolved via `NewResource` + init, which propagated errors. A token that can list devices but not blueprints (Iru carries per-endpoint permission flags), or a device referencing an item absent from the listing, failed the *entire* `iru.devices { blueprint { … } }` query — even though the top-level `iru.blueprints` accessor already degrades to an empty list on access-denied. The accessors now resolve from the memoized tenant-wide listing and degrade to null on access-denied or a not-found reference, matching the list-level behavior. (The `init` functions remain for direct `iru.blueprint(id:)` / `iru.user(id:)` lookups, where a not-found error is correct.)

### 3. Per-device fetches serialized behind one mutex (performance)
`GetDeviceDetails` / `GetDeviceApps` / `GetDeviceParameters` held a single shared mutex across the HTTP round trip. Since MQL evaluates `iru.devices { … }` blocks in goroutines, every device's detail fetch serialized behind that lock (a 500-device fleet fetched one device at a time). Replaced with a generic per-key memoizer that dedupes per device while letting different devices fetch in parallel. Failed fetches are not cached, preserving the existing retry-on-transient-error behavior.

## Tests
Added `TestPaginateArrayMultiPage` — the `/devices` offset-paging loop was only ever exercised with a single sub-limit page, so a truncation regression (stopping after page one, or advancing the offset wrong) would have gone uncaught. The new test serves 300 + 50 rows and asserts full coverage, correct ordering across pages, and a two-request count.

## Verification
- `go build ./...` clean
- `go test ./connection/...` passes (existing + new tests)
- No schema (`.lr`) changes, so no codegen / `.lr.versions` churn.
