### PR TITLE
🐛 openai: fix silent-empty on wrong key type, null absent timestamps, husk single-object lookups

### DIFF
--- a/providers/openai/resources/openai.go
+++ b/providers/openai/resources/openai.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/openai/openai-go/v3"
@@ -21,6 +22,45 @@ func unixToTime(ts int64) time.Time {
 		return time.Time{}
 	}
 	return time.Unix(ts, 0)
+}
+
+// unixToNullableTime converts a Unix timestamp to a time pointer, returning nil
+// for a zero timestamp. The OpenAI API surfaces absent times as 0; wrapping the
+// result through llx.TimeDataPtr then emits null instead of a year-1 timestamp.
+func unixToNullableTime(ts int64) *time.Time {
+	if ts == 0 {
+		return nil
+	}
+	t := unixToTime(ts)
+	return &t
+}
+
+// dataPlaneClient returns the project-scoped client used for data-plane
+// collections (models, files, vector stores, fine-tuning). It returns a
+// descriptive error when the connection was built from an admin key (which
+// cannot read data-plane resources), and (nil, nil) when no credentials exist.
+func dataPlaneClient(conn *connection.OpenaiConnection, resource string) (*openai.Client, error) {
+	if c := conn.Client(); c != nil {
+		return c, nil
+	}
+	if conn.AdminClient() != nil {
+		return nil, fmt.Errorf("%s requires a project API key (sk-proj-...); the configured admin key cannot read data-plane resources", resource)
+	}
+	return nil, nil
+}
+
+// adminPlaneClient returns the admin client used for organization collections
+// (users, invites, audit logs, projects). It returns a descriptive error when
+// the connection was built from a project key (which cannot read organization
+// resources), and (nil, nil) when no credentials exist.
+func adminPlaneClient(conn *connection.OpenaiConnection, resource string) (*openai.Client, error) {
+	if c := conn.AdminClient(); c != nil {
+		return c, nil
+	}
+	if conn.Client() != nil {
+		return nil, fmt.Errorf("%s requires an admin API key (sk-admin-...); the configured project key cannot read organization resources", resource)
+	}
+	return nil, nil
 }
 
 func isAccessDenied(err error) bool {

--- a/providers/openai/resources/openai.lr.go
+++ b/providers/openai/resources/openai.lr.go
@@ -38,7 +38,7 @@ func init() {
 			Create: createOpenai,
 		},
 		"openai.model": {
-			// to override args, implement: initOpenaiModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOpenaiModel,
 			Create: createOpenaiModel,
 		},
 		"openai.file": {
@@ -46,15 +46,15 @@ func init() {
 			Create: createOpenaiFile,
 		},
 		"openai.fineTuningJob": {
-			// to override args, implement: initOpenaiFineTuningJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOpenaiFineTuningJob,
 			Create: createOpenaiFineTuningJob,
 		},
 		"openai.vectorStore": {
-			// to override args, implement: initOpenaiVectorStore(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOpenaiVectorStore,
 			Create: createOpenaiVectorStore,
 		},
 		"openai.project": {
-			// to override args, implement: initOpenaiProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOpenaiProject,
 			Create: createOpenaiProject,
 		},
 		"openai.project.apiKey": {

--- a/providers/openai/resources/openai_file.go
+++ b/providers/openai/resources/openai_file.go
@@ -12,9 +12,26 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+// mapFile builds the resource args for an openai.file. Both the collection path
+// and the single-object init share it so the two paths cannot diverge.
+func mapFile(f openai.FileObject) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":      llx.StringData(f.ID),
+		"id":        llx.StringData(f.ID),
+		"filename":  llx.StringData(f.Filename),
+		"bytes":     llx.IntData(f.Bytes),
+		"createdAt": llx.TimeDataPtr(unixToNullableTime(f.CreatedAt)),
+		"purpose":   llx.StringData(string(f.Purpose)),
+		"status":    llx.StringData(string(f.Status)),
+	}
+}
+
 func (r *mqlOpenai) files() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.Client()
+	client, err := dataPlaneClient(conn, "openai.files")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -24,16 +41,7 @@ func (r *mqlOpenai) files() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		f := iter.Current()
-		created := unixToTime(f.CreatedAt)
-		mqlFile, err := CreateResource(r.MqlRuntime, "openai.file", map[string]*llx.RawData{
-			"__id":      llx.StringData(f.ID),
-			"id":        llx.StringData(f.ID),
-			"filename":  llx.StringData(f.Filename),
-			"bytes":     llx.IntData(f.Bytes),
-			"createdAt": llx.TimeData(created),
-			"purpose":   llx.StringData(string(f.Purpose)),
-			"status":    llx.StringData(string(f.Status)),
-		})
+		mqlFile, err := CreateResource(r.MqlRuntime, "openai.file", mapFile(f))
 		if err != nil {
 			return nil, err
 		}
@@ -63,26 +71,21 @@ func initOpenaiFile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	}
 
 	conn := openaiConn(runtime)
