### PR TITLE
🧹 claude: add pure-Go unit tests for discovery, platform, and asset identity

### DIFF
--- a/providers/claude/connection/platform_test.go
+++ b/providers/claude/connection/platform_test.go
@@ -1,0 +1,58 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClaudeOrgPlatform(t *testing.T) {
+	p := NewClaudeOrgPlatform("org_123")
+	require.NotNil(t, p)
+
+	// catalog metadata is applied
+	assert.Equal(t, "claude-organization", p.Name)
+	assert.Equal(t, "Claude Organization", p.Title)
+	assert.Contains(t, p.Family, "claude")
+
+	// the org id must land in the technology URL segments
+	assert.Equal(t, []string{"ai", "claude", "organization", "org_123"}, p.TechnologyUrlSegments)
+}
+
+func TestNewClaudeWorkspacePlatform(t *testing.T) {
+	p := NewClaudeWorkspacePlatform("org_123", "wrkspc_1")
+	require.NotNil(t, p)
+
+	assert.Equal(t, "claude-workspace", p.Name)
+	assert.Equal(t, "Claude Workspace", p.Title)
+
+	// both the org and workspace ids must be preserved, in order
+	assert.Equal(t,
+		[]string{"ai", "claude", "organization", "org_123", "workspace", "wrkspc_1"},
+		p.TechnologyUrlSegments)
+}
+
+func TestNewClaudeAPIPlatform(t *testing.T) {
+	p := NewClaudeAPIPlatform("https://api.anthropic.com")
+	require.NotNil(t, p)
+
+	assert.Equal(t, "claude", p.Name)
+	assert.Equal(t, "Claude", p.Title)
+	assert.Equal(t, []string{"ai", "claude", "https://api.anthropic.com"}, p.TechnologyUrlSegments)
+}
+
+func TestClaudeIdentifiers(t *testing.T) {
+	// The identifiers are keyed by a single id each; a workspace identifier is
+	// keyed by the workspace id alone (not the org id), which is what asset
+	// detection and discovery both rely on to match.
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/claude/organization/org_123",
+		NewClaudeOrgIdentifier("org_123"))
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/claude/workspace/wrkspc_1",
+		NewClaudeWorkspaceIdentifier("wrkspc_1"))
+}

--- a/providers/claude/provider/provider.go
+++ b/providers/claude/provider/provider.go
@@ -140,30 +140,42 @@ func (s *Service) connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 }
 
 func (s *Service) detect(asset *inventory.Asset, conn *connection.ClaudeConnection) error {
-	orgID := conn.OrgID()
-	orgName := conn.OrgName()
-	workspaceID := conn.Conf.Options[connection.WorkspaceIDOption]
+	name, platform, platformIDs := claudeAssetIdentity(
+		conn.OrgID(),
+		conn.OrgName(),
+		conn.Conf.Options[connection.WorkspaceIDOption],
+		conn.Host(),
+	)
+	asset.Name = name
+	asset.Platform = platform
+	asset.PlatformIds = platformIDs
+	return nil
+}
 
