### PR TITLE
🐛 kustomize: discover nested overlays + surface deprecated-alias fields

### DIFF
--- a/providers/kustomize/connection/connection.go
+++ b/providers/kustomize/connection/connection.go
@@ -140,6 +140,12 @@ var scanSkipDirs = map[string]struct{}{
 	"build":        {},
 }
 
+// maxScanDepth bounds the recursive subdirectory scan so a path aimed at a
+// large monorepo root (with no kustomization anywhere near the top) can't walk
+// the entire tree. The canonical base/overlays/<env>[/<region>] layouts sit
+// well within this depth.
+const maxScanDepth = 10
+
 // loadKustomizations finds and parses kustomization files from a path.
 func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 	fi, err := os.Stat(kustomizePath)
@@ -163,11 +169,37 @@ func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 		return nil, err
 	}
 
-	// Otherwise scan subdirectories
+	// Otherwise scan subdirectories recursively. A one-level scan silently
+	// missed the canonical Kustomize layout (base/ next to overlays/<env>/),
+	// where the actual deployment overlays live two levels below the repo
+	// root — the tool would find only the base and drop every overlay.
 	var entries []*KustomizationEntry
-	dirEntries, err := os.ReadDir(kustomizePath)
-	if err != nil {
+	if err := scanForKustomizations(kustomizePath, 0, &entries); err != nil {
 		return nil, err
+	}
+	return entries, nil
+}
+
+// scanForKustomizations walks subdirectories of dir looking for kustomization
+// files. A directory that itself contains a kustomization owns its whole
+// subtree (its resources and overlays are its own concern), so the scan
+// records it and does not descend into it; only kustomization-free glue
+// directories (e.g. overlays/) are recursed through to reach nested overlays.
+func scanForKustomizations(dir string, depth int, entries *[]*KustomizationEntry) error {
+	if depth > maxScanDepth {
+		return nil
+	}
+
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		// The root directory not being readable is a real failure the caller
+		// should see; a single unreadable subdir deeper in the tree should
+		// not abort discovery of everything else.
+		if depth == 0 {
+			return err
+		}
+		log.Warn().Err(err).Str("path", dir).Msg("failed to read directory during kustomization scan; skipping")
+		return nil
 	}
 
 	for _, de := range dirEntries {
@@ -185,20 +217,25 @@ func loadKustomizations(kustomizePath string) ([]*KustomizationEntry, error) {
 		if _, skip := scanSkipDirs[name]; skip {
 			continue
 		}
-		subPath := filepath.Join(kustomizePath, name)
+		subPath := filepath.Join(dir, name)
 		entry, err := loadSingleKustomization(subPath)
-		if err == nil {
-			entries = append(entries, entry)
-			continue
-		}
-		// Quiet skip when the subdir simply has no kustomization
-		// file; loud warning when a file exists but won't parse.
-		if !errors.Is(err, ErrNoKustomization) {
+		switch {
+		case err == nil:
+			// Found a kustomization here; this directory owns its subtree,
+			// so don't descend further into it.
+			*entries = append(*entries, entry)
+		case errors.Is(err, ErrNoKustomization):
+			// No kustomization at this level; descend to find nested overlays.
+			if err := scanForKustomizations(subPath, depth+1, entries); err != nil {
+				return err
+			}
+		default:
+			// A file exists but won't parse: loud warning, then skip.
 			log.Warn().Err(err).Str("path", subPath).Msg("failed to load kustomization; skipping")
 		}
 	}
 
-	return entries, nil
+	return nil
 }
 
 func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
@@ -215,6 +252,14 @@ func loadSingleKustomization(dir string) (*KustomizationEntry, error) {
 		if err := k.Unmarshal(data); err != nil {
 			return nil, err
 		}
+		// Unmarshal leaves deprecated field aliases in their legacy slots.
+		// FixKustomization reconciles them into the modern fields: bases into
+		// resources, imageTags into images, and the singular env into a
+		// generator's envs. Without it the raw-field accessors (resourceRefs,
+		// images, and a generator's envs) silently omit entries declared with
+		// the older syntax. This only affects our in-memory view; rendering
+		// runs krusty against the filesystem path independently.
+		k.FixKustomization()
 		return &KustomizationEntry{
 			Path:          dir,
 			Kustomization: k,

--- a/providers/kustomize/connection/connection_test.go
+++ b/providers/kustomize/connection/connection_test.go
@@ -42,6 +42,63 @@ func TestLoadKustomizations_BasicFixtureStillWorks(t *testing.T) {
 	assert.Equal(t, "../testdata/basic", entries[0].Path)
 }
 
+// A one-level subdir scan silently missed the canonical Kustomize layout:
+// base/ alongside overlays/<env>/, where the real deployment overlays live
+// two levels below the root. Pointing at the root found only base/ and
+// dropped every overlay. The scan now recurses, stopping at each directory
+// that owns a kustomization.
+func TestLoadKustomizations_RecursesIntoNestedOverlays(t *testing.T) {
+	entries, err := loadKustomizations("../testdata/nested-overlays")
+	require.NoError(t, err)
+
+	got := map[string]bool{}
+	for _, e := range entries {
+		got[e.Path] = true
+	}
+	assert.Truef(t, got["../testdata/nested-overlays/base"], "base should be discovered, got %v", got)
+	assert.Truef(t, got["../testdata/nested-overlays/overlays/dev"], "dev overlay (depth 2) should be discovered, got %v", got)
+	assert.Truef(t, got["../testdata/nested-overlays/overlays/prod"], "prod overlay (depth 2) should be discovered, got %v", got)
+	assert.Len(t, entries, 3)
+}
+
+// A directory that owns a kustomization owns its whole subtree; the scan must
+// not descend into it and emit a second entry for a nested resources/ dir that
+// happens to carry its own kustomization file.
+func TestLoadKustomizations_DoesNotDescendIntoOwnedSubtree(t *testing.T) {
+	tmp := t.TempDir()
+	// Root has no kustomization, so the scan recurses.
+	overlay := filepath.Join(tmp, "overlay")
+	nested := filepath.Join(overlay, "components", "extra")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	kust := []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n")
+	require.NoError(t, os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), kust, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "kustomization.yaml"), kust, 0o644))
+
+	entries, err := loadKustomizations(tmp)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the owning overlay dir should be discovered, not its nested subtree")
+	assert.Equal(t, overlay, entries[0].Path)
+}
+
+// FixKustomization reconciles deprecated field aliases into the modern
+// fields. Without it the raw-field accessors silently omit entries declared
+// with the older syntax (bases, imageTags, singular env).
+func TestLoadSingleKustomization_MergesDeprecatedFields(t *testing.T) {
+	entry, err := loadSingleKustomization("../testdata/deprecated-fields")
+	require.NoError(t, err)
+	k := entry.Kustomization
+
+	assert.Contains(t, k.Resources, "../base", "bases: entry should be merged into resources")
+
+	require.Len(t, k.Images, 1, "imageTags: entry should be merged into images")
+	assert.Equal(t, "nginx", k.Images[0].Name)
+	assert.Equal(t, "1.2.3", k.Images[0].NewTag)
+
+	require.Len(t, k.ConfigMapGenerator, 1)
+	assert.Contains(t, k.ConfigMapGenerator[0].EnvSources, "config.env",
+		"singular env: should be merged into envs")
+}
+
 // NewKustomizeConnection used to deref asset.Connections[0] unconditionally;
 // passing a nil asset or one with no connections now produces a clear error
 // instead of a runtime panic.

