### PR TITLE
🐛 tailscale: fix OAuth scope cap, tailnet asset identity, and unqueryable discovered assets

### DIFF
--- a/providers/tailscale/connection/connection.go
+++ b/providers/tailscale/connection/connection.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -48,12 +49,19 @@ const (
 	TAILSCALE_BASE_URL_VAR            = "TAILSCALE_BASE_URL"
 )
 
+// defaultTailnetPlaceholder is the fallback tailnet label used when the user
+// did not name a tailnet and we could not derive it from the API.
+const defaultTailnetPlaceholder = "default"
+
 type TailscaleConnection struct {
 	plugin.Connection
 	Conf  *inventory.Config
 	asset *inventory.Asset
 
 	client *tsclient.Client
+
+	tailnetOnce sync.Once
+	tailnet     string
 }
 
 func NewTailscaleConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*TailscaleConnection, error) {
@@ -85,17 +93,19 @@ func NewTailscaleConnection(id uint32, asset *inventory.Asset, conf *inventory.C
 				TAILSCALE_OAUTH_CLIENT_SECRET_VAR,
 			)
 		}
+		// Scopes are deliberately left empty. Tailscale scopes access per
+		// resource (policy_file:read, auth_keys, webhooks:read, dns:read,
+		// log_streaming:read, feature_settings:read, devices:routes:read, ...),
+		// and a client-credentials token is narrowed to whatever scopes the
+		// token request names. Requesting a fixed subset here would cap every
+		// OAuth user at that subset no matter what their client was granted,
+		// while requesting the full set would break clients that were granted
+		// less. Omitting the scope parameter issues a token carrying exactly
+		// the scopes the OAuth client itself holds, so the grant made in the
+		// Tailscale admin console is what decides access.
 		conn.client.HTTP = tsclient.OAuthConfig{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
-			Scopes: []string{
-				// Used in resources/tailscale.go `devices()`
-				// Used in resources/device.go `initTailscaleDevice()`
-				"devices:core:read",
-				// Used in resources/tailscale.go `users()`
-				// Used in resources/user.go `initTailscaleUser()`
-				"users:read",
-			},
 		}.HTTPClient()
 		log.Info().Str("method", "OAuth").Msg("tailscale> authentication configured")
 
