### PR TITLE
🐛 nmap: fix version() panic on non-Homebrew hosts + harden host/discovery parsing

### DIFF
--- a/providers/nmap/resources/discovery.go
+++ b/providers/nmap/resources/discovery.go
@@ -30,7 +30,7 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 	if !ok || networkValue == "" {
 		return nil, nil
 	}
-	networks := strings.Split(networkValue, ",")
+	networks := splitNetworks(networkValue)
 	assetList := []*inventory.Asset{}
 
 	for i := range networks {
@@ -72,6 +72,21 @@ func Discover(runtime *plugin.Runtime, opts map[string]string) (*inventory.Inven
 		Assets: assetList,
 	}}
 	return in, nil
+}
+
+// splitNetworks parses the comma-separated "networks" discovery option into
+// individual scan targets, trimming surrounding whitespace and dropping empty
+// entries so a value like "10.0.0.0/24, 10.0.1.0/24" does not yield a target
+// with a leading space (which nmap rejects).
+func splitNetworks(value string) []string {
+	parts := strings.Split(value, ",")
+	networks := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			networks = append(networks, trimmed)
+		}
+	}
+	return networks
 }
 
 func handleTargets(targets []string) []string {

--- a/providers/nmap/resources/discovery_test.go
+++ b/providers/nmap/resources/discovery_test.go
@@ -1,0 +1,30 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitNetworks(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected []string
+	}{
+		{"single", "10.0.0.0/24", []string{"10.0.0.0/24"}},
+		{"comma separated", "10.0.0.0/24,10.0.1.0/24", []string{"10.0.0.0/24", "10.0.1.0/24"}},
+		{"trims whitespace", "10.0.0.0/24, 10.0.1.0/24", []string{"10.0.0.0/24", "10.0.1.0/24"}},
+		{"drops empty entries", "10.0.0.0/24,,", []string{"10.0.0.0/24"}},
+		{"empty string", "", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, splitNetworks(tt.value))
+		})
+	}
+}