--- a/providers/kustomize/provider/provider_test.go
+++ b/providers/kustomize/provider/provider_test.go
@@ -354,6 +354,28 @@ func TestMultiOverlayDirectory(t *testing.T) {
 	require.Len(t, kustsResp.Data.Array, 2)
 }
 
+// The canonical Kustomize layout puts overlays two levels below the root
+// (base/ next to overlays/<env>/). A one-level scan found only base/ and
+// silently dropped every overlay; the recursive scan discovers all three.
+func TestNestedOverlayDirectory(t *testing.T) {
+	srv, resp := newTestService("../testdata/nested-overlays")
+
+	kustResp := getData(t, srv, resp.Id, "kustomize", "", "")
+	kustID := string(kustResp.Data.Value)
+
+	kustsResp := getData(t, srv, resp.Id, "kustomize", kustID, "kustomizations")
+	require.Len(t, kustsResp.Data.Array, 3, "base plus both nested overlays should be discovered")
+
+	namespaces := map[string]bool{}
+	for _, k := range kustsResp.Data.Array {
+		kID := string(k.Value)
+		nsResp := getData(t, srv, resp.Id, "kustomize.kustomization", kID, "namespace")
+		namespaces[string(nsResp.Data.Value)] = true
+	}
+	assert.True(t, namespaces["dev"], "dev overlay should be present")
+	assert.True(t, namespaces["prod"], "prod overlay should be present")
+}
+
 func TestStagingOverlay(t *testing.T) {
 	// Point directly at the staging overlay which references ../base
 	srv, resp := newTestService("../testdata/multi-overlay/staging")

--- a/providers/kustomize/resources/kustomize.go
+++ b/providers/kustomize/resources/kustomize.go
@@ -20,7 +20,10 @@ func (r *mqlKustomize) id() (string, error) {
 }
 
 func (r *mqlKustomize) kustomizations() ([]any, error) {
-	conn := r.MqlRuntime.Connection.(*connection.KustomizeConnection)
+	conn, ok := r.MqlRuntime.Connection.(*connection.KustomizeConnection)
+	if !ok {
+		return nil, errors.New("kustomize: connection is not a KustomizeConnection")
+	}
 	entries := conn.Kustomizations()
 
 	var mqlKusts []any

--- a/providers/kustomize/testdata/deprecated-fields/kustomization.yaml
+++ b/providers/kustomize/testdata/deprecated-fields/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../base
+
+imageTags:
+  - name: nginx
+    newTag: "1.2.3"
+
+configMapGenerator:
+  - name: app-config
+    env: config.env

--- a/providers/kustomize/testdata/nested-overlays/base/deployment.yaml
+++ b/providers/kustomize/testdata/nested-overlays/base/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.0.0

--- a/providers/kustomize/testdata/nested-overlays/base/kustomization.yaml
+++ b/providers/kustomize/testdata/nested-overlays/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml

--- a/providers/kustomize/testdata/nested-overlays/overlays/dev/kustomization.yaml
+++ b/providers/kustomize/testdata/nested-overlays/overlays/dev/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dev
+
+resources:
+  - ../../base

--- a/providers/kustomize/testdata/nested-overlays/overlays/prod/kustomization.yaml
+++ b/providers/kustomize/testdata/nested-overlays/overlays/prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: prod
+
+resources:
+  - ../../base


### PR DESCRIPTION
## What

Static bug-review fixes for the `kustomize` provider. Each addresses a case where the provider silently under-reported without any error — the worst kind of bug for an audit tool, because the incomplete answer looks valid.

### 1. Recursive kustomization discovery (silent under-coverage)

The subdirectory scan only descended **one level**. Pointed at a repo root with the canonical Kustomize layout —

```
myapp/
  base/kustomization.yaml
  overlays/dev/kustomization.yaml     # 2 levels deep
  overlays/prod/kustomization.yaml    # 2 levels deep
```

— it found `base/` and silently dropped both overlays, so `kustomize.kustomizations` returned only the least-interesting entry and omitted the actual deployment configs. The scan now recurses (bounded by `maxScanDepth`), and stops descending at any directory that owns a kustomization so an overlay's own subtree isn't double-counted.

Discovery-based scans (the GitHub IaC integration targets each exact kustomization dir) and direct-at-overlay CLI usage were already fine; this only affected a manual scan aimed at a nested tree.

### 2. Reconcile deprecated field aliases (silent data loss)

`Kustomization.Unmarshal` deliberately does not call `FixKustomization`, so the deprecated `bases:`, `imageTags:`, and singular `env:` aliases stay in their legacy struct fields. The raw-field accessors (`resourceRefs`, `images`, a generator's `envs`) read only the modern fields, so anything declared with the older syntax was invisible — including an env-file feeding a Secret generator. We now call `FixKustomization()` after `Unmarshal`. This only affects the in-memory view; rendering runs `krusty` against the filesystem independently, so `resources()` was already complete.

### 3. Guard the connection type assertion (panic hardening)

`kustomizations()` used a bare `Connection.(*KustomizeConnection)` assertion while every other site used comma-ok. Now returns a clear error instead of risking a panic.

## Tests

- `TestLoadKustomizations_RecursesIntoNestedOverlays` — base + both nested overlays discovered
- `TestLoadKustomizations_DoesNotDescendIntoOwnedSubtree` — owning dir isn't double-counted
- `TestLoadSingleKustomization_MergesDeprecatedFields` — bases/imageTags/env reconciled
- `TestNestedOverlayDirectory` — end-to-end discovery through the real `Connect` path

Existing tests (`TestMultiOverlayDirectory`, hidden/noise-dir skip, malformed-root propagation) still pass.

## Deliberately not changed

- **SDK `DisallowUnknownFields`** — a `kustomization.yaml` using a field newer than the pinned `sigs.k8s.io/kustomize/api` module fails to load. Inherent to the SDK's strict decoder; noted as upgrade-sensitivity.
- **Patch path-escape guard** — a patch `path:` that escapes the kustomization directory drops its content behind a logged warning. Deliberate path-traversal defense, kept as-is.