@@ -146,12 +156,67 @@ func (t *TailscaleConnection) Verify() error {
 	//
 	// API specifications https://tailscale.com/api
 	_, err := t.client.Devices().Get(context.Background(), "m0nd00")
-	if err != nil {
-		if strings.Contains(err.Error(), "401") {
-			return errors.New("invalid authentication provided, verify the provided credentials, use --help for more details")
-		}
+	if err == nil {
+		return nil
 	}
+
+	switch APIStatusCode(err) {
+	case 401:
+		return errors.New("invalid authentication provided, verify the provided credentials, use --help for more details")
+	case 403:
+		// The credential is valid but cannot read devices. For an OAuth client
+		// that means the devices:core:read scope was never granted, which we
+		// report now rather than letting every device query fail later.
+		return errors.New("the provided credentials are not authorized to read devices. " +
+			"When using an OAuth client, grant it the scopes for the resources you intend to query " +
+			"(at minimum devices:core:read), then try again")
+	}
+
+	// Any other failure (a 404 for the probe device, a transient network error)
+	// is not evidence of bad credentials, so we let the scan proceed.
 	return nil
+}
+
+// ResolveTailnet returns the tailnet this connection targets.
+//
+// When the user named a tailnet we use it verbatim. Otherwise the client talks
+// to the default tailnet of the credential ("-"), and Tailscale offers no
+// endpoint that names it directly. We recover it from the tailnet's own users,
+// so that two tailnets scanned without an explicit name do not collapse onto a
+// single asset identity. Shared users belong to the tailnet they were shared
+// from, not this one, so they are skipped.
+//
+// The lookup runs at most once per connection and falls back to a placeholder
+// when it cannot be performed, which keeps a credential without users:read
+// working exactly as it did before.
+func (t *TailscaleConnection) ResolveTailnet() string {
+	t.tailnetOnce.Do(func() {
+		if value, set := GetTailnet(t.Conf); set {
+			t.tailnet = value
+			return
+		}
+
+		t.tailnet = defaultTailnetPlaceholder
+
+		users, err := t.client.Users().List(context.Background(), nil, nil)
+		if err != nil {
+			log.Debug().Err(err).
+				Msg("tailscale> unable to resolve the tailnet, falling back to the default identifier")
+			return
+		}
+
+		for i := range users {
+			if users[i].Type == tsclient.UserTypeShared {
+				continue
+			}
+			if users[i].TailnetID != "" {
+				t.tailnet = users[i].TailnetID
+				log.Debug().Str("tailnet", t.tailnet).Msg("tailscale> resolved tailnet")
+				return
+			}
+		}
+	})
+	return t.tailnet
 }
 
 func (t *TailscaleConnection) Asset() *inventory.Asset {
@@ -173,17 +238,7 @@ func (t *TailscaleConnection) PlatformInfo() (*inventory.Platform, error) {
 }
 
 func (t *TailscaleConnection) Identifier() string {
-	tailnet, set := GetTailnet(t.Conf)
-	if !set {
-		// When no tailnet was specified, we will be using the default tailnet of the
-		// authentication method being used to make API calls. Tailscale recommend this
-		// option for most users. (https://tailscale.com/api)
-		//
-		// NOTE that today, we cannot make an API call to get the actual tailnet
-		tailnet = "default"
-	}
-
-	return PlatformIdTailscaleTailnet + tailnet
+	return PlatformIdTailscaleTailnet + t.ResolveTailnet()
 }
 
 func NewTailscaleDeviceIdentifier(deviceId string) string {
@@ -195,6 +250,32 @@ func NewTailscaleDevicePlatform(deviceId string) *inventory.Platform {
 	}
 	PlatformByName("tailscale-device").Apply(p)
 	return p
+}
+
+// DeviceIdFromAsset returns the Tailscale device id carried by the asset's
+// platform ids, or an empty string when the asset is not a discovered device.
+// Resources use it so that a bare `tailscale.device` resolves to the device the
+// asset represents instead of requiring an explicit id argument.
+func DeviceIdFromAsset(asset *inventory.Asset) string {
+	return platformIdSuffix(asset, PlatformIdTailscaleDevice)
+}
+
+// UserIdFromAsset returns the Tailscale user id carried by the asset's platform
+// ids, or an empty string when the asset is not a discovered user.
+func UserIdFromAsset(asset *inventory.Asset) string {
+	return platformIdSuffix(asset, PlatformIdTailscaleUser)
+}
+
+func platformIdSuffix(asset *inventory.Asset, prefix string) string {
+	if asset == nil {
+		return ""
+	}
+	for _, platformId := range asset.PlatformIds {
+		if suffix, found := strings.CutPrefix(platformId, prefix); found && suffix != "" {
+			return suffix
+		}
+	}
+	return ""
 }
 
 func NewTailscaleUserIdentifier(userId string) string {

--- a/providers/tailscale/connection/errors.go
+++ b/providers/tailscale/connection/errors.go
@@ -1,0 +1,66 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+)
+
+// The Tailscale client models API failures as tsclient.APIError, but keeps the
+// HTTP status on an unexported field and only exposes tsclient.IsNotFound. The
+// status is however rendered into the error string by APIError.Error(), which
+// formats as "<message> (<status>)". We recover it from there so callers can
+// distinguish an authorization failure from a genuine absence.
+var apiStatusRe = regexp.MustCompile(`\((\d{3})\)$`)
+
+// APIStatusCode returns the HTTP status code of a Tailscale API error, or 0
+// when err is not a Tailscale API error (a transport failure, a context
+// cancellation, a JSON decode error).
+func APIStatusCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	// Only trust the string form once we know this really is an APIError.
+	var apiErr tsclient.APIError
+	if !errors.As(err, &apiErr) {
+		return 0
+	}
+
+	match := apiStatusRe.FindStringSubmatch(apiErr.Error())
+	if match == nil {
+		return 0
+	}
+
+	code, convErr := strconv.Atoi(match[1])
+	if convErr != nil {
+		return 0
+	}
+	return code
+}
+
+// IsAccessDenied reports whether err is a Tailscale API authorization failure:
+// either the credential is invalid (401) or it lacks the scope required for the
+// endpoint (403). OAuth clients are scoped per resource, so a tailnet the
+// caller can otherwise read may still refuse individual endpoints.
+func IsAccessDenied(err error) bool {
+	switch APIStatusCode(err) {
+	case 401, 403:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsUnavailable reports whether err indicates the endpoint carries no data for
+// this tailnet, either because nothing is configured (404) or because the
+// tailnet's plan does not include the feature (403). Callers use it to degrade
+// an optional collection to empty rather than failing the whole query.
+func IsUnavailable(err error) bool {
+	return tsclient.IsNotFound(err) || APIStatusCode(err) == 403
+}

--- a/providers/tailscale/connection/errors_test.go
+++ b/providers/tailscale/connection/errors_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+)
+
+// apiErrorWithStatus produces a genuine tsclient.APIError by driving the real
+// client against a stub server. tsclient keeps the HTTP status on an unexported
+// field, so the error cannot be constructed directly, and asserting against a
+// hand-rolled stand-in would not prove APIStatusCode parses what the SDK
+// actually emits.
+func apiErrorWithStatus(t *testing.T, status int) error {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(`{"message":"stub failure"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := &tsclient.Client{BaseURL: baseURL, Tailnet: "example.com", APIKey: "stub"}
+	_, err = client.Devices().Get(context.Background(), "stub-device")
+	require.Error(t, err, "the stub server must produce an API error")
+	return err
+}
+
+func TestAPIStatusCode(t *testing.T) {
+	for _, status := range []int{400, 401, 403, 404, 429, 500} {
+		err := apiErrorWithStatus(t, status)
+		assert.Equal(t, status, APIStatusCode(err), "status %d", status)
+	}
+}
+
+func TestAPIStatusCode_NonAPIErrors(t *testing.T) {
+	assert.Equal(t, 0, APIStatusCode(nil))
+	assert.Equal(t, 0, APIStatusCode(errors.New("dial tcp: connection refused")))
+	// A plain error that merely mentions a status must not be mistaken for one.
+	assert.Equal(t, 0, APIStatusCode(errors.New("request to /v2/thing (403) failed")))
+}
+
+func TestAPIStatusCode_WrappedError(t *testing.T) {
+	err := apiErrorWithStatus(t, 403)
+	assert.Equal(t, 403, APIStatusCode(errors.Join(errors.New("context"), err)))
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	assert.True(t, IsAccessDenied(apiErrorWithStatus(t, 401)))
+	assert.True(t, IsAccessDenied(apiErrorWithStatus(t, 403)))
+	assert.False(t, IsAccessDenied(apiErrorWithStatus(t, 404)))
+	assert.False(t, IsAccessDenied(apiErrorWithStatus(t, 500)))
+	assert.False(t, IsAccessDenied(nil))
+	assert.False(t, IsAccessDenied(errors.New("boom")))
+}
+
+func TestIsUnavailable(t *testing.T) {
+	// Nothing configured for this log type.
+	assert.True(t, IsUnavailable(apiErrorWithStatus(t, 404)))
+	// Feature not included in the tailnet's plan, or scope not granted.
+	assert.True(t, IsUnavailable(apiErrorWithStatus(t, 403)))
+	// A real failure must still surface.
+	assert.False(t, IsUnavailable(apiErrorWithStatus(t, 500)))
+	assert.False(t, IsUnavailable(apiErrorWithStatus(t, 401)))
+	assert.False(t, IsUnavailable(nil))
+}
+
+// TestIsNotFoundStillWorks guards the assumption IsUnavailable is built on:
+// that the SDK's own 404 helper agrees with our status parsing.
+func TestIsNotFoundStillWorks(t *testing.T) {
+	err := apiErrorWithStatus(t, 404)
+	assert.True(t, tsclient.IsNotFound(err))
+	assert.Equal(t, 404, APIStatusCode(err))
+}

--- a/providers/tailscale/connection/identity_test.go
+++ b/providers/tailscale/connection/identity_test.go
@@ -1,0 +1,108 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+func TestDeviceIdFromAsset(t *testing.T) {
+	tests := []struct {
+		name  string
+		asset *inventory.Asset
+		want  string
+	}{
+		{name: "nil asset", asset: nil, want: ""},
+		{name: "no platform ids", asset: &inventory.Asset{}, want: ""},
+		{
+			name:  "device asset",
+			asset: &inventory.Asset{PlatformIds: []string{NewTailscaleDeviceIdentifier("nodeidCNTRL")}},
+			want:  "nodeidCNTRL",
+		},
+		{
+			name: "device id found among several platform ids",
+			asset: &inventory.Asset{PlatformIds: []string{
+				"//platformid.api.mondoo.app/runtime/other/thing",
+				NewTailscaleDeviceIdentifier("12345"),
+			}},
+			want: "12345",
+		},
+		{
+			// A user asset must not answer a device lookup: the two prefixes
+			// are distinct and must not cross-match.
+			name:  "user asset does not match",
+			asset: &inventory.Asset{PlatformIds: []string{NewTailscaleUserIdentifier("uid-1")}},
+			want:  "",
+		},
+		{
+			// A prefix with nothing after it carries no id and must not be
+			// injected, or it would defeat the init's own emptiness check.
+			name:  "bare prefix yields nothing",
+			asset: &inventory.Asset{PlatformIds: []string{PlatformIdTailscaleDevice}},
+			want:  "",
+		},
+		{
+			name:  "tailnet asset does not match",
+			asset: &inventory.Asset{PlatformIds: []string{PlatformIdTailscaleTailnet + "example.com"}},
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DeviceIdFromAsset(tc.asset))
+		})
+	}
+}
+
+func TestUserIdFromAsset(t *testing.T) {
+	tests := []struct {
+		name  string
+		asset *inventory.Asset
+		want  string
+	}{
+		{name: "nil asset", asset: nil, want: ""},
+		{name: "no platform ids", asset: &inventory.Asset{}, want: ""},
+		{
+			name:  "user asset",
+			asset: &inventory.Asset{PlatformIds: []string{NewTailscaleUserIdentifier("uid-abc123")}},
+			want:  "uid-abc123",
+		},
+		{
+			name:  "device asset does not match",
+			asset: &inventory.Asset{PlatformIds: []string{NewTailscaleDeviceIdentifier("12345")}},
+			want:  "",
+		},
+		{
+			name:  "bare prefix yields nothing",
+			asset: &inventory.Asset{PlatformIds: []string{PlatformIdTailscaleUser}},
+			want:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, UserIdFromAsset(tc.asset))
+		})
+	}
+}
+
+// TestIdentifierUsesExplicitTailnet covers the path that needs no API call:
+// when the user names a tailnet, the asset identity is derived from it
+// directly and two different tailnets cannot collide.
+func TestIdentifierUsesExplicitTailnet(t *testing.T) {
+	conn := &TailscaleConnection{
+		Conf: &inventory.Config{Options: map[string]string{OPTION_TAILNET: "example.com"}},
+	}
+	assert.Equal(t, "example.com", conn.ResolveTailnet())
+	assert.Equal(t, PlatformIdTailscaleTailnet+"example.com", conn.Identifier())
+
+	other := &TailscaleConnection{
+		Conf: &inventory.Config{Options: map[string]string{OPTION_TAILNET: "other.example.org"}},
+	}
+	assert.NotEqual(t, conn.Identifier(), other.Identifier())
+}

--- a/providers/tailscale/resources/acl.go
+++ b/providers/tailscale/resources/acl.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -23,7 +24,7 @@ import (
 // is required the first time `raw()` is read.
 type mqlTailscaleAclPolicyInternal struct {
 	rawLock    sync.Mutex
-	rawFetched bool
+	rawFetched atomic.Bool
 	rawValue   string
 }
 
@@ -31,21 +32,33 @@ func (a *mqlTailscaleAclPolicy) id() (string, error) {
 	return "tailscale/tailnet/" + a.Tailnet.Data + "/aclPolicy", nil
 }
 
-func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, acl *tsclient.ACL) (plugin.Resource, error) {
-	autoApproverExitNodes := []any{}
-	autoApproverRoutes := map[string]any{}
-	if acl.AutoApprovers != nil {
-		for _, v := range acl.AutoApprovers.ExitNode {
-			autoApproverExitNodes = append(autoApproverExitNodes, v)
-		}
-		for k, owners := range acl.AutoApprovers.Routes {
-			arr := make([]any, 0, len(owners))
-			for _, owner := range owners {
-				arr = append(arr, owner)
-			}
-			autoApproverRoutes[k] = arr
-		}
+// flattenAutoApprovers splits a policy's auto-approver block into the exit-node
+// list and the route-to-owners map the resource exposes. A policy with no
+// autoApprovers section yields empty values rather than nulls, so a query
+// asserting that nothing is auto-approved reads false instead of passing on a
+// null comparison.
+func flattenAutoApprovers(autoApprovers *tsclient.ACLAutoApprovers) (exitNodes []any, routes map[string]any) {
+	exitNodes = []any{}
+	routes = map[string]any{}
+	if autoApprovers == nil {
+		return exitNodes, routes
 	}
+
+	for _, v := range autoApprovers.ExitNode {
+		exitNodes = append(exitNodes, v)
+	}
+	for k, owners := range autoApprovers.Routes {
+		arr := make([]any, 0, len(owners))
+		for _, owner := range owners {
+			arr = append(arr, owner)
+		}
+		routes[k] = arr
+	}
+	return exitNodes, routes
+}
+
+func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, acl *tsclient.ACL) (plugin.Resource, error) {
+	autoApproverExitNodes, autoApproverRoutes := flattenAutoApprovers(acl.AutoApprovers)
 
 	acls, err := structSliceToDictSlice(acl.ACLs)
 	if err != nil {
@@ -90,12 +103,12 @@ func createTailscaleAclPolicyResource(runtime *plugin.Runtime, tailnet string, a
 // are independent API calls and may briefly diverge if the policy is edited
 // between them.
 func (a *mqlTailscaleAclPolicy) raw() (string, error) {
-	if a.rawFetched {
+	if a.rawFetched.Load() {
 		return a.rawValue, nil
 	}
 	a.rawLock.Lock()
 	defer a.rawLock.Unlock()
-	if a.rawFetched {
+	if a.rawFetched.Load() {
 		return a.rawValue, nil
 	}
 	conn := a.MqlRuntime.Connection.(*connection.TailscaleConnection)
@@ -104,7 +117,7 @@ func (a *mqlTailscaleAclPolicy) raw() (string, error) {
 		return "", err
 	}
 	a.rawValue = raw.HuJSON
-	a.rawFetched = true
+	a.rawFetched.Store(true)
 	return a.rawValue, nil
 }
 

--- a/providers/tailscale/resources/acl_test.go
+++ b/providers/tailscale/resources/acl_test.go
@@ -1,0 +1,203 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+)
+
+func TestStructSliceToDictSlice_ACLEntries(t *testing.T) {
+	entries := []tsclient.ACLEntry{
+		{
+			Action:        "accept",
+			Source:        []string{"group:eng"},
+			Destination:   []string{"tag:prod:22"},
+			Protocol:      "tcp",
+			Ports:         []string{"22"},
+			Users:         []string{"root"},
+			SourcePosture: []string{"posture:latestMac"},
+		},
+		// An entry where every optional field is empty must still round-trip,
+		// since `omitempty` drops the keys entirely.
+		{Action: "accept"},
+	}
+
+	out, err := structSliceToDictSlice(entries)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	first, ok := out[0].(map[string]any)
+	require.True(t, ok, "entries must decode to map[string]any so MQL can index them")
+	// Keys are the SDK's JSON tags, which is the contract the .lr docs promise.
+	assert.Equal(t, "accept", first["action"])
+	assert.Equal(t, []any{"group:eng"}, first["src"])
+	assert.Equal(t, []any{"tag:prod:22"}, first["dst"])
+	assert.Equal(t, "tcp", first["proto"])
+	assert.Equal(t, []any{"22"}, first["ports"])
+	assert.Equal(t, []any{"root"}, first["users"])
+	assert.Equal(t, []any{"posture:latestMac"}, first["srcPosture"])
+
+	second, ok := out[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "accept", second["action"])
+	assert.NotContains(t, second, "src")
+}
+
+func TestStructSliceToDictSlice_ValuesAreJSONNative(t *testing.T) {
+	// llx dicts accept only JSON-native values. ACLSSH carries a Duration,
+	// which must arrive as a string rather than a time.Duration.
+	ssh := []tsclient.ACLSSH{{
+		Action:          "check",
+		Users:           []string{"autogroup:nonroot"},
+		Source:          []string{"autogroup:member"},
+		Destination:     []string{"autogroup:self"},
+		CheckPeriod:     tsclient.Duration(20 * 60 * 60 * 1000 * 1000 * 1000),
+		EnforceRecorder: true,
+	}}
+
+	out, err := structSliceToDictSlice(ssh)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	entry, ok := out[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "check", entry["action"])
+	assert.Equal(t, true, entry["enforceRecorder"])
+	assert.IsType(t, "", entry["checkPeriod"], "checkPeriod must serialize as a string")
+	assert.Equal(t, "20h0m0s", entry["checkPeriod"])
+}
+
+func TestStructSliceToDictSlice_Empty(t *testing.T) {
+	out, err := structSliceToDictSlice([]tsclient.ACLEntry{})
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, out, "an empty policy section is an empty list, not nil")
+
+	out, err = structSliceToDictSlice[tsclient.ACLEntry](nil)
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, out)
+}
+
+func TestStructSliceToDictSlice_NestedGrants(t *testing.T) {
+	grants := []tsclient.NodeAttrGrant{{
+		Target: []string{"*"},
+		Attr:   []string{"funnel"},
+		App: map[string][]*tsclient.NodeAttrGrantApp{
+			"tailscale.com/app-connectors": {{
+				Name:       "github",
+				Connectors: []string{"tag:connector"},
+				Domains:    []string{"github.com"},
+			}},
+		},
+	}}
+
+	out, err := structSliceToDictSlice(grants)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	entry, ok := out[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"*"}, entry["target"])
+
+	app, ok := entry["app"].(map[string]any)
+	require.True(t, ok, "nested app grants must stay traversable")
+	connectors, ok := app["tailscale.com/app-connectors"].([]any)
+	require.True(t, ok)
+	require.Len(t, connectors, 1)
+	first, ok := connectors[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "github", first["name"])
+}
+
+func TestFlattenAutoApprovers(t *testing.T) {
+	tests := []struct {
+		name          string
+		in            *tsclient.ACLAutoApprovers
+		wantExitNodes []any
+		wantRoutes    map[string]any
+	}{
+		{
+			// A policy with no autoApprovers block must read as "nothing is
+			// auto-approved", not as null.
+			name:          "nil block",
+			in:            nil,
+			wantExitNodes: []any{},
+			wantRoutes:    map[string]any{},
+		},
+		{
+			name:          "empty block",
+			in:            &tsclient.ACLAutoApprovers{},
+			wantExitNodes: []any{},
+			wantRoutes:    map[string]any{},
+		},
+		{
+			name: "exit nodes only",
+			in: &tsclient.ACLAutoApprovers{
+				ExitNode: []string{"tag:exit", "group:admins"},
+			},
+			wantExitNodes: []any{"tag:exit", "group:admins"},
+			wantRoutes:    map[string]any{},
+		},
+		{
+			name: "routes and exit nodes",
+			in: &tsclient.ACLAutoApprovers{
+				ExitNode: []string{"tag:exit"},
+				Routes: map[string][]string{
+					"10.0.0.0/8":     {"group:eng", "tag:router"},
+					"192.168.0.0/16": {},
+				},
+			},
+			wantExitNodes: []any{"tag:exit"},
+			wantRoutes: map[string]any{
+				"10.0.0.0/8":     []any{"group:eng", "tag:router"},
+				"192.168.0.0/16": []any{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			exitNodes, routes := flattenAutoApprovers(tc.in)
+			assert.Equal(t, tc.wantExitNodes, exitNodes)
+			assert.Equal(t, tc.wantRoutes, routes)
+		})
+	}
+}
+
+func TestStringSliceMapToAny(t *testing.T) {
+	out := stringSliceMapToAny(map[string][]string{
+		"group:eng":   {"alice@example.com", "bob@example.com"},
+		"group:empty": {},
+	})
+
+	assert.Equal(t, map[string]any{
+		"group:eng":   []any{"alice@example.com", "bob@example.com"},
+		"group:empty": []any{},
+	}, out)
+
+	assert.Equal(t, map[string]any{}, stringSliceMapToAny(nil))
+}
+
+func TestStringMapToAny(t *testing.T) {
+	out := stringMapToAny(map[string]string{
+		"vpn":  "100.64.0.1",
+		"prod": "10.0.0.0/24",
+	})
+
+	assert.Equal(t, map[string]any{
+		"vpn":  "100.64.0.1",
+		"prod": "10.0.0.0/24",
+	}, out)
+
+	assert.Equal(t, map[string]any{}, stringMapToAny(nil))
+}
+
+func TestStringSliceToAny(t *testing.T) {
+	assert.Equal(t, []any{"posture:latestMac", "posture:hasScreenLock"},
+		stringSliceToAny([]string{"posture:latestMac", "posture:hasScreenLock"}))
+	assert.Equal(t, []any{}, stringSliceToAny(nil))
+}

--- a/providers/tailscale/resources/args.go
+++ b/providers/tailscale/resources/args.go
@@ -1,0 +1,49 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// withDefaultArg returns args with name set to value, unless args already
+// carries name or value is empty. It returns the map so callers can safely
+// pass a nil one, which would otherwise panic on assignment.
+func withDefaultArg(args map[string]*llx.RawData, name string, value string) map[string]*llx.RawData {
+	if value == "" {
+		return args
+	}
+	if _, ok := args[name]; ok {
+		return args
+	}
+	if args == nil {
+		args = map[string]*llx.RawData{}
+	}
+	args[name] = llx.StringData(value)
+	return args
+}
+
+// requiredStringArg reads a mandatory string argument out of an init's args.
+//
+// The value is asserted with comma-ok rather than a bare type assertion: a
+// resource argument that resolves to null arrives with a nil Value, and a
+// panic inside a provider goroutine takes down the whole scan rather than the
+// single query that caused it.
+func requiredStringArg(args map[string]*llx.RawData, name string) (string, error) {
+	raw, ok := args[name]
+	if !ok || raw == nil || raw.Value == nil {
+		return "", fmt.Errorf("missing required argument '%s'", name)
+	}
+
+	value, ok := raw.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("wrong type for argument '%s', expected a string", name)
+	}
+	if value == "" {
+		return "", fmt.Errorf("missing required argument '%s'", name)
+	}
+	return value, nil
+}

--- a/providers/tailscale/resources/args_test.go
+++ b/providers/tailscale/resources/args_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestWithDefaultArg(t *testing.T) {
+	t.Run("fills an absent argument", func(t *testing.T) {
+		args := withDefaultArg(map[string]*llx.RawData{}, "id", "nodeidCNTRL")
+		require.Contains(t, args, "id")
+		assert.Equal(t, "nodeidCNTRL", args["id"].Value)
+	})
+
+	t.Run("never overrides an explicit argument", func(t *testing.T) {
+		args := withDefaultArg(map[string]*llx.RawData{"id": llx.StringData("explicit")}, "id", "from-asset")
+		assert.Equal(t, "explicit", args["id"].Value)
+	})
+
+	t.Run("an empty value is not injected", func(t *testing.T) {
+		// An empty asset-derived id must not be written, or it would satisfy
+		// the presence check while carrying nothing to look up.
+		args := withDefaultArg(map[string]*llx.RawData{}, "id", "")
+		assert.NotContains(t, args, "id")
+	})
+
+	t.Run("a nil map is allocated rather than panicking", func(t *testing.T) {
+		args := withDefaultArg(nil, "id", "nodeidCNTRL")
+		require.NotNil(t, args)
+		assert.Equal(t, "nodeidCNTRL", args["id"].Value)
+	})
+
+	t.Run("a nil map with no value stays nil", func(t *testing.T) {
+		assert.Nil(t, withDefaultArg(nil, "id", ""))
+	})
+}
+
+func TestRequiredStringArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]*llx.RawData
+		want    string
+		wantErr string
+	}{
+		{
+			name: "present",
+			args: map[string]*llx.RawData{"id": llx.StringData("nodeidCNTRL")},
+			want: "nodeidCNTRL",
+		},
+		{
+			name:    "absent",
+			args:    map[string]*llx.RawData{},
+			wantErr: "missing required argument 'id'",
+		},
+		{
+			name:    "nil raw data",
+			args:    map[string]*llx.RawData{"id": nil},
+			wantErr: "missing required argument 'id'",
+		},
+		{
+			// A null argument reaches the init with a nil Value. A bare type
+			// assertion would panic here, and a panic in a provider goroutine
+			// takes down the whole scan.
+			name:    "null value",
+			args:    map[string]*llx.RawData{"id": llx.NilData},
+			wantErr: "missing required argument 'id'",
+		},
+		{
+			name:    "empty string",
+			args:    map[string]*llx.RawData{"id": llx.StringData("")},
+			wantErr: "missing required argument 'id'",
+		},
+		{
+			name:    "wrong type",
+			args:    map[string]*llx.RawData{"id": llx.IntData(42)},
+			wantErr: "wrong type for argument 'id', expected a string",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := requiredStringArg(tc.args, "id")
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, err.Error())
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/providers/tailscale/resources/device.go
+++ b/providers/tailscale/resources/device.go
@@ -5,8 +5,8 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"sync"
+	"sync/atomic"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -18,9 +18,11 @@ import (
 
 // mqlTailscaleDeviceInternal caches subnet route lookups so the advertised
 // and enabled route accessors share a single SubnetRoutes API call.
+// routesFetched is atomic because those two accessors are distinct MQL fields,
+// which the runtime may resolve concurrently.
 type mqlTailscaleDeviceInternal struct {
 	routesLock    sync.Mutex
-	routesFetched bool
+	routesFetched atomic.Bool
 	routes        *tsclient.DeviceRoutes
 }
 
@@ -29,14 +31,18 @@ func (r *mqlTailscaleDevice) id() (string, error) {
 }
 
 func initTailscaleDevice(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	id, ok := args["id"]
-	if !ok {
-		// TODO try to get the id from the connection
-		return nil, nil, errors.New("missing required argument 'id'")
+	conn := runtime.Connection.(*connection.TailscaleConnection)
+
+	// On a discovered device asset the device is implied by the asset itself, so
+	// a bare `tailscale.device` resolves without an explicit id argument.
+	args = withDefaultArg(args, "id", connection.DeviceIdFromAsset(conn.Asset()))
+
+	id, err := requiredStringArg(args, "id")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	conn := runtime.Connection.(*connection.TailscaleConnection)
-	device, err := conn.Client().Devices().Get(context.Background(), id.Value.(string))
+	device, err := conn.Client().Devices().Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -75,12 +81,12 @@ func createTailscaleDeviceResource(runtime *plugin.Runtime, device *tsclient.Dev
 }
 
 func (d *mqlTailscaleDevice) fetchRoutes() (*tsclient.DeviceRoutes, error) {
-	if d.routesFetched {
+	if d.routesFetched.Load() {
 		return d.routes, nil
 	}
 	d.routesLock.Lock()
 	defer d.routesLock.Unlock()
-	if d.routesFetched {
+	if d.routesFetched.Load() {
 		return d.routes, nil
 	}
 	conn := d.MqlRuntime.Connection.(*connection.TailscaleConnection)
@@ -89,7 +95,7 @@ func (d *mqlTailscaleDevice) fetchRoutes() (*tsclient.DeviceRoutes, error) {
 		return nil, err
 	}
 	d.routes = routes
-	d.routesFetched = true
+	d.routesFetched.Store(true)
 	return d.routes, nil
 }
 

--- a/providers/tailscale/resources/discovery.go
+++ b/providers/tailscale/resources/discovery.go
@@ -101,8 +101,12 @@ func discover(runtime *plugin.Runtime, targets []string) ([]*inventory.Asset, er
 	return assetList, nil
 }
 
+// getMqlTailscale returns the tailnet resource discovery lists devices and
+// users from. It goes through NewResource so the resource's init runs and its
+// tailnet, and therefore its cache key, is populated. Building it with the raw
+// constructor would leave both empty.
 func getMqlTailscale(runtime *plugin.Runtime) (*mqlTailscale, error) {
-	res, err := createTailscale(runtime, map[string]*llx.RawData{})
+	res, err := NewResource(runtime, "tailscale", map[string]*llx.RawData{})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/tailscale/resources/discovery_test.go
+++ b/providers/tailscale/resources/discovery_test.go
@@ -1,0 +1,47 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers/tailscale/connection"
+)
+
+func TestHandleTargets(t *testing.T) {
+	everything := []string{connection.DiscoveryDevices, connection.DiscoveryUsers}
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{name: "all expands", in: []string{connection.DiscoveryAll}, want: everything},
+		{name: "auto expands", in: []string{connection.DiscoveryAuto}, want: everything},
+		{
+			name: "all wins over a narrower sibling",
+			in:   []string{connection.DiscoveryDevices, connection.DiscoveryAll},
+			want: everything,
+		},
+		{
+			name: "explicit targets pass through",
+			in:   []string{connection.DiscoveryUsers},
+			want: []string{connection.DiscoveryUsers},
+		},
+		{name: "empty stays empty", in: []string{}, want: []string{}},
+		{name: "nil stays nil", in: nil, want: nil},
+		{
+			name: "unknown targets pass through and are ignored downstream",
+			in:   []string{"nope"},
+			want: []string{"nope"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, handleTargets(tc.in))
+		})
+	}
+}

--- a/providers/tailscale/resources/keys.go
+++ b/providers/tailscale/resources/keys.go
@@ -20,8 +20,9 @@ func (r *mqlTailscaleAuthKey) id() (string, error) {
 }
 
 // timeIsSet reports whether a Tailscale timestamp represents a real value.
-// Tailscale encodes "unset" timestamps as the zero time (Unix epoch 0 /
-// 0001-01-01), which the resource carries as a nil or zero-valued *time.Time.
+// Tailscale encodes "unset" timestamps as the Go zero time (0001-01-01), which
+// the resource carries as a nil or zero-valued *time.Time. A genuine Unix epoch
+// 0 is a real instant in Go terms and is therefore reported as set.
 func timeIsSet(t *time.Time) bool {
 	return t != nil && !t.IsZero()
 }
@@ -45,13 +46,13 @@ func (r *mqlTailscaleAuthKey) isRevoked() (bool, error) {
 }
 
 func initTailscaleAuthKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	id, ok := args["id"]
-	if !ok {
-		return nil, nil, errors.New("missing required argument 'id'")
+	id, err := requiredStringArg(args, "id")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	conn := runtime.Connection.(*connection.TailscaleConnection)
-	key, err := conn.Client().Keys().Get(context.Background(), id.Value.(string))
+	key, err := conn.Client().Keys().Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/tailscale/resources/logstream.go
+++ b/providers/tailscale/resources/logstream.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -30,10 +31,13 @@ func createTailscaleLogstreamResource(runtime *plugin.Runtime, tailnet string, l
 }
 
 // logstreams returns the configured log streams for the tailnet. There are at
-// most two — one for configuration audit logs and one for network flow logs.
+// most two, one for configuration audit logs and one for network flow logs.
 // A 404 from the Tailscale API means no destination is configured for that
-// log type; the API returning an empty struct (DestinationType == "") means
-// the same. Either case is skipped.
+// log type, and a 403 means the tailnet's plan does not include log streaming
+// or the credential lacks the log_streaming:read scope. The API returning an
+// empty struct (DestinationType == "") means the same as a 404. Every such
+// case is skipped so the field degrades to an empty list rather than failing
+// the whole query.
 func (t *mqlTailscale) logstreams() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.TailscaleConnection)
 	ctx := context.Background()
@@ -47,7 +51,9 @@ func (t *mqlTailscale) logstreams() ([]any, error) {
 	for _, logType := range []tsclient.LogType{tsclient.LogTypeConfig, tsclient.LogTypeNetwork} {
 		cfg, err := conn.Client().Logging().LogstreamConfiguration(ctx, logType)
 		if err != nil {
-			if tsclient.IsNotFound(err) {
+			if connection.IsUnavailable(err) {
+				log.Debug().Err(err).Str("logType", string(logType)).
+					Msg("tailscale> no log stream available for this tailnet")
 				continue
 			}
 			return nil, err

--- a/providers/tailscale/resources/tailscale.go
+++ b/providers/tailscale/resources/tailscale.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -15,10 +16,12 @@ import (
 )
 
 // mqlTailscaleInternal caches tailnet-level settings so multiple field accessors
-// share the result of a single TailnetSettings API call.
+// share the result of a single TailnetSettings API call. settingsFetched is
+// atomic because the accessors that read it are distinct MQL fields, which the
+// runtime may resolve concurrently.
 type mqlTailscaleInternal struct {
 	settingsLock    sync.Mutex
-	settingsFetched bool
+	settingsFetched atomic.Bool
 	settings        *tsclient.TailnetSettings
 }
 
@@ -28,18 +31,9 @@ func (r *mqlTailscale) id() (string, error) {
 
 func initTailscale(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	conn := runtime.Connection.(*connection.TailscaleConnection)
-	tailnet, set := connection.GetTailnet(conn.Conf)
-	if !set {
-		// When no tailnet was specified, we will be using the default tailnet of the
-		// authentication method being used to make API calls. Tailscale recommend this
-		// option for most users. (https://tailscale.com/api)
-		//
-		// NOTE that today, we cannot make an API call to get the actual tailnet
-		tailnet = "default"
-	}
 	mqlResource, err := CreateResource(runtime, "tailscale",
 		map[string]*llx.RawData{
-			"tailnet": llx.StringData(tailnet),
+			"tailnet": llx.StringData(conn.ResolveTailnet()),
 		})
 	if err != nil {
 		return args, nil, err
@@ -89,18 +83,21 @@ func (t *mqlTailscale) users() ([]any, error) {
 func (t *mqlTailscale) nameservers() ([]any, error) {
 	conn := t.MqlRuntime.Connection.(*connection.TailscaleConnection)
 	nameservers, err := conn.Client().DNS().Nameservers(context.Background())
-	return convert.SliceAnyToInterface(nameservers), err
+	if err != nil {
+		return nil, err
+	}
+	return convert.SliceAnyToInterface(nameservers), nil
 }
 
 // fetchSettings returns the cached TailnetSettings, fetching it on first call.
 // Multiple tailnet-level field accessors share the same response.
 func (t *mqlTailscale) fetchSettings() (*tsclient.TailnetSettings, error) {
-	if t.settingsFetched {
+	if t.settingsFetched.Load() {
 		return t.settings, nil
 	}
 	t.settingsLock.Lock()
 	defer t.settingsLock.Unlock()
-	if t.settingsFetched {
+	if t.settingsFetched.Load() {
 		return t.settings, nil
 	}
 	conn := t.MqlRuntime.Connection.(*connection.TailscaleConnection)
@@ -109,7 +106,7 @@ func (t *mqlTailscale) fetchSettings() (*tsclient.TailnetSettings, error) {
 		return nil, err
 	}
 	t.settings = settings
-	t.settingsFetched = true
+	t.settingsFetched.Store(true)
 	return t.settings, nil
 }
 

--- a/providers/tailscale/resources/user.go
+++ b/providers/tailscale/resources/user.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -18,13 +17,18 @@ func (r *mqlTailscaleUser) id() (string, error) {
 }
 
 func initTailscaleUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	id, ok := args["id"]
-	if !ok {
-		return nil, nil, errors.New("missing required argument 'id'")
+	conn := runtime.Connection.(*connection.TailscaleConnection)
+
+	// On a discovered user asset the user is implied by the asset itself, so a
+	// bare `tailscale.user` resolves without an explicit id argument.
+	args = withDefaultArg(args, "id", connection.UserIdFromAsset(conn.Asset()))
+
+	id, err := requiredStringArg(args, "id")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	conn := runtime.Connection.(*connection.TailscaleConnection)
-	user, err := conn.Client().Users().Get(context.Background(), id.Value.(string))
+	user, err := conn.Client().Users().Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/tailscale/resources/webhooks.go
+++ b/providers/tailscale/resources/webhooks.go
@@ -5,7 +5,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 
 	tsclient "github.com/tailscale/tailscale-client-go/v2"
 	"go.mondoo.com/mql/v13/llx"
@@ -19,13 +18,13 @@ func (r *mqlTailscaleWebhook) id() (string, error) {
 }
 
 func initTailscaleWebhook(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	id, ok := args["endpointId"]
-	if !ok {
-		return nil, nil, errors.New("missing required argument 'endpointId'")
+	id, err := requiredStringArg(args, "endpointId")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	conn := runtime.Connection.(*connection.TailscaleConnection)
-	wh, err := conn.Client().Webhooks().Get(context.Background(), id.Value.(string))
+	wh, err := conn.Client().Webhooks().Get(context.Background(), id)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes the findings from a static bug review of the tailscale provider — defects a compiler and the existing tests cannot catch. The two most significant both hand the user a confidently wrong answer rather than an error.

## OAuth tokens were capped at two scopes

`connection.go` named `devices:core:read` and `users:read` in the client-credentials token request. That **narrows** the issued token to exactly those two, no matter what the OAuth client was granted in the admin console.

Tailscale scopes access per resource, so every accessor added after the original provider PR returned 403 for OAuth users:

| Accessor | Scope it actually needs |
|---|---|
| `aclPolicy` (+ `raw`) | `policy_file:read` |
| `authKeys` | auth-keys read |
| `webhooks` | `webhooks:read` |
| `nameservers` | `dns:read` |
| `logstreams` | `log_streaming:read` |
| 7 tailnet-settings fields | `feature_settings:read` |
| `device.advertisedRoutes` / `enabledRoutes` | `devices:routes:read` — **not** covered by `devices:core` |

The scope list was last touched in the original provider PR (#5214); the ACL/settings/routes resources landed in #7376 and authKey/webhook/logstream in #7809, and neither updated it. The inline comments still enumerated only `devices()` and `users()`. Token auth was unaffected, which is why this went unnoticed.

**Fix:** omit the scope parameter entirely. The issued token then carries exactly the scopes the OAuth client itself holds, making the admin-console grant the authority. Adding the missing scopes explicitly would be the worse fix — a token request naming a scope the client wasn't granted returns `invalid_scope`, breaking existing users outright.

## Two tailnets scanned without `--tailnet` shared one asset identity

Both `Identifier()` and `initTailscale` fell back to the literal `"default"`, so the platform id and the resource cache key were identical across orgs. An MSP scanning two tailnets — neither passing the optional argument, which Tailscale itself recommends omitting — produced one asset, and the second scan overwrote the first. `tailscale.tailnet` also reported `"default"`, so a report couldn't distinguish them either.

The tailnet is now derived from a non-shared user's `tailnetId`, cached once per connection. Shared users are skipped because they belong to the tailnet they were shared *from* — the SDK's own tests show a `UserTypeShared` user carrying a different tailnet's id. The lookup degrades to the old placeholder when it isn't permitted, so a credential without users:read behaves exactly as before.

## Discovered device and user assets could not be queried

Discovery emits assets with `tailscale-device` / `tailscale-user` platforms and platform ids, but no init ever read them, so a bare `tailscale.device { authorized }` on a discovered asset failed with `missing required argument 'id'`. Since `scan` defaults to `--discover auto`, these assets were created by default and then couldn't be asserted on. Both inits now resolve the id from the asset, following the AWS `getAssetIdentifier` convention.

## Also fixed

- **`logstreams` hard-failed on a 403.** Log streaming is plan-gated; a tailnet without it failed the whole field instead of returning an empty list.
- **Three lazy-load double-check locks used a plain `bool`.** The unsynchronized fast-path read raced the write. `plugin.GetOrCompute` does no locking of its own, and the accessors sharing each cache are distinct MQL fields the runtime may resolve concurrently. Now `atomic.Bool`.
- **Four inits asserted `args[...].Value.(string)` bare.** A null argument arrives with a nil `Value`, and a panic in a provider goroutine takes down the whole scan rather than the one query. They now share a comma-ok helper.
- **`Verify()` substring-matched `"401"`.** It now classifies the status properly and reports a 403 as an under-scoped credential at connect time, rather than letting it surface later as scattered per-field errors.
- **`nameservers()`** returned converted data alongside a non-nil error.
- **Discovery** built the tailnet resource with the raw constructor, leaving its tailnet and cache key empty. Now goes through `NewResource` so the init runs.
- **`timeIsSet`'s comment** claimed Unix epoch 0 was "unset", contradicting the function and its own test.

## Tests

The provider had one resource-layer test. Added coverage for the pure-Go logic where wrong-data bugs actually live:

- **ACL policy converters** — the most security-sensitive mapping in the provider, previously untested: JSON-tag fidelity, `omitempty` round-tripping, JSON-native value types (a `Duration` must serialize as a string for llx dicts), nested app grants, and auto-approver flattening including the nil-block case.
- **Error classification** — driven against a real `httptest` server so it validates what the SDK actually emits. `tsclient` keeps the HTTP status on an unexported field and only ships `IsNotFound`, so `APIStatusCode` recovers it from the formatted error; `errors.As` proves the error is an `APIError` first, so a plain error mentioning a status can't be mistaken for one.
- **Platform-id extraction** — including that device and user prefixes don't cross-match and a bare prefix yields nothing.
- **Argument extraction** and **discovery target expansion**.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test -race ./...` passes
- `make providers/build/tailscale` succeeds
- No schema change — `.lr`, `.lr.go`, `.lr.versions`, and `.resources.json` are untouched by codegen

Not verified against a live tailnet — I don't have Tailscale credentials here. The two items worth confirming there: that `tailnetId` is populated on the users response for a real tailnet (it degrades safely to the old placeholder if not), and whether a plan without log streaming returns 403 or 404 (both are now handled).
