### PR TITLE
🐛 portainer: fix deprecated-field reads, discovery panic, and RBAC gaps

### DIFF
--- a/providers/portainer/connection/connection.go
+++ b/providers/portainer/connection/connection.go
@@ -121,7 +121,7 @@ func NewPortainerConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 
 	cli := client.NewPortainerClient(host, accessToken, opts...)
 
-	// validate credentials early and capture instance metadata for the platform id
+	// reach the instance early and capture its metadata for the platform id
 	status, err := cli.GetSystemStatus()
 	if err != nil {
 		return nil, errors.New("failed to connect to Portainer: " + err.Error())
@@ -131,6 +131,16 @@ func NewPortainerConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 	if status != nil {
 		conn.instanceID = status.InstanceID
 		conn.version = status.Version
+	}
+
+	// The system status endpoint is public, so reaching it proves the address
+	// points at a Portainer instance but says nothing about the access token.
+	// Make one authenticated call so an invalid or expired token fails here,
+	// with a message that names the cause, instead of surfacing later as an
+	// unattributed error on every single resource. The result is memoized on
+	// the connection, so discovery and portainer.environments reuse it.
+	if _, err := conn.Endpoints(); err != nil {
+		return nil, errors.New("failed to authenticate against Portainer, check the access token: " + err.Error())
 	}
 	return conn, nil
 }
@@ -225,6 +235,20 @@ func (c *PortainerConnection) EdgeGroups() ([]*models.EdgegroupsDecoratedEdgeGro
 
 func (c *PortainerConnection) InstanceID() string {
 	return c.instanceID
+}
+
+// InstanceKey returns the identifier platform ids are built from. It prefers
+// the instance id reported by the server and falls back to the hostname, so
+// that instances which report no id do not all collapse onto the same platform
+// id (and therefore onto the same asset).
+func (c *PortainerConnection) InstanceKey() string {
+	if c.instanceID != "" {
+		return c.instanceID
+	}
+	if c.hostname != "" {
+		return c.hostname
+	}
+	return "unknown"
 }
 
 func (c *PortainerConnection) Version() string {

--- a/providers/portainer/connection/connection_test.go
+++ b/providers/portainer/connection/connection_test.go
@@ -66,9 +66,82 @@ func TestMembershipRole(t *testing.T) {
 	}
 }
 
+// TestEnvironmentStatus covers all four states Portainer declares for an
+// endpoint. 3 and 4 are only reachable on cloud-provisioned environments, and
+// mapping them to "unknown" used to hide error-state environments from any
+// audit that filtered on "down".
 func TestEnvironmentStatus(t *testing.T) {
-	cases := map[int64]string{1: "up", 2: "down", 0: "unknown", 99: "unknown"}
+	cases := map[int64]string{
+		1:  "up",
+		2:  "down",
+		3:  "provisioning",
+		4:  "error",
+		0:  "unknown",
+		5:  "unknown",
+		99: "unknown",
+	}
 	for in, want := range cases {
 		assert.Equalf(t, want, EnvironmentStatus(in), "EnvironmentStatus(%d)", in)
 	}
+}
+
+func TestAccessPolicyRole(t *testing.T) {
+	cases := map[int64]string{
+		1:  "environment_administrator",
+		2:  "helpdesk_user",
+		3:  "standard_user",
+		4:  "readonly_user",
+		5:  "operator_user",
+		0:  "unknown",
+		6:  "unknown",
+		-1: "unknown",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, AccessPolicyRole(in), "AccessPolicyRole(%d)", in)
+	}
+}
+
+func TestEdgeStackDeploymentType(t *testing.T) {
+	cases := map[int64]string{0: "compose", 1: "kubernetes", 2: "unknown", 99: "unknown"}
+	for in, want := range cases {
+		assert.Equalf(t, want, EdgeStackDeploymentType(in), "EdgeStackDeploymentType(%d)", in)
+	}
+}
+
+// TestInstanceKey pins the platform-id fallback: without it, every instance
+// that reports no instance id would share the platform id ".../instance/" and
+// collapse onto a single asset.
+func TestInstanceKey(t *testing.T) {
+	cases := []struct {
+		name       string
+		instanceID string
+		hostname   string
+		want       string
+	}{
+		{"instance id wins", "inst-1", "portainer.example.com", "inst-1"},
+		{"falls back to hostname", "", "portainer.example.com", "portainer.example.com"},
+		{"falls back to a constant", "", "", "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &PortainerConnection{instanceID: tc.instanceID, hostname: tc.hostname}
+			assert.Equal(t, tc.want, conn.InstanceKey())
+		})
+	}
+}
+
+func TestPlatformIDs(t *testing.T) {
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/portainer/instance/inst-1",
+		NewInstancePlatformID("inst-1"))
+	assert.Equal(t,
+		"//platformid.api.mondoo.app/runtime/portainer/instance/inst-1/environment/7",
+		NewEnvironmentPlatformID("inst-1", 7))
+
+	// two instances without an id must not collide once the key falls back
+	a := &PortainerConnection{hostname: "a.example.com"}
+	b := &PortainerConnection{hostname: "b.example.com"}
+	assert.NotEqual(t,
+		NewInstancePlatformID(a.InstanceKey()),
+		NewInstancePlatformID(b.InstanceKey()))
 }

--- a/providers/portainer/connection/platform.go
+++ b/providers/portainer/connection/platform.go
@@ -96,12 +96,38 @@ func IsEdgeEnvironment(t int64) bool {
 }
 
 // EnvironmentStatus maps the Portainer endpoint status enum to a string.