-	client := conn.Client()
+	client, err := dataPlaneClient(conn, "openai.file")
+	if err != nil {
+		return nil, nil, err
+	}
 	if client == nil {
 		return nil, nil, fmt.Errorf("cannot fetch file %s: no project API key configured", fileID)
 	}
 	f, err := client.Files.Get(context.Background(), fileID)
 	if err != nil {
-		if isAccessDenied(err) {
-			return args, nil, nil
-		}
+		// Returning (args, nil, nil) here would let the runtime build a husk
+		// resource from just the id, leaving every other field unset and
+		// surfacing as "primitive with no type information" on access. Report
+		// the failure instead.
 		return nil, nil, fmt.Errorf("failed to get file %s: %w", fileID, err)
 	}
 
-	created := unixToTime(f.CreatedAt)
-	args["__id"] = llx.StringData(f.ID)
-	args["id"] = llx.StringData(f.ID)
-	args["filename"] = llx.StringData(f.Filename)
-	args["bytes"] = llx.IntData(f.Bytes)
-	args["createdAt"] = llx.TimeData(created)
-	args["purpose"] = llx.StringData(string(f.Purpose))
-	args["status"] = llx.StringData(string(f.Status))
-
-	return args, nil, nil
+	return mapFile(*f), nil, nil
 }

--- a/providers/openai/resources/openai_finetuning.go
+++ b/providers/openai/resources/openai_finetuning.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/openai/openai-go/v3"
 	"go.mondoo.com/mql/v13/llx"
@@ -18,9 +17,65 @@ type mqlOpenaiFineTuningJobInternal struct {
 	cacheValidationFileID string
 }
 
+// mapFineTuningJob builds the resource args for an openai.fineTuningJob. Both
+// the collection path and the single-object init share it so the two paths
+// cannot diverge. The training/validation file IDs are cached on the resource
+// separately by the caller (see newFineTuningJob).
+func mapFineTuningJob(j openai.FineTuningJob) map[string]*llx.RawData {
+	var nEpochs any
+	if j.Hyperparameters.NEpochs.OfAuto != "" {
+		nEpochs = string(j.Hyperparameters.NEpochs.OfAuto)
+	} else {
+		nEpochs = j.Hyperparameters.NEpochs.OfInt
+	}
+	hyperparams := map[string]any{
+		"n_epochs": nEpochs,
+	}
+
+	var errInfo any
+	if j.Error.Code != "" {
+		errInfo = map[string]any{
+			"code":    j.Error.Code,
+			"message": j.Error.Message,
+			"param":   j.Error.Param,
+		}
+	}
+
+	return map[string]*llx.RawData{
+		"__id":            llx.StringData(j.ID),
+		"id":              llx.StringData(j.ID),
+		"model":           llx.StringData(j.Model),
+		"status":          llx.StringData(string(j.Status)),
+		"createdAt":       llx.TimeDataPtr(unixToNullableTime(j.CreatedAt)),
+		"finishedAt":      llx.TimeDataPtr(unixToNullableTime(j.FinishedAt)),
+		"fineTunedModel":  llx.StringData(j.FineTunedModel),
+		"trainedTokens":   llx.IntData(j.TrainedTokens),
+		"seed":            llx.IntData(j.Seed),
+		"organizationId":  llx.StringData(j.OrganizationID),
+		"hyperparameters": llx.DictData(hyperparams),
+		"error":           llx.DictData(errInfo),
+	}
+}
+
+// newFineTuningJob creates the resource and caches the file IDs needed by the
+// typed trainingFile/validationFile accessors.
+func newFineTuningJob(runtime *plugin.Runtime, j openai.FineTuningJob) (*mqlOpenaiFineTuningJob, error) {
+	res, err := CreateResource(runtime, "openai.fineTuningJob", mapFineTuningJob(j))
+	if err != nil {
+		return nil, err
+	}
+	job := res.(*mqlOpenaiFineTuningJob)
+	job.cacheTrainingFileID = j.TrainingFile
+	job.cacheValidationFileID = j.ValidationFile
+	return job, nil
+}
+
 func (r *mqlOpenai) fineTuningJobs() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.Client()