-	if workspaceID != "" && workspaceID != "default" {
-		asset.Name = "Claude Workspace " + workspaceID
-		asset.Platform = connection.NewClaudeWorkspacePlatform(orgID, workspaceID)
-		asset.PlatformIds = []string{connection.NewClaudeWorkspaceIdentifier(workspaceID)}
-	} else if orgID != "" {
+// claudeAssetIdentity picks the asset name, platform, and platform IDs from the
+// scoping information available on the connection. A concrete workspace wins
+// over the organization, which in turn wins over the bare API host. A
+// workspace-id of "default" is treated as "no workspace" and falls through to
+// the organization.
+func claudeAssetIdentity(orgID, orgName, workspaceID, host string) (string, *inventory.Platform, []string) {
+	switch {
+	case workspaceID != "" && workspaceID != "default":
+		return "Claude Workspace " + workspaceID,
+			connection.NewClaudeWorkspacePlatform(orgID, workspaceID),
+			[]string{connection.NewClaudeWorkspaceIdentifier(workspaceID)}
+	case orgID != "":
 		name := "Claude Organization"
 		if orgName != "" {
 			name = "Claude Organization " + orgName
 		}
-		asset.Name = name
-		asset.Platform = connection.NewClaudeOrgPlatform(orgID)
-		asset.PlatformIds = []string{connection.NewClaudeOrgIdentifier(orgID)}
-	} else {
-		host := conn.Host()
-		asset.Name = "Claude (" + host + ")"
-		asset.Platform = connection.NewClaudeAPIPlatform(host)
-		asset.PlatformIds = []string{"//platformid.api.mondoo.app/runtime/claude/host/" + host}
+		return name,
+			connection.NewClaudeOrgPlatform(orgID),
+			[]string{connection.NewClaudeOrgIdentifier(orgID)}
+	default:
+		return "Claude (" + host + ")",
+			connection.NewClaudeAPIPlatform(host),
+			[]string{"//platformid.api.mondoo.app/runtime/claude/host/" + host}
 	}
-
-	return nil
 }
 
 func (s *Service) MockConnect(req *plugin.ConnectReq, callback plugin.ProviderCallback) (*plugin.ConnectRes, error) {

--- a/providers/claude/provider/provider_test.go
+++ b/providers/claude/provider/provider_test.go
@@ -1,0 +1,76 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/claude/connection"
+)
+
+func TestClaudeAssetIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		orgID       string
+		orgName     string
+		workspaceID string
+		host        string
+
+		wantName     string
+		wantPlatform string
+		wantID       string
+	}{
+		{
+			name:        "workspace scope wins over org",
+			orgID:       "org_123",
+			orgName:     "Acme",
+			workspaceID: "wrkspc_1",
+			host:        "https://api.anthropic.com",
+			wantName:    "Claude Workspace wrkspc_1",
+			// asserts the workspace-id, not the org-id, keys the identifier
+			wantPlatform: "claude-workspace",
+			wantID:       connection.PlatformIdWorkspace + "wrkspc_1",
+		},
+		{
+			name:        "default workspace falls through to org",
+			orgID:       "org_123",
+			orgName:     "Acme",
+			workspaceID: "default",
+			host:        "https://api.anthropic.com",
+			// "default" must not mint a workspace-scoped identity
+			wantName:     "Claude Organization Acme",
+			wantPlatform: "claude-organization",
+			wantID:       connection.PlatformIdOrg + "org_123",
+		},
+		{
+			name:         "org without name omits the trailing name",
+			orgID:        "org_123",
+			workspaceID:  "",
+			host:         "https://api.anthropic.com",
+			wantName:     "Claude Organization",
+			wantPlatform: "claude-organization",
+			wantID:       connection.PlatformIdOrg + "org_123",
+		},
+		{
+			name:         "no org falls back to bare host",
+			host:         "https://api.anthropic.com",
+			wantName:     "Claude (https://api.anthropic.com)",
+			wantPlatform: "claude",
+			wantID:       "//platformid.api.mondoo.app/runtime/claude/host/https://api.anthropic.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, platform, ids := claudeAssetIdentity(tt.orgID, tt.orgName, tt.workspaceID, tt.host)
+
+			assert.Equal(t, tt.wantName, name)
+			require.NotNil(t, platform)
+			assert.Equal(t, tt.wantPlatform, platform.Name)
+			require.Equal(t, []string{tt.wantID}, ids)
+		})
+	}
+}

--- a/providers/claude/resources/discovery_test.go
+++ b/providers/claude/resources/discovery_test.go
@@ -1,0 +1,53 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers/claude/connection"
+)
+
+func TestHandleTargets(t *testing.T) {
+	expanded := []string{connection.DiscoveryOrg, connection.DiscoveryWorkspaces}
+
+	tests := []struct {
+		name    string
+		targets []string
+		want    []string
+	}{
+		{
+			name:    "all expands to the full target set",
+			targets: []string{connection.DiscoveryAll},
+			want:    expanded,
+		},
+		{
+			name:    "auto expands to the full target set",
+			targets: []string{connection.DiscoveryAuto},
+			want:    expanded,
+		},
+		{
+			name:    "all wins even when mixed with explicit targets",
+			targets: []string{connection.DiscoveryOrg, connection.DiscoveryAll},
+			want:    expanded,
+		},
+		{
+			name:    "explicit targets pass through untouched",
+			targets: []string{connection.DiscoveryWorkspaces},
+			want:    []string{connection.DiscoveryWorkspaces},
+		},
+		{
+			name:    "empty stays empty",
+			targets: []string{},
+			want:    []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, handleTargets(tt.targets))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds pure-Go unit tests for the `claude` provider's discovery, platform, and asset-identity logic, and makes the asset-identity decision testable by extracting it from `Service.detect` into a pure helper.

A static bug review of the provider came up clean, but flagged these three pieces of pure-Go logic as untested. They're exactly where a wrong result silently *misclassifies an asset* (wrong platform, wrong platform id) rather than erroring, so they're worth locking down.

## Changes

- **Refactor:** pull the workspace-vs-org-vs-host selection out of `Service.detect` into a pure `claudeAssetIdentity(orgID, orgName, workspaceID, host)` function. `detect` is now thin glue that assigns the returned name/platform/ids onto the asset. No behavior change.
- **`TestClaudeAssetIdentity`** — covers all four branches, including the `workspace-id == "default"` sentinel that must fall through to the organization (not mint a workspace-scoped identity) and the org-without-name case.
- **`TestHandleTargets`** — the `all`/`auto` discovery-target expansion, the "`all` wins when mixed with explicit targets" case, and explicit/empty passthrough.
- **Platform-builder tests** — assert the `TechnologyUrlSegments` and platform identifiers for the org, workspace, and bare-host platforms, and that a workspace identifier is keyed by the workspace id alone (what detection and discovery both match on).

## Testing

```
go build ./...            # clean
go test ./...             # all packages pass, incl. the new tests
```

## Not covered here

`convertRateLimits` maps admin-API rate-limit type slugs (e.g. `input_tokens_per_minute_cache_aware`) to fields; a wrong slug would silently report `0`. The slug lookup itself (`AdminRateLimit.LimitValue`) is already unit-tested, but whether the slugs match what the live API returns can only be confirmed against a real org, so it's left for live verification rather than a unit test.