+// Portainer declares the status as enums 1,2,3,4: the open-source edition only
+// names 1 (up) and 2 (down), while 3 (provisioning) and 4 (error) are reported
+// by cloud-provisioned environments and carry a StatusMessage.
 func EnvironmentStatus(s int64) string {
 	switch s {
 	case 1:
 		return "up"
 	case 2:
 		return "down"
+	case 3:
+		return "provisioning"
+	case 4:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// AccessPolicyRole maps a Portainer environment role id, as it appears in the
+// team and user access policies, to the role name used by the API.
+func AccessPolicyRole(r int64) string {
+	switch r {
+	case 1:
+		return "environment_administrator"
+	case 2:
+		return "helpdesk_user"
+	case 3:
+		return "standard_user"
+	case 4:
+		return "readonly_user"
+	case 5:
+		return "operator_user"
 	default:
 		return "unknown"
 	}
@@ -199,5 +225,5 @@ func (c *PortainerConnection) SubAssetPlatform() (*inventory.Platform, string, s
 	// The environment type is stored as a connection option at discovery time;
 	// fall back to 0 ("unknown") only if it is missing or malformed.
 	envType, _ := strconv.ParseInt(c.Conf.Options[OptionEnvironmentType], 10, 64)
-	return EnvironmentPlatform(envType), NewEnvironmentPlatformID(c.instanceID, envID), "Portainer environment " + envIDStr
+	return EnvironmentPlatform(envType), NewEnvironmentPlatformID(c.InstanceKey(), envID), "Portainer environment " + envIDStr
 }

--- a/providers/portainer/provider/provider.go
+++ b/providers/portainer/provider/provider.go
@@ -156,7 +156,7 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.PortainerConne
 		}
 	}
 	asset.Platform = connection.InstancePlatform()
-	asset.PlatformIds = []string{connection.NewInstancePlatformID(conn.InstanceID())}
+	asset.PlatformIds = []string{connection.NewInstancePlatformID(conn.InstanceKey())}
 	return nil
 }
 

--- a/providers/portainer/resources/discovery.go
+++ b/providers/portainer/resources/discovery.go
@@ -33,7 +33,7 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 		return nil, err
 	}
 