--- a/providers/nmap/resources/host.go
+++ b/providers/nmap/resources/host.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"github.com/rs/zerolog/log"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -39,19 +38,39 @@ func initNmapHost(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[st
 	return args, nil, nil
 }
 
-func newMqlNmapHost(runtime *plugin.Runtime, host nmap.Host) (*mqlNmapHost, error) {
-	name := ""
-	if len(host.Addresses) == 1 {
-		name = host.Addresses[0].Addr
-	} else {
-		entries := []string{}
-		for _, addr := range host.Addresses {
-			if addr.Addr != "" {
-				entries = append(entries, addr.Addr)
+// hostScanName picks a single, scannable identifier for a host from its
+// addresses. A host frequently reports more than one address (e.g. an IPv4
+// address plus a MAC address on a local segment). We must not join them into
+// one string, because the result is later handed back to nmap as a scan
+// target and a comma-joined value is not a valid target. We prefer an IP
+// address (IPv4, then IPv6) and fall back to the first non-empty address.
+func hostScanName(addresses []nmap.Address) string {
+	var ipv6, fallback string
+	for _, addr := range addresses {
+		if addr.Addr == "" {
+			continue
+		}
+		switch addr.AddrType {
+		case "ipv4":
+			return addr.Addr
+		case "ipv6":
+			if ipv6 == "" {
+				ipv6 = addr.Addr
+			}
+		default:
+			if fallback == "" {
+				fallback = addr.Addr
 			}
 		}
-		name = strings.Join(entries, ", ")
 	}
+	if ipv6 != "" {
+		return ipv6
+	}
+	return fallback
+}
+
+func newMqlNmapHost(runtime *plugin.Runtime, host nmap.Host) (*mqlNmapHost, error) {
+	name := hostScanName(host.Addresses)
 
 	mqlNmapHostResource, err := CreateResource(runtime, "nmap.host", map[string]*llx.RawData{
 		"__id": llx.StringData("nmap.host/" + name),
@@ -131,8 +150,9 @@ func (r *mqlNmapHost) scan() error {
 	if len(result.Hosts) == 0 {
 		return nil
 	} else if len(result.Hosts) > 1 {
+		err := errors.New("nmap scan returned more than one host")
 		setError(err)
-		return errors.New("nmap scan returned more than one host")
+		return err
 	}
 
 	host := result.Hosts[0]

--- a/providers/nmap/resources/host_test.go
+++ b/providers/nmap/resources/host_test.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/Ullaakut/nmap/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostScanName(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []nmap.Address
+		expected  string
+	}{
+		{
+			name:      "no addresses",
+			addresses: nil,
+			expected:  "",
+		},
+		{
+			name:      "single ipv4",
+			addresses: []nmap.Address{{Addr: "192.0.2.10", AddrType: "ipv4"}},
+			expected:  "192.0.2.10",
+		},
+		{
+			// A local-segment host commonly reports both an IPv4 and a MAC
+			// address. We must return the scannable IPv4, never a joined
+			// string or the MAC.
+			name: "ipv4 plus mac prefers ipv4",
+			addresses: []nmap.Address{
+				{Addr: "192.0.2.10", AddrType: "ipv4"},
+				{Addr: "AA:BB:CC:DD:EE:FF", AddrType: "mac", Vendor: "Acme"},
+			},
+			expected: "192.0.2.10",
+		},
+		{
+			name: "mac listed first still prefers ipv4",
+			addresses: []nmap.Address{
+				{Addr: "AA:BB:CC:DD:EE:FF", AddrType: "mac"},
+				{Addr: "192.0.2.10", AddrType: "ipv4"},
+			},
+			expected: "192.0.2.10",
+		},
+		{
+			name: "no ipv4 falls back to ipv6",
+			addresses: []nmap.Address{
+				{Addr: "AA:BB:CC:DD:EE:FF", AddrType: "mac"},
+				{Addr: "2001:db8::1", AddrType: "ipv6"},
+			},
+			expected: "2001:db8::1",
+		},
+		{
+			name: "only mac falls back to the mac",
+			addresses: []nmap.Address{
+				{Addr: "AA:BB:CC:DD:EE:FF", AddrType: "mac"},
+			},
+			expected: "AA:BB:CC:DD:EE:FF",
+		},
+		{
+			name: "skips empty addresses",
+			addresses: []nmap.Address{
+				{Addr: "", AddrType: "ipv4"},
+				{Addr: "2001:db8::1", AddrType: "ipv6"},
+			},
+			expected: "2001:db8::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hostScanName(tt.addresses))
+		})
+	}
+}

--- a/providers/nmap/resources/nmap_version.go
+++ b/providers/nmap/resources/nmap_version.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"bufio"
 	"context"
+	"errors"
 	"github.com/Ullaakut/nmap/v3"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
@@ -34,7 +35,11 @@ func parseNmapVersionOutput(r io.Reader) nmapVersion {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "Nmap version") {
-			version.Version = strings.TrimSpace(strings.Split(line, " ")[2])
+			// "Nmap version 7.95 ( https://nmap.org )" -> the third field is the version
+			fields := strings.Fields(line)
+			if len(fields) >= 3 {
+				version.Version = fields[2]
+			}
 			continue
 		}
 		m := strings.Split(line, ":")
@@ -65,10 +70,10 @@ func (r *mqlNmap) version() (*mqlNmapVersionInformation, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	// retrieve nmap version
+	// retrieve nmap version. We let the SDK resolve the nmap binary from PATH
+	// (as the scan resources do) rather than hardcoding an install path.
 	scanner, err := nmap.NewScanner(
 		ctx,
-		nmap.WithBinaryPath("/opt/homebrew/bin/nmap"),
 		// we can ignore the deprecation warning since the -V flag is not supported by the nmap library
 		nmap.WithCustomArguments("-V"),
 	)
@@ -76,9 +81,14 @@ func (r *mqlNmap) version() (*mqlNmapVersionInformation, error) {
 		return nil, err
 	}
 
-	// NOTE: -V does not return xml output so run does not parse the output
-	// Therefore we cannot trust the err return value
+	// NOTE: -V does not return xml output, so Run cannot parse it and returns a
+	// non-nil error we intentionally ignore. But Run also returns a nil result
+	// when the nmap process fails to start (e.g. the binary is missing), so we
+	// must guard against a nil result before reading it to avoid a panic.
 	results, _, _ := scanner.Run()
+	if results == nil {
+		return nil, errors.New("unable to run nmap to determine its version")
+	}
 
 	info := parseNmapVersionOutput(results.ToReader())
 

--- a/providers/nmap/resources/nmap_version_test.go
+++ b/providers/nmap/resources/nmap_version_test.go
@@ -23,3 +23,30 @@ Available nsock engines: kqueue poll select
 	assert.Equal(t, []string{}, version.CompiledWithout)
 	assert.Equal(t, []string{"kqueue", "poll", "select"}, version.AvailableNsockEngines)
 }
+
+func TestNmapVersionParsingLinux(t *testing.T) {
+	const nmapVersionOutput = `Nmap version 7.94 ( https://nmap.org )
+Platform: x86_64-pc-linux-gnu
+Compiled with: liblua-5.4.6 openssl-3.0.13 nmap-libssh2-1.11.0 nmap-libz-1.3 libpcre2-10.42 nmap-libpcap-1.10.4 nmap-libdnet-1.12 ipv6
+Compiled without:
+Available nsock engines: epoll poll select
+`
+	version := parseNmapVersionOutput(strings.NewReader(nmapVersionOutput))
+	assert.Equal(t, "7.94", version.Version)
+	assert.Equal(t, "x86_64-pc-linux-gnu", version.Platform)
+	assert.Equal(t, []string{"epoll", "poll", "select"}, version.AvailableNsockEngines)
+}
+
+// A malformed "Nmap version" line must not panic on the version-field index.
+func TestNmapVersionParsingMalformed(t *testing.T) {
+	version := parseNmapVersionOutput(strings.NewReader("Nmap version\nPlatform: x86_64-pc-linux-gnu\n"))
+	assert.Equal(t, "", version.Version)
+	assert.Equal(t, "x86_64-pc-linux-gnu", version.Platform)
+}
+
+func TestNmapVersionParsingEmpty(t *testing.T) {
+	version := parseNmapVersionOutput(strings.NewReader(""))
+	assert.Equal(t, "", version.Version)
+	assert.Equal(t, "", version.Platform)
+	assert.Equal(t, []string{}, version.CompiledWith)
+}


### PR DESCRIPTION
## Summary

Fixes a crash and several parsing defects in the `nmap` provider found during a static bug review. The headline bug makes the `nmap.versionInformation` resource panic on essentially every host that isn't an Apple-Silicon Mac with Homebrew.

## The panic (HIGH)

`nmap.versionInformation` did two unsafe things together:

1. Hardcoded the nmap binary path to `/opt/homebrew/bin/nmap` — an Apple-Silicon-Homebrew-only location. The scan resources (`nmap.host`, `nmap.network`) deliberately do **not** set a path; they let the SDK resolve `nmap` from `PATH`. So `version()` was already inconsistent and broken on Linux, Intel-Mac Homebrew (`/usr/local/bin/nmap`), and any packaged deployment.
2. Discarded the error from `scanner.Run()` and immediately dereferenced its result.

The SDK's `Run()` returns a nil `*Run` when the nmap process fails to start (which the wrong binary path guarantees off the developer's machine). `ToReader()` has a **value receiver**, so `results.ToReader()` on a nil pointer auto-dereferences and panics — unrecoverable, taking down the whole scan.

**Fix:** drop the hardcoded `WithBinaryPath` (resolve from `PATH` like the scan resources), and guard the nil result before reading it.

## Other fixes

- **`parseNmapVersionOutput`** — replaced `strings.Split(line, " ")[2]` with `strings.Fields` + a length check so a malformed `Nmap version` line can't panic on an out-of-range index.
- **`newMqlNmapHost`** (correctness) — a host reporting multiple addresses (e.g. an IPv4 address plus a MAC address on a local segment) was turned into a comma-joined `name` that later got handed back to nmap as an invalid scan target on field drill-down. Extracted `hostScanName()` to pick one scannable address, preferring IPv4, then IPv6, then any non-empty address.
- **`Discover`** — trims whitespace and drops empty entries when splitting the comma-separated `networks` option, so `"a/24, b/24"` no longer produces a target with a leading space.
- **`host.scan`** — builds the ">1 host" error before passing it to `setError()` instead of passing the already-cleared nil error.

## Tests

Added unit tests for the pure-Go logic touched:
- version parser: Linux platform line, malformed line (no panic), empty input
- `hostScanName` address selection (ipv4/ipv6/mac ordering, empty skips)
- `splitNetworks` (trimming, empty-drop)

`go test ./providers/nmap/resources/...` passes; provider builds clean.