+	client, err := dataPlaneClient(conn, "openai.fineTuningJobs")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -30,61 +85,11 @@ func (r *mqlOpenai) fineTuningJobs() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		j := iter.Current()
-		created := unixToTime(j.CreatedAt)
-
-		var finishedAt *time.Time
-		if j.FinishedAt != 0 {
-			t := unixToTime(j.FinishedAt)
-			finishedAt = &t
-		}
-
-		var trainedTokens int64
-		if j.TrainedTokens != 0 {
-			trainedTokens = j.TrainedTokens
-		}
-
-		var nEpochs any
-		if j.Hyperparameters.NEpochs.OfAuto != "" {
-			nEpochs = string(j.Hyperparameters.NEpochs.OfAuto)
-		} else {
-			nEpochs = j.Hyperparameters.NEpochs.OfInt
-		}
-		hyperparams := map[string]any{
-			"n_epochs": nEpochs,
-		}
-
-		var errInfo any
-		if j.Error.Code != "" {
-			errInfo = map[string]any{
-				"code":    j.Error.Code,
-				"message": j.Error.Message,
-				"param":   j.Error.Param,
-			}
-		}
-
-		mqlJob, err := CreateResource(r.MqlRuntime, "openai.fineTuningJob", map[string]*llx.RawData{
-			"__id":            llx.StringData(j.ID),
-			"id":              llx.StringData(j.ID),
-			"model":           llx.StringData(j.Model),
-			"status":          llx.StringData(string(j.Status)),
-			"createdAt":       llx.TimeData(created),
-			"finishedAt":      llx.TimeDataPtr(finishedAt),
-			"fineTunedModel":  llx.StringData(j.FineTunedModel),
-			"trainedTokens":   llx.IntData(trainedTokens),
-			"seed":            llx.IntData(j.Seed),
-			"organizationId":  llx.StringData(j.OrganizationID),
-			"hyperparameters": llx.DictData(hyperparams),
-			"error":           llx.DictData(errInfo),
-		})
+		job, err := newFineTuningJob(r.MqlRuntime, j)
 		if err != nil {
 			return nil, err
 		}
-
-		job := mqlJob.(*mqlOpenaiFineTuningJob)
-		job.cacheTrainingFileID = j.TrainingFile
-		job.cacheValidationFileID = j.ValidationFile
-
-		res = append(res, mqlJob)
+		res = append(res, job)
 	}
 	if err := iter.Err(); err != nil {
 		if isAccessDenied(err) {
@@ -93,6 +98,38 @@ func (r *mqlOpenai) fineTuningJobs() ([]any, error) {
 		return nil, fmt.Errorf("failed to list fine-tuning jobs: %w", err)
 	}
 	return res, nil
+}
+
+func initOpenaiFineTuningJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok || idRaw == nil || idRaw.Value == nil {
+		return args, nil, nil
+	}
+	jobID, ok := idRaw.Value.(string)
+	if !ok || jobID == "" {
+		return args, nil, nil
+	}
+
+	conn := openaiConn(runtime)
+	client, err := dataPlaneClient(conn, "openai.fineTuningJob")
+	if err != nil {
+		return nil, nil, err
+	}
+	if client == nil {
+		return nil, nil, fmt.Errorf("cannot fetch fine-tuning job %s: no project API key configured", jobID)
+	}
+	j, err := client.FineTuning.Jobs.Get(context.Background(), jobID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get fine-tuning job %s: %w", jobID, err)
+	}
+	job, err := newFineTuningJob(runtime, *j)
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, job, nil
 }
 
 func (r *mqlOpenaiFineTuningJob) trainingFile() (*mqlOpenaiFile, error) {

--- a/providers/openai/resources/openai_model.go
+++ b/providers/openai/resources/openai_model.go
@@ -8,12 +8,28 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openai/openai-go/v3"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// mapModel builds the resource args for an openai.model. Both the collection
+// path and the single-object init share it so the two paths cannot diverge.
+func mapModel(m openai.Model) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":      llx.StringData(m.ID),
+		"id":        llx.StringData(m.ID),
+		"createdAt": llx.TimeDataPtr(unixToNullableTime(m.Created)),
+		"ownedBy":   llx.StringData(m.OwnedBy),
+	}
+}
 
 func (r *mqlOpenai) models() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.Client()
+	client, err := dataPlaneClient(conn, "openai.models")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -23,13 +39,7 @@ func (r *mqlOpenai) models() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		m := iter.Current()
-		created := unixToTime(m.Created)
-		mqlModel, err := CreateResource(r.MqlRuntime, "openai.model", map[string]*llx.RawData{
-			"__id":      llx.StringData(m.ID),
-			"id":        llx.StringData(m.ID),
-			"createdAt": llx.TimeData(created),
-			"ownedBy":   llx.StringData(m.OwnedBy),
-		})
+		mqlModel, err := CreateResource(r.MqlRuntime, "openai.model", mapModel(m))
 		if err != nil {
 			return nil, err
 		}
@@ -42,6 +52,34 @@ func (r *mqlOpenai) models() ([]any, error) {
 		return nil, fmt.Errorf("failed to list models: %w", err)
 	}
 	return res, nil