-	instanceID := conn.InstanceID()
+	instanceID := conn.InstanceKey()
 	assets := []*inventory.Asset{}
 	for _, e := range endpoints {
 		if !matchesEnvironmentTargets(targets, e.Type) {
@@ -41,6 +41,12 @@ func Discover(runtime *plugin.Runtime) (*inventory.Inventory, error) {
 		}
 
 		cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+		// Clone preserves a nil options map, which an asset defined in an
+		// inventory file without an options block carries; writing into it
+		// would panic.
+		if cfg.Options == nil {
+			cfg.Options = map[string]string{}
+		}
 		cfg.Options[connection.OptionEnvironmentID] = strconv.FormatInt(e.ID, 10)
 		cfg.Options[connection.OptionEnvironmentType] = strconv.FormatInt(e.Type, 10)
 

--- a/providers/portainer/resources/environment_groups.go
+++ b/providers/portainer/resources/environment_groups.go
@@ -24,6 +24,8 @@ func newMqlPortainerEnvironmentGroup(runtime *plugin.Runtime, g *models.Portaine
 		"description":        llx.StringData(g.Description),
 		"teamAccessPolicies": llx.DictData(accessPoliciesToDict(g.TeamAccessPolicies)),
 		"userAccessPolicies": llx.DictData(accessPoliciesToDict(g.UserAccessPolicies)),
+		"teamAccessRoles":    llx.DictData(accessRolesToDict(g.TeamAccessPolicies)),
+		"userAccessRoles":    llx.DictData(accessRolesToDict(g.UserAccessPolicies)),
 	})
 	if err != nil {
 		return nil, err

--- a/providers/portainer/resources/environments.go
+++ b/providers/portainer/resources/environments.go
@@ -25,6 +25,27 @@ func accessPoliciesToDict(policies map[string]models.PortainerAccessPolicy) map[
 	return res
 }
 
+// accessRolesToDict is accessPoliciesToDict with the role id resolved to the
+// role name the Portainer API uses, so audits do not have to hardcode the
+// numeric ids.
+func accessRolesToDict(policies map[string]models.PortainerAccessPolicy) map[string]any {
+	res := make(map[string]any, len(policies))
+	for k, v := range policies {
+		res[k] = connection.AccessPolicyRole(v.RoleID)
+	}
+	return res
+}
+
+// tlsConfig reads the environment's TLS posture. The top-level TLS field on the
+// endpoint has been deprecated since Portainer's DBVersion 4 and is no longer
+// written by the server, so the live values come from TLSConfig.
+func tlsConfig(e *models.PortainereeEndpoint) (enabled, skipVerify bool) {
+	if e.TLSConfig == nil {
+		return false, false
+	}
+	return e.TLSConfig.TLS, e.TLSConfig.TLSSkipVerify
+}
+
 // securitySettingsToDict flattens the per-environment container-security
 // overrides into a dict keyed by setting name. Returns nil when the endpoint
 // carries no overrides so the field resolves to an empty dict.
@@ -46,6 +67,7 @@ func securitySettingsToDict(s *models.PortainerEndpointSecuritySettings) map[str
 }
 
 func newMqlPortainerEnvironment(runtime *plugin.Runtime, e *models.PortainereeEndpoint) (*mqlPortainerEnvironment, error) {
+	tlsEnabled, tlsSkipVerify := tlsConfig(e)
 	res, err := CreateResource(runtime, "portainer.environment", map[string]*llx.RawData{
 		"__id":                 llx.StringData("portainer.environment/" + strconv.FormatInt(e.ID, 10)),
 		"id":                   llx.IntData(e.ID),
@@ -54,10 +76,13 @@ func newMqlPortainerEnvironment(runtime *plugin.Runtime, e *models.PortainereeEn
 		"status":               llx.StringData(connection.EnvironmentStatus(e.Status)),
 		"url":                  llx.StringData(e.URL),
 		"publicUrl":            llx.StringData(e.PublicURL),
-		"tlsEnabled":           llx.BoolData(e.TLS),
+		"tlsEnabled":           llx.BoolData(tlsEnabled),
+		"tlsSkipVerify":        llx.BoolData(tlsSkipVerify),
 		"containerEngine":      llx.StringData(e.ContainerEngine),
 		"teamAccessPolicies":   llx.DictData(accessPoliciesToDict(e.TeamAccessPolicies)),
 		"userAccessPolicies":   llx.DictData(accessPoliciesToDict(e.UserAccessPolicies)),
+		"teamAccessRoles":      llx.DictData(accessRolesToDict(e.TeamAccessPolicies)),
+		"userAccessRoles":      llx.DictData(accessRolesToDict(e.UserAccessPolicies)),
 		"edgeId":               llx.StringData(e.EdgeID),
 		"heartbeat":            llx.BoolData(e.Heartbeat),
 		"userTrusted":          llx.BoolData(e.UserTrusted),

--- a/providers/portainer/resources/portainer.lr
+++ b/providers/portainer/resources/portainer.lr
@@ -80,8 +80,12 @@ portainer.settings @defaults("authenticationMethod requiredPasswordLength") {
   disableKubeShell bool
   // Whether kubeconfig download is disabled
   disableKubeconfigDownload bool
-  // Whether host-management features are enabled
-  enableHostManagementFeatures bool
+  // Host-management features
+  //
+  // Deprecated in favor of the per-environment securitySettings override of
+  // the same name. Portainer stopped maintaining this instance-wide flag, so
+  // it reads false regardless of how individual environments are configured.
+  enableHostManagementFeatures @maturity("deprecated") bool
   // Whether syncing of built-in Kubernetes roles is disabled
   disableKubeRolesSync bool
   // Custom kubectl shell image used for the Kubernetes web console
@@ -146,6 +150,12 @@ portainer.team @defaults("name") {
   name string
   // Users that are members of this team
   members() []portainer.user
+  // Membership roles keyed by username, with leader or member as the value
+  //
+  // Team leaders may manage the team's roster and see the team in listings
+  // that plain members do not, so the split matters when auditing who can
+  // widen a team's inherited environment access.
+  memberRoles() dict
 }
 
 // Portainer environment
@@ -164,7 +174,7 @@ portainer.environment @defaults("name type status") {
   name string
   // Environment type: docker, agent-docker, azure-aci, edge-agent-docker, kubernetes, agent-kubernetes, or edge-agent-kubernetes
   type string
-  // Connection status: up, down, or unknown
+  // Connection status: up, down, provisioning, error, or unknown
   status string
   // API endpoint URL of the environment
   url string
@@ -172,6 +182,12 @@ portainer.environment @defaults("name type status") {
   publicUrl string
   // Whether the connection to the environment uses TLS
   tlsEnabled bool
+  // Whether verification of the environment's TLS certificate is skipped
+  //
+  // True when Portainer is configured to accept the environment's server
+  // certificate without validating it, which leaves the control-plane
+  // connection open to interception. Only meaningful when tlsEnabled is true.
+  tlsSkipVerify bool
   // Container engine in use, for example docker or podman
   containerEngine string
   // Tags assigned to the environment
@@ -180,6 +196,18 @@ portainer.environment @defaults("name type status") {
   teamAccessPolicies dict
   // User access policies keyed by user id, with the granted role id as the value
   userAccessPolicies dict
+  // Team access roles keyed by team id, with the granted role name as the value
+  //
+  // The same grants as teamAccessPolicies with the role id resolved to its
+  // name: environment_administrator, helpdesk_user, standard_user,
+  // readonly_user, or operator_user. An unrecognized role id maps to unknown.
+  teamAccessRoles dict
+  // User access roles keyed by user id, with the granted role name as the value
+  //
+  // The same grants as userAccessPolicies with the role id resolved to its
+  // name: environment_administrator, helpdesk_user, standard_user,
+  // readonly_user, or operator_user. An unrecognized role id maps to unknown.
+  userAccessRoles dict
   // Environment group (endpoint group) this environment belongs to
   group() portainer.environmentGroup
   // Edge agent identifier, for Edge environments
@@ -236,6 +264,18 @@ portainer.environmentGroup @defaults("name") {
   teamAccessPolicies dict
   // User access policies keyed by user id, with the granted role id as the value
   userAccessPolicies dict
+  // Team access roles keyed by team id, with the granted role name as the value
+  //
+  // The same grants as teamAccessPolicies with the role id resolved to its
+  // name: environment_administrator, helpdesk_user, standard_user,
+  // readonly_user, or operator_user. An unrecognized role id maps to unknown.
+  teamAccessRoles dict
+  // User access roles keyed by user id, with the granted role name as the value
+  //
+  // The same grants as userAccessPolicies with the role id resolved to its
+  // name: environment_administrator, helpdesk_user, standard_user,
+  // readonly_user, or operator_user. An unrecognized role id maps to unknown.
+  userAccessRoles dict
 }
 
 // Portainer edge group
@@ -275,7 +315,7 @@ portainer.edgeStack @defaults("name") {
   edgeGroups() []portainer.edgeGroup
   // Number of environments the stack is deployed to
   numDeployments int
-  // Stack file version
+  // Stack revision, incremented on each update
   version int
   // Time the Edge stack was created (null if unset)
   creationDate time

--- a/providers/portainer/resources/portainer.lr.go
+++ b/providers/portainer/resources/portainer.lr.go
@@ -290,6 +290,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"portainer.team.members": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerTeam).GetMembers()).ToDataRes(types.Array(types.Resource("portainer.user")))
 	},
+	"portainer.team.memberRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerTeam).GetMemberRoles()).ToDataRes(types.Dict)
+	},
 	"portainer.environment.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironment).GetId()).ToDataRes(types.Int)
 	},
@@ -311,6 +314,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"portainer.environment.tlsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironment).GetTlsEnabled()).ToDataRes(types.Bool)
 	},
+	"portainer.environment.tlsSkipVerify": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerEnvironment).GetTlsSkipVerify()).ToDataRes(types.Bool)
+	},
 	"portainer.environment.containerEngine": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironment).GetContainerEngine()).ToDataRes(types.String)
 	},
