### PR TITLE
🐛 github: fix aliased cache keys, wrong-repo lookups, and owner-nil panics

### DIFF
--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -160,14 +160,20 @@ func org(runtime *plugin.Runtime, orgName string, conn *connection.GithubConnect
 	if stringx.ContainsAnyOf(targets, connection.DiscoveryUsers) {
 		for i := range org.GetMembers().Data {
 			user := org.GetMembers().Data[i].(*mqlGithubUser)
-			if user.Name.Data == "" {
+			if user.Login.Data == "" {
 				continue
+			}
+			// Most GitHub accounts leave the profile name blank; fall back to
+			// the login so those members are still discovered.
+			name := user.Name.Data
+			if name == "" {
+				name = user.Login.Data
 			}
 			cfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
 			cfg.Options["user"] = user.Login.Data
 			assetList = append(assetList, &inventory.Asset{
 				PlatformIds: []string{connection.NewGithubUserIdentifier(user.Login.Data)},
-				Name:        user.Name.Data,
+				Name:        name,
 				Platform:    connection.NewGithubUserPlatform(user.Login.Data),
 				Labels:      map[string]string{},
 				Connections: []*inventory.Config{cfg},
@@ -251,6 +257,11 @@ func user(runtime *plugin.Runtime, userName string, conn *connection.GithubConne
 			}
 			repoCfg := conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
 			repoCfg.Options["repository"] = repo.Name.Data
+			// The repository resource resolves its owner from the "owner" /
+			// "organization" options; a user-scoped config carries neither, so
+			// without this every repo asset discovered here fails to
+			// initialize github.repository.
+			repoCfg.Options["owner"] = user.Login.Data
 			assetList = append(assetList, &inventory.Asset{
 				PlatformIds: []string{connection.NewGitHubRepoIdentifier(user.Login.Data, repo.Name.Data)},
 				Name:        user.Login.Data + "/" + repo.Name.Data,
@@ -538,7 +549,15 @@ func repoIacFromTree(ctx context.Context, client *github.Client, repo *mqlGithub
 		return out, nil
 	}
 
-	tree, _, err := client.Git.GetTree(ctx, repo.Owner.Data.Login.Data, repo.Name.Data, ref, true)
+	owner, err := repoOwner(repo)
+	if err != nil {
+		return nil, err
+	}
+	if owner.Login.Error != nil {
+		return nil, owner.Login.Error
+	}
+
+	tree, _, err := client.Git.GetTree(ctx, owner.Login.Data, repo.Name.Data, ref, true)
 	if err != nil {
 		return nil, err
 	}
@@ -548,9 +567,18 @@ func repoIacFromTree(ctx context.Context, client *github.Client, repo *mqlGithub
 		log.Warn().Str("project", repo.FullName.Data).Msg("github repository tree is truncated; some IaC files may not be discovered")
 	}
 
+	return classifyIacTree(tree.Entries), nil
+}
+
+// classifyIacTree sorts the blobs of a repository tree into the IaC entry
+// points each detector needs. The switch ordering mirrors the GitLab provider
+// so the two behave identically — notably, Chart.yaml and kustomization.yaml
+// match their own cases and so do not also count as k8s manifests.
+func classifyIacTree(entries []*github.TreeEntry) *repoIac {
+	out := &repoIac{}
 	helmSeen := map[string]bool{}
 	kustomizeSeen := map[string]bool{}
-	for _, entry := range tree.Entries {
+	for _, entry := range entries {
 		if entry.GetType() != "blob" {
 			continue
 		}
@@ -582,7 +610,7 @@ func repoIacFromTree(ctx context.Context, client *github.Client, repo *mqlGithub
 			out.hasYaml = true
 		}
 	}
-	return out, nil
+	return out
 }
 
 // gitAsset builds a child asset that clones the repository and scans it with the
@@ -629,7 +657,15 @@ func discoverTerraform(conn *connection.GithubConnection, repo *mqlGithubReposit
 
 // hasTerraformHcl will check if the repository contains terraform files
 func hasTerraformHcl(ctx context.Context, client *github.Client, repo *mqlGithubRepository) (bool, error) {
-	languages, _, err := client.Repositories.ListLanguages(ctx, repo.Owner.Data.Login.Data, repo.Name.Data)
+	owner, err := repoOwner(repo)
+	if err != nil {
+		return false, err
+	}
+	if owner.Login.Error != nil {
+		return false, owner.Login.Error
+	}
+
+	languages, _, err := client.Repositories.ListLanguages(ctx, owner.Login.Data, repo.Name.Data)
 	if err != nil {
 		return false, err
 	}

--- a/providers/github/resources/discovery.go
+++ b/providers/github/resources/discovery.go
@@ -5,7 +5,7 @@ package resources
 
 import (
 	"context"
-	"path/filepath"
+	gopath "path"
 	"strings"
 	"time"
 
@@ -587,7 +587,7 @@ func classifyIacTree(entries []*github.TreeEntry) *repoIac {
 			continue
 		}
 
-		base := filepath.Base(path)
+		base := gopath.Base(path)
 		switch {
 		case strings.HasSuffix(path, ".bicep"):
 			out.hasBicep = true
@@ -726,7 +726,7 @@ func cloudformationTemplatePaths(ctx context.Context, client *github.Client, rep
 		if isHiddenPath(path) || seen[path] {
 			continue
 		}
-		switch strings.ToLower(filepath.Ext(path)) {
+		switch strings.ToLower(gopath.Ext(path)) {
 		case ".yaml", ".yml", ".json", ".template":
 			seen[path] = true
 			paths = append(paths, path)
@@ -747,10 +747,12 @@ func isDockerfile(base string) bool {
 }
 
 // iacDir returns the repo-relative directory containing the given file, with a
-// top-level file ("." from filepath.Dir) normalized to "" so it joins onto the
-// clone root cleanly.
-func iacDir(path string) string {
-	if dir := filepath.Dir(path); dir != "." {
+// top-level file (".") normalized to "" so it joins onto the clone root
+// cleanly. Repository paths are always slash-separated, so this uses path
+// rather than path/filepath, which on Windows would treat the whole path as a
+// single segment.
+func iacDir(filePath string) string {
+	if dir := gopath.Dir(filePath); dir != "." {
 		return dir
 	}
 	return ""

--- a/providers/github/resources/discovery_iac_test.go
+++ b/providers/github/resources/discovery_iac_test.go
@@ -1,0 +1,102 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func blob(path string) *github.TreeEntry {
+	return &github.TreeEntry{Path: github.Ptr(path), Type: github.Ptr("blob")}
+}
+
+func TestIsDockerfile(t *testing.T) {
+	for _, base := range []string{"Dockerfile", "Dockerfile.prod", "app.Dockerfile", "app.dockerfile"} {
+		assert.True(t, isDockerfile(base), base)
+	}
+	for _, base := range []string{"DockerfileLint.md", "dockerfile-notes.txt", "Chart.yaml", "docker-compose.yml"} {
+		assert.False(t, isDockerfile(base), base)
+	}
+}
+
+func TestIsKustomization(t *testing.T) {
+	for _, base := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+		assert.True(t, isKustomization(base), base)
+	}
+	for _, base := range []string{"kustomization.json", "Kustomization.yaml", "kustomize.yaml"} {
+		assert.False(t, isKustomization(base), base)
+	}
+}
+
+func TestIacDir(t *testing.T) {
+	assert.Equal(t, "", iacDir("Chart.yaml"))
+	assert.Equal(t, "charts/app", iacDir("charts/app/Chart.yaml"))
+}
+
+func TestIsHiddenPath(t *testing.T) {
+	assert.True(t, isHiddenPath(".github/workflows/ci.yml"))
+	assert.True(t, isHiddenPath(".drone.yml"))
+	assert.True(t, isHiddenPath("deploy/.hidden/app.yaml"))
+	assert.False(t, isHiddenPath("deploy/app.yaml"))
+}
+
+func TestClassifyIacTree(t *testing.T) {
+	t.Run("classifies each entry point", func(t *testing.T) {
+		got := classifyIacTree([]*github.TreeEntry{
+			blob("infra/main.bicep"),
+			blob("charts/app/Chart.yaml"),
+			blob("charts/app/templates/deployment.yaml"),
+			blob("overlays/prod/kustomization.yaml"),
+			blob("Dockerfile"),
+			blob("services/api.Dockerfile"),
+			blob("deploy/manifest.yaml"),
+		})
+
+		assert.True(t, got.hasBicep)
+		assert.True(t, got.hasYaml)
+		assert.Equal(t, []string{"charts/app"}, got.helmChartDirs)
+		assert.Equal(t, []string{"overlays/prod"}, got.kustomizeDirs)
+		assert.Equal(t, []string{"Dockerfile", "services/api.Dockerfile"}, got.dockerfiles)
+	})
+
+	t.Run("skips trees, hidden paths and mql bundles", func(t *testing.T) {
+		got := classifyIacTree([]*github.TreeEntry{
+			{Path: github.Ptr("charts"), Type: github.Ptr("tree")},
+			blob(".github/workflows/ci.yml"),
+			blob("mql.yaml"),
+			blob("policies/mql.yml"),
+		})
+
+		assert.False(t, got.hasYaml)
+		assert.False(t, got.hasBicep)
+		assert.Empty(t, got.helmChartDirs)
+		assert.Empty(t, got.dockerfiles)
+	})
+
+	t.Run("deduplicates chart and kustomize directories", func(t *testing.T) {
+		got := classifyIacTree([]*github.TreeEntry{
+			blob("charts/app/Chart.yaml"),
+			blob("charts/app/Chart.yaml"),
+			blob("overlays/prod/kustomization.yaml"),
+			blob("overlays/prod/kustomization.yml"),
+		})
+
+		assert.Equal(t, []string{"charts/app"}, got.helmChartDirs)
+		assert.Equal(t, []string{"overlays/prod"}, got.kustomizeDirs)
+	})
+
+	// Chart.yaml and kustomization.yaml match their own cases and must not also
+	// register the repository as carrying k8s manifests.
+	t.Run("chart and kustomize files are not k8s manifests", func(t *testing.T) {
+		got := classifyIacTree([]*github.TreeEntry{
+			blob("charts/app/Chart.yaml"),
+			blob("overlays/prod/kustomization.yaml"),
+		})
+
+		assert.False(t, got.hasYaml)
+	})
+}

--- a/providers/github/resources/discovery_iac_test.go
+++ b/providers/github/resources/discovery_iac_test.go
@@ -35,6 +35,23 @@ func TestIsKustomization(t *testing.T) {
 func TestIacDir(t *testing.T) {
 	assert.Equal(t, "", iacDir("Chart.yaml"))
 	assert.Equal(t, "charts/app", iacDir("charts/app/Chart.yaml"))
+
+	// Repository paths are slash-separated whatever the scanner runs on. This
+	// fails on Windows if iacDir uses path/filepath, which treats the whole
+	// path as one segment.
+	assert.Equal(t, "a/b/c", iacDir("a/b/c/Chart.yaml"))
+}
+
+// Same concern one level up: the classifier takes a file's base name to match
+// Dockerfile and kustomization.yaml, so it has to split on "/" everywhere.
+func TestClassifyIacTreeSplitsOnSlash(t *testing.T) {
+	got := classifyIacTree([]*github.TreeEntry{
+		blob("services/api/Dockerfile"),
+		blob("overlays/prod/kustomization.yaml"),
+	})
+
+	assert.Equal(t, []string{"services/api/Dockerfile"}, got.dockerfiles)
+	assert.Equal(t, []string{"overlays/prod"}, got.kustomizeDirs)
 }
 
 func TestIsHiddenPath(t *testing.T) {

--- a/providers/github/resources/git.go
+++ b/providers/github/resources/git.go
@@ -27,9 +27,19 @@ func (g *mqlGitCommitAuthor) id() (string, error) {
 	return "git.commitAuthor/" + g.Sha.Data, nil
 }
 
-func newMqlGitAuthor(runtime *plugin.Runtime, sha string, a *github.CommitAuthor) (any, error) {
+// commitAuthorID keys a commit identity by both the commit sha and the role it
+// plays on that commit. A commit carries two identities (author and committer)
+// which frequently differ; keying on the sha alone made the second one collide
+// with the first in the resource cache, so every committer resolved to the
+// commit's author.
+func commitAuthorID(sha, role string) string {
+	return "git.commitAuthor/" + sha + "/" + role
+}
+
+func newMqlGitAuthor(runtime *plugin.Runtime, sha string, role string, a *github.CommitAuthor) (any, error) {
 	date := a.GetDate()
 	return CreateResource(runtime, "git.commitAuthor", map[string]*llx.RawData{
+		"__id":  llx.StringData(commitAuthorID(sha, role)),
 		"sha":   llx.StringData(sha),
 		"name":  llx.StringData(a.GetName()),
 		"email": llx.StringData(a.GetEmail()),
@@ -43,12 +53,12 @@ func (g *mqlGitCommit) id() (string, error) {
 
 func newMqlGitCommit(runtime *plugin.Runtime, sha string, c *github.Commit) (any, error) {
 	// we have to pass-in the sha because the sha is often not set c.GetSHA()
-	author, err := newMqlGitAuthor(runtime, sha, c.GetAuthor())
+	author, err := newMqlGitAuthor(runtime, sha, "author", c.GetAuthor())
 	if err != nil {
 		return nil, err
 	}
 
-	committer, err := newMqlGitAuthor(runtime, sha, c.GetCommitter())
+	committer, err := newMqlGitAuthor(runtime, sha, "committer", c.GetCommitter())
 	if err != nil {
 		return nil, err
 	}

--- a/providers/github/resources/github.lr
+++ b/providers/github/resources/github.lr
@@ -1618,6 +1618,12 @@ private github.mergeRequest @defaults("id state") {
   reviews() []github.review
   // Pull request repository name
   repoName string
+  // Login of the account that owns the pull request's repository
+  //
+  // The organization or user the repository belongs to, which is what
+  // addresses the repository in the API. This is distinct from owner, which
+  // is the account that authored the pull request.
+  repoOwnerLogin string
   // Pull request milestone
   milestone github.milestone
   // Whether the pull request has been merged

--- a/providers/github/resources/github.lr.go
+++ b/providers/github/resources/github.lr.go
@@ -1908,6 +1908,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"github.mergeRequest.repoName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubMergeRequest).GetRepoName()).ToDataRes(types.String)
 	},
+	"github.mergeRequest.repoOwnerLogin": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubMergeRequest).GetRepoOwnerLogin()).ToDataRes(types.String)
+	},
 	"github.mergeRequest.milestone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubMergeRequest).GetMilestone()).ToDataRes(types.Resource("github.milestone"))
 	},
@@ -4731,6 +4734,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.mergeRequest.repoName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubMergeRequest).RepoName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"github.mergeRequest.repoOwnerLogin": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubMergeRequest).RepoOwnerLogin, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"github.mergeRequest.milestone": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -11015,6 +11022,7 @@ type mqlGithubMergeRequest struct {
 	Commits            plugin.TValue[[]any]
 	Reviews            plugin.TValue[[]any]
 	RepoName           plugin.TValue[string]
+	RepoOwnerLogin     plugin.TValue[string]
 	Milestone          plugin.TValue[*mqlGithubMilestone]
 	Merged             plugin.TValue[bool]
 	MergedAt           plugin.TValue[*time.Time]
@@ -11136,6 +11144,10 @@ func (c *mqlGithubMergeRequest) GetReviews() *plugin.TValue[[]any] {
 
 func (c *mqlGithubMergeRequest) GetRepoName() *plugin.TValue[string] {
 	return &c.RepoName
+}
+
+func (c *mqlGithubMergeRequest) GetRepoOwnerLogin() *plugin.TValue[string] {
+	return &c.RepoOwnerLogin
 }
 
 func (c *mqlGithubMergeRequest) GetMilestone() *plugin.TValue[*mqlGithubMilestone] {

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -288,6 +288,7 @@ github.mergeRequest.milestone 11.4.122
 github.mergeRequest.number 9.0.0
 github.mergeRequest.owner 9.0.0
 github.mergeRequest.repoName 9.0.0
+github.mergeRequest.repoOwnerLogin 13.7.5
 github.mergeRequest.requestedReviewers 13.1.1
 github.mergeRequest.reviews 9.0.0
 github.mergeRequest.state 9.0.0

--- a/providers/github/resources/github.lr.versions
+++ b/providers/github/resources/github.lr.versions
@@ -288,7 +288,7 @@ github.mergeRequest.milestone 11.4.122
 github.mergeRequest.number 9.0.0
 github.mergeRequest.owner 9.0.0
 github.mergeRequest.repoName 9.0.0
-github.mergeRequest.repoOwnerLogin 13.7.5
+github.mergeRequest.repoOwnerLogin 13.7.6
 github.mergeRequest.requestedReviewers 13.1.1
 github.mergeRequest.reviews 9.0.0
 github.mergeRequest.state 9.0.0

--- a/providers/github/resources/github_actions_secrets.go
+++ b/providers/github/resources/github_actions_secrets.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"fmt"
+
 	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -432,14 +434,33 @@ func (g *mqlGithubActionsVariable) selectedRepositories() ([]any, error) {
 	return reposToMql(g.MqlRuntime, all)
 }
 
+// repoOwner returns the repository's owner resource. The owner is legitimately
+// null on fork entries and on repositories built from a partial API response
+// (see newMqlGithubRepository and reposToMql), so callers must never
+// dereference g.Owner.Data without going through this helper — doing so panics
+// the whole GetData call.
+func repoOwner(g *mqlGithubRepository) (*mqlGithubUser, error) {
+	if g.Owner.Error != nil {
+		return nil, g.Owner.Error
+	}
+	if g.Owner.Data == nil {
+		name := ""
+		if g.Name.Error == nil {
+			name = g.Name.Data
+		}
+		return nil, fmt.Errorf("repository %q has no owner information available", name)
+	}
+	return g.Owner.Data, nil
+}
+
 func repoOwnerAndName(g *mqlGithubRepository) (string, string, error) {
 	if g.Name.Error != nil {
 		return "", "", g.Name.Error
 	}
-	if g.Owner.Error != nil {
-		return "", "", g.Owner.Error
+	owner, err := repoOwner(g)
+	if err != nil {
+		return "", "", err
 	}
-	owner := g.Owner.Data
 	if owner.Login.Error != nil {
 		return "", "", owner.Login.Error
 	}

--- a/providers/github/resources/github_audit.go
+++ b/providers/github/resources/github_audit.go
@@ -21,6 +21,10 @@ func (g *mqlGithubAuditLogEntry) id() (string, error) {
 	return "github.auditLogEntry/" + g.DocumentId.Data, nil
 }
 
+// maxAuditLogPages bounds how much of the audit log a single query pulls into
+// memory: paginationPerPage entries per page, so 100 pages is 10,000 entries.
+const maxAuditLogPages = 100
+
 // auditLog returns the audit log entries for an organization.
 // Note: This requires GitHub Enterprise Cloud.
 func (g *mqlGithubOrganization) auditLog() ([]any, error) {
@@ -36,7 +40,17 @@ func (g *mqlGithubOrganization) auditLog() ([]any, error) {
 	}
 
 	var allEntries []*github.AuditEntry
-	for {
+	for page := 0; ; page++ {
+		if page >= maxAuditLogPages {
+			// The audit log of a busy organization is effectively unbounded and
+			// is read entirely into memory here. Stop at a fixed number of
+			// pages and say so, rather than growing until the scan runs out of
+			// memory.
+			log.Warn().
+				Int("entries", len(allEntries)).
+				Msg("stopped reading the organization audit log at the page limit; the result is truncated")
+			break
+		}
 		entries, resp, err := conn.Client().Organizations.GetAuditLog(conn.Context(), orgLogin, opts)
 		if err != nil {
 			// Audit log is only available for GitHub Enterprise Cloud

--- a/providers/github/resources/github_copilot.go
+++ b/providers/github/resources/github_copilot.go
@@ -254,18 +254,10 @@ func initGithubRepositoryCopilotCloudAgent(runtime *plugin.Runtime, args map[str
 
 func (g *mqlGithubRepository) copilotCloudAgent() (*mqlGithubRepositoryCopilotCloudAgent, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	cfg, _, err := conn.Client().Copilot.GetCloudAgentConfiguration(conn.Context(), ownerLogin, repoName)
 	if err != nil {

--- a/providers/github/resources/github_environments.go
+++ b/providers/github/resources/github_environments.go
@@ -45,24 +45,25 @@ func (g *mqlGithubDeploymentStatus) id() (string, error) {
 	return "github.deploymentStatus/" + strconv.FormatInt(g.Id.Data, 10), nil
 }
 
+// creatorData wraps an optional user resource for a CreateResource argument.
+// Passing a nil *mqlGithubUser straight to llx.ResourceData stores a typed nil,
+// which the runtime records as set-but-not-null and then dereferences when it
+// serializes the field. NilData records a proper null instead.
+func creatorData(user *mqlGithubUser) *llx.RawData {
+	if user == nil {
+		return llx.NilData
+	}
+	return llx.ResourceData(user, "github.user")
+}
+
 // environments returns the deployment environments for a repository.
 func (g *mqlGithubRepository) environments() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	opts := &github.EnvironmentListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -178,20 +179,10 @@ type mqlGithubEnvironmentInternal struct {
 func (g *mqlGithubRepository) deployments() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	opts := &github.DeploymentsListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -259,7 +250,7 @@ func deploymentsToMql(runtime *plugin.Runtime, owner, repo string, deployments [
 			"task":        llx.StringDataPtr(d.Task),
 			"environment": llx.StringDataPtr(d.Environment),
 			"description": llx.StringDataPtr(d.Description),
-			"creator":     llx.ResourceData(creator, "github.user"),
+			"creator":     creatorData(creator),
 			"createdAt":   llx.TimeDataPtr(githubTimestamp(d.CreatedAt)),
 			"updatedAt":   llx.TimeDataPtr(githubTimestamp(d.UpdatedAt)),
 			"payload":     llx.MapData(payload, types.Any),
@@ -341,7 +332,7 @@ func (g *mqlGithubDeployment) latestStatus() (*mqlGithubDeploymentStatus, error)
 		"state":          llx.StringDataPtr(status.State),
 		"description":    llx.StringDataPtr(status.Description),
 		"environment":    llx.StringDataPtr(status.Environment),
-		"creator":        llx.ResourceData(creator, "github.user"),
+		"creator":        creatorData(creator),
 		"createdAt":      llx.TimeDataPtr(githubTimestamp(status.CreatedAt)),
 		"updatedAt":      llx.TimeDataPtr(githubTimestamp(status.UpdatedAt)),
 		"targetUrl":      llx.StringDataPtr(status.TargetURL),

--- a/providers/github/resources/github_ids_test.go
+++ b/providers/github/resources/github_ids_test.go
@@ -1,0 +1,90 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Every builder here keys a resource that is only unique within a repository,
+// an owner, or a runner scope. The tests below pin the property that matters:
+// two things that can legitimately coexist in one scan must not share a key.
+
+func TestCommitAuthorID(t *testing.T) {
+	sha := "7730d2707fdb6422f335fddc944ab169d45f3aa5"
+
+	assert.Equal(t, "git.commitAuthor/"+sha+"/author", commitAuthorID(sha, "author"))
+	assert.NotEqual(t, commitAuthorID(sha, "author"), commitAuthorID(sha, "committer"),
+		"a commit's author and committer must not share a cache key")
+}
+
+func TestCollaboratorID(t *testing.T) {
+	assert.Equal(t, "github.collaborator/mondoohq/cnquery/42",
+		collaboratorID("mondoohq", "cnquery", 42))
+
+	assert.NotEqual(t,
+		collaboratorID("mondoohq", "cnquery", 42),
+		collaboratorID("mondoohq", "cnspec", 42),
+		"the same user on two repositories must not share a cache key")
+}
+
+func TestAlertID(t *testing.T) {
+	assert.Equal(t, "github.dependabotAlert/mondoohq/cnquery/1",
+		alertID("github.dependabotAlert", "mondoohq", "cnquery", 1))
+
+	// Alert numbers restart at 1 in every repository.
+	assert.NotEqual(t,
+		alertID("github.dependabotAlert", "mondoohq", "cnquery", 1),
+		alertID("github.dependabotAlert", "mondoohq", "cnspec", 1))
+
+	// Different alert kinds share the number space too.
+	assert.NotEqual(t,
+		alertID("github.dependabotAlert", "mondoohq", "cnquery", 1),
+		alertID("github.codeScanningAlert", "mondoohq", "cnquery", 1))
+}
+
+func TestBranchID(t *testing.T) {
+	assert.Equal(t, "github.branch/mondoohq/cnquery/main", branchID("mondoohq", "cnquery", "main"))
+
+	// A fork keeps the repository name of its upstream.
+	assert.NotEqual(t,
+		branchID("mondoohq", "cnquery", "main"),
+		branchID("someone-else", "cnquery", "main"))
+}
+
+func TestCodeownersRuleID(t *testing.T) {
+	assert.Equal(t, "github.codeowners.rule/mondoohq/cnquery/*/1",
+		codeownersRuleID("mondoohq", "cnquery", "*", 1))
+
+	// "* @org/team" on line 1 is near-universal across repositories.
+	assert.NotEqual(t,
+		codeownersRuleID("mondoohq", "cnquery", "*", 1),
+		codeownersRuleID("mondoohq", "cnspec", "*", 1))
+}
+
+func TestRunnerID(t *testing.T) {
+	assert.Equal(t, "github.runner/orgs/mondoohq/7", runnerID("orgs/mondoohq", 7))
+
+	// Organization and repository runners are numbered independently.
+	assert.NotEqual(t,
+		runnerID("orgs/mondoohq", 7),
+		runnerID("repos/mondoohq/cnquery", 7))
+}
+
+func TestRunnerLabelID(t *testing.T) {
+	scope := "orgs/mondoohq"
+
+	// Read-only labels reuse the same ids on every runner, so the key has to
+	// carry the runner as well as the label name.
+	assert.NotEqual(t,
+		runnerLabelID(scope, 1, "self-hosted"),
+		runnerLabelID(scope, 2, "self-hosted"))
+
+	// The API omits the id for some labels; distinct names must still differ.
+	assert.NotEqual(t,
+		runnerLabelID(scope, 0, "gpu"),
+		runnerLabelID(scope, 0, "arm64"))
+}

--- a/providers/github/resources/github_ids_test.go
+++ b/providers/github/resources/github_ids_test.go
@@ -66,25 +66,54 @@ func TestCodeownersRuleID(t *testing.T) {
 }
 
 func TestRunnerID(t *testing.T) {
-	assert.Equal(t, "github.runner/orgs/mondoohq/7", runnerID("orgs/mondoohq", 7))
+	assert.Equal(t, "github.runner/orgs/mondoohq/7", runnerID("orgs/mondoohq", "7"))
 
 	// Organization and repository runners are numbered independently.
 	assert.NotEqual(t,
-		runnerID("orgs/mondoohq", 7),
-		runnerID("repos/mondoohq/cnquery", 7))
+		runnerID("orgs/mondoohq", "7"),
+		runnerID("repos/mondoohq/cnquery", "7"))
+}
+
+func TestRunnerKey(t *testing.T) {
+	id := func(v int64) *int64 { return &v }
+	name := func(v string) *string { return &v }
+
+	assert.Equal(t, "7", runnerKey(&ghRunnerExt{ID: id(7), Name: name("builder-1")}, 0))
+
+	// An absent id falls back to the name, which is unique within the scope.
+	// Keying both on the id's zero value would collapse them onto one resource.
+	assert.NotEqual(t,
+		runnerKey(&ghRunnerExt{Name: name("builder-1")}, 0),
+		runnerKey(&ghRunnerExt{Name: name("builder-2")}, 1))
+
+	// With neither an id nor a name, the listing position keeps them distinct.
+	assert.NotEqual(t,
+		runnerKey(&ghRunnerExt{}, 0),
+		runnerKey(&ghRunnerExt{}, 1))
+
+	// A name-keyed runner must not collide with the runner whose id is that name.
+	assert.NotEqual(t,
+		runnerKey(&ghRunnerExt{Name: name("7")}, 0),
+		runnerKey(&ghRunnerExt{ID: id(7)}, 1))
 }
 
 func TestRunnerLabelID(t *testing.T) {
 	scope := "orgs/mondoohq"
+	name := func(v string) *string { return &v }
 
 	// Read-only labels reuse the same ids on every runner, so the key has to
 	// carry the runner as well as the label name.
 	assert.NotEqual(t,
-		runnerLabelID(scope, 1, "self-hosted"),
-		runnerLabelID(scope, 2, "self-hosted"))
+		runnerLabelID(scope, "1", "self-hosted"),
+		runnerLabelID(scope, "2", "self-hosted"))
 
 	// The API omits the id for some labels; distinct names must still differ.
 	assert.NotEqual(t,
-		runnerLabelID(scope, 0, "gpu"),
-		runnerLabelID(scope, 0, "arm64"))
+		runnerLabelID(scope, "1", "gpu"),
+		runnerLabelID(scope, "1", "arm64"))
+
+	// Labels on two id-less runners stay separate, since the runner key does.
+	assert.NotEqual(t,
+		runnerLabelID(scope, runnerKey(&ghRunnerExt{Name: name("builder-1")}, 0), "self-hosted"),
+		runnerLabelID(scope, runnerKey(&ghRunnerExt{Name: name("builder-2")}, 1), "self-hosted"))
 }

--- a/providers/github/resources/github_org.go
+++ b/providers/github/resources/github_org.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -606,7 +605,10 @@ func (g *mqlGithubPackage) repository() (*mqlGithubRepository, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
 	if g.packageRepository == "" {
-		return nil, errors.New("could not load the repository")
+		// Container and other registry packages are not always attached to a
+		// repository; that is a valid empty state, not a failure.
+		g.Repository.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
 	}
 
 	repoName := g.packageRepository
@@ -624,6 +626,10 @@ func (g *mqlGithubPackage) repository() (*mqlGithubRepository, error) {
 		return nil, g.Owner.Error
 	}
 	owner := g.Owner.Data
+	if owner == nil {
+		g.Repository.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 
 	if owner.Login.Error != nil {
 		return nil, owner.Login.Error

--- a/providers/github/resources/github_pages.go
+++ b/providers/github/resources/github_pages.go
@@ -40,18 +40,10 @@ func initGithubRepositoryPages(runtime *plugin.Runtime, args map[string]*llx.Raw
 
 func (g *mqlGithubRepository) pages() (*mqlGithubRepositoryPages, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	pages, _, err := conn.Client().Repositories.GetPagesInfo(conn.Context(), ownerLogin, repoName)
 	if err != nil {

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -652,7 +652,7 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 		return nil, nil
 	}
 	if owner.Login.Error != nil {
-		log.Debug().Err(err).Msg("note: branch protection can only be accessed by admin users")
+		log.Debug().Err(owner.Login.Error).Msg("note: branch protection can only be accessed by admin users")
 		if strings.Contains(owner.Login.Error.Error(), "404") {
 			g.ProtectionRules.State = plugin.StateIsSet | plugin.StateIsNull
 			return nil, nil

--- a/providers/github/resources/github_repo.go
+++ b/providers/github/resources/github_repo.go
@@ -217,7 +217,11 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 				if err != nil {
 					return nil, nil, err
 				}
-				obj, err = CreateResource(runtime, "github.user", map[string]*llx.RawData{
+				// NewResource so the user's init runs and fills in the id;
+				// CreateResource would cache a bare resource under the
+				// degenerate key "github.user/0" and shadow the real user for
+				// the rest of the scan.
+				obj, err = NewResource(runtime, "github.user", map[string]*llx.RawData{
 					"login": llx.StringData(userId.Name),
 				})
 				if err != nil {
@@ -279,7 +283,10 @@ func initGithubRepository(runtime *plugin.Runtime, args map[string]*llx.RawData)
 
 	// if the repo is not cached, we fetch it from the github api
 	if owner != "" {
-		// we reach this point if the repo was not cached
+		// we reach this point if the repo was not cached. Use the resolved
+		// owner rather than the organization name: when the organization
+		// lookup fell through to the user path, the org name is not the
+		// account that holds the repository.
 		ghRepo, _, err := conn.Client().Repositories.Get(conn.Context(), owner, reponame)
 		if err != nil {
 			return nil, nil, err
@@ -304,18 +311,10 @@ func (g *mqlGithubLicense) id() (string, error) {
 
 func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	repoLicense, _, err := conn.Client().Repositories.License(conn.Context(), ownerLogin, repoName)
 	if err != nil {
@@ -348,18 +347,10 @@ func (g *mqlGithubRepository) license() (*mqlGithubLicense, error) {
 
 func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.PullRequestListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -448,6 +439,7 @@ func (g *mqlGithubRepository) getMergeRequests(state string) ([]any, error) {
 
 		r, err := CreateResource(g.MqlRuntime, "github.mergeRequest", map[string]*llx.RawData{
 			"id":                 llx.IntDataPtr(pr.ID),
+			"repoOwnerLogin":     llx.StringData(ownerLogin),
 			"number":             llx.IntData(int64(pr.GetNumber())),
 			"state":              llx.StringDataPtr(pr.State),
 			"labels":             llx.ArrayData(labels, types.Any),
@@ -507,19 +499,14 @@ func (g *mqlGithubMergeRequest) id() (string, error) {
 
 func (g *mqlGithubRepository) branches() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
+	owner, err := repoOwner(g)
+	if err != nil {
+		return nil, err
 	}
-	owner := g.Owner.Data
-
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	if g.DefaultBranchName.Error != nil {
 		return nil, g.DefaultBranchName.Error
@@ -553,7 +540,7 @@ func (g *mqlGithubRepository) branches() ([]any, error) {
 			defaultBranch = true
 		}
 
-		mqlBranch, err := newMqlBranch(g.MqlRuntime, branch, owner, repoName, defaultBranch)
+		mqlBranch, err := newMqlBranch(g.MqlRuntime, branch, owner, ownerLogin, repoName, defaultBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -562,8 +549,16 @@ func (g *mqlGithubRepository) branches() ([]any, error) {
 	return res, nil
 }
 
-func newMqlBranch(runtime *plugin.Runtime, branch *github.Branch, owner *mqlGithubUser, repoName string, defaultBranch bool) (*mqlGithubBranch, error) {
+// branchID keys a branch by owner as well as repository. Repository names are
+// only unique within an owner, and forks keep the name of the repository they
+// were forked from, so an owner-less key aliased branches across forks.
+func branchID(ownerLogin, repoName, branchName string) string {
+	return "github.branch/" + ownerLogin + "/" + repoName + "/" + branchName
+}
+
+func newMqlBranch(runtime *plugin.Runtime, branch *github.Branch, owner *mqlGithubUser, ownerLogin string, repoName string, defaultBranch bool) (*mqlGithubBranch, error) {
 	mqlBranch, err := CreateResource(runtime, "github.branch", map[string]*llx.RawData{
+		"__id":          llx.StringData(branchID(ownerLogin, repoName, branch.GetName())),
 		"name":          llx.StringData(branch.GetName()),
 		"isProtected":   llx.BoolData(branch.GetProtected()),
 		"headCommitSha": llx.StringData(branch.GetCommit().GetSHA()),
@@ -579,19 +574,14 @@ func newMqlBranch(runtime *plugin.Runtime, branch *github.Branch, owner *mqlGith
 
 func (g *mqlGithubRepository) defaultBranch() (*mqlGithubBranch, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
+	owner, err := repoOwner(g)
+	if err != nil {
+		return nil, err
 	}
-	owner := g.Owner.Data
-
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	if g.DefaultBranchName.Error != nil {
 		return nil, g.DefaultBranchName.Error
@@ -609,7 +599,7 @@ func (g *mqlGithubRepository) defaultBranch() (*mqlGithubBranch, error) {
 		return nil, err
 	}
 
-	return newMqlBranch(g.MqlRuntime, branch, owner, repoName, true)
+	return newMqlBranch(g.MqlRuntime, branch, owner, ownerLogin, repoName, true)
 }
 
 type githubDismissalRestrictions struct {
@@ -657,6 +647,10 @@ func (g *mqlGithubBranch) protectionRules() (*mqlGithubBranchprotection, error) 
 		return nil, g.Owner.Error
 	}
 	owner := g.Owner.Data
+	if owner == nil {
+		g.ProtectionRules.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
 	if owner.Login.Error != nil {
 		log.Debug().Err(err).Msg("note: branch protection can only be accessed by admin users")
 		if strings.Contains(owner.Login.Error.Error(), "404") {
@@ -860,8 +854,12 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 	var err error
 	conn := runtime.Connection.(*connection.GithubConnection)
 
-	// if the github author is nil, we have to load the commit again
-	if rc.Author == nil || rc.Commit == nil {
+	// If the commit payload is missing we have to load the commit again. A nil
+	// Author is not a reason to refetch: it means the commit's email is not
+	// linked to any GitHub account, and the detail endpoint reports the same
+	// null. Refetching on it cost one extra API call per unlinked commit and
+	// changed nothing.
+	if rc.Commit == nil {
 		rc, _, err = conn.Client().Repositories.GetCommit(conn.Context(), owner, repo, rc.GetSHA(), nil)
 		if err != nil {
 			return nil, err
@@ -917,18 +915,10 @@ func newMqlGithubCommit(runtime *plugin.Runtime, rc *github.RepositoryCommit, ow
 func (g *mqlGithubRepository) commits() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.CommitsListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -965,21 +955,31 @@ func (g *mqlGithubRepository) commits() ([]any, error) {
 	return res, nil
 }
 
+// mergeRequestRepo returns the owner login and name of the repository a pull
+// request belongs to. It reads repoOwnerLogin rather than owner: owner is the
+// account that *authored* the pull request, which for organization
+// repositories is almost never the account that owns the repository. Addressing
+// the API with the author's login used to 404 and, because the callers treat a
+// 404 as "nothing here", silently returned no commits and no reviews.
+func mergeRequestRepo(g *mqlGithubMergeRequest) (string, string, error) {
+	if g.RepoName.Error != nil {
+		return "", "", g.RepoName.Error
+	}
+	if g.RepoOwnerLogin.Error != nil {
+		return "", "", g.RepoOwnerLogin.Error
+	}
+	if g.RepoOwnerLogin.Data == "" {
+		return "", "", errors.New("pull request is missing the owner of its repository")
+	}
+	return g.RepoOwnerLogin.Data, g.RepoName.Data, nil
+}
+
 func (g *mqlGithubMergeRequest) reviews() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	var err error
-	if g.RepoName.Error != nil {
-		return nil, g.RepoName.Error
+	ownerLogin, repoName, err := mergeRequestRepo(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.RepoName.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 	if g.Number.Error != nil {
 		return nil, g.Number.Error
 	}
@@ -1033,18 +1033,10 @@ func (g *mqlGithubMergeRequest) reviews() ([]any, error) {
 
 func (g *mqlGithubMergeRequest) commits() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.RepoName.Error != nil {
-		return nil, g.RepoName.Error
+	ownerLogin, repoName, err := mergeRequestRepo(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.RepoName.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 	if g.Number.Error != nil {
 		return nil, g.Number.Error
 	}
@@ -1084,18 +1076,10 @@ func (g *mqlGithubMergeRequest) commits() ([]any, error) {
 func (g *mqlGithubRepository) contributors() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.ListContributorsOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -1132,18 +1116,10 @@ func (g *mqlGithubRepository) contributors() ([]any, error) {
 func (g *mqlGithubRepository) collaborators() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.ListCollaboratorsOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -1177,6 +1153,7 @@ func (g *mqlGithubRepository) collaborators() ([]any, error) {
 		permissions := permissionsFromUser(contributor)
 
 		mqlContributor, err := CreateResource(g.MqlRuntime, "github.collaborator", map[string]*llx.RawData{
+			"__id":        llx.StringData(collaboratorID(ownerLogin, repoName, contributor.GetID())),
 			"id":          llx.IntDataPtr(contributor.ID),
 			"user":        llx.ResourceData(mqlUser, mqlUser.MqlName()),
 			"permissions": llx.ArrayData(convert.SliceAnyToInterface[string](permissions), types.String),
@@ -1187,6 +1164,21 @@ func (g *mqlGithubRepository) collaborators() ([]any, error) {
 		res = append(res, mqlContributor)
 	}
 	return res, nil
+}
+
+// collaboratorID keys a collaborator by the repository the permissions apply
+// to. The same account collaborates on many repositories with different
+// permission sets, so keying on the user alone made every repository after the
+// first reuse the first one's permissions.
+func collaboratorID(ownerLogin, repoName string, userID int64) string {
+	return "github.collaborator/" + ownerLogin + "/" + repoName + "/" + strconv.FormatInt(userID, 10)
+}
+
+// alertID keys a security alert by repository. Alert numbers are assigned per
+// repository and restart at 1, so an unqualified number aliased alerts across
+// every repository reached in the same scan.
+func alertID(resource, ownerLogin, repoName string, number int64) string {
+	return resource + "/" + ownerLogin + "/" + repoName + "/" + strconv.FormatInt(number, 10)
 }
 
 func permissionsFromUser(u *github.User) []string {
@@ -1215,18 +1207,10 @@ func permissionsFromUser(u *github.User) []string {
 func (g *mqlGithubRepository) adminCollaborators() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.ListCollaboratorsOptions{
 		Permission:  "admin",
@@ -1261,6 +1245,7 @@ func (g *mqlGithubRepository) adminCollaborators() ([]any, error) {
 		permissions := permissionsFromUser(contributor)
 
 		mqlContributor, err := CreateResource(g.MqlRuntime, "github.collaborator", map[string]*llx.RawData{
+			"__id":        llx.StringData(collaboratorID(ownerLogin, repoName, contributor.GetID())),
 			"id":          llx.IntDataPtr(contributor.ID),
 			"user":        llx.ResourceData(mqlUser, mqlUser.MqlName()),
 			"permissions": llx.ArrayData(convert.SliceAnyToInterface[string](permissions), types.String),
@@ -1276,18 +1261,10 @@ func (g *mqlGithubRepository) adminCollaborators() ([]any, error) {
 func (g *mqlGithubRepository) releases() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	ownerName := g.Owner.Data
-	if ownerName.Login.Error != nil {
-		return nil, ownerName.Login.Error
-	}
-	ownerLogin := ownerName.Login.Data
 
 	listOpts := &github.ListOptions{
 		PerPage: paginationPerPage,
@@ -1353,18 +1330,10 @@ func (g *mqlGithubWebhook) id() (string, error) {
 func (g *mqlGithubRepository) webhooks() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.ListOptions{
 		PerPage: paginationPerPage,
@@ -1422,18 +1391,10 @@ type mqlGithubWorkflowInternal struct {
 func (g *mqlGithubRepository) workflows() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	if g.FullName.Error != nil {
 		return nil, g.FullName.Error
@@ -1495,14 +1456,19 @@ func (g *mqlGithubRepository) workflows() ([]any, error) {
 	return res, nil
 }
 
-func newMqlGithubFile(runtime *plugin.Runtime, ownerName string, repoName string, content *github.RepositoryContent) (*mqlGithubFile, error) {
-	isBinary := false
-	if convert.ToValue(content.Type) == "file" {
-		file := strings.Split(convert.ToValue(content.Path), ".")
-		if len(file) == 2 {
-			isBinary = binaryFileTypes[file[1]]
-		}
+// isBinaryFile reports whether a repository entry is a known binary artifact,
+// based on its file extension. It uses path.Ext rather than splitting the whole
+// path on ".", which misclassified every file living under a directory that has
+// a dot in its name (`v1.2/tool.exe`, `.github/x.exe`).
+func isBinaryFile(fileType, filePath string) bool {
+	if fileType != "file" {
+		return false
 	}
+	return binaryFileTypes[strings.TrimPrefix(path.Ext(filePath), ".")]
+}
+
+func newMqlGithubFile(runtime *plugin.Runtime, ownerName string, repoName string, content *github.RepositoryContent) (*mqlGithubFile, error) {
+	isBinary := isBinaryFile(convert.ToValue(content.Type), convert.ToValue(content.Path))
 	res, err := CreateResource(runtime, "github.file", map[string]*llx.RawData{
 		"path":        llx.StringDataPtr(content.Path),
 		"name":        llx.StringDataPtr(content.Name),
@@ -1543,19 +1509,10 @@ func newMqlGithubFileDoesNotExist(runtime *plugin.Runtime, ownerName string, rep
 func (g *mqlGithubRepository) files() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 	_, dirContent, _, err := conn.Client().Repositories.GetContents(conn.Context(), ownerLogin, repoName, "", &github.RepositoryContentGetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -1604,6 +1561,12 @@ var binaryFileTypes = map[string]bool{
 }
 
 func (g *mqlGithubFile) id() (string, error) {
+	// Include the owner: repository names are unique only within an owner, and
+	// forks keep the name of their upstream repository.
+	if g.OwnerName.Error != nil {
+		return "", g.OwnerName.Error
+	}
+	o := g.OwnerName.Data
 	if g.RepoName.Error != nil {
 		return "", g.RepoName.Error
 	}
@@ -1616,7 +1579,7 @@ func (g *mqlGithubFile) id() (string, error) {
 		return "", g.Sha.Error
 	}
 	s := g.Sha.Data
-	return r + "/" + p + "/" + s, nil
+	return o + "/" + r + "/" + p + "/" + s, nil
 }
 
 func (g *mqlGithubFile) files() ([]any, error) {
@@ -1650,22 +1613,10 @@ func (g *mqlGithubFile) files() ([]any, error) {
 	}
 	res := []any{}
 	for i := range dirContent {
-		isBinary := false
-		if convert.ToValue(dirContent[i].Type) == "file" {
-			file := strings.Split(convert.ToValue(dirContent[i].Path), ".")
-			if len(file) == 2 {
-				isBinary = binaryFileTypes[file[1]]
-			}
-		}
-		mqlFile, err := CreateResource(g.MqlRuntime, "github.file", map[string]*llx.RawData{
-			"path":      llx.StringDataPtr(dirContent[i].Path),
-			"name":      llx.StringDataPtr(dirContent[i].Name),
-			"type":      llx.StringDataPtr(dirContent[i].Type),
-			"sha":       llx.StringDataPtr(dirContent[i].SHA),
-			"isBinary":  llx.BoolData(isBinary),
-			"ownerName": llx.StringData(ownerName),
-			"repoName":  llx.StringData(repoName),
-		})
+		// Build through the shared constructor so nested entries carry the same
+		// fields as top-level ones. Setting them here by hand left downloadUrl
+		// and exists unset, which reaches the client as a value with no type.
+		mqlFile, err := newMqlGithubFile(g.MqlRuntime, ownerName, repoName, dirContent[i])
 		if err != nil {
 			return nil, err
 		}
@@ -1721,19 +1672,10 @@ func (g *mqlGithubFile) content() (string, error) {
 
 func (g *mqlGithubRepository) forks() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.RepositoryListForksOptions{
 		ListOptions: github.ListOptions{
@@ -1771,19 +1713,10 @@ func (g *mqlGithubRepository) forks() ([]any, error) {
 
 func (g *mqlGithubRepository) stargazers() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.ListOptions{
 		PerPage: paginationPerPage,
@@ -1842,19 +1775,10 @@ func (g *mqlGithubRepository) closedIssues() ([]any, error) {
 
 func (g *mqlGithubRepository) getIssues(state string) ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.IssueListByRepoOptions{
 		State: state,
@@ -2013,19 +1937,10 @@ func newMqlGithubMilestone(runtime *plugin.Runtime, milestone *github.Milestone)
 
 func (g *mqlGithubRepository) milestones() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.MilestoneListOptions{
 		State: "all",
@@ -2104,19 +2019,10 @@ type mqlGithubRepositoryInternal struct {
 func (g *mqlGithubRepository) findSpecialFiles() error {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	specialDirectories := []string{".", ".github"}
 
@@ -2143,11 +2049,14 @@ func (g *mqlGithubRepository) findSpecialFiles() error {
 			if dirContent[i].GetType() != "file" {
 				continue
 			}
-			if _, ok := foundFiles[dirContent[i].GetName()]; ok {
+
+			// foundFiles is keyed lowercase; probe it the same way, otherwise
+			// which copy of a file wins depends on how the second one happens
+			// to be capitalized.
+			name := strings.ToLower(dirContent[i].GetName())
+			if _, ok := foundFiles[name]; ok {
 				continue
 			}
-
-			name := strings.ToLower(dirContent[i].GetName())
 			if _, ok := specialFilesCaseInsensitive[name]; ok {
 				v := specialFilesCaseInsensitive[name]
 				if v != nil {
@@ -2184,19 +2093,10 @@ func (g *mqlGithubDependabotAlert) id() (string, error) {
 
 func (g *mqlGithubRepository) dependabotAlerts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.ListAlertsOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -2253,6 +2153,7 @@ func (g *mqlGithubRepository) dependabotAlerts() ([]any, error) {
 		}
 
 		mqlAlert, err := CreateResource(g.MqlRuntime, "github.dependabotAlert", map[string]*llx.RawData{
+			"__id":                  llx.StringData(alertID("github.dependabotAlert", ownerLogin, repoName, int64(alert.GetNumber()))),
 			"number":                llx.IntData(int64(alert.GetNumber())),
 			"state":                 llx.StringData(alert.GetState()),
 			"severity":              llx.StringData(alert.GetSecurityVulnerability().GetSeverity()),
@@ -2288,19 +2189,10 @@ func (g *mqlGithubSecretScanningAlert) id() (string, error) {
 
 func (g *mqlGithubRepository) secretScanningAlerts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.SecretScanningAlertListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -2354,6 +2246,7 @@ func (g *mqlGithubRepository) secretScanningAlerts() ([]any, error) {
 		}
 
 		mqlAlert, err := CreateResource(g.MqlRuntime, "github.secretScanningAlert", map[string]*llx.RawData{
+			"__id":                     llx.StringData(alertID("github.secretScanningAlert", ownerLogin, repoName, int64(alert.GetNumber()))),
 			"number":                   llx.IntData(int64(alert.GetNumber())),
 			"state":                    llx.StringData(alert.GetState()),
 			"resolution":               llx.StringData(alert.GetResolution()),
@@ -2392,19 +2285,10 @@ func (g *mqlGithubCodeScanningAlert) id() (string, error) {
 
 func (g *mqlGithubRepository) codeScanningAlerts() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.AlertListOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -2473,6 +2357,7 @@ func (g *mqlGithubRepository) codeScanningAlerts() ([]any, error) {
 		}
 
 		mqlAlert, err := CreateResource(g.MqlRuntime, "github.codeScanningAlert", map[string]*llx.RawData{
+			"__id":               llx.StringData(alertID("github.codeScanningAlert", ownerLogin, repoName, int64(alert.GetNumber()))),
 			"number":             llx.IntData(int64(alert.GetNumber())),
 			"state":              llx.StringData(alert.GetState()),
 			"rule":               llx.DictData(rule),
@@ -2502,22 +2387,20 @@ func (g *mqlGithubRepository) codeScanningAlerts() ([]any, error) {
 func (g *mqlGithubRepository) spdxSbom() (*mqlGithubRepositorySbom, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	result, _, err := conn.Client().DependencyGraph.GetSBOM(conn.Context(), ownerLogin, repoName)
 	if err != nil {
+		// The dependency graph is not enabled on every repository, and reading
+		// it needs its own permission; both are a valid empty state.
+		if isAccessDeniedOrNotFound(err) {
+			log.Debug().Err(err).Msg("SPDX SBOM is not accessible for this repository")
+			g.SpdxSbom.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 	if result == nil || result.SBOM == nil {
@@ -2609,19 +2492,10 @@ func (g *mqlGithubRepositoryRuleset) id() (string, error) {
 func (g *mqlGithubRepository) rulesets() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.RepositoryListRulesetsOptions{
 		ListOptions: github.ListOptions{PerPage: paginationPerPage},
@@ -2702,18 +2576,10 @@ func (g *mqlGithubRepositoryActionsSettings) id() (string, error) {
 func (g *mqlGithubRepository) actionsSettings() (*mqlGithubRepositoryActionsSettings, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	perms, _, err := conn.Client().Repositories.GetActionsPermissions(conn.Context(), ownerLogin, repoName)
 	if err != nil {

--- a/providers/github/resources/github_repo_owner_test.go
+++ b/providers/github/resources/github_repo_owner_test.go
@@ -1,0 +1,130 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestRepoOwner(t *testing.T) {
+	owner := &mqlGithubUser{
+		Login: plugin.TValue[string]{Data: "mondoohq", State: plugin.StateIsSet},
+	}
+
+	t.Run("owner present", func(t *testing.T) {
+		repo := &mqlGithubRepository{
+			Name:  plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+			Owner: plugin.TValue[*mqlGithubUser]{Data: owner, State: plugin.StateIsSet},
+		}
+
+		got, err := repoOwner(repo)
+		require.NoError(t, err)
+		assert.Equal(t, owner, got)
+
+		ownerLogin, repoName, err := repoOwnerAndName(repo)
+		require.NoError(t, err)
+		assert.Equal(t, "mondoohq", ownerLogin)
+		assert.Equal(t, "cnquery", repoName)
+	})
+
+	// newMqlGithubRepository stores a null owner for repositories the API
+	// returned without one. Reading Owner.Data directly used to panic here.
+	t.Run("owner explicitly null", func(t *testing.T) {
+		repo := &mqlGithubRepository{
+			Name:  plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+			Owner: plugin.TValue[*mqlGithubUser]{State: plugin.StateIsSet | plugin.StateIsNull},
+		}
+
+		_, err := repoOwner(repo)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cnquery")
+
+		_, _, err = repoOwnerAndName(repo)
+		require.Error(t, err)
+	})
+
+	// reposToMql builds repositories from a partial response, which leaves the
+	// owner unset rather than null.
+	t.Run("owner never set", func(t *testing.T) {
+		repo := &mqlGithubRepository{
+			Name: plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+		}
+
+		_, err := repoOwner(repo)
+		require.Error(t, err)
+	})
+
+	t.Run("owner carries an error", func(t *testing.T) {
+		boom := errors.New("boom")
+		repo := &mqlGithubRepository{
+			Name:  plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+			Owner: plugin.TValue[*mqlGithubUser]{Error: boom, State: plugin.StateIsSet},
+		}
+
+		_, err := repoOwner(repo)
+		assert.Equal(t, boom, err)
+	})
+}
+
+func TestMergeRequestRepo(t *testing.T) {
+	// owner is the pull request's author; repoOwnerLogin is the account that
+	// holds the repository. Only the latter addresses the API correctly.
+	t.Run("uses the repository owner", func(t *testing.T) {
+		mr := &mqlGithubMergeRequest{
+			RepoName:       plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+			RepoOwnerLogin: plugin.TValue[string]{Data: "mondoohq", State: plugin.StateIsSet},
+			Owner: plugin.TValue[*mqlGithubUser]{
+				Data:  &mqlGithubUser{Login: plugin.TValue[string]{Data: "some-contributor", State: plugin.StateIsSet}},
+				State: plugin.StateIsSet,
+			},
+		}
+
+		ownerLogin, repoName, err := mergeRequestRepo(mr)
+		require.NoError(t, err)
+		assert.Equal(t, "mondoohq", ownerLogin)
+		assert.Equal(t, "cnquery", repoName)
+	})
+
+	t.Run("missing repository owner errors", func(t *testing.T) {
+		mr := &mqlGithubMergeRequest{
+			RepoName: plugin.TValue[string]{Data: "cnquery", State: plugin.StateIsSet},
+		}
+
+		_, _, err := mergeRequestRepo(mr)
+		require.Error(t, err)
+	})
+}
+
+func TestIsBinaryFile(t *testing.T) {
+	tests := []struct {
+		fileType string
+		path     string
+		want     bool
+	}{
+		{"file", "app.exe", true},
+		{"file", "tools/app.exe", true},
+		// Regression: splitting the whole path on "." classified anything under
+		// a dotted directory as non-binary.
+		{"file", "v1.2/tool.exe", true},
+		{"file", ".github/helper.exe", true},
+		{"file", "dist/lib.so", true},
+		{"file", "README.md", false},
+		{"file", "Makefile", false},
+		{"file", "archive.tar.gz", false},
+		// Directories are never binaries, whatever they are named.
+		{"dir", "vendor.exe", false},
+		{"", "app.exe", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path+"/"+tt.fileType, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBinaryFile(tt.fileType, tt.path))
+		})
+	}
+}

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -30,6 +30,14 @@ type ghRunnerExt struct {
 	Labels       []*github.RunnerLabels `json:"labels,omitempty"`
 }
 
+// idValue returns the runner id, or 0 when the API omitted it.
+func (r *ghRunnerExt) idValue() int64 {
+	if r == nil || r.ID == nil {
+		return 0
+	}
+	return *r.ID
+}
+
 type ghRunnersListResp struct {
 	TotalCount int            `json:"total_count"`
 	Runners    []*ghRunnerExt `json:"runners"`
@@ -79,6 +87,7 @@ func (g *mqlGithubOrganization) runners() ([]any, error) {
 	}
 	orgLogin := g.Login.Data
 
+	scope := "orgs/" + orgLogin
 	allRunners, err := listRunnersRaw(conn.Context(), conn.Client(), fmt.Sprintf("orgs/%s/actions/runners", orgLogin))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -91,28 +100,19 @@ func (g *mqlGithubOrganization) runners() ([]any, error) {
 		return nil, err
 	}
 
-	return runnersToMql(g.MqlRuntime, allRunners)
+	return runnersToMql(g.MqlRuntime, scope, allRunners)
 }
 
 // runners returns the self-hosted runners for a repository.
 func (g *mqlGithubRepository) runners() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
 
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
 
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
-
+	scope := "repos/" + ownerLogin + "/" + repoName
 	allRunners, err := listRunnersRaw(conn.Context(), conn.Client(), fmt.Sprintf("repos/%s/%s/actions/runners", ownerLogin, repoName))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -125,16 +125,32 @@ func (g *mqlGithubRepository) runners() ([]any, error) {
 		return nil, err
 	}
 
-	return runnersToMql(g.MqlRuntime, allRunners)
+	return runnersToMql(g.MqlRuntime, scope, allRunners)
 }
 
-// runnersToMql converts a list of GitHub runners to MQL resources.
-func runnersToMql(runtime *plugin.Runtime, runners []*ghRunnerExt) ([]any, error) {
+// runnerID keys a runner by the scope that registered it. Organization and
+// repository runners are numbered independently, so an unqualified id aliased an
+// org runner with a repository runner that happened to share a number.
+func runnerID(scope string, id int64) string {
+	return "github.runner/" + scope + "/" + strconv.FormatInt(id, 10)
+}
+
+// runnerLabelID keys a label by runner and name. Read-only labels ("self-hosted",
+// "linux", ...) share fixed ids across every runner, and the API omits the id for
+// some custom labels, which collapsed those labels onto a single resource.
+func runnerLabelID(scope string, runner int64, name string) string {
+	return "github.runnerLabel/" + scope + "/" + strconv.FormatInt(runner, 10) + "/" + name
+}
+
+// runnersToMql converts a list of GitHub runners to MQL resources. scope is the
+// API path prefix the runners were listed from, used to key them.
+func runnersToMql(runtime *plugin.Runtime, scope string, runners []*ghRunnerExt) ([]any, error) {
 	res := []any{}
 	for _, runner := range runners {
 		labels := []any{}
 		for _, label := range runner.Labels {
 			labelRes, err := CreateResource(runtime, "github.runnerLabel", map[string]*llx.RawData{
+				"__id": llx.StringData(runnerLabelID(scope, runner.idValue(), label.GetName())),
 				"id":   llx.IntDataDefault(label.ID, 0),
 				"name": llx.StringDataPtr(label.Name),
 				"type": llx.StringDataPtr(label.Type),
@@ -146,6 +162,7 @@ func runnersToMql(runtime *plugin.Runtime, runners []*ghRunnerExt) ([]any, error
 		}
 
 		r, err := CreateResource(runtime, "github.runner", map[string]*llx.RawData{
+			"__id":         llx.StringData(runnerID(scope, runner.idValue())),
 			"id":           llx.IntDataDefault(runner.ID, 0),
 			"name":         llx.StringDataPtr(runner.Name),
 			"os":           llx.StringDataPtr(runner.OS),

--- a/providers/github/resources/github_runners.go
+++ b/providers/github/resources/github_runners.go
@@ -128,29 +128,46 @@ func (g *mqlGithubRepository) runners() ([]any, error) {
 	return runnersToMql(g.MqlRuntime, scope, allRunners)
 }
 
+// runnerKey identifies a runner within its scope. The id is the natural key, but
+// it is a pointer in the API payload: falling back to a shared zero would alias
+// every id-less runner onto one resource, so the name (unique per scope) and
+// finally the listing position stand in for it.
+func runnerKey(runner *ghRunnerExt, idx int) string {
+	if id := runner.idValue(); id != 0 {
+		return strconv.FormatInt(id, 10)
+	}
+	if name := runner.Name; name != nil && *name != "" {
+		return "name/" + *name
+	}
+	log.Warn().Int("position", idx).Msg("github runner has neither an id nor a name, keying it by listing position")
+	return "position/" + strconv.Itoa(idx)
+}
+
 // runnerID keys a runner by the scope that registered it. Organization and
 // repository runners are numbered independently, so an unqualified id aliased an
 // org runner with a repository runner that happened to share a number.
-func runnerID(scope string, id int64) string {
-	return "github.runner/" + scope + "/" + strconv.FormatInt(id, 10)
+func runnerID(scope string, key string) string {
+	return "github.runner/" + scope + "/" + key
 }
 
 // runnerLabelID keys a label by runner and name. Read-only labels ("self-hosted",
 // "linux", ...) share fixed ids across every runner, and the API omits the id for
 // some custom labels, which collapsed those labels onto a single resource.
-func runnerLabelID(scope string, runner int64, name string) string {
-	return "github.runnerLabel/" + scope + "/" + strconv.FormatInt(runner, 10) + "/" + name
+func runnerLabelID(scope string, runnerKey string, name string) string {
+	return "github.runnerLabel/" + scope + "/" + runnerKey + "/" + name
 }
 
 // runnersToMql converts a list of GitHub runners to MQL resources. scope is the
 // API path prefix the runners were listed from, used to key them.
 func runnersToMql(runtime *plugin.Runtime, scope string, runners []*ghRunnerExt) ([]any, error) {
 	res := []any{}
-	for _, runner := range runners {
+	for idx, runner := range runners {
+		key := runnerKey(runner, idx)
+
 		labels := []any{}
 		for _, label := range runner.Labels {
 			labelRes, err := CreateResource(runtime, "github.runnerLabel", map[string]*llx.RawData{
-				"__id": llx.StringData(runnerLabelID(scope, runner.idValue(), label.GetName())),
+				"__id": llx.StringData(runnerLabelID(scope, key, label.GetName())),
 				"id":   llx.IntDataDefault(label.ID, 0),
 				"name": llx.StringDataPtr(label.Name),
 				"type": llx.StringDataPtr(label.Type),
@@ -162,7 +179,7 @@ func runnersToMql(runtime *plugin.Runtime, scope string, runners []*ghRunnerExt)
 		}
 
 		r, err := CreateResource(runtime, "github.runner", map[string]*llx.RawData{
-			"__id":         llx.StringData(runnerID(scope, runner.idValue())),
+			"__id":         llx.StringData(runnerID(scope, key)),
 			"id":           llx.IntDataDefault(runner.ID, 0),
 			"name":         llx.StringDataPtr(runner.Name),
 			"os":           llx.StringDataPtr(runner.OS),

--- a/providers/github/resources/github_security.go
+++ b/providers/github/resources/github_security.go
@@ -906,18 +906,10 @@ func (g *mqlGithubDeployKey) repository() (*mqlGithubRepository, error) {
 
 func (g *mqlGithubRepository) deployKeys() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	listOpts := &github.ListOptions{PerPage: paginationPerPage}
 	var allKeys []*github.Key
@@ -1050,6 +1042,13 @@ func (g *mqlGithubCodeownersRule) id() (string, error) {
 	return fmt.Sprintf("github.codeowners.rule/%s/%d", g.Pattern.Data, g.LineNumber.Data), nil
 }
 
+// codeownersRuleID keys a CODEOWNERS rule by repository. Patterns repeat across
+// repositories (`*` on line 1 is near-universal), so an unqualified key made
+// every repository after the first report the first one's owners.
+func codeownersRuleID(ownerLogin, repoName, pattern string, lineNumber int) string {
+	return fmt.Sprintf("github.codeowners.rule/%s/%s/%s/%d", ownerLogin, repoName, pattern, lineNumber)
+}
+
 // codeownersCandidatePaths returns the locations CODEOWNERS may live at, in
 // resolution priority order.
 var codeownersCandidatePaths = []string{
@@ -1108,18 +1107,10 @@ func parseCodeowners(content string) []codeownersRule {
 
 func (g *mqlGithubRepository) codeowners() (*mqlGithubRepositoryCodeowners, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GithubConnection)
-	if g.Name.Error != nil {
-		return nil, g.Name.Error
+	ownerLogin, repoName, err := repoOwnerAndName(g)
+	if err != nil {
+		return nil, err
 	}
-	repoName := g.Name.Data
-	if g.Owner.Error != nil {
-		return nil, g.Owner.Error
-	}
-	owner := g.Owner.Data
-	if owner.Login.Error != nil {
-		return nil, owner.Login.Error
-	}
-	ownerLogin := owner.Login.Data
 
 	resID := llx.StringData(fmt.Sprintf("github.repository.codeowners/%s/%s", ownerLogin, repoName))
 
@@ -1147,6 +1138,7 @@ func (g *mqlGithubRepository) codeowners() (*mqlGithubRepositoryCodeowners, erro
 	rules := []any{}
 	for _, r := range parseCodeowners(content) {
 		rr, err := CreateResource(g.MqlRuntime, "github.codeowners.rule", map[string]*llx.RawData{
+			"__id":       llx.StringData(codeownersRuleID(ownerLogin, repoName, r.pattern, r.lineNumber)),
 			"pattern":    llx.StringData(r.pattern),
 			"owners":     llx.ArrayData(convert.SliceAnyToInterface[string](r.owners), types.String),
 			"lineNumber": llx.IntData(int64(r.lineNumber)),

--- a/providers/github/resources/github_user.go
+++ b/providers/github/resources/github_user.go
@@ -4,7 +4,9 @@
 package resources
 
 import (
+	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -280,6 +282,13 @@ func (g *mqlGithubGistfile) content() (string, error) {
 	resp, err := ranger.DefaultHttpClient().Get(rawUrl)
 	if err != nil {
 		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Without this check an error page's body would be handed back as the
+		// file's content.
+		return "", fmt.Errorf("could not fetch gist file %s: %s", rawUrl, resp.Status)
 	}
 
 	data, err := io.ReadAll(resp.Body)

--- a/providers/github/resources/github_workflow.go
+++ b/providers/github/resources/github_workflow.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-github/v89/github"
 	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers/github/connection"
 	"sigs.k8s.io/yaml"
@@ -31,7 +32,9 @@ func (g *mqlGithubWorkflow) configuration() (any, error) {
 	}
 	file := fileTValue.Data
 	if file == nil {
-		return nil, errors.New("workflow file not found")
+		// The workflow file is not on the default branch; there is no
+		// configuration to parse.
+		return nil, nil
 	}
 
 	contentTValue := file.GetContent()
@@ -98,8 +101,12 @@ func (g *mqlGithubWorkflow) file() (*mqlGithubFile, error) {
 			Str("branch", defaultBranch).
 			Msg("failed to get workflow file contents")
 
+		// A workflow can be registered from a branch other than the default
+		// one, in which case the file is not there to read. Report that as a
+		// null file rather than failing the query.
 		if strings.Contains(err.Error(), "404") {
-			return nil, errors.New("file not found, got 404")
+			g.File.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Static bug review of the `github` provider (v13.7.4, go-github v89). These are the defects that reach users as **wrong data with no error** — the worst kind, because the wrong answer looks valid.

## Silent wrong data

**`git.commit.committer` was always the commit's author.** `git.commitAuthor.id()` returned `git.commitAuthor/<sha>`, and both the author and the committer of a commit were created with that same key. `CreateResource` returns the cached resource on a key hit and discards the new data, so the committer resource *was* the author resource. Any check comparing author against committer, or asserting the committer is a corporate identity, was reading the wrong field and passing. The key now carries the role.

**`github.mergeRequest.commits` and `.reviews` came back empty for almost every pull request.** Both passed `mergeRequest.owner` — the account that *authored* the PR — as the repository owner. On an organization repository that addresses `alice/cnquery`, which does not exist; the API 404s and both accessors treat a 404 as "nothing here". Adds a `repoOwnerLogin` field, populated from the repository the PRs were listed from, and looks the repository up with that.

**Per-repository resources aliased each other across repositories.** Their cache keys were unique only *within* a repository, but an org-scoped asset traverses many repositories in one runtime, so the first repository's resource was returned for every later one:

| resource | collided on |
|---|---|
| `github.collaborator` | the same user on two repos → second repo reported the first's permissions |
| `github.codeowners.rule` | `*` on line 1 is near-universal → wrong owners |
| `github.dependabotAlert` / `secretScanningAlert` / `codeScanningAlert` | alert numbers restart at 1 per repository |
| `github.branch`, `github.branchprotection`, `github.file` | forks keep the name of their upstream repository |
| `github.runner`, `github.runnerLabel` | org and repo runners are numbered independently |

**Repositories discovered through a user scope could not be scanned.** The user path emitted repo assets carrying neither `owner` nor `organization`, so `initGithubRepository` failed on every one with `no user and no org specified`. One-line fix in discovery; the org path was unaffected because it keeps `organization` in the config.

**`--discover users` skipped members with no profile name** — a large share of GitHub accounts leave it blank. Falls back to the login.

**Nested `github.file.files()` left `exists` and `downloadUrl` unset**, which crosses the plugin boundary as a value with no type information. Now built through the shared constructor.

**`isBinary` was wrong for any dotted path.** It split the whole path on `.` and required exactly two parts, so `v1.2/tool.exe` and `.github/helper.exe` were never binaries. Uses the file extension.

## Panics

**36 accessors dereferenced `repository.owner` without a nil check** — while the provider itself stores a null owner for fork entries, and `reposToMql` builds repositories from a partial response that never sets one. `headCommit` had the guard (with a comment explaining the hazard); nothing else did. All now route through a shared `repoOwner` helper.

**`github.deployment.creator` / `github.deploymentStatus.creator` stored a typed nil.** `RawToTValue` treats a typed nil pointer as set-and-not-null, so serializing the field called `MqlID()` on a nil receiver.

## Robustness and cost

- `github.package.repository`, `github.workflow.file` and `github.repository.spdxSbom` report a legitimately absent value as null instead of failing the query. Registry packages are often not attached to a repository, and `repository.repository.fullName` is in the package's `@defaults`, so a repo-less package used to error on a bare listing.
- The organization audit log was read into memory unbounded (cursor-paged with no filter). It stops at a page limit and logs that the result is truncated.
- Commits were refetched whenever the author was nil — exactly the case where the detail endpoint also returns null. One wasted API call per commit whose email is not linked to a GitHub account.
- Gist file contents leaked the response body and returned an error page's body as file content.
- The special-files scan probed a lowercase-keyed set with the original casing, so whether the root or the `.github` copy of `SECURITY.md` won depended on capitalization.
- `initGithubRepository` cached a user under the degenerate key `github.user/0` (shadowing that user for the rest of the scan) and looked the repository up under the organization name even on the user-fallback path.

## Verified clean

Pagination is correct throughout — ~40 list loops all page on `resp.NextPage` at 100/page, the GraphQL IP-allow-list follows `pageInfo.hasNextPage`, and the raw runner/audit-log fetches follow their cursors. No stub or placeholder data, no bare type assertions on runtime data, no range-variable pointer capture. The `types.Any` passed to `llx.ArrayData` for `[]dict` fields is harmless: the generated getter re-stamps the declared schema type.

## Tests

15 new unit tests over the pure-Go logic this touches — the cache-key builders (each asserting that two things which can coexist in one scan do not share a key), the owner guard across its null/unset/error cases, the binary-file check, and the IaC tree classifier, which is extracted from the API call so it can be tested at all. `go test ./resources/ ./connection/ ./provider/` passes; `make providers/build/github` is clean.

Not live-verified against a real org — happy to run the provider-verification pass if you'd like that before merge.