+}
+
+func initOpenaiModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok || idRaw == nil || idRaw.Value == nil {
+		return args, nil, nil
+	}
+	modelID, ok := idRaw.Value.(string)
+	if !ok || modelID == "" {
+		return args, nil, nil
+	}
+
+	conn := openaiConn(runtime)
+	client, err := dataPlaneClient(conn, "openai.model")
+	if err != nil {
+		return nil, nil, err
+	}
+	if client == nil {
+		return nil, nil, fmt.Errorf("cannot fetch model %s: no project API key configured", modelID)
+	}
+	m, err := client.Models.Get(context.Background(), modelID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get model %s: %w", modelID, err)
+	}
+	return mapModel(*m), nil, nil
 }
 
 func (r *mqlOpenaiModel) isFineTuned() (bool, error) {

--- a/providers/openai/resources/openai_org.go
+++ b/providers/openai/resources/openai_org.go
@@ -14,7 +14,10 @@ import (
 
 func (r *mqlOpenai) users() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.users")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -24,15 +27,6 @@ func (r *mqlOpenai) users() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		u := iter.Current()
-		addedAt := unixToTime(u.AddedAt)
-		created := unixToTime(u.Created)
-
-		var apiKeyLastUsedAt *time.Time
-		if u.APIKeyLastUsedAt != 0 {
-			t := unixToTime(u.APIKeyLastUsedAt)
-			apiKeyLastUsedAt = &t
-		}
-
 		mqlUser, err := CreateResource(r.MqlRuntime, "openai.organizationUser", map[string]*llx.RawData{
 			"__id":             llx.StringData(u.ID),
 			"id":               llx.StringData(u.ID),
@@ -42,9 +36,9 @@ func (r *mqlOpenai) users() ([]any, error) {
 			"isDefault":        llx.BoolData(u.IsDefault),
 			"isScimManaged":    llx.BoolData(u.IsScimManaged),
 			"isServiceAccount": llx.BoolData(u.IsServiceAccount),
-			"addedAt":          llx.TimeData(addedAt),
-			"createdAt":        llx.TimeData(created),
-			"apiKeyLastUsedAt": llx.TimeDataPtr(apiKeyLastUsedAt),
+			"addedAt":          llx.TimeDataPtr(unixToNullableTime(u.AddedAt)),
+			"createdAt":        llx.TimeDataPtr(unixToNullableTime(u.Created)),
+			"apiKeyLastUsedAt": llx.TimeDataPtr(unixToNullableTime(u.APIKeyLastUsedAt)),
 		})
 		if err != nil {
 			return nil, err
@@ -62,7 +56,10 @@ func (r *mqlOpenai) users() ([]any, error) {
 
 func (r *mqlOpenai) invites() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.invites")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -72,29 +69,15 @@ func (r *mqlOpenai) invites() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		inv := iter.Current()
-		created := unixToTime(inv.CreatedAt)
-
-		var acceptedAt *time.Time
-		if inv.AcceptedAt != 0 {
-			t := unixToTime(inv.AcceptedAt)
-			acceptedAt = &t
-		}
-
-		var expiresAt *time.Time
-		if inv.ExpiresAt != 0 {
-			t := unixToTime(inv.ExpiresAt)
-			expiresAt = &t
-		}
-
 		mqlInvite, err := CreateResource(r.MqlRuntime, "openai.invite", map[string]*llx.RawData{
 			"__id":       llx.StringData(inv.ID),
 			"id":         llx.StringData(inv.ID),
 			"email":      llx.StringData(inv.Email),
 			"role":       llx.StringData(string(inv.Role)),
 			"status":     llx.StringData(string(inv.Status)),
-			"createdAt":  llx.TimeData(created),
-			"acceptedAt": llx.TimeDataPtr(acceptedAt),
-			"expiresAt":  llx.TimeDataPtr(expiresAt),
+			"createdAt":  llx.TimeDataPtr(unixToNullableTime(inv.CreatedAt)),
+			"acceptedAt": llx.TimeDataPtr(unixToNullableTime(inv.AcceptedAt)),
+			"expiresAt":  llx.TimeDataPtr(unixToNullableTime(inv.ExpiresAt)),
 		})
 		if err != nil {
 			return nil, err
@@ -110,9 +93,29 @@ func (r *mqlOpenai) invites() ([]any, error) {
 	return res, nil
 }
 
+// auditLogActor derives the actor type and a human-readable actor identifier
+// from an audit log entry's actor. For a session the identifier is the user's
+// email; for an API key it is the key ID; otherwise it falls back to the actor
+// type string.
+func auditLogActor(actor openai.AdminOrganizationAuditLogListResponseActor) (actorType string, actorID string) {
+	actorType = actor.Type
+	switch actorType {
+	case "session":
+		actorID = actor.Session.User.Email
+	case "api_key":
+		actorID = actor.APIKey.ID
+	default:
+		actorID = actorType
+	}
+	return actorType, actorID
+}
+
 func (r *mqlOpenai) auditLogs() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.auditLogs")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -127,26 +130,15 @@ func (r *mqlOpenai) auditLogs() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		entry := iter.Current()
-		effectiveAt := unixToTime(entry.EffectiveAt)
-
-		actorType := entry.Actor.Type
-		var actorId string
-		switch actorType {
-		case "session":
-			actorId = entry.Actor.Session.User.Email
-		case "api_key":
-			actorId = entry.Actor.APIKey.ID
-		default:
-			actorId = string(actorType)
-		}
+		actorType, actorID := auditLogActor(entry.Actor)
 
 		mqlLog, err := CreateResource(r.MqlRuntime, "openai.auditLog", map[string]*llx.RawData{
 			"__id":        llx.StringData(entry.ID),
 			"id":          llx.StringData(entry.ID),
 			"type":        llx.StringData(string(entry.Type)),
-			"effectiveAt": llx.TimeData(effectiveAt),
+			"effectiveAt": llx.TimeDataPtr(unixToNullableTime(entry.EffectiveAt)),
 			"actorType":   llx.StringData(actorType),
-			"actorId":     llx.StringData(actorId),
+			"actorId":     llx.StringData(actorID),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/openai/resources/openai_project.go
+++ b/providers/openai/resources/openai_project.go
@@ -6,15 +6,32 @@ package resources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/openai/openai-go/v3"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// mapProject builds the resource args for an openai.project. Both the
+// collection path and the single-object init share it so the two paths cannot
+// diverge.
+func mapProject(p openai.Project) map[string]*llx.RawData {
+	return map[string]*llx.RawData{
+		"__id":       llx.StringData(p.ID),
+		"id":         llx.StringData(p.ID),
+		"name":       llx.StringData(p.Name),
+		"status":     llx.StringData(string(p.Status)),
+		"createdAt":  llx.TimeDataPtr(unixToNullableTime(p.CreatedAt)),
+		"archivedAt": llx.TimeDataPtr(unixToNullableTime(p.ArchivedAt)),
+	}
+}
 
 func (r *mqlOpenai) projects() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.projects")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -24,22 +41,7 @@ func (r *mqlOpenai) projects() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		p := iter.Current()
-		created := unixToTime(p.CreatedAt)
-
-		var archivedAt *time.Time
-		if p.ArchivedAt != 0 {
-			t := unixToTime(p.ArchivedAt)
-			archivedAt = &t
-		}
-
-		mqlProject, err := CreateResource(r.MqlRuntime, "openai.project", map[string]*llx.RawData{
-			"__id":       llx.StringData(p.ID),
-			"id":         llx.StringData(p.ID),
-			"name":       llx.StringData(p.Name),
-			"status":     llx.StringData(string(p.Status)),
-			"createdAt":  llx.TimeData(created),
-			"archivedAt": llx.TimeDataPtr(archivedAt),
-		})
+		mqlProject, err := CreateResource(r.MqlRuntime, "openai.project", mapProject(p))
 		if err != nil {
 			return nil, err
 		}
@@ -54,9 +56,40 @@ func (r *mqlOpenai) projects() ([]any, error) {
 	return res, nil
 }
 
+func initOpenaiProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok || idRaw == nil || idRaw.Value == nil {
+		return args, nil, nil
+	}
+	projectID, ok := idRaw.Value.(string)
+	if !ok || projectID == "" {
+		return args, nil, nil
+	}
+
+	conn := openaiConn(runtime)
+	client, err := adminPlaneClient(conn, "openai.project")
+	if err != nil {
+		return nil, nil, err
+	}
+	if client == nil {
+		return nil, nil, fmt.Errorf("cannot fetch project %s: no admin API key configured", projectID)
+	}
+	p, err := client.Admin.Organization.Projects.Get(context.Background(), projectID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get project %s: %w", projectID, err)
+	}
+	return mapProject(*p), nil, nil
+}
+
 func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.project.apiKeys")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -66,13 +99,6 @@ func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		k := iter.Current()
-		created := unixToTime(k.CreatedAt)
-
-		var lastUsedAt *time.Time
-		if k.LastUsedAt != 0 {
-			t := unixToTime(k.LastUsedAt)
-			lastUsedAt = &t
-		}
 
 		ownerType := k.Owner.Type
 		var ownerName, ownerId string
@@ -90,8 +116,8 @@ func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 			"id":            llx.StringData(k.ID),
 			"name":          llx.StringData(k.Name),
 			"redactedValue": llx.StringData(k.RedactedValue),
-			"createdAt":     llx.TimeData(created),
-			"lastUsedAt":    llx.TimeDataPtr(lastUsedAt),
+			"createdAt":     llx.TimeDataPtr(unixToNullableTime(k.CreatedAt)),
+			"lastUsedAt":    llx.TimeDataPtr(unixToNullableTime(k.LastUsedAt)),
 			"ownerType":     llx.StringData(ownerType),
 			"ownerName":     llx.StringData(ownerName),
 			"ownerId":       llx.StringData(ownerId),
@@ -112,7 +138,10 @@ func (r *mqlOpenaiProject) apiKeys() ([]any, error) {
 
 func (r *mqlOpenaiProject) serviceAccounts() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.AdminClient()
+	client, err := adminPlaneClient(conn, "openai.project.serviceAccounts")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -122,14 +151,13 @@ func (r *mqlOpenaiProject) serviceAccounts() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		sa := iter.Current()
-		created := unixToTime(sa.CreatedAt)
 
 		mqlSA, err := CreateResource(r.MqlRuntime, "openai.project.serviceAccount", map[string]*llx.RawData{
 			"__id":      llx.StringData(sa.ID),
 			"id":        llx.StringData(sa.ID),
 			"name":      llx.StringData(sa.Name),
 			"role":      llx.StringData(string(sa.Role)),
-			"createdAt": llx.TimeData(created),
+			"createdAt": llx.TimeDataPtr(unixToNullableTime(sa.CreatedAt)),
 		})
 		if err != nil {
 			return nil, err

--- a/providers/openai/resources/openai_test.go
+++ b/providers/openai/resources/openai_test.go
@@ -6,8 +6,12 @@ package resources
 import (
 	"testing"
 
+	"github.com/openai/openai-go/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/openai/connection"
 )
 
 func TestUnixToTime(t *testing.T) {
@@ -20,6 +24,105 @@ func TestUnixToTime(t *testing.T) {
 	got := unixToTime(ts)
 	assert.False(t, got.IsZero())
 	assert.Equal(t, ts, got.Unix())
+}
+
+func TestUnixToNullableTime(t *testing.T) {
+	// A zero timestamp must become a nil pointer so llx.TimeDataPtr emits null
+	// rather than a year-1 timestamp.
+	assert.Nil(t, unixToNullableTime(0))
+
+	ts := int64(1719878400)
+	got := unixToNullableTime(ts)
+	require.NotNil(t, got)
+	assert.Equal(t, ts, got.Unix())
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	assert.False(t, isAccessDenied(nil))
+	assert.True(t, isAccessDenied(&openai.Error{StatusCode: 401}))
+	assert.True(t, isAccessDenied(&openai.Error{StatusCode: 403}))
+	assert.False(t, isAccessDenied(&openai.Error{StatusCode: 404}))
+	assert.False(t, isAccessDenied(&openai.Error{StatusCode: 500}))
+	assert.False(t, isAccessDenied(assert.AnError))
+}
+
+func newTestConn(t *testing.T, token string) *connection.OpenaiConnection {
+	t.Helper()
+	// Clear env so an ambient key can't leak into the no-token case, and set an
+	// organization so the constructor skips its best-effort /v1/me network call.
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_ORG_ID", "")
+	t.Setenv("OPENAI_PROJECT_ID", "")
+	conf := &inventory.Config{Options: map[string]string{
+		connection.OrganizationOption: "org-test",
+	}}
+	if token != "" {
+		conf.Options[connection.TokenOption] = token
+	}
+	conn, err := connection.NewOpenaiConnection(0, &inventory.Asset{}, conf)
+	require.NoError(t, err)
+	return conn
+}
+
+func TestDataPlaneClient(t *testing.T) {
+	// A project key can read data-plane resources.
+	c, err := dataPlaneClient(newTestConn(t, "sk-proj-abc"), "openai.models")
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+
+	// An admin key cannot; it must surface a descriptive error rather than an
+	// empty result that looks like "no models".
+	c, err = dataPlaneClient(newTestConn(t, "sk-admin-abc"), "openai.models")
+	assert.Error(t, err)
+	assert.Nil(t, c)
+
+	// No credentials degrades to (nil, nil) so the collection returns empty.
+	c, err = dataPlaneClient(newTestConn(t, ""), "openai.models")
+	assert.NoError(t, err)
+	assert.Nil(t, c)
+}
+
+func TestAdminPlaneClient(t *testing.T) {
+	// An admin key can read organization resources.
+	c, err := adminPlaneClient(newTestConn(t, "sk-admin-abc"), "openai.users")
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+
+	// A project key cannot; it must surface a descriptive error.
+	c, err = adminPlaneClient(newTestConn(t, "sk-proj-abc"), "openai.users")
+	assert.Error(t, err)
+	assert.Nil(t, c)
+
+	// No credentials degrades to (nil, nil).
+	c, err = adminPlaneClient(newTestConn(t, ""), "openai.users")
+	assert.NoError(t, err)
+	assert.Nil(t, c)
+}
+
+func TestAuditLogActor(t *testing.T) {
+	session := openai.AdminOrganizationAuditLogListResponseActor{
+		Type: "session",
+		Session: openai.AdminOrganizationAuditLogListResponseActorSession{
+			User: openai.AdminOrganizationAuditLogListResponseActorSessionUser{Email: "user@example.com"},
+		},
+	}
+	at, id := auditLogActor(session)
+	assert.Equal(t, "session", at)
+	assert.Equal(t, "user@example.com", id)
+
+	apiKey := openai.AdminOrganizationAuditLogListResponseActor{
+		Type:   "api_key",
+		APIKey: openai.AdminOrganizationAuditLogListResponseActorAPIKey{ID: "key_123"},
+	}
+	at, id = auditLogActor(apiKey)
+	assert.Equal(t, "api_key", at)
+	assert.Equal(t, "key_123", id)
+
+	// Unknown actor types fall back to the type string.
+	other := openai.AdminOrganizationAuditLogListResponseActor{Type: "scim"}
+	at, id = auditLogActor(other)
+	assert.Equal(t, "scim", at)
+	assert.Equal(t, "scim", id)
 }
 
 func newTestModel(id string) *mqlOpenaiModel {

--- a/providers/openai/resources/openai_vectorstore.go
+++ b/providers/openai/resources/openai_vectorstore.go
@@ -6,15 +6,58 @@ package resources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/openai/openai-go/v3"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
+
+// mapVectorStore builds the resource args for an openai.vectorStore. Both the
+// collection path and the single-object init share it so the two paths cannot
+// diverge.
+func mapVectorStore(vs openai.VectorStore) map[string]*llx.RawData {
+	fileCounts := map[string]any{
+		"in_progress": vs.FileCounts.InProgress,
+		"completed":   vs.FileCounts.Completed,
+		"failed":      vs.FileCounts.Failed,
+		"cancelled":   vs.FileCounts.Cancelled,
+		"total":       vs.FileCounts.Total,
+	}
+
+	var expiresAfter any
+	if vs.ExpiresAfter.Days != 0 {
+		expiresAfter = map[string]any{
+			"anchor": string(vs.ExpiresAfter.Anchor),
+			"days":   vs.ExpiresAfter.Days,
+		}
+	}
+
+	metadata := make(map[string]any)
+	for k, v := range vs.Metadata {
+		metadata[k] = v
+	}
+
+	return map[string]*llx.RawData{
+		"__id":         llx.StringData(vs.ID),
+		"id":           llx.StringData(vs.ID),
+		"name":         llx.StringData(vs.Name),
+		"status":       llx.StringData(string(vs.Status)),
+		"usageBytes":   llx.IntData(vs.UsageBytes),
+		"createdAt":    llx.TimeDataPtr(unixToNullableTime(vs.CreatedAt)),
+		"lastActiveAt": llx.TimeDataPtr(unixToNullableTime(vs.LastActiveAt)),
+		"fileCounts":   llx.DictData(fileCounts),
+		"expiresAfter": llx.DictData(expiresAfter),
+		"expiresAt":    llx.TimeDataPtr(unixToNullableTime(vs.ExpiresAt)),
+		"metadata":     llx.DictData(metadata),
+	}
+}
 
 func (r *mqlOpenai) vectorStores() ([]any, error) {
 	conn := openaiConn(r.MqlRuntime)
-	client := conn.Client()
+	client, err := dataPlaneClient(conn, "openai.vectorStores")
+	if err != nil {
+		return nil, err
+	}
 	if client == nil {
 		return []any{}, nil
 	}
@@ -24,54 +67,7 @@ func (r *mqlOpenai) vectorStores() ([]any, error) {
 	var res []any
 	for iter.Next() {
 		vs := iter.Current()
-		created := unixToTime(vs.CreatedAt)
-
-		var lastActiveAt *time.Time
-		if vs.LastActiveAt != 0 {
-			t := unixToTime(vs.LastActiveAt)
-			lastActiveAt = &t
-		}
-
-		var expiresAt *time.Time
-		if vs.ExpiresAt != 0 {
-			t := unixToTime(vs.ExpiresAt)
-			expiresAt = &t
-		}
-
-		fileCounts := map[string]any{
-			"in_progress": vs.FileCounts.InProgress,
-			"completed":   vs.FileCounts.Completed,
-			"failed":      vs.FileCounts.Failed,
-			"cancelled":   vs.FileCounts.Cancelled,
-			"total":       vs.FileCounts.Total,
-		}
-
-		var expiresAfter any
-		if vs.ExpiresAfter.Days != 0 {
-			expiresAfter = map[string]any{
-				"anchor": string(vs.ExpiresAfter.Anchor),
-				"days":   vs.ExpiresAfter.Days,
-			}
-		}
-
-		metadata := make(map[string]any)
-		for k, v := range vs.Metadata {
-			metadata[k] = v
-		}
-
-		mqlVS, err := CreateResource(r.MqlRuntime, "openai.vectorStore", map[string]*llx.RawData{
-			"__id":         llx.StringData(vs.ID),
-			"id":           llx.StringData(vs.ID),
-			"name":         llx.StringData(vs.Name),
-			"status":       llx.StringData(string(vs.Status)),
-			"usageBytes":   llx.IntData(vs.UsageBytes),
-			"createdAt":    llx.TimeData(created),
-			"lastActiveAt": llx.TimeDataPtr(lastActiveAt),
-			"fileCounts":   llx.DictData(fileCounts),
-			"expiresAfter": llx.DictData(expiresAfter),
-			"expiresAt":    llx.TimeDataPtr(expiresAt),
-			"metadata":     llx.DictData(metadata),
-		})
+		mqlVS, err := CreateResource(r.MqlRuntime, "openai.vectorStore", mapVectorStore(vs))
 		if err != nil {
 			return nil, err
 		}
@@ -84,4 +80,32 @@ func (r *mqlOpenai) vectorStores() ([]any, error) {
 		return nil, fmt.Errorf("failed to list vector stores: %w", err)
 	}
 	return res, nil
+}
+
+func initOpenaiVectorStore(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	idRaw, ok := args["id"]
+	if !ok || idRaw == nil || idRaw.Value == nil {
+		return args, nil, nil
+	}
+	vsID, ok := idRaw.Value.(string)
+	if !ok || vsID == "" {
+		return args, nil, nil
+	}
+
+	conn := openaiConn(runtime)
+	client, err := dataPlaneClient(conn, "openai.vectorStore")
+	if err != nil {
+		return nil, nil, err
+	}
+	if client == nil {
+		return nil, nil, fmt.Errorf("cannot fetch vector store %s: no project API key configured", vsID)
+	}
+	vs, err := client.VectorStores.Get(context.Background(), vsID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get vector store %s: %w", vsID, err)
+	}
+	return mapVectorStore(*vs), nil, nil
 }


### PR DESCRIPTION
## What

Fixes four defect classes found in a static bug review of the `openai` provider. Each is the "wrong data looks valid" kind that a compiler and the passing test suite don't catch.

### 1. Silent data loss on key-type mismatch (MEDIUM)
The connection builds **exactly one** of the project (data-plane) or admin (org-plane) client, chosen by token prefix. So:
- an **admin key** (`sk-admin-…`) silently returned empty `models` / `files` / `vectorStores` / `fineTuningJobs` — the provider's core AIBOM data;
- a **project key** silently returned empty `users` / `invites` / `auditLogs` / `projects`.

A "0 results" that actually means "wrong key type" can make a policy pass vacuously. New `dataPlaneClient` / `adminPlaneClient` helpers return a **descriptive error** when the required key type is absent, and still degrade to empty only when there are no credentials at all.

### 2. Absent timestamps rendered as year-1 instead of null (LOW–MEDIUM)
`llx.TimeData` wraps its value unconditionally, so a zero unix time (how the API signals absent — e.g. `organizationUser.created`, which the SDK marks neither `required` nor `nullable`) surfaced as `0001-01-01` rather than null. The optional fields already guarded this; the "always present" ones didn't. All timestamp fields now route through a shared `unixToNullableTime` helper — matching the intent the provider's own `TestUnixToTime` documents.

### 3. Husk single-object lookups (LOW)
`initOpenaiFile` fell through to `(args, nil, nil)` on access-denied, building a blank resource whose fields surface client-side as `primitive with no type information`. That path now returns an error.

### 4. Missing single-object inits (LOW)
Only `openai.file` had an `init`, so `openai.model(id: "gpt-4o")` etc. returned a husk. Added inits for `model` / `fineTuningJob` / `vectorStore` / `project`.

## How
Each resource's field mapping is extracted into a shared `mapX()` used by **both** the collection path and the new single-object init, so the two paths cannot diverge (closing the "resolves differently through list vs single-object" bug class by construction).

No `.lr` schema change — no new fields, no version bumps. The only generated-code change is the five `Init:` wirings in `openai.lr.go`.

## Tests
Added unit tests for the new pure-Go logic: `unixToNullableTime`, `isAccessDenied`, the audit-log actor derivation (`auditLogActor`), and plane-client selection (`dataPlaneClient` / `adminPlaneClient`). `go test ./providers/openai/...` passes; full provider build is clean.

Not live-verified against a real OpenAI account (no creds in this environment); behavior changes are covered by the unit tests above and can be batch-verified separately.