@@ -322,6 +328,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"portainer.environment.userAccessPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironment).GetUserAccessPolicies()).ToDataRes(types.Dict)
+	},
+	"portainer.environment.teamAccessRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerEnvironment).GetTeamAccessRoles()).ToDataRes(types.Dict)
+	},
+	"portainer.environment.userAccessRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerEnvironment).GetUserAccessRoles()).ToDataRes(types.Dict)
 	},
 	"portainer.environment.group": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironment).GetGroup()).ToDataRes(types.Resource("portainer.environmentGroup"))
@@ -364,6 +376,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"portainer.environmentGroup.userAccessPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEnvironmentGroup).GetUserAccessPolicies()).ToDataRes(types.Dict)
+	},
+	"portainer.environmentGroup.teamAccessRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerEnvironmentGroup).GetTeamAccessRoles()).ToDataRes(types.Dict)
+	},
+	"portainer.environmentGroup.userAccessRoles": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlPortainerEnvironmentGroup).GetUserAccessRoles()).ToDataRes(types.Dict)
 	},
 	"portainer.edgeGroup.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlPortainerEdgeGroup).GetId()).ToDataRes(types.Int)
@@ -643,6 +661,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPortainerTeam).Members, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"portainer.team.memberRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerTeam).MemberRoles, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"portainer.environment.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPortainerEnvironment).__id, ok = v.Value.(string)
 		return
@@ -675,6 +697,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlPortainerEnvironment).TlsEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"portainer.environment.tlsSkipVerify": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerEnvironment).TlsSkipVerify, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"portainer.environment.containerEngine": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPortainerEnvironment).ContainerEngine, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -689,6 +715,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"portainer.environment.userAccessPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPortainerEnvironment).UserAccessPolicies, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"portainer.environment.teamAccessRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerEnvironment).TeamAccessRoles, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"portainer.environment.userAccessRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerEnvironment).UserAccessRoles, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"portainer.environment.group": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -753,6 +787,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"portainer.environmentGroup.userAccessPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlPortainerEnvironmentGroup).UserAccessPolicies, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"portainer.environmentGroup.teamAccessRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerEnvironmentGroup).TeamAccessRoles, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"portainer.environmentGroup.userAccessRoles": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlPortainerEnvironmentGroup).UserAccessRoles, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
 	"portainer.edgeGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1344,9 +1386,10 @@ type mqlPortainerTeam struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlPortainerTeamInternal it will be used here
-	Id      plugin.TValue[int64]
-	Name    plugin.TValue[string]
-	Members plugin.TValue[[]any]
+	Id          plugin.TValue[int64]
+	Name        plugin.TValue[string]
+	Members     plugin.TValue[[]any]
+	MemberRoles plugin.TValue[any]
 }
 
 // createPortainerTeam creates a new instance of this resource
@@ -1405,6 +1448,12 @@ func (c *mqlPortainerTeam) GetMembers() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlPortainerTeam) GetMemberRoles() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.MemberRoles, func() (any, error) {
+		return c.memberRoles()
+	})
+}
+
 // mqlPortainerEnvironment for the portainer.environment resource
 type mqlPortainerEnvironment struct {
 	MqlRuntime *plugin.Runtime
@@ -1417,10 +1466,13 @@ type mqlPortainerEnvironment struct {
 	Url                  plugin.TValue[string]
 	PublicUrl            plugin.TValue[string]
 	TlsEnabled           plugin.TValue[bool]
+	TlsSkipVerify        plugin.TValue[bool]
 	ContainerEngine      plugin.TValue[string]
 	Tags                 plugin.TValue[[]any]
 	TeamAccessPolicies   plugin.TValue[any]
 	UserAccessPolicies   plugin.TValue[any]
+	TeamAccessRoles      plugin.TValue[any]
+	UserAccessRoles      plugin.TValue[any]
 	Group                plugin.TValue[*mqlPortainerEnvironmentGroup]
 	EdgeId               plugin.TValue[string]
 	Heartbeat            plugin.TValue[bool]
@@ -1489,6 +1541,10 @@ func (c *mqlPortainerEnvironment) GetTlsEnabled() *plugin.TValue[bool] {
 	return &c.TlsEnabled
 }
 
+func (c *mqlPortainerEnvironment) GetTlsSkipVerify() *plugin.TValue[bool] {
+	return &c.TlsSkipVerify
+}
+
 func (c *mqlPortainerEnvironment) GetContainerEngine() *plugin.TValue[string] {
 	return &c.ContainerEngine
 }
@@ -1515,6 +1571,14 @@ func (c *mqlPortainerEnvironment) GetTeamAccessPolicies() *plugin.TValue[any] {
 
 func (c *mqlPortainerEnvironment) GetUserAccessPolicies() *plugin.TValue[any] {
 	return &c.UserAccessPolicies
+}
+
+func (c *mqlPortainerEnvironment) GetTeamAccessRoles() *plugin.TValue[any] {
+	return &c.TeamAccessRoles
+}
+
+func (c *mqlPortainerEnvironment) GetUserAccessRoles() *plugin.TValue[any] {
+	return &c.UserAccessRoles
 }
 
 func (c *mqlPortainerEnvironment) GetGroup() *plugin.TValue[*mqlPortainerEnvironmentGroup] {
@@ -1613,6 +1677,8 @@ type mqlPortainerEnvironmentGroup struct {
 	Tags               plugin.TValue[[]any]
 	TeamAccessPolicies plugin.TValue[any]
 	UserAccessPolicies plugin.TValue[any]
+	TeamAccessRoles    plugin.TValue[any]
+	UserAccessRoles    plugin.TValue[any]
 }
 
 // createPortainerEnvironmentGroup creates a new instance of this resource
@@ -1681,6 +1747,14 @@ func (c *mqlPortainerEnvironmentGroup) GetTeamAccessPolicies() *plugin.TValue[an
 
 func (c *mqlPortainerEnvironmentGroup) GetUserAccessPolicies() *plugin.TValue[any] {
 	return &c.UserAccessPolicies
+}
+
+func (c *mqlPortainerEnvironmentGroup) GetTeamAccessRoles() *plugin.TValue[any] {
+	return &c.TeamAccessRoles
+}
+
+func (c *mqlPortainerEnvironmentGroup) GetUserAccessRoles() *plugin.TValue[any] {
+	return &c.UserAccessRoles
 }
 
 // mqlPortainerEdgeGroup for the portainer.edgeGroup resource

--- a/providers/portainer/resources/portainer.lr.versions
+++ b/providers/portainer/resources/portainer.lr.versions
@@ -31,10 +31,13 @@ portainer.environment.securitySettings 13.0.0
 portainer.environment.status 13.0.0
 portainer.environment.tags 13.0.0
 portainer.environment.teamAccessPolicies 13.0.0
+portainer.environment.teamAccessRoles 13.1.5
 portainer.environment.tlsEnabled 13.0.0
+portainer.environment.tlsSkipVerify 13.1.5
 portainer.environment.type 13.0.0
 portainer.environment.url 13.0.0
 portainer.environment.userAccessPolicies 13.0.0
+portainer.environment.userAccessRoles 13.1.5
 portainer.environment.userTrusted 13.0.0
 portainer.environmentGroup 13.0.0
 portainer.environmentGroup.description 13.0.0
@@ -42,7 +45,9 @@ portainer.environmentGroup.id 13.0.0
 portainer.environmentGroup.name 13.0.0
 portainer.environmentGroup.tags 13.0.0
 portainer.environmentGroup.teamAccessPolicies 13.0.0
+portainer.environmentGroup.teamAccessRoles 13.1.5
 portainer.environmentGroup.userAccessPolicies 13.0.0
+portainer.environmentGroup.userAccessRoles 13.1.5
 portainer.environmentGroups 13.0.0
 portainer.environments 13.0.0
 portainer.instanceId 13.0.0
@@ -89,6 +94,7 @@ portainer.tag.name 13.0.0
 portainer.tags 13.0.0
 portainer.team 13.0.0
 portainer.team.id 13.0.0
+portainer.team.memberRoles 13.1.5
 portainer.team.members 13.0.0
 portainer.team.name 13.0.0
 portainer.teams 13.0.0

--- a/providers/portainer/resources/resources_test.go
+++ b/providers/portainer/resources/resources_test.go
@@ -49,6 +49,132 @@ func TestAccessPoliciesToDict(t *testing.T) {
 	assert.Empty(t, accessPoliciesToDict(nil))
 }
 
+func TestAccessRolesToDict(t *testing.T) {
+	got := accessRolesToDict(map[string]models.PortainerAccessPolicy{
+		"5": {RoleID: 1},
+		"8": {RoleID: 4},
+		"9": {RoleID: 42},
+	})
+	assert.Equal(t, "environment_administrator", got["5"])
+	assert.Equal(t, "readonly_user", got["8"])
+	assert.Equal(t, "unknown", got["9"])
+
+	assert.Empty(t, accessRolesToDict(nil))
+}
+
+// TestTLSConfig is a regression test: the endpoint's top-level TLS field has
+// been deprecated since Portainer's DBVersion 4 and is no longer written by the
+// server, so reading it reported "no TLS" for every environment. The live
+// values come from TLSConfig.
+func TestTLSConfig(t *testing.T) {
+	// the deprecated top-level field must not be consulted
+	enabled, skip := tlsConfig(&models.PortainereeEndpoint{TLS: true})
+	assert.False(t, enabled, "deprecated TLS field must be ignored")
+	assert.False(t, skip)
+
+	enabled, skip = tlsConfig(&models.PortainereeEndpoint{
+		TLSConfig: &models.PortainerTLSConfiguration{TLS: true, TLSSkipVerify: true},
+	})
+	assert.True(t, enabled)
+	assert.True(t, skip)
+
+	enabled, skip = tlsConfig(&models.PortainereeEndpoint{
+		TLSConfig: &models.PortainerTLSConfiguration{TLS: true},
+	})
+	assert.True(t, enabled)
+	assert.False(t, skip)
+
+	// a missing TLSConfig is a plaintext connection, not a panic
+	enabled, skip = tlsConfig(&models.PortainereeEndpoint{})
+	assert.False(t, enabled)
+	assert.False(t, skip)
+}
+
+// TestUserTheme covers the deprecated UserTheme field being superseded by
+// ThemeSettings.
+func TestUserTheme(t *testing.T) {
+	assert.Equal(t, "dark", userTheme(&models.PortainereeUser{
+		ThemeSettings: &models.PortainereeUserThemeSettings{Color: "dark"},
+		UserTheme:     "light",
+	}), "ThemeSettings wins over the deprecated field")
+
+	assert.Equal(t, "light", userTheme(&models.PortainereeUser{UserTheme: "light"}),
+		"falls back to the legacy field when ThemeSettings is absent")
+
+	assert.Equal(t, "light", userTheme(&models.PortainereeUser{
+		ThemeSettings: &models.PortainereeUserThemeSettings{},
+		UserTheme:     "light",
+	}), "an empty ThemeSettings color falls back too")
+
+	assert.Empty(t, userTheme(&models.PortainereeUser{}))
+}
+
+// TestUserTeams is a regression test: a membership pointing at a team the token
+// cannot see used to yield a team with an empty name, which also poisoned the
+// resource cache for that team id.
+func TestUserTeams(t *testing.T) {
+	teams := []*models.PortainerTeam{
+		{ID: 1, Name: "platform"},
+		{ID: 2, Name: "security"},
+	}
+	memberships := []*models.PortainerTeamMembership{
+		{ID: 10, UserID: 100, TeamID: 1, Role: 1},
+		{ID: 11, UserID: 100, TeamID: 2, Role: 2},
+		{ID: 12, UserID: 101, TeamID: 2, Role: 2},
+		// dangling: team 99 is not visible to this token
+		{ID: 13, UserID: 100, TeamID: 99, Role: 2},
+	}
+
+	got := userTeams(memberships, teams, 100)
+	require.Len(t, got, 2, "the dangling membership must be skipped")
+	assert.Equal(t, "platform", got[0].Name)
+	assert.Equal(t, "security", got[1].Name)
+
+	assert.Len(t, userTeams(memberships, teams, 101), 1)
+	assert.Empty(t, userTeams(memberships, teams, 999))
+}
+
+func TestTeamMembers(t *testing.T) {
+	users := []*models.PortainereeUser{
+		{ID: 100, Username: "alice"},
+		{ID: 101, Username: "bob"},
+	}
+	memberships := []*models.PortainerTeamMembership{
+		{ID: 10, UserID: 100, TeamID: 1, Role: 1},
+		{ID: 11, UserID: 101, TeamID: 1, Role: 2},
+		{ID: 12, UserID: 100, TeamID: 2, Role: 2},
+		// dangling: user 999 is not visible to this token
+		{ID: 13, UserID: 999, TeamID: 1, Role: 2},
+	}
+
+	got := teamMembers(memberships, users, 1)
+	require.Len(t, got, 2, "the dangling membership must be skipped")
+	assert.Equal(t, "alice", got[0].Username)
+	assert.Equal(t, "bob", got[1].Username)
+
+	assert.Len(t, teamMembers(memberships, users, 2), 1)
+	assert.Empty(t, teamMembers(memberships, users, 3))
+}
+
+// TestTeamMemberRoles covers the leader/member split, which the membership role
+// carries and which nothing surfaced before.
+func TestTeamMemberRoles(t *testing.T) {
+	users := []*models.PortainereeUser{
+		{ID: 100, Username: "alice"},
+		{ID: 101, Username: "bob"},
+	}
+	memberships := []*models.PortainerTeamMembership{
+		{ID: 10, UserID: 100, TeamID: 1, Role: 1},
+		{ID: 11, UserID: 101, TeamID: 1, Role: 2},
+		{ID: 12, UserID: 999, TeamID: 1, Role: 2},
+	}
+
+	got := teamMemberRoles(memberships, users, 1)
+	assert.Equal(t, map[string]any{"alice": "leader", "bob": "member"}, got)
+
+	assert.Empty(t, teamMemberRoles(memberships, users, 2))
+}
+
 func TestMatchesEnvironmentTargets(t *testing.T) {
 	const (
 		dockerType = int64(1) // docker

--- a/providers/portainer/resources/settings.go
+++ b/providers/portainer/resources/settings.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"errors"
+
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/portainer/connection"
@@ -37,6 +39,9 @@ func (r *mqlPortainer) settings() (*mqlPortainerSettings, error) {
 	settings, err := conn.Client().GetSettings()
 	if err != nil {
 		return nil, err
+	}
+	if settings == nil {
+		return nil, errors.New("Portainer returned no settings")
 	}
 
 	var requiredPasswordLength int64

--- a/providers/portainer/resources/teams.go
+++ b/providers/portainer/resources/teams.go
@@ -43,6 +43,50 @@ func (r *mqlPortainer) teams() ([]any, error) {
 	return res, nil
 }
 
+// teamMembers resolves the memberships of one team to the matching users.
+// Memberships pointing at a user that is not in the list are skipped: the users
+// endpoint hides administrator accounts from non-administrator tokens, and
+// orphaned memberships outlive a deleted user.
+func teamMembers(memberships []*models.PortainerTeamMembership, users []*models.PortainereeUser, teamID int64) []*models.PortainereeUser {
+	userByID := make(map[int64]*models.PortainereeUser, len(users))
+	for _, u := range users {
+		userByID[u.ID] = u
+	}
+
+	res := []*models.PortainereeUser{}
+	for _, m := range memberships {
+		if m.TeamID != teamID {
+			continue
+		}
+		if u, ok := userByID[m.UserID]; ok {
+			res = append(res, u)
+		}
+	}
+	return res
+}
+
+// teamMemberRoles maps one team's memberships to a username-keyed dict of
+// membership role names, skipping members that cannot be resolved to a user.
+func teamMemberRoles(memberships []*models.PortainerTeamMembership, users []*models.PortainereeUser, teamID int64) map[string]any {
+	userByID := make(map[int64]*models.PortainereeUser, len(users))
+	for _, u := range users {
+		userByID[u.ID] = u
+	}
+
+	res := map[string]any{}
+	for _, m := range memberships {
+		if m.TeamID != teamID {
+			continue
+		}
+		u, ok := userByID[m.UserID]
+		if !ok {
+			continue
+		}
+		res[u.Username] = connection.MembershipRole(m.Role)
+	}
+	return res
+}
+
 // members returns the users that belong to the team, resolved through the
 // instance team memberships.
 func (r *mqlPortainerTeam) members() ([]any, error) {
@@ -56,20 +100,9 @@ func (r *mqlPortainerTeam) members() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	userByID := make(map[int64]*models.PortainereeUser, len(users))
-	for _, u := range users {
-		userByID[u.ID] = u
-	}
 
 	res := []any{}
-	for _, m := range memberships {
-		if m.TeamID != r.Id.Data {
-			continue
-		}
-		u, ok := userByID[m.UserID]
-		if !ok {
-			continue
-		}
+	for _, u := range teamMembers(memberships, users, r.Id.Data) {
 		mqlUser, err := newMqlPortainerUser(r.MqlRuntime, u)
 		if err != nil {
 			return nil, err
@@ -77,4 +110,19 @@ func (r *mqlPortainerTeam) members() ([]any, error) {
 		res = append(res, mqlUser)
 	}
 	return res, nil
+}
+
+// memberRoles reports each member's role within the team, keyed by username.
+func (r *mqlPortainerTeam) memberRoles() (any, error) {
+	conn := r.MqlRuntime.Connection.(*connection.PortainerConnection)
+
+	memberships, err := conn.TeamMemberships()
+	if err != nil {
+		return nil, err
+	}
+	users, err := conn.Users()
+	if err != nil {
+		return nil, err
+	}
+	return teamMemberRoles(memberships, users, r.Id.Data), nil
 }

--- a/providers/portainer/resources/users.go
+++ b/providers/portainer/resources/users.go
@@ -12,6 +12,16 @@ import (
 	"go.mondoo.com/mql/v13/providers/portainer/connection"
 )
 
+// userTheme reads the account's UI theme. The top-level UserTheme field is
+// deprecated; the value Portainer maintains lives in ThemeSettings, so prefer
+// that and fall back to the legacy field for older instances.
+func userTheme(u *models.PortainereeUser) string {
+	if u.ThemeSettings != nil && u.ThemeSettings.Color != "" {
+		return u.ThemeSettings.Color
+	}
+	return u.UserTheme
+}
+
 func newMqlPortainerUser(runtime *plugin.Runtime, u *models.PortainereeUser) (*mqlPortainerUser, error) {
 	res, err := CreateResource(runtime, "portainer.user", map[string]*llx.RawData{
 		"__id":         llx.StringData("portainer.user/" + strconv.FormatInt(u.ID, 10)),
@@ -19,7 +29,7 @@ func newMqlPortainerUser(runtime *plugin.Runtime, u *models.PortainereeUser) (*m
 		"username":     llx.StringData(u.Username),
 		"role":         llx.StringData(connection.UserRole(u.Role)),
 		"useCache":     llx.BoolData(u.UseCache),
-		"theme":        llx.StringData(u.UserTheme),
+		"theme":        llx.StringData(userTheme(u)),
 		"tokenIssueAt": llx.TimeDataPtr(unixTimePtr(u.TokenIssueAt)),
 	})
 	if err != nil {
@@ -60,21 +70,39 @@ func (r *mqlPortainerUser) teams() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	teamNameByID := make(map[int64]string, len(teams))
-	for _, t := range teams {
-		teamNameByID[t.ID] = t.Name
-	}
-
 	res := []any{}
-	for _, m := range memberships {
-		if m.UserID != r.Id.Data {
-			continue
-		}
-		mqlTeam, err := newMqlPortainerTeam(r.MqlRuntime, m.TeamID, teamNameByID[m.TeamID])
+	for _, t := range userTeams(memberships, teams, r.Id.Data) {
+		mqlTeam, err := newMqlPortainerTeam(r.MqlRuntime, t.ID, t.Name)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, mqlTeam)
 	}
 	return res, nil
+}
+
+// userTeams resolves the memberships of one user to the matching teams.
+//
+// A membership can reference a team that is not in the list: the teams endpoint
+// only returns the caller's own teams for non-administrator tokens, and
+// orphaned memberships outlive a deleted team. Those are skipped rather than
+// emitting a team with an empty name, which would also poison the resource
+// cache for that team id, since the first resource created under a given __id
+// is the one every later lookup returns.
+func userTeams(memberships []*models.PortainerTeamMembership, teams []*models.PortainerTeam, userID int64) []*models.PortainerTeam {
+	teamByID := make(map[int64]*models.PortainerTeam, len(teams))
+	for _, t := range teams {
+		teamByID[t.ID] = t
+	}
+
+	res := []*models.PortainerTeam{}
+	for _, m := range memberships {
+		if m.UserID != userID {
+			continue
+		}
+		if t, ok := teamByID[m.TeamID]; ok {
+			res = append(res, t)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
Static bug review of the `portainer` provider surfaced twelve issues. The headline finding is three **deprecated Portainer API fields being shipped as live data** — the worst class of defect for an inventory tool, because they return a valid-looking value with no error, so an audit over them fails vacuously rather than failing loudly.

## Silent wrong data

**`portainer.environment.tlsEnabled` was always `false`.** It read `portaineree.Endpoint.TLS`, which Portainer marks *"Deprecated fields / Deprecated in DBVersion == 4"* in both the SDK model and its own `api/portainer.go` (where it additionally carries `swaggerignore:"true"`). Portainer's endpoint-create handler builds `TLSConfig` via `crypto.CreateTLSConfigurationFromBytes(...)` and never assigns `endpoint.TLS`, so no environment created in years has it set.

The user-visible effect: `portainer.environments { name tlsEnabled }` reported "no TLS" for every environment, including TLS-secured agent connections. A policy asserting all environments connect over TLS failed on a fully compliant instance; read the other way, "nothing uses TLS" was a confident false alarm on a security-critical boolean.

Now reads `TLSConfig.TLS`, and exposes `tlsSkipVerify` from `TLSConfig.TLSSkipVerify` alongside — that one is the more actionable signal, since agent environments routinely enable it.

**`portainer.settings.enableHostManagementFeatures`** reads a field deprecated in v26; the maintained value is the per-environment `securitySettings` override the provider already surfaces correctly. Marked `@maturity("deprecated")` and pointed at the replacement rather than removed, since it has shipped.

**`portainer.user.theme`** read the deprecated `UserTheme`. Now prefers `ThemeSettings.color`, falling back to the legacy field for older instances.

## Correctness and robustness

- **Discovery panicked on inventory-file assets.** `discovery.go` wrote into the cloned config's `Options` map without a nil check. `Config.Clone` preserves a nil map, so an asset defined in an inventory file with no `options:` block (address via `PORTAINER_ADDRESS`) hit `assignment to entry in nil map` and killed the connect. Every other provider that does this guards it — hcp, mongodbatlas, gcp, azure, alicloud, hetzner, nutanix, databricks, nextdns, os.
- **Connect claimed to validate credentials, but didn't.** It probed `/system/status`, which Portainer documents as **"Access policy: public"** (and is the only SDK call taking no auth writer). An expired or typo'd token connected "successfully" and then failed on every resource with nothing attributing it to the credential. Now followed by one authenticated call, reusing the connection's memoized endpoint list so it costs no extra round-trip.
- **`EnvironmentStatus` mapped only up/down.** Portainer declares the status as `enums:"1,2,3,4"`; cloud-provisioned environments report 3 (provisioning) and 4 (error), and `EndpointStatusMessage` is documented as accompanying exactly those. Both rendered as `"unknown"`, so an audit filtering on `status == "down"` silently missed error-state environments.
- **`user.teams` fabricated empty team names.** A membership referencing a team absent from the list yielded `{id: N, name: ""}`. This is reachable in practice: the teams endpoint returns only the caller's own teams for non-administrator tokens, and orphaned memberships outlive a deleted team. It also poisoned the resource cache, since the first resource stored under a given `__id` is what every later lookup returns. Now skipped, matching what `team.members` already did.
- **`GetSettings` was dereferenced without a nil guard**, unlike the sibling status call one file over.
- **The instance platform id had no fallback** when the server reports no instance id, collapsing every such instance onto `.../instance/` and therefore onto one asset upstream. Falls back to the hostname.

## RBAC coverage

- **Access-policy role ids were raw integers** while every other Portainer enum is mapped to a string, forcing policies to hardcode magic numbers for the least legible part of Portainer RBAC. Added `teamAccessRoles` / `userAccessRoles` on both `portainer.environment` and `portainer.environmentGroup`, keyed identically so they join with the existing dicts. The shipped fields keep their type — no breaking change.
- **Team membership roles were fetched and discarded**, leaving `MembershipRole` as dead code and the leader/member split unqueryable. Team leaders can manage a team's roster, so this matters when auditing who can widen inherited environment access. Added `portainer.team.memberRoles`, keyed by username.

Also corrected the `edgeStack.version` doc comment, which described the separate `StackFileVersion` field.

## Reviewed and found clean

Worth recording, since a review that only lists problems hides its own coverage: no stub or placeholder data anywhere (every `.lr` field has a real population path); no pagination truncation (all eight SDK list wrappers are single-shot, and `EndpointList`'s `start`/`limit` are optional with Portainer returning the full set when omitted); correct `StateIsNull` handling on the one singular-resource accessor; no `__id` collisions; no range-variable pointer capture; no unguarded assertions on external data; `cachedList` concurrency is correct.

## Tests

The membership joins, TLS and theme resolution, and the enum mappers are all pure Go, so each fix ships with a unit test — including regression tests named for the specific defect (the deprecated `TLS` field must be ignored; the dangling membership must be skipped). Also closes two pre-existing coverage gaps the review flagged: `EdgeStackDeploymentType` was the only enum mapper without a test, and the platform-id builders were only asserted incidentally.

`go test ./...` passes for the provider; `gofmt`, `go vet`, and codegen are clean.

## Not covered here

Findings 1 and 6 were confirmed against Portainer's upstream source and swagger rather than a live instance. A `provider-verification` pass against a real Portainer server would be a cheap confirmation that `TLSConfig.TLS` populates as expected on agent environments.
