### PR TITLE
🐛 gitlab: fix cross-project __id collisions, fabricated fields, and discovery duplication

### DIFF
--- a/providers/gitlab/connection/connection.go
+++ b/providers/gitlab/connection/connection.go
@@ -5,11 +5,11 @@ package connection
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
 	"strconv"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -41,15 +41,21 @@ func NewGitLabConnection(id uint32, asset *inventory.Asset, conf *inventory.Conf
 		token = os.Getenv("GITLAB_TOKEN")
 	}
 
-	// if a secret was provided, it always overrides the env variable since it has precedence
+	// If credentials were supplied they are authoritative — falling back to the
+	// option/env token when the only credential is one we can't use would
+	// silently scan as a different account than the inventory asked for.
 	if len(conf.Credentials) > 0 {
+		token = ""
 		for i := range conf.Credentials {
 			cred := conf.Credentials[i]
 			if cred.Type == vault.CredentialType_password {
 				token = string(cred.Secret)
-			} else {
-				log.Warn().Str("credential-type", cred.Type.String()).Msg("unsupported credential type for GitLab provider")
+				break
 			}
+			log.Warn().Str("credential-type", cred.Type.String()).Msg("unsupported credential type for GitLab provider")
+		}
+		if token == "" {
+			return nil, errors.New("gitlab provider requires a password/token credential, but none of the supplied credentials are usable")
 		}
 	}
 
@@ -118,30 +124,21 @@ func (c *GitLabConnection) Group() (*gitlab.Group, error) {
 	}
 	log.Debug().Str("id", gid).Msgf("finding group")
 
-	if c.groupID == "" {
-		// if group name has a slash, we know its a subgroup
-		if names := strings.Split(c.groupName, "/"); len(names) > 1 {
-			return c.findSubgroup(names[0], names[1])
-		}
-	}
-
+	// A full path ("acme/platform/api") is a valid group id for this endpoint:
+	// the SDK URL-escapes it for us, so nested groups resolve in one call. The
+	// previous subgroup traversal matched on the group's *display* name rather
+	// than its path (so a group renamed away from its slug was unreachable)
+	// and kept only the first two path segments, silently resolving "a/b" when
+	// the caller asked for "a/b/c".
 	var err error
 	c.group, _, err = c.Client().Groups.GetGroup(gid, nil)
-	return c.group, err
-}
-
-func (c *GitLabConnection) findSubgroup(parentId string, name string) (*gitlab.Group, error) {
-	log.Debug().Msgf("find subgroup for %s %s", parentId, name)
-	groups, err := DiscoverSubAndDescendantGroupsForGroup(c, parentId)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot find gitlab group %q: %w", gid, err)
 	}
-	for i := range groups {
-		if name == groups[i].Name {
-			return groups[i], nil
-		}
+	if c.group == nil {
+		return nil, fmt.Errorf("gitlab group %q not found", gid)
 	}
-	return nil, errors.New("not found")
+	return c.group, nil
 }
 
 func (c *GitLabConnection) IsGroup() bool {
@@ -189,21 +186,53 @@ func (c *GitLabConnection) Project() (*gitlab.Project, error) {
 	return c.project, err
 }
 
+// DiscoverSubAndDescendantGroupsForGroup returns every group beneath rootGroup.
+//
+// GitLab's descendant_groups endpoint already returns direct children as well
+// as deeper ones, so the two result sets overlap; entries are deduplicated by
+// id. Without that, every direct subgroup was discovered twice, which in turn
+// made discoverGroupProjects walk each of their project lists twice.
+//
+// A failure is surfaced rather than swallowed at debug level: a token that
+// cannot read subgroups previously produced an empty tree that was
+// indistinguishable from a group that genuinely has none, and the caller's
+// error handling was unreachable because this always returned a nil error.
 func DiscoverSubAndDescendantGroupsForGroup(conn *GitLabConnection, rootGroup string) ([]*gitlab.Group, error) {
 	var list []*gitlab.Group
+	var errs []error
+	seen := map[int64]bool{}
+
+	appendUnique := func(groups []*gitlab.Group) {
+		for _, g := range groups {
+			if g == nil || seen[g.ID] {
+				continue
+			}
+			seen[g.ID] = true
+			list = append(list, g)
+		}
+	}
+
 	// discover subgroups
 	subgroups, err := groupSubgroups(conn, rootGroup)
 	if err != nil {
-		log.Debug().Err(err).Msgf("cannot discover subgroups for %v", rootGroup)
+		log.Warn().Err(err).Msgf("cannot discover subgroups for %v; results may be incomplete", rootGroup)
+		errs = append(errs, err)
 	} else {
-		list = append(list, subgroups...)
+		appendUnique(subgroups)
 	}
 	// discover descendant groups
 	descgroups, err := groupDescendantGroups(conn, rootGroup)
 	if err != nil {
-		log.Debug().Err(err).Msgf("cannot discover descendant groups for %v", rootGroup)
+		log.Warn().Err(err).Msgf("cannot discover descendant groups for %v; results may be incomplete", rootGroup)
+		errs = append(errs, err)
 	} else {
-		list = append(list, descgroups...)
+		appendUnique(descgroups)
+	}
+
+	// Only a total failure is fatal: if either endpoint answered we still have
+	// a usable (if partial) tree, and the warnings above say so.
+	if len(list) == 0 && len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 	return list, nil
 }

--- a/providers/gitlab/connection/connection_test.go
+++ b/providers/gitlab/connection/connection_test.go
@@ -1,30 +1,139 @@
 // Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build debugtest
-// +build debugtest
-
 package connection
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
 
-func TestGitlab(t *testing.T) {
-	p, err := New(&inventory.Config{
-		Options: map[string]string{
-			"token": "<add-token-here>",
-			"group": "mondoolabs",
-		},
-	})
-	require.NoError(t, err)
+func testConfig(options map[string]string, creds ...*vault.Credential) *inventory.Config {
+	if options == nil {
+		options = map[string]string{}
+	}
+	return &inventory.Config{Options: options, Credentials: creds}
+}
 
-	id, err := p.Identifier()
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(id, "//platformid.api.mondoo.app/runtime/gitlab/group/"))
+func TestNewGitLabConnectionCredentials(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "")
+
+	t.Run("token option is accepted", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"token": "opt-token", "group": "acme"}))
+		require.NoError(t, err)
+		assert.True(t, conn.IsGroup())
+		assert.False(t, conn.IsProject())
+	})
+
+	t.Run("env token is used when no option is set", func(t *testing.T) {
+		t.Setenv("GITLAB_TOKEN", "env-token")
+		_, err := NewGitLabConnection(1, &inventory.Asset{}, testConfig(map[string]string{"group": "acme"}))
+		require.NoError(t, err)
+	})
+
+	t.Run("missing token is an error", func(t *testing.T) {
+		_, err := NewGitLabConnection(1, &inventory.Asset{}, testConfig(nil))
+		require.Error(t, err)
+	})
+
+	t.Run("password credential is used", func(t *testing.T) {
+		_, err := NewGitLabConnection(1, &inventory.Asset{}, testConfig(
+			map[string]string{"group": "acme"},
+			&vault.Credential{Type: vault.CredentialType_password, Secret: []byte("cred-token")},
+		))
+		require.NoError(t, err)
+	})
+
+	t.Run("an unusable credential does not silently fall back to the env token", func(t *testing.T) {
+		// Supplying a credential the provider cannot use previously left the
+		// env/option token in place, so the scan ran as a different account
+		// than the inventory asked for — with only a warning in the log.
+		t.Setenv("GITLAB_TOKEN", "env-token")
+		_, err := NewGitLabConnection(1, &inventory.Asset{}, testConfig(
+			map[string]string{"group": "acme"},
+			&vault.Credential{Type: vault.CredentialType_private_key, Secret: []byte("nope")},
+		))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential")
+	})
+}
+
+func TestGroupID(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "token")
+
+	tests := []struct {
+		name    string
+		groupID string
+		want    int64
+	}{
+		{"numeric id", "42", 42},
+		{"unset", "", 0},
+		{"non-numeric", "acme", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := NewGitLabConnection(1, &inventory.Asset{},
+				testConfig(map[string]string{"group": "acme", "group-id": tt.groupID}))
+			require.NoError(t, err)
+			// GroupID swallows a parse failure and reports 0. Callers that
+			// build asset platform ids must not rely on it — see
+			// Service.detect, which resolves the real group instead.
+			assert.Equal(t, tt.want, conn.GroupID())
+		})
+	}
+}
+
+func TestPID(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "token")
+
+	t.Run("project-id wins", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"group": "acme", "project": "api", "project-id": "77"}))
+		require.NoError(t, err)
+		pid, err := conn.PID()
+		require.NoError(t, err)
+		assert.Equal(t, "77", pid)
+	})
+
+	t.Run("falls back to group/project path", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"group": "acme/platform", "project": "api"}))
+		require.NoError(t, err)
+		pid, err := conn.PID()
+		require.NoError(t, err)
+		assert.Equal(t, "acme/platform/api", pid)
+	})
+
+	t.Run("missing project is an error", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"group": "acme"}))
+		require.NoError(t, err)
+		_, err = conn.PID()
+		require.Error(t, err)
+	})
+}
+
+func TestIsGroupIsProject(t *testing.T) {
+	t.Setenv("GITLAB_TOKEN", "token")
+
+	t.Run("project-id alone marks a project", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"project-id": "77"}))
+		require.NoError(t, err)
+		assert.True(t, conn.IsProject())
+		assert.False(t, conn.IsGroup())
+	})
+
+	t.Run("nested group path is still a group", func(t *testing.T) {
+		conn, err := NewGitLabConnection(1, &inventory.Asset{},
+			testConfig(map[string]string{"group": "acme/platform/api"}))
+		require.NoError(t, err)
+		assert.True(t, conn.IsGroup())
+		assert.Equal(t, "acme/platform/api", conn.GroupName())
+	})
 }

--- a/providers/gitlab/provider/discovery.go
+++ b/providers/gitlab/provider/discovery.go
@@ -4,7 +4,11 @@
 package provider
 
 import (
-	"path/filepath"
+	// GitLab tree paths are always "/"-separated, so they must be manipulated
+	// with the "path" package. path/filepath rewrites separators on Windows,
+	// which produced backslash directory options that the chained helm and
+	// kustomize connections then failed to resolve inside the clone.
+	gopath "path"
 	"strconv"
 	"strings"
 
@@ -130,12 +134,17 @@ func (s *Service) discoverGroups(root *inventory.Asset, conn *connection.GitLabC
 		}
 		groups := []*gitlab.Group{group}
 		assets := []*inventory.Asset{}
-		if names := strings.Split(group.Name, "/"); len(names) > 1 {
+		// A subgroup is identified by FullPath having more than one segment;
+		// Group.Name is a display name and never carries the "/", so this
+		// guard used to never fire. FullPath is also what the subgroup
+		// endpoints need — Path is only the leaf slug, which GitLab resolves
+		// at the root namespace and could match an unrelated top-level group.
+		if isSubgroup(group) {
 			log.Debug().Msg("skipping subgroup discovery for subgroup")
 			return assets, groups, nil
 		}
 		// discover subgroups and descendant groups
-		subgroups, err := connection.DiscoverSubAndDescendantGroupsForGroup(conn, group.Path)
+		subgroups, err := connection.DiscoverSubAndDescendantGroupsForGroup(conn, group.FullPath)
 		if err != nil {
 			log.Error().Err(err).Msg("unable to discover sub groups")
 			return []*inventory.Asset{}, []*gitlab.Group{group}, err
@@ -150,7 +159,7 @@ func (s *Service) discoverGroups(root *inventory.Asset, conn *connection.GitLabC
 		return nil, nil, err
 	}
 
-	conf := conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))
+	conf := conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
 	conf.Type = GitlabGroupConnection
 	conf.Options = map[string]string{
 		"group":    group.FullPath,
@@ -165,12 +174,12 @@ func (s *Service) discoverGroups(root *inventory.Asset, conn *connection.GitLabC
 
 	groups := []*gitlab.Group{group}
 	assets := []*inventory.Asset{asset}
-	if names := strings.Split(group.Name, "/"); len(names) > 1 {
+	if isSubgroup(group) {
 		log.Debug().Msg("skipping subgroup discovery for subgroup")
 		return assets, groups, nil
 	}
 	// discover subgroups and descendant groups
-	subgroups, err := connection.DiscoverSubAndDescendantGroupsForGroup(conn, group.Path)
+	subgroups, err := connection.DiscoverSubAndDescendantGroupsForGroup(conn, group.FullPath)
 	if err != nil {
 		log.Error().Err(err).Msg("unable to discover sub groups")
 		return []*inventory.Asset{}, []*gitlab.Group{group}, err
@@ -199,11 +208,26 @@ func (s *Service) discoverProjects(root *inventory.Asset, conn *connection.GitLa
 
 		for j := range groupProjects {
 			project := groupProjects[j]
-			conf := conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))
+			if projects[project.ID] != nil {
+				continue
+			}
+
+			// Attribute the project to the namespace that owns it, not the
+			// group we happened to enumerate. GitLab's group projects endpoint
+			// includes projects merely *shared* into the group, and stamping
+			// those with the sharing group produced a second, disjoint set of
+			// platform ids for the same repository — so it was discovered,
+			// scanned, and reported twice.
+			ownerID, ownerPath := group.ID, group.FullPath
+			if project.Namespace != nil && project.Namespace.ID > 0 {
+				ownerID, ownerPath = project.Namespace.ID, project.Namespace.FullPath
+			}
+
+			conf := conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
 			conf.Type = GitlabProjectConnection
 			conf.Options = map[string]string{
-				"group":      group.FullPath,
-				"group-id":   strconv.FormatInt(group.ID, 10),
+				"group":      ownerPath,
+				"group-id":   strconv.FormatInt(ownerID, 10),
 				"project":    project.Name,
 				"project-id": strconv.FormatInt(project.ID, 10),
 				"url":        conn.Conf.Options["url"],
@@ -213,10 +237,7 @@ func (s *Service) discoverProjects(root *inventory.Asset, conn *connection.GitLa
 				Connections: []*inventory.Config{conf},
 			}
 
-			s.detectAsProject(asset, group.ID, group.FullPath, project)
-			if err != nil {
-				return nil, nil, err
-			}
+			s.detectAsProject(asset, ownerID, ownerPath, project)
 
 			assets = append(assets, asset)
 			projects[project.ID] = project
@@ -254,13 +275,16 @@ func (s *Service) convertGitlabGroupsToAssetGroups(groups []*gitlab.Group, conn 
 	var list []*inventory.Asset
 	// convert to assets
 	for _, group := range groups {
-		conf := conn.Conf.Clone(inventory.WithParentConnectionId(conn.ID()))
-		if conf.Options == nil {
-			conf.Options = map[string]string{}
+		conf := conn.Conf.Clone(inventory.WithoutDiscovery(), inventory.WithParentConnectionId(conn.ID()))
+		// Replace the map wholesale rather than merging into the parent's: a
+		// root config carrying --project would otherwise leave "project" set on
+		// every discovered group asset, so IsProject() reports true for a group
+		// and the connection resolves the wrong thing entirely.
+		conf.Options = map[string]string{
+			"group":    group.FullPath,
+			"group-id": strconv.FormatInt(group.ID, 10),
+			"url":      conn.Conf.Options["url"],
 		}
-		conf.Options["group"] = group.FullPath
-		conf.Options["group-id"] = strconv.FormatInt(group.ID, 10)
-		conf.Options["url"] = conn.Conf.Options["url"]
 		conf.Type = GitlabGroupConnection
 		asset := &inventory.Asset{
 			Connections: []*inventory.Config{conf},
@@ -472,7 +496,7 @@ func discoverRepoTypes(client *gitlab.Client, pid any) (*discoveredTypes, error)
 			continue
 		}
 
-		base := filepath.Base(node.Path)
+		base := gopath.Base(node.Path)
 		switch {
 		case strings.HasSuffix(node.Path, ".tf"):
 			out.terraform = true
@@ -520,7 +544,7 @@ func cloudformationTemplatePaths(client *gitlab.Client, pid any) ([]string, erro
 			if isHiddenPath(blob.Path) || seen[blob.Path] {
 				continue
 			}
-			switch strings.ToLower(filepath.Ext(blob.Path)) {
+			switch strings.ToLower(gopath.Ext(blob.Path)) {
 			case ".yaml", ".yml", ".json", ".template":
 				seen[blob.Path] = true
 				paths = append(paths, blob.Path)
@@ -560,13 +584,20 @@ func isHiddenPath(p string) bool {
 }
 
 // iacDir returns the repo-relative directory containing the given file, with a
-// top-level file ("." from filepath.Dir) normalized to "" so it joins onto the
+// top-level file ("." from path.Dir) normalized to "" so it joins onto the
 // clone root cleanly.
-func iacDir(path string) string {
-	if dir := filepath.Dir(path); dir != "." {
+func iacDir(p string) string {
+	if dir := gopath.Dir(p); dir != "." {
 		return dir
 	}
 	return ""
+}
+
+// isSubgroup reports whether a group is nested under another group. GitLab
+// group names are display names and never contain a "/", so the nesting has to
+// be read off FullPath.
+func isSubgroup(group *gitlab.Group) bool {
+	return strings.Contains(group.FullPath, "/")
 }
 
 // isDockerfile reports whether a base file name follows a Dockerfile naming

--- a/providers/gitlab/provider/discovery_test.go
+++ b/providers/gitlab/provider/discovery_test.go
@@ -1,0 +1,97 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+func TestIsSubgroup(t *testing.T) {
+	// GitLab group names are display names and never contain a "/", so the
+	// nesting has to be read off FullPath. Testing Name instead meant the
+	// "skip subgroup discovery for a subgroup" guard never fired.
+	tests := []struct {
+		name  string
+		group *gitlab.Group
+		want  bool
+	}{
+		{"top-level group", &gitlab.Group{Name: "acme", Path: "acme", FullPath: "acme"}, false},
+		{"subgroup", &gitlab.Group{Name: "platform", Path: "platform", FullPath: "acme/platform"}, true},
+		{"deeply nested", &gitlab.Group{Name: "api", Path: "api", FullPath: "acme/platform/api"}, true},
+		{
+			"display name differs from path",
+			&gitlab.Group{Name: "Platform Team", Path: "platform", FullPath: "acme/platform"},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSubgroup(tt.group))
+		})
+	}
+}
+
+func TestIacDir(t *testing.T) {
+	// Repository paths are POSIX. Using path/filepath here rewrote separators
+	// on Windows, so the directory handed to the chained helm/kustomize
+	// connections could not be found inside the clone.
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"Chart.yaml", ""},
+		{"charts/frontend/Chart.yaml", "charts/frontend"},
+		{"deploy/overlays/prod/kustomization.yaml", "deploy/overlays/prod"},
+		{"a/b/c/d.yaml", "a/b/c"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := iacDir(tt.path)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, `\`, "repo paths must stay POSIX-separated")
+		})
+	}
+}
+
+func TestIsHiddenPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"Chart.yaml", false},
+		{"charts/frontend/Chart.yaml", false},
+		{".gitlab-ci.yml", true},
+		{".gitlab/CODEOWNERS", true},
+		{"a/.hidden/b.yaml", true},
+		{"a/b/.env", true},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isHiddenPath(tt.path))
+		})
+	}
+}
+
+func TestIsDockerfile(t *testing.T) {
+	for _, base := range []string{"Dockerfile", "Dockerfile.prod", "app.Dockerfile", "app.dockerfile"} {
+		assert.True(t, isDockerfile(base), base)
+	}
+	for _, base := range []string{"Chart.yaml", "README.md", "docker-compose.yml", "Dockerfilex"} {
+		assert.False(t, isDockerfile(base), base)
+	}
+}
+
+func TestIsKustomization(t *testing.T) {
+	for _, base := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+		assert.True(t, isKustomization(base), base)
+	}
+	for _, base := range []string{"Chart.yaml", "values.yaml", "kustomize.yaml"} {
+		assert.False(t, isKustomization(base), base)
+	}
+}

--- a/providers/gitlab/provider/provider.go
+++ b/providers/gitlab/provider/provider.go
@@ -226,7 +226,19 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.GitLabConnecti
 		if err != nil {
 			return err
 		}
-		s.detectAsProject(asset, conn.GroupID(), conn.GroupName(), project) // TODO fix 0
+		// Resolve the owning group rather than reading it off the CLI options:
+		// ParseCLI never sets group-id, so conn.GroupID() fell back to 0 and
+		// produced platform id ".../group/0/project/<id>". Discovery stamps the
+		// real group id, so the same project scanned both ways split into two
+		// assets with separate history. Prefer the project's own namespace,
+		// which is also correct for a project reached outside its group.
+		groupID, groupFullPath := conn.GroupID(), conn.GroupName()
+		if project.Namespace != nil && project.Namespace.ID > 0 {
+			groupID, groupFullPath = project.Namespace.ID, project.Namespace.FullPath
+		} else if group, gerr := conn.Group(); gerr == nil && group != nil {
+			groupID, groupFullPath = group.ID, group.FullPath
+		}
+		s.detectAsProject(asset, groupID, groupFullPath, project)
 	} else {
 		group, err := conn.Group()
 		if err != nil {

--- a/providers/gitlab/resources/gitlab.go
+++ b/providers/gitlab/resources/gitlab.go
@@ -3,10 +3,38 @@
 
 package resources
 
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// isoTimePtr converts the SDK's date-only ISOTime into a *time.Time, keeping
+// nil as nil. Callers must always set the resulting field (via
+// llx.TimeDataPtr, which maps nil to a proper MQL null) rather than skipping
+// the map key: an absent key leaves the field *unset* rather than null, and
+// unset fields cross the plugin boundary as an empty DataRes that surfaces as
+// "llx: encountered a primitive with no type information, coercing to null".
+func isoTimePtr(t *gitlab.ISOTime) *time.Time {
+	if t == nil {
+		return nil
+	}
+	converted := time.Time(*t)
+	return &converted
+}
+
 func mapAccessLevelToRole(accessLevel int) string {
 	switch accessLevel {
+	case 0:
+		return "No access"
+	case 5:
+		return "Minimal Access"
 	case 10:
 		return "Guest"
+	case 15:
+		return "Planner"
 	case 20:
 		return "Reporter"
 	case 30:
@@ -15,7 +43,39 @@ func mapAccessLevelToRole(accessLevel int) string {
 		return "Maintainer"
 	case 50:
 		return "Owner"
+	case 60:
+		return "Admin"
 	default:
 		return "Unknown"
 	}
+}
+
+// projectScopedID builds a cache key for a resource that is only unique within
+// a single project. GitLab identifies many project children by values that
+// repeat across projects (branch names, file paths, release tags, variable
+// keys), so the owning project id has to be part of the key. Without it, a
+// query that walks several projects at once (`gitlab.group.projects { ... }`)
+// resolves every project after the first to the first one's resource, because
+// the runtime caches on resourceName + "\x00" + __id.
+func projectScopedID(resource string, projectID int64, parts ...string) string {
+	return scopedID(resource, projectID, parts...)
+}
+
+// groupScopedID is the group-level counterpart of projectScopedID, for children
+// that repeat across groups (SAML links, CI/CD variables).
+func groupScopedID(resource string, groupID int64, parts ...string) string {
+	return scopedID(resource, groupID, parts...)
+}
+
+// userScopedID is the user-level counterpart, for children that repeat across
+// users (external identities).
+func userScopedID(resource string, userID int64, parts ...string) string {
+	return scopedID(resource, userID, parts...)
+}
+
+func scopedID(resource string, ownerID int64, parts ...string) string {
+	segments := make([]string, 0, len(parts)+2)
+	segments = append(segments, resource, strconv.FormatInt(ownerID, 10))
+	segments = append(segments, parts...)
+	return strings.Join(segments, "/")
 }

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -271,9 +271,16 @@ private gitlab.member @defaults("user role") {
   id int
   // User associated with this membership
   user gitlab.user
-  // Access level of the user within the group or project (e.g., Guest, Reporter, Developer, Maintainer, Owner)
+  // Role name derived from the numeric access level
+  //
+  // One of No access, Minimal Access, Guest, Planner, Reporter, Developer,
+  // Maintainer, Owner, or Admin. Unknown is reported for any access level the
+  // provider does not recognize.
   role string
-  // Numeric access level backing the role (10 Guest, 20 Reporter, 30 Developer, 40 Maintainer, 50 Owner)
+  // Numeric access level backing the role
+  //
+  // One of 0 No access, 5 Minimal Access, 10 Guest, 15 Planner, 20 Reporter,
+  // 30 Developer, 40 Maintainer, 50 Owner, or 60 Admin.
   accessLevel int
   // Membership state (for example active or awaiting)
   state string
@@ -1515,7 +1522,10 @@ private gitlab.project.label @defaults("name color") {
   // Label description
   description string
   // HTML-formatted description
-  descriptionHtml string
+  //
+  // Deprecated in favor of description. The GitLab client library does not
+  // model the API's description_html field, so this always resolves to null.
+  descriptionHtml @maturity("deprecated") string
   // Count of open issues with this label
   openIssuesCount int
   // Count of closed issues with this label
@@ -1543,7 +1553,10 @@ private gitlab.group.label @defaults("name color") {
   // Label description
   description string
   // HTML-formatted description
-  descriptionHtml string
+  //
+  // Deprecated in favor of description. The GitLab client library does not
+  // model the API's description_html field, so this always resolves to null.
+  descriptionHtml @maturity("deprecated") string
   // Count of open issues with this label
   openIssuesCount int
   // Count of closed issues with this label
@@ -2162,6 +2175,10 @@ private gitlab.project.containerRegistryRepository @defaults("path tagsCount sta
   // When the most recent cleanup policy run started for this repository
   cleanupPolicyStartedAt time
   // Tag count snapshot
+  //
+  // Null when the repository was reached through a group rollup, because the
+  // group-level registry listing has no tag-count parameter. Iterate tags for
+  // an exact count in that case.
   tagsCount int
   // Repository delete status
   //

--- a/providers/gitlab/resources/gitlab.lr
+++ b/providers/gitlab/resources/gitlab.lr
@@ -1495,6 +1495,9 @@ private gitlab.project.milestone @defaults("internalId title state") {
   // Creation timestamp
   createdAt time
   // Whether the milestone has passed its due date
+  //
+  // Null when GitLab does not report the flag, which is not the same as the
+  // milestone being current.
   expired bool
   // Project this milestone belongs to
   project() gitlab.project

--- a/providers/gitlab/resources/gitlab.lr.go
+++ b/providers/gitlab/resources/gitlab.lr.go
@@ -6770,12 +6770,7 @@ func createGitlabUserExternalIdentity(runtime *plugin.Runtime, args map[string]*
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.user.externalIdentity", res.__id)
@@ -7005,12 +7000,7 @@ func createGitlabMember(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.member", res.__id)
@@ -7905,12 +7895,7 @@ func createGitlabGroupSamlGroupLink(runtime *plugin.Runtime, args map[string]*ll
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.group.samlGroupLink", res.__id)
@@ -9679,12 +9664,7 @@ func createGitlabProjectCodeowners(runtime *plugin.Runtime, args map[string]*llx
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.codeowners", res.__id)
@@ -9746,12 +9726,7 @@ func createGitlabProjectCodeownersRule(runtime *plugin.Runtime, args map[string]
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.codeowners.rule", res.__id)
@@ -9909,12 +9884,7 @@ func createGitlabProjectProtectedBranch(runtime *plugin.Runtime, args map[string
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.protectedBranch", res.__id)
@@ -10073,12 +10043,7 @@ func createGitlabProjectFile(runtime *plugin.Runtime, args map[string]*llx.RawDa
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.file", res.__id)
@@ -10762,12 +10727,7 @@ func createGitlabProjectRelease(runtime *plugin.Runtime, args map[string]*llx.Ra
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.release", res.__id)
@@ -10870,12 +10830,7 @@ func createGitlabProjectVariable(runtime *plugin.Runtime, args map[string]*llx.R
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.variable", res.__id)
@@ -11278,12 +11233,7 @@ func createGitlabGroupVariable(runtime *plugin.Runtime, args map[string]*llx.Raw
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.group.variable", res.__id)
@@ -13264,12 +13214,7 @@ func createGitlabProjectContainerExpirationPolicy(runtime *plugin.Runtime, args 
 		return res, err
 	}
 
-	if res.__id == "" {
-		res.__id, err = res.id()
-		if err != nil {
-			return nil, err
-		}
-	}
+	// to override __id implement: id() (string, error)
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("gitlab.project.containerExpirationPolicy", res.__id)

--- a/providers/gitlab/resources/gitlab_dicts_test.go
+++ b/providers/gitlab/resources/gitlab_dicts_test.go
@@ -1,0 +1,156 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// assertDictSerializable mirrors llx's dict2primitive allow-list. Values placed
+// in a `dict` or `[]dict` field are serialized by that function, which errors
+// on anything outside this set — so a *time.Time or an int32 in a dict fails
+// the whole field at query time rather than at compile time. Note a typed nil
+// pointer is *not* caught by a `== nil` check inside dict2primitive either,
+// because the interface itself is non-nil.
+func assertDictSerializable(t *testing.T, value any, path string) {
+	t.Helper()
+	switch v := value.(type) {
+	case nil, bool, int64, float64, string:
+		// JSON-native, fine
+	case []any:
+		for i := range v {
+			assertDictSerializable(t, v[i], path+"[]")
+		}
+	case map[string]any:
+		for k, item := range v {
+			assertDictSerializable(t, item, path+"."+k)
+		}
+	default:
+		t.Fatalf("%s: %T is not a JSON-native dict value (llx dict2primitive accepts only nil/bool/int64/float64/string/[]any/map[string]any)", path, value)
+	}
+}
+
+func TestReleaseDictsAreSerializable(t *testing.T) {
+	authored := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	committed := time.Date(2026, 3, 2, 11, 30, 0, 0, time.UTC)
+	collected := time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC)
+
+	t.Run("commit with timestamps", func(t *testing.T) {
+		got := releaseCommitToDict(gitlab.Commit{
+			ID:            "abc123",
+			ShortID:       "abc",
+			Title:         "ship it",
+			AuthorName:    "Ada",
+			AuthoredDate:  &authored,
+			CommittedDate: &committed,
+			WebURL:        "https://gitlab.com/acme/api/-/commit/abc123",
+		})
+		assertDictSerializable(t, got, "commit")
+
+		m, ok := got.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "2026-03-01T10:00:00Z", m["authoredDate"])
+		assert.Equal(t, "2026-03-02T11:30:00Z", m["committedDate"])
+	})
+
+	t.Run("commit with nil timestamps", func(t *testing.T) {
+		// A nil *time.Time must become an untyped nil, not a typed nil that
+		// slips past dict2primitive's nil check and hits its error branch.
+		got := releaseCommitToDict(gitlab.Commit{ID: "abc123"})
+		assertDictSerializable(t, got, "commit")
+
+		m, ok := got.(map[string]any)
+		require.True(t, ok)
+		assert.Nil(t, m["authoredDate"])
+		assert.Nil(t, m["committedDate"])
+	})
+
+	t.Run("empty commit is dropped", func(t *testing.T) {
+		assert.Nil(t, releaseCommitToDict(gitlab.Commit{}))
+	})
+
+	t.Run("evidences", func(t *testing.T) {
+		got := releaseEvidencesToDicts([]*gitlab.ReleaseEvidence{
+			{SHA: "sha1", Filepath: "https://example.com/e.json", CollectedAt: &collected},
+			nil, // nil entries are skipped, not mapped to a zero dict
+			{SHA: "sha2"},
+		})
+		assertDictSerializable(t, []any(got), "evidences")
+		require.Len(t, got, 2)
+
+		first := got[0].(map[string]any)
+		assert.Equal(t, "2026-03-03T12:00:00Z", first["collectedAt"])
+		assert.Nil(t, got[1].(map[string]any)["collectedAt"])
+	})
+
+	t.Run("assets", func(t *testing.T) {
+		got := releaseAssetsToDict(gitlab.ReleaseAssets{
+			Count:   2,
+			Sources: []gitlab.ReleaseAssetsSource{{Format: "zip", URL: "https://example.com/a.zip"}},
+			Links: []*gitlab.ReleaseLink{
+				{ID: 7, Name: "binary", URL: "https://example.com/bin", LinkType: gitlab.PackageLinkType, External: true},
+				nil,
+			},
+		})
+		assertDictSerializable(t, got, "assets")
+
+		m := got.(map[string]any)
+		assert.Len(t, m["links"], 1)
+	})
+}
+
+func TestOtherDictConvertersAreSerializable(t *testing.T) {
+	accessLevel := gitlab.AccessLevelValue(40)
+
+	cases := map[string]any{
+		"sharedWithGroups": []any(projectSharedGroupsToDicts([]gitlab.ProjectSharedWithGroup{
+			{GroupID: 3, GroupName: "platform", GroupFullPath: "acme/platform", GroupAccessLevel: 30},
+		})),
+		"groups": []any(groupsToDicts([]*gitlab.Group{
+			{ID: 7, Name: "platform", FullPath: "acme/platform", Visibility: gitlab.PrivateVisibility},
+			nil,
+		})),
+		"deployAccessLevels": []any(envDeployAccessLevelsToDicts([]*gitlab.EnvironmentAccessDescription{
+			{AccessLevel: 40, AccessLevelDescription: "Maintainers", UserID: 1, GroupID: 2},
+			nil,
+		})),
+		"envApprovalRules": []any(envApprovalRulesToDicts([]*gitlab.EnvironmentApprovalRule{
+			{ID: 1, AccessLevel: 30, RequiredApprovalCount: 2},
+			nil,
+		})),
+		"groupSharedGroups": []any(groupSharedGroupsToDicts([]gitlab.SharedWithGroup{
+			{GroupID: 9, GroupName: "sec", GroupFullPath: "acme/sec", GroupAccessLevel: 50},
+		})),
+		"ldapGroupLinks": []any(ldapGroupLinksToDicts([]*gitlab.LDAPGroupLink{
+			{CN: "devs", Filter: "", Provider: "ldapmain", GroupAccess: 30},
+			nil,
+		})),
+		"branchProtectionDefaults": branchProtectionDefaultsToDict(&gitlab.BranchProtectionDefaults{
+			AllowForcePush: true,
+			AllowedToPush:  []*gitlab.GroupAccessLevel{{AccessLevel: &accessLevel}, nil, {}},
+		}),
+	}
+
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			assertDictSerializable(t, value, name)
+		})
+	}
+
+	t.Run("nil branch protection defaults", func(t *testing.T) {
+		assert.Nil(t, branchProtectionDefaultsToDict(nil))
+	})
+}
+
+func TestDictTime(t *testing.T) {
+	assert.Nil(t, dictTime(nil), "a nil timestamp must be an untyped nil")
+
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	assert.Equal(t, "2026-01-02T03:04:05Z", dictTime(&ts))
+}

--- a/providers/gitlab/resources/gitlab_governance.go
+++ b/providers/gitlab/resources/gitlab_governance.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -26,20 +28,13 @@ func (r *mqlGitlabProjectApprovalRule) id() (string, error) {
 	return "gitlab.project.approvalRule/" + strconv.FormatInt(r.Id.Data, 10), nil
 }
 
-func (r *mqlGitlabProjectCodeowners) id() (string, error) {
-	return "gitlab.project.codeowners/" + r.Path.Data, nil
-}
-
-func (r *mqlGitlabProjectCodeownersRule) id() (string, error) {
-	return "gitlab.project.codeowners.rule/" +
-		strconv.FormatInt(r.LineNumber.Data, 10) + "/" +
-		r.Pattern.Data, nil
-}
-
 // -----------------------------------------------------------------------------
 // Runner — fetch full details on demand via GetRunnerDetails. Stored in an
 // Internal struct so a single API call satisfies every detail accessor.
 // -----------------------------------------------------------------------------
+
+// gitlabRunnerScopeWarn logs once per session when runner details are denied.
+var gitlabRunnerScopeWarn sync.Once
 
 type mqlGitlabProjectRunnerInternal struct {
 	detailsOnce sync.Once
@@ -50,7 +45,20 @@ type mqlGitlabProjectRunnerInternal struct {
 func (r *mqlGitlabProjectRunner) loadDetails() (*gitlab.RunnerDetails, error) {
 	r.detailsOnce.Do(func() {
 		conn := r.MqlRuntime.Connection.(*connection.GitLabConnection)
-		details, _, err := conn.Client().Runners.GetRunnerDetails(int(r.Id.Data))
+		details, resp, err := conn.Client().Runners.GetRunnerDetails(int(r.Id.Data))
+		// ListProjectRunners includes instance-wide shared runners, but
+		// GET /runners/:id requires admin (or ownership) for those. Degrading
+		// keeps `runners { runUntagged }` usable on a project-scoped token;
+		// the accessors already return explicit false/zero when details are
+		// absent, so a miss fails an assertion rather than passing it.
+		if err != nil && resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 403 || resp.StatusCode == 404) {
+			gitlabRunnerScopeWarn.Do(func() {
+				log.Warn().Int("status", resp.StatusCode).
+					Msg("gitlab token cannot read /runners/:id; runner detail fields will report zero values")
+			})
+			r.details, r.detailsErr = nil, nil
+			return
+		}
 		r.details = details
 		r.detailsErr = err
 	})
@@ -153,25 +161,30 @@ var codeownersCandidatePaths = []string{"CODEOWNERS", ".gitlab/CODEOWNERS", "doc
 func (p *mqlGitlabProject) codeowners() (*mqlGitlabProjectCodeowners, error) {
 	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)
 	projectID := int(p.Id.Data)
-	defaultBranch := p.DefaultBranch.Data
-	if defaultBranch == "" {
-		// fall back to "main" — most modern GitLab projects use it;
-		// when this still 404s we surface a present=false resource.
-		defaultBranch = "main"
+
+	// GetRawFileOptions.Ref is optional and GitLab defaults it to the project
+	// HEAD, so an unknown default branch means "let the server pick" rather
+	// than guessing "main". Guessing produced a confident present=false for
+	// any project still on master whose resource reached us without the
+	// defaultBranch field populated.
+	opts := &gitlab.GetRawFileOptions{}
+	if defaultBranch := p.DefaultBranch.Data; defaultBranch != "" {
+		opts.Ref = gitlab.Ptr(defaultBranch)
 	}
 
 	var content []byte
 	var foundPath string
 	for _, path := range codeownersCandidatePaths {
-		body, resp, err := conn.Client().RepositoryFiles.GetRawFile(projectID, path, &gitlab.GetRawFileOptions{
-			Ref: gitlab.Ptr(defaultBranch),
-		})
+		body, resp, err := conn.Client().RepositoryFiles.GetRawFile(projectID, path, opts)
 		if err == nil {
 			content = body
 			foundPath = path
 			break
 		}
-		if resp != nil && resp.StatusCode == 404 {
+		// 403 means the token cannot read this repository at all; keep
+		// probing the remaining candidates and fall through to present=false
+		// rather than failing the whole resource graph mid-group-scan.
+		if resp != nil && (resp.StatusCode == 404 || resp.StatusCode == 403) {
 			continue
 		}
 		return nil, err
@@ -185,6 +198,9 @@ func (p *mqlGitlabProject) codeowners() (*mqlGitlabProjectCodeowners, error) {
 			owners = append(owners, o)
 		}
 		mqlRule, err := CreateResource(p.MqlRuntime, "gitlab.project.codeowners.rule", map[string]*llx.RawData{
+			// lineNumber+pattern repeats across projects — "1/*" is the most
+			// common first line there is — so the project has to be in the key.
+			"__id":              llx.StringData(projectScopedID("gitlab.project.codeowners.rule", p.Id.Data, strconv.Itoa(rule.LineNumber), rule.Pattern)),
 			"lineNumber":        llx.IntData(int64(rule.LineNumber)),
 			"section":           llx.StringData(rule.Section),
 			"optional":          llx.BoolData(rule.Optional),
@@ -200,6 +216,10 @@ func (p *mqlGitlabProject) codeowners() (*mqlGitlabProjectCodeowners, error) {
 	}
 
 	res, err := CreateResource(p.MqlRuntime, "gitlab.project.codeowners", map[string]*llx.RawData{
+		// The path is one of three fixed candidates (or ""), so keying on it
+		// gave the whole runtime four possible cache entries — every project
+		// in a group scan shared one CODEOWNERS resource.
+		"__id":    llx.StringData(projectScopedID("gitlab.project.codeowners", p.Id.Data)),
 		"present": llx.BoolData(foundPath != ""),
 		"path":    llx.StringData(foundPath),
 		"content": llx.StringData(string(content)),
@@ -224,9 +244,17 @@ type codeownersRule struct {
 }
 
 // sectionHeader matches `[Section]`, `[Section][2]`, `^[Section]`,
-// `^[Section][2]`. The first group captures the optional `^`, the
-// second the section name, the third the optional approval count.
-var sectionHeader = regexp.MustCompile(`^(\^?)\[([^\]]+)\](?:\[(\d+)\])?\s*$`)
+// `^[Section][2]`, and each of those followed by default owners
+// (`[Section] @team`). The first group captures the optional `^`, the second
+// the section name, the third the optional approval count, and the fourth any
+// trailing default owners.
+//
+// The trailing-owners form is documented GitLab syntax. Requiring the line to
+// end at the brackets made `[Database] @dba-team` fall through to the rule
+// branch, which both emitted a phantom rule whose pattern was the literal
+// "[Database]" and left the section state pointing at the *previous* section —
+// so every rule after it reported the wrong required/optional flag.
+var sectionHeader = regexp.MustCompile(`^(\^?)\[([^\]]+)\](?:\[(\d+)\])?(?:\s+(.*))?$`)
 
 // parseCodeowners turns the raw CODEOWNERS text into a slice of
 // rules. Comments (lines starting with #) and blank lines are
@@ -251,6 +279,7 @@ func parseCodeowners(content string) []codeownersRule {
 	}
 	var rules []codeownersRule
 	var currentSection string
+	var currentDefaultOwners []string
 	currentRequired := true
 	currentOptional := false
 	currentApprovals := 0
@@ -271,14 +300,18 @@ func parseCodeowners(content string) []codeownersRule {
 					currentApprovals = n
 				}
 			}
+			currentDefaultOwners = strings.Fields(m[4])
 			continue
 		}
 		fields := strings.Fields(line)
-		if len(fields) < 1 {
-			continue
-		}
 		pattern := fields[0]
 		owners := fields[1:]
+		// A pattern with no owners of its own inherits the section's default
+		// owners; without this the path reads as unowned even though the
+		// section header assigns it a team.
+		if len(owners) == 0 {
+			owners = currentDefaultOwners
+		}
 		rules = append(rules, codeownersRule{
 			LineNumber:        lineNum + 1,
 			Section:           currentSection,
@@ -291,11 +324,6 @@ func parseCodeowners(content string) []codeownersRule {
 	}
 	return rules
 }
-
-// Compile-time guards: panics with a clear stack if the generated
-// resource ever loses these fields (e.g. via a .lr rename) instead
-// of producing an opaque nil-deref later.
-var _ = plugin.StateIsSet
 
 // -----------------------------------------------------------------------------
 // Vulnerabilities — surfaced from GitLab's security report scanners (SAST,
@@ -515,18 +543,30 @@ func fetchVulnerabilities(conn *connection.GitLabConnection, scope, fullPath str
 				return nil, err
 			}
 			errs = resp.Errors
-			if resp.Data.Project != nil {
-				page = resp.Data.Project.Vulnerabilities
+			// GraphQL answers HTTP 200 with data.project = null (and often no
+			// errors array) when the path doesn't resolve or isn't visible to
+			// this token. Treating that as "no vulnerabilities" reported a
+			// clean bill of health for a project we never actually read.
+			if resp.Data.Project == nil {
+				if isVulnerabilitiesUnavailable(errs) {
+					return nil, nil
+				}
+				return nil, fmt.Errorf("gitlab project %q not found or not visible to this token", fullPath)
 			}
+			page = resp.Data.Project.Vulnerabilities
 		case "group":
 			var resp gqlGroupVulnResponse
 			if _, err := conn.Client().GraphQL.Do(gitlab.GraphQLQuery{Query: query}, &resp); err != nil {
 				return nil, err
 			}
 			errs = resp.Errors
-			if resp.Data.Group != nil {
-				page = resp.Data.Group.Vulnerabilities
+			if resp.Data.Group == nil {
+				if isVulnerabilitiesUnavailable(errs) {
+					return nil, nil
+				}
+				return nil, fmt.Errorf("gitlab group %q not found or not visible to this token", fullPath)
 			}
+			page = resp.Data.Group.Vulnerabilities
 		default:
 			return nil, fmt.Errorf("unsupported scope %q", scope)
 		}

--- a/providers/gitlab/resources/gitlab_governance_test.go
+++ b/providers/gitlab/resources/gitlab_governance_test.go
@@ -164,3 +164,61 @@ func TestParseCodeowners(t *testing.T) {
 		assert.Equal(t, 0, rules[1].ApprovalsRequired)
 	})
 }
+
+func TestParseCodeownersSectionsWithDefaultOwners(t *testing.T) {
+	// GitLab lets a section header carry default owners, which apply to every
+	// pattern in the section that does not name its own. Rejecting that form
+	// turned the header into a rule whose pattern was the literal "[Database]"
+	// and, worse, left the section state pointing at the *previous* section —
+	// so a required section was reported as optional for the rest of the file.
+	t.Run("required section with default owners", func(t *testing.T) {
+		rules := parseCodeowners("[Database] @dba-team\ndb/schema.rb\ndb/migrate/ @migrations\n")
+		require.Len(t, rules, 2, "the header must not become a rule")
+
+		assert.Equal(t, "db/schema.rb", rules[0].Pattern)
+		assert.Equal(t, "Database", rules[0].Section)
+		assert.True(t, rules[0].Required)
+		assert.False(t, rules[0].Optional)
+		assert.Equal(t, []string{"@dba-team"}, rules[0].Owners,
+			"a pattern with no owners inherits the section defaults")
+
+		assert.Equal(t, "db/migrate/", rules[1].Pattern)
+		assert.Equal(t, []string{"@migrations"}, rules[1].Owners,
+			"an explicit owner list wins over the section defaults")
+	})
+
+	t.Run("optional section with approvals and default owners", func(t *testing.T) {
+		rules := parseCodeowners("^[Review][2] @a @b\nsrc/\n")
+		require.Len(t, rules, 1)
+		assert.Equal(t, "Review", rules[0].Section)
+		assert.True(t, rules[0].Optional)
+		assert.False(t, rules[0].Required)
+		assert.Equal(t, 2, rules[0].ApprovalsRequired)
+		assert.Equal(t, []string{"@a", "@b"}, rules[0].Owners)
+	})
+
+	t.Run("section state advances past a default-owner header", func(t *testing.T) {
+		rules := parseCodeowners("^[Optional]\nexperiments/ @lab\n[Database] @dba\ndb/schema.rb\n")
+		require.Len(t, rules, 2)
+
+		assert.Equal(t, "Optional", rules[0].Section)
+		assert.True(t, rules[0].Optional)
+
+		assert.Equal(t, "Database", rules[1].Section)
+		assert.True(t, rules[1].Required, "the required section must not inherit optional")
+		assert.False(t, rules[1].Optional)
+	})
+
+	t.Run("bare headers still parse", func(t *testing.T) {
+		rules := parseCodeowners("[Docs]\nREADME.md @docs\n")
+		require.Len(t, rules, 1)
+		assert.Equal(t, "Docs", rules[0].Section)
+		assert.Equal(t, []string{"@docs"}, rules[0].Owners)
+	})
+
+	t.Run("pattern with no owners and no section defaults", func(t *testing.T) {
+		rules := parseCodeowners("docs/\n")
+		require.Len(t, rules, 1)
+		assert.Empty(t, rules[0].Owners, "an unowned path must stay unowned")
+	})
+}

--- a/providers/gitlab/resources/gitlab_group.go
+++ b/providers/gitlab/resources/gitlab_group.go
@@ -23,10 +23,6 @@ func (u *mqlGitlabUser) id() (string, error) {
 	return "gitlab.user/" + strconv.FormatInt(u.Id.Data, 10), nil
 }
 
-func (m *mqlGitlabMember) id() (string, error) {
-	return "gitlab.member/" + strconv.FormatInt(m.Id.Data, 10), nil
-}
-
 // mqlGitlabMemberInternal caches source data needed to resolve the member's
 // typed references (createdBy user, custom member role) lazily.
 type mqlGitlabMemberInternal struct {
@@ -109,16 +105,31 @@ func newMqlGitlabMemberRole(runtime *plugin.Runtime, role *gitlab.MemberRole) (*
 func (g *mqlGitlabGroup) memberRoles() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GitLabConnection)
 
-	roles, resp, err := conn.Client().MemberRolesService.ListMemberRoles(int(g.Id.Data))
-	if err != nil {
-		if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
-			return []any{}, nil // not available on this GitLab tier
+	// ListMemberRoles takes no typed options struct, but the endpoint still
+	// paginates and GitLab defaults to 20 per page — a group with more custom
+	// roles than that would silently report only the first 20. gitlab.WithNext
+	// drives the next page for offset, keyset, and cursor styles alike, and is
+	// what samlGroupLinks below already uses for the same SDK shape.
+	var allRoles []*gitlab.MemberRole
+	var nextOpts []gitlab.RequestOptionFunc
+	for {
+		roles, resp, err := conn.Client().MemberRolesService.ListMemberRoles(int(g.Id.Data), nextOpts...)
+		if err != nil {
+			if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
+				return []any{}, nil // not available on this GitLab tier
+			}
+			return nil, err
 		}
-		return nil, err
+		allRoles = append(allRoles, roles...)
+		next, hasNext := gitlab.WithNext(resp)
+		if !hasNext {
+			break
+		}
+		nextOpts = []gitlab.RequestOptionFunc{next}
 	}
 
 	var mqlRoles []any
-	for _, role := range roles {
+	for _, role := range allRoles {
 		mqlRole, err := newMqlGitlabMemberRole(g.MqlRuntime, role)
 		if err != nil {
 			return nil, err
@@ -326,6 +337,10 @@ func (g *mqlGitlabGroup) members() ([]any, error) {
 				Page:    page,
 				PerPage: perPage,
 			},
+			// GitLab omits is_using_seat from the members payload unless it is
+			// asked for, and the SDK models it as a plain bool — without this
+			// every member would decode as isUsingSeat=false.
+			ShowSeatInfo: gitlab.Ptr(true),
 		})
 		if err != nil {
 			return nil, err
@@ -363,6 +378,13 @@ func (g *mqlGitlabGroup) members() ([]any, error) {
 		}
 
 		memberInfo := map[string]*llx.RawData{
+			// GroupMember.ID is the *user* id, so it repeats for every group
+			// and project that user belongs to. ListAllGroupMembers also
+			// returns inherited members, which means a parent-group membership
+			// and a subgroup membership for the same user land in the same
+			// runtime — keying on the user id alone made the second one
+			// resolve to the first, hiding a deliberately narrowed role.
+			"__id":        llx.StringData(groupScopedID("gitlab.member/group", g.Id.Data, strconv.FormatInt(member.ID, 10))),
 			"id":          llx.IntData(member.ID),
 			"user":        llx.ResourceData(mqlUser, "gitlab.user"),
 			"role":        llx.StringData(role),
@@ -475,12 +497,16 @@ func (g *mqlGitlabGroup) labels() ([]any, error) {
 	var mqlLabels []any
 	for _, label := range allLabels {
 		labelInfo := map[string]*llx.RawData{
-			"id":                     llx.IntData(label.ID),
-			"name":                   llx.StringData(label.Name),
-			"color":                  llx.StringData(label.Color),
-			"textColor":              llx.StringData(label.TextColor),
-			"description":            llx.StringData(label.Description),
-			"descriptionHtml":        llx.StringData(""), // Not in API response
+			"id":          llx.IntData(label.ID),
+			"name":        llx.StringData(label.Name),
+			"color":       llx.StringData(label.Color),
+			"textColor":   llx.StringData(label.TextColor),
+			"description": llx.StringData(label.Description),
+			// The SDK's Label struct does not model description_html, so we have
+			// no value to report. Null says "unknown"; an empty string would
+			// claim, for every label on every project, that no HTML
+			// description exists.
+			"descriptionHtml":        llx.NilData,
 			"openIssuesCount":        llx.IntData(label.OpenIssuesCount),
 			"closedIssuesCount":      llx.IntData(label.ClosedIssuesCount),
 			"openMergeRequestsCount": llx.IntData(label.OpenMergeRequestsCount),
@@ -702,11 +728,6 @@ type mqlGitlabGroupSamlGroupLinkInternal struct {
 	groupID int64
 }
 
-// id function for gitlab.group.samlGroupLink
-func (s *mqlGitlabGroupSamlGroupLink) id() (string, error) {
-	return "gitlab.group.samlGroupLink/" + strconv.FormatInt(s.groupID, 10) + "/" + s.Provider.Data + "/" + s.Name.Data, nil
-}
-
 // samlGroupLinks fetches SAML group links for the group.
 //
 // SAML group links are a Premium/Ultimate feature. On lower tiers the API
@@ -742,6 +763,11 @@ func (g *mqlGitlabGroup) samlGroupLinks() ([]any, error) {
 	var mqlLinks []any
 	for _, link := range allLinks {
 		linkInfo := map[string]*llx.RawData{
+			// The group id has to be passed here rather than read back out of
+			// the Internal struct by id(): CreateResource computes __id during
+			// construction, so a field assigned afterwards is always still
+			// zero at that point and every link keyed as ".../0/provider/name".
+			"__id":         llx.StringData(groupScopedID("gitlab.group.samlGroupLink", g.Id.Data, link.Provider, link.Name)),
 			"name":         llx.StringData(link.Name),
 			"accessLevel":  llx.IntData(int64(link.AccessLevel)),
 			"memberRoleId": llx.IntData(link.MemberRoleID),
@@ -1005,10 +1031,6 @@ func (g *mqlGitlabGroup) parentGroup() (*mqlGitlabGroup, error) {
 	return res.(*mqlGitlabGroup), nil
 }
 
-func (v *mqlGitlabGroupVariable) id() (string, error) {
-	return "gitlab.group.variable/" + v.Key.Data + "/" + v.EnvironmentScope.Data, nil
-}
-
 // variables lists the group-level CI/CD variables. These are inherited by
 // every project in the group.
 func (g *mqlGitlabGroup) variables() ([]any, error) {
@@ -1042,6 +1064,11 @@ func (g *mqlGitlabGroup) variables() ([]any, error) {
 	var mqlVars []any
 	for _, v := range allVars {
 		varInfo := map[string]*llx.RawData{
+			// Subgroups routinely redefine a parent group's variable at the
+			// same scope (that is the whole point of group-level variables),
+			// so key+scope without the group id aliases the override onto the
+			// parent's row — including its masked/protected flags.
+			"__id":             llx.StringData(groupScopedID("gitlab.group.variable", g.Id.Data, v.Key, v.EnvironmentScope)),
 			"key":              llx.StringData(v.Key),
 			"variableType":     llx.StringData(string(v.VariableType)),
 			"protected":        llx.BoolData(v.Protected),

--- a/providers/gitlab/resources/gitlab_ids_test.go
+++ b/providers/gitlab/resources/gitlab_ids_test.go
@@ -1,0 +1,147 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The runtime caches resources under resourceName + "\x00" + __id, and
+// CreateResource returns the *cached* instance on a key hit — discarding the
+// data it was just handed. Any child resource whose GitLab identifier is only
+// unique within its parent therefore has to carry the parent in its key, or a
+// query that walks several parents at once (gitlab.group.projects { ... })
+// silently reports the first parent's data for all of them.
+//
+// These tests pin that property for the id builders. They are cheap and they
+// are exactly what was missing when the collisions shipped.
+
+func TestScopedIDsDistinguishParents(t *testing.T) {
+	t.Run("same child value under different projects", func(t *testing.T) {
+		a := projectScopedID("gitlab.project.protectedBranch", 1, "main")
+		b := projectScopedID("gitlab.project.protectedBranch", 2, "main")
+		assert.NotEqual(t, a, b, "a protected branch named main must not alias across projects")
+	})
+
+	t.Run("same variable key and scope under different projects", func(t *testing.T) {
+		a := projectScopedID("gitlab.project.variable", 1, "AWS_SECRET_ACCESS_KEY", "*")
+		b := projectScopedID("gitlab.project.variable", 2, "AWS_SECRET_ACCESS_KEY", "*")
+		assert.NotEqual(t, a, b)
+	})
+
+	t.Run("same release tag under different projects", func(t *testing.T) {
+		assert.NotEqual(t,
+			projectScopedID("gitlab.project.release", 1, "v1.0.0"),
+			projectScopedID("gitlab.project.release", 2, "v1.0.0"))
+	})
+
+	t.Run("same file path under different projects", func(t *testing.T) {
+		assert.NotEqual(t,
+			projectScopedID("gitlab.project.file", 1, "main", "README.md"),
+			projectScopedID("gitlab.project.file", 2, "main", "README.md"))
+	})
+
+	t.Run("same file path at different refs", func(t *testing.T) {
+		assert.NotEqual(t,
+			projectScopedID("gitlab.project.file", 1, "main", "README.md"),
+			projectScopedID("gitlab.project.file", 1, "develop", "README.md"),
+			"content() reads the ref, so two refs are two resources")
+	})
+
+	t.Run("same user in different groups and projects", func(t *testing.T) {
+		// GroupMember.ID / ProjectMember.ID is the *user* id, so the same
+		// person yields the same value in every membership they hold.
+		// The key also has to name the *kind* of parent: gitlab.member is
+		// built from both the group and the project path, so a group with id
+		// 10 and a project with id 10 would otherwise share a key.
+		inGroup := groupScopedID("gitlab.member/group", 10, "1234")
+		inOtherGroup := groupScopedID("gitlab.member/group", 20, "1234")
+		inProject := projectScopedID("gitlab.member/project", 10, "1234")
+
+		assert.NotEqual(t, inGroup, inOtherGroup)
+		assert.NotEqual(t, inGroup, inProject,
+			"a group membership and a project membership are different grants")
+	})
+
+	t.Run("same SAML provider and group name under different groups", func(t *testing.T) {
+		assert.NotEqual(t,
+			groupScopedID("gitlab.group.samlGroupLink", 1, "saml", "developers"),
+			groupScopedID("gitlab.group.samlGroupLink", 2, "saml", "developers"))
+	})
+
+	t.Run("same identity tuple under different users", func(t *testing.T) {
+		// A provider that reports an empty extern_uid would otherwise collapse
+		// every user's identity onto one resource.
+		assert.NotEqual(t,
+			userScopedID("gitlab.user.externalIdentity", 1, "ldapmain", ""),
+			userScopedID("gitlab.user.externalIdentity", 2, "ldapmain", ""))
+	})
+
+	t.Run("singleton children still differ per parent", func(t *testing.T) {
+		// containerExpirationPolicy, approvalSetting and codeowners have no
+		// child key at all — the parent id is the only thing separating them.
+		for _, resource := range []string{
+			"gitlab.project.containerExpirationPolicy",
+			"gitlab.project.approvalSetting",
+			"gitlab.project.codeowners",
+		} {
+			assert.NotEqual(t, projectScopedID(resource, 1), projectScopedID(resource, 2), resource)
+			assert.NotEmpty(t, projectScopedID(resource, 1), resource)
+		}
+	})
+}
+
+func TestScopedIDsAreStable(t *testing.T) {
+	// The same inputs must always produce the same key, or resources stop
+	// being shared across a scan and asset continuity breaks between runs.
+	assert.Equal(t,
+		projectScopedID("gitlab.project.release", 42, "v1.0.0"),
+		projectScopedID("gitlab.project.release", 42, "v1.0.0"))
+
+	assert.Equal(t, "gitlab.project.release/42/v1.0.0",
+		projectScopedID("gitlab.project.release", 42, "v1.0.0"))
+	assert.Equal(t, "gitlab.project.approvalSetting/42",
+		projectScopedID("gitlab.project.approvalSetting", 42))
+}
+
+func TestMapAccessLevelToRole(t *testing.T) {
+	// Every access level GitLab actually issues must map to a name. Reporting
+	// "Unknown" for 60 made an instance admin indistinguishable from the
+	// no-access user at 0.
+	tests := []struct {
+		accessLevel int
+		want        string
+	}{
+		{0, "No access"},
+		{5, "Minimal Access"},
+		{10, "Guest"},
+		{15, "Planner"},
+		{20, "Reporter"},
+		{30, "Developer"},
+		{40, "Maintainer"},
+		{50, "Owner"},
+		{60, "Admin"},
+		// genuinely unmapped values still fall through
+		{7, "Unknown"},
+		{-1, "Unknown"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, mapAccessLevelToRole(tt.accessLevel), "accessLevel=%d", tt.accessLevel)
+	}
+
+	t.Run("distinct levels get distinct names", func(t *testing.T) {
+		seen := map[string]int{}
+		for _, level := range []int{0, 5, 10, 15, 20, 30, 40, 50, 60} {
+			role := mapAccessLevelToRole(level)
+			require.NotEqual(t, "Unknown", role, "level %d must be mapped", level)
+			if prev, ok := seen[role]; ok {
+				t.Fatalf("levels %d and %d both map to %q", prev, level, role)
+			}
+			seen[role] = level
+		}
+	})
+}

--- a/providers/gitlab/resources/gitlab_namespace.go
+++ b/providers/gitlab/resources/gitlab_namespace.go
@@ -68,6 +68,25 @@ func initGitlabNamespace(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 
 	conn := runtime.Connection.(*connection.GitLabConnection)
 
+	// gitlab.namespace(id: N) has to look up that namespace. Falling through to
+	// the connection's own group here fetched a *different* namespace and then
+	// overwrote args["id"] with its id, so the caller silently got authoritative
+	// data for something they never asked for.
+	if idArg, ok := args["id"]; ok && idArg != nil && idArg.Error == nil {
+		nsID, ok := idArg.Value.(int64)
+		if !ok {
+			return nil, nil, errors.New("gitlab.namespace: id must be an integer")
+		}
+		ns, _, err := conn.Client().Namespaces.GetNamespace(int(nsID))
+		if err != nil {
+			return nil, nil, err
+		}
+		for k, v := range namespaceArgs(ns) {
+			args[k] = v
+		}
+		return args, nil, nil
+	}
+
 	if !conn.IsGroup() {
 		return nil, nil, errors.New("gitlab.namespace requires a group connection, use --group to specify a group")
 	}

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -2074,14 +2074,14 @@ func newMqlGitlabPipelineFromDetail(runtime *plugin.Runtime, pl *gitlab.Pipeline
 	// resolved. This spares the lazy accessors (user(), duration(), …) a
 	// redundant GetPipeline when they're read off a package-file pipeline.
 	//
-	// The write has to happen *inside* the Once: CreateResource can hand back
-	// a cached pipeline that another goroutine is already reading through
+	// The write has to happen *inside* the Once: CreateResource can hand back a
+	// cached pipeline that another goroutine is already reading through
 	// loadDetails, and a bare assignment carries no happens-before edge with
-	// the write in there. Doing it here also clears a stale error from an
-	// earlier failed fetch, which the payload we hold now supersedes.
+	// the write in there. If that Once has already run, this is a no-op and the
+	// existing details stand — which is fine, since a cache hit means the same
+	// pipeline id and therefore the same payload.
 	pipeline.detailsOnce.Do(func() {
 		pipeline.details = pl
-		pipeline.detailsErr = nil
 	})
 	return pipeline, nil
 }

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -172,13 +172,34 @@ func initGitlabProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	// 403/404 yields a bare resource so the typed back-ref doesn't fail the
 	// whole resource graph on insufficient perms.
 	if idArg, ok := args["id"]; ok && idArg != nil && idArg.Error == nil {
-		pid := int(idArg.Value.(int64))
-		project, resp, err := conn.Client().Projects.GetProject(pid, nil)
+		pid, ok := idArg.Value.(int64)
+		if !ok {
+			return nil, nil, errors.New("gitlab.project: id must be an integer")
+		}
+		project, resp, err := conn.Client().Projects.GetProject(int(pid), nil)
 		if err != nil {
 			if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
 				return args, nil, nil
 			}
 			return nil, nil, err
+		}
+		args = getGitlabProjectArgs(project)
+		return args, nil, nil
+	}
+
+	// GetProject also accepts a URL-encoded full path, and the SDK escapes it
+	// for us. Without this branch, `gitlab.project(fullPath: "acme/other")`
+	// fell through to the connection's own project and then overwrote fullPath
+	// with that project's value — returning a fully-populated resource for a
+	// different project than the caller asked for.
+	if pathArg, ok := args["fullPath"]; ok && pathArg != nil && pathArg.Error == nil {
+		fullPath, ok := pathArg.Value.(string)
+		if !ok || fullPath == "" {
+			return nil, nil, errors.New("gitlab.project: fullPath must be a non-empty string")
+		}
+		project, _, err := conn.Client().Projects.GetProject(fullPath, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("gitlab.project with fullPath %q not found: %w", fullPath, err)
 		}
 		args = getGitlabProjectArgs(project)
 		return args, nil, nil
@@ -232,8 +253,9 @@ func (p *mqlGitlabProject) approvalSettings() (*mqlGitlabProjectApprovalSetting,
 	}
 
 	approvalSettings := map[string]*llx.RawData{
-		"approvalsBeforeMerge":                      llx.IntData(int64(approvalConfig.ApprovalsBeforeMerge)),
-		"resetApprovalsOnPush":                      llx.BoolData(approvalConfig.ResetApprovalsOnPush),
+		"__id":                 llx.StringData(projectScopedID("gitlab.project.approvalSetting", p.Id.Data)),
+		"approvalsBeforeMerge": llx.IntData(int64(approvalConfig.ApprovalsBeforeMerge)),
+		"resetApprovalsOnPush": llx.BoolData(approvalConfig.ResetApprovalsOnPush),
 		"disableOverridingApproversPerMergeRequest": llx.BoolData(approvalConfig.DisableOverridingApproversPerMergeRequest),
 		"mergeRequestsAuthorApproval":               llx.BoolData(approvalConfig.MergeRequestsAuthorApproval),
 		"mergeRequestsDisableCommittersApproval":    llx.BoolData(approvalConfig.MergeRequestsDisableCommittersApproval),
@@ -285,7 +307,7 @@ func (p *mqlGitlabProject) approvalRules() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		branches, err := approvalRuleProtectedBranches(p.MqlRuntime, rule.ProtectedBranches, defaultBranchName)
+		branches, err := approvalRuleProtectedBranches(p.MqlRuntime, p.Id.Data, rule.ProtectedBranches, defaultBranchName)
 		if err != nil {
 			return nil, err
 		}
@@ -357,29 +379,57 @@ func groupsToDicts(groups []*gitlab.Group) []any {
 	return out
 }
 
+// newMqlProtectedBranch builds a gitlab.project.protectedBranch from the SDK
+// type. Both gitlab.project.protectedBranches() and the approval-rule path go
+// through here so the two producers agree on the cache key *and* on the field
+// set: a branch built by one and then fetched through the other must not be
+// missing its access levels.
+//
+// The cache key is project-qualified because a branch name ("main") is only
+// unique within a project. Keying on the name alone made every project in a
+// `gitlab.group.projects { protectedBranches }` query resolve to the first
+// project's branch settings.
+func newMqlProtectedBranch(runtime *plugin.Runtime, projectID int64, b *gitlab.ProtectedBranch, defaultBranchName string) (plugin.Resource, error) {
+	prefix := projectScopedID("gitlab.project.protectedBranch", projectID, b.Name)
+
+	push, err := projectBranchAccessLevels(runtime, prefix+"/push", b.PushAccessLevels)
+	if err != nil {
+		return nil, err
+	}
+	merge, err := projectBranchAccessLevels(runtime, prefix+"/merge", b.MergeAccessLevels)
+	if err != nil {
+		return nil, err
+	}
+	unprotect, err := projectBranchAccessLevels(runtime, prefix+"/unprotect", b.UnprotectAccessLevels)
+	if err != nil {
+		return nil, err
+	}
+
+	return CreateResource(runtime, "gitlab.project.protectedBranch", map[string]*llx.RawData{
+		"__id":                  llx.StringData(prefix),
+		"name":                  llx.StringData(b.Name),
+		"allowForcePush":        llx.BoolData(b.AllowForcePush),
+		"defaultBranch":         llx.BoolData(b.Name == defaultBranchName),
+		"codeOwnerApproval":     llx.BoolData(b.CodeOwnerApprovalRequired),
+		"pushAccessLevels":      llx.ArrayData(push, types.Resource("gitlab.protectedBranch.accessLevel")),
+		"mergeAccessLevels":     llx.ArrayData(merge, types.Resource("gitlab.protectedBranch.accessLevel")),
+		"unprotectAccessLevels": llx.ArrayData(unprotect, types.Resource("gitlab.protectedBranch.accessLevel")),
+	})
+}
+
 // approvalRuleProtectedBranches constructs the per-branch sub-resources
 // associated with an approval rule. defaultBranchName comes from the parent
 // project so each branch's `defaultBranch` flag stays consistent with the
-// values surfaced by gitlab.project.protectedBranches().
-//
-// Both this path and gitlab.project.protectedBranches() populate the same four
-// fields (name, allowForcePush, defaultBranch, codeOwnerApproval) from the
-// same SDK type (*gitlab.ProtectedBranch). The GitLab `/approval_rules`
-// response embeds the full ProtectedBranch object — not a name-only summary —
-// so caching by name produces identical data regardless of which producer
-// touches the cache first.
-func approvalRuleProtectedBranches(runtime *plugin.Runtime, branches []*gitlab.ProtectedBranch, defaultBranchName string) ([]any, error) {
+// values surfaced by gitlab.project.protectedBranches(). The GitLab
+// `/approval_rules` response embeds the full ProtectedBranch object, not a
+// name-only summary, so the shared constructor can populate every field.
+func approvalRuleProtectedBranches(runtime *plugin.Runtime, projectID int64, branches []*gitlab.ProtectedBranch, defaultBranchName string) ([]any, error) {
 	out := make([]any, 0, len(branches))
 	for _, b := range branches {
 		if b == nil {
 			continue
 		}
-		mqlBranch, err := CreateResource(runtime, "gitlab.project.protectedBranch", map[string]*llx.RawData{
-			"name":              llx.StringData(b.Name),
-			"allowForcePush":    llx.BoolData(b.AllowForcePush),
-			"defaultBranch":     llx.BoolData(b.Name == defaultBranchName),
-			"codeOwnerApproval": llx.BoolData(b.CodeOwnerApprovalRequired),
-		})
+		mqlBranch, err := newMqlProtectedBranch(runtime, projectID, b, defaultBranchName)
 		if err != nil {
 			return nil, err
 		}
@@ -416,11 +466,6 @@ func (p *mqlGitlabProject) mergeMethod() (string, error) {
 	return mergeMethodString, nil
 }
 
-// id function for gitlab.project.protectedBranch
-func (g *mqlGitlabProjectProtectedBranch) id() (string, error) {
-	return g.Name.Data, nil
-}
-
 // protectedBranches fetches protected branch settings
 func (p *mqlGitlabProject) protectedBranches() ([]any, error) {
 	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)
@@ -445,33 +490,7 @@ func (p *mqlGitlabProject) protectedBranches() ([]any, error) {
 
 	var mqlProtectedBranches []any
 	for _, branch := range protectedBranches {
-		isDefaultBranch := branch.Name == defaultBranch
-
-		prefix := "gitlab.project.protectedBranch/" + branch.Name
-		push, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/push", branch.PushAccessLevels)
-		if err != nil {
-			return nil, err
-		}
-		merge, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/merge", branch.MergeAccessLevels)
-		if err != nil {
-			return nil, err
-		}
-		unprotect, err := projectBranchAccessLevels(p.MqlRuntime, prefix+"/unprotect", branch.UnprotectAccessLevels)
-		if err != nil {
-			return nil, err
-		}
-
-		branchSettings := map[string]*llx.RawData{
-			"name":                  llx.StringData(branch.Name),
-			"allowForcePush":        llx.BoolData(branch.AllowForcePush),
-			"defaultBranch":         llx.BoolData(isDefaultBranch),
-			"codeOwnerApproval":     llx.BoolData(branch.CodeOwnerApprovalRequired),
-			"pushAccessLevels":      llx.ArrayData(push, types.Resource("gitlab.protectedBranch.accessLevel")),
-			"mergeAccessLevels":     llx.ArrayData(merge, types.Resource("gitlab.protectedBranch.accessLevel")),
-			"unprotectAccessLevels": llx.ArrayData(unprotect, types.Resource("gitlab.protectedBranch.accessLevel")),
-		}
-
-		mqlProtectedBranch, err := CreateResource(p.MqlRuntime, "gitlab.project.protectedBranch", branchSettings)
+		mqlProtectedBranch, err := newMqlProtectedBranch(p.MqlRuntime, p.Id.Data, branch, defaultBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -846,6 +865,10 @@ func (p *mqlGitlabProject) projectMembers() ([]any, error) {
 				Page:    page,
 				PerPage: perPage,
 			},
+			// GitLab omits is_using_seat from the members payload unless it is
+			// asked for, and the SDK models it as a plain bool — without this
+			// every member would decode as isUsingSeat=false.
+			ShowSeatInfo: gitlab.Ptr(true),
 		})
 		if err != nil {
 			return nil, err
@@ -883,6 +906,13 @@ func (p *mqlGitlabProject) projectMembers() ([]any, error) {
 		}
 
 		memberInfo := map[string]*llx.RawData{
+			// ProjectMember.ID is the *user* id, not a membership id, so it is
+			// the same value in every project and group the user belongs to.
+			// The membership is what this resource models, so the key has to
+			// carry the owning project too — otherwise a user who is Owner in
+			// one project and Guest in another resolves to whichever
+			// membership was materialized first.
+			"__id":        llx.StringData(projectScopedID("gitlab.member/project", p.Id.Data, strconv.FormatInt(int64(member.ID), 10))),
 			"id":          llx.IntData(int64(member.ID)),
 			"user":        llx.ResourceData(mqlUser, "gitlab.user"),
 			"role":        llx.StringData(role),
@@ -907,11 +937,6 @@ func (p *mqlGitlabProject) projectMembers() ([]any, error) {
 	}
 
 	return mqlMembers, nil
-}
-
-// id function for gitlab.project.file
-func (f *mqlGitlabProjectFile) id() (string, error) {
-	return f.Path.Data, nil
 }
 
 // mqlGitlabProjectFileInternal carries the parent project context needed to
@@ -990,6 +1015,13 @@ func (p *mqlGitlabProject) projectFiles() ([]any, error) {
 			continue
 		}
 		fileInfo := map[string]*llx.RawData{
+			// A repo path ("README.md") repeats across projects, and the ref
+			// decides which revision content() reads, so both belong in the
+			// key. Keying on the path alone let one project's file resource be
+			// handed back for another project — and the projectID/ref assigned
+			// just below would then be written onto the *cached* resource,
+			// pointing content() at the wrong repository.
+			"__id": llx.StringData(projectScopedID("gitlab.project.file", p.Id.Data, defaultBranch, file.Path)),
 			"path": llx.StringData(file.Path),
 			"type": llx.StringData(file.Type),
 			"name": llx.StringData(file.Name),
@@ -1150,17 +1182,11 @@ func createMilestoneResource(runtime *plugin.Runtime, milestone *gitlab.Mileston
 		"createdAt":   llx.TimeDataPtr(milestone.CreatedAt),
 	}
 
-	// Convert ISOTime to time.Time for startDate
-	if milestone.StartDate != nil {
-		t := time.Time(*milestone.StartDate)
-		milestoneInfo["startDate"] = llx.TimeDataPtr(&t)
-	}
-
-	// Convert ISOTime to time.Time for dueDate
-	if milestone.DueDate != nil {
-		t := time.Time(*milestone.DueDate)
-		milestoneInfo["dueDate"] = llx.TimeDataPtr(&t)
-	}
+	// Always set these keys. Skipping them for a milestone with no start/due
+	// date leaves the field unset rather than null, which surfaces client-side
+	// as "primitive with no type information" instead of a clean null.
+	milestoneInfo["startDate"] = llx.TimeDataPtr(isoTimePtr(milestone.StartDate))
+	milestoneInfo["dueDate"] = llx.TimeDataPtr(isoTimePtr(milestone.DueDate))
 
 	// Handle expired field (pointer to bool)
 	if milestone.Expired != nil {
@@ -1470,11 +1496,6 @@ func (p *mqlGitlabProject) issues() ([]any, error) {
 	return mqlIssues, nil
 }
 
-// id function for gitlab.project.release
-func (r *mqlGitlabProjectRelease) id() (string, error) {
-	return r.TagName.Data, nil
-}
-
 // releases fetches the list of releases for the project
 func (p *mqlGitlabProject) releases() ([]any, error) {
 	conn := p.MqlRuntime.Connection.(*connection.GitLabConnection)
@@ -1508,6 +1529,9 @@ func (p *mqlGitlabProject) releases() ([]any, error) {
 	var mqlReleases []any
 	for _, release := range allReleases {
 		releaseInfo := map[string]*llx.RawData{
+			// A release tag ("v1.0.0") is unique per project, not per
+			// instance, so the project id has to be part of the key.
+			"__id":            llx.StringData(projectScopedID("gitlab.project.release", p.Id.Data, release.TagName)),
 			"tagName":         llx.StringData(release.TagName),
 			"name":            llx.StringData(release.Name),
 			"description":     llx.StringData(release.Description),
@@ -1552,6 +1576,19 @@ func (r *mqlGitlabProjectRelease) authorUser() (*mqlGitlabUser, error) {
 	return res.(*mqlGitlabUser), nil
 }
 
+// dictTime renders a timestamp for embedding in a dict field. Dict values are
+// serialized by llx's dict2primitive, which accepts only JSON-native types
+// (nil, bool, int64, float64, string, []any, map[string]any) — handing it a
+// *time.Time fails the whole field at query time, and a typed nil pointer
+// fails too because the interface is non-nil. RFC3339 keeps the value both
+// serializable and comparable.
+func dictTime(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.Format(time.RFC3339)
+}
+
 func releaseCommitToDict(c gitlab.Commit) any {
 	if c.ID == "" {
 		return nil
@@ -1561,8 +1598,8 @@ func releaseCommitToDict(c gitlab.Commit) any {
 		"shortId":       c.ShortID,
 		"title":         c.Title,
 		"authorName":    c.AuthorName,
-		"authoredDate":  c.AuthoredDate,
-		"committedDate": c.CommittedDate,
+		"authoredDate":  dictTime(c.AuthoredDate),
+		"committedDate": dictTime(c.CommittedDate),
 		"webUrl":        c.WebURL,
 	}
 }
@@ -1576,7 +1613,7 @@ func releaseEvidencesToDicts(evidences []*gitlab.ReleaseEvidence) []any {
 		out = append(out, map[string]any{
 			"sha":         e.SHA,
 			"filepath":    e.Filepath,
-			"collectedAt": e.CollectedAt,
+			"collectedAt": dictTime(e.CollectedAt),
 		})
 	}
 	return out
@@ -1608,11 +1645,6 @@ func releaseAssetsToDict(a gitlab.ReleaseAssets) any {
 		"sources": sources,
 		"links":   links,
 	}
-}
-
-// id function for gitlab.project.variable
-func (v *mqlGitlabProjectVariable) id() (string, error) {
-	return v.Key.Data + "/" + v.EnvironmentScope.Data, nil
 }
 
 // variables fetches the list of CI/CD variables for the project
@@ -1648,6 +1680,11 @@ func (p *mqlGitlabProject) variables() ([]any, error) {
 	var mqlVariables []any
 	for _, v := range allVariables {
 		varInfo := map[string]*llx.RawData{
+			// CI/CD variable keys are deliberately reused across projects
+			// (AWS_ACCESS_KEY_ID, NPM_TOKEN, ...), so key+scope alone aliases
+			// between them — and the aliased row carries the other project's
+			// masked/protected flags.
+			"__id":             llx.StringData(projectScopedID("gitlab.project.variable", p.Id.Data, v.Key, v.EnvironmentScope)),
 			"key":              llx.StringData(v.Key),
 			"variableType":     llx.StringData(string(v.VariableType)),
 			"protected":        llx.BoolData(v.Protected),
@@ -1733,17 +1770,11 @@ func (p *mqlGitlabProject) milestones() ([]any, error) {
 			"createdAt":   llx.TimeDataPtr(milestone.CreatedAt),
 		}
 
-		// Convert ISOTime to time.Time for startDate
-		if milestone.StartDate != nil {
-			t := time.Time(*milestone.StartDate)
-			milestoneInfo["startDate"] = llx.TimeDataPtr(&t)
-		}
-
-		// Convert ISOTime to time.Time for dueDate
-		if milestone.DueDate != nil {
-			t := time.Time(*milestone.DueDate)
-			milestoneInfo["dueDate"] = llx.TimeDataPtr(&t)
-		}
+		// Always set these keys. Skipping them for a milestone with no start/due
+		// date leaves the field unset rather than null, which surfaces client-side
+		// as "primitive with no type information" instead of a clean null.
+		milestoneInfo["startDate"] = llx.TimeDataPtr(isoTimePtr(milestone.StartDate))
+		milestoneInfo["dueDate"] = llx.TimeDataPtr(isoTimePtr(milestone.DueDate))
 
 		// Handle expired field (pointer to bool)
 		if milestone.Expired != nil {
@@ -1801,12 +1832,16 @@ func (p *mqlGitlabProject) labels() ([]any, error) {
 	var mqlLabels []any
 	for _, label := range allLabels {
 		labelInfo := map[string]*llx.RawData{
-			"id":                     llx.IntData(label.ID),
-			"name":                   llx.StringData(label.Name),
-			"color":                  llx.StringData(label.Color),
-			"textColor":              llx.StringData(label.TextColor),
-			"description":            llx.StringData(label.Description),
-			"descriptionHtml":        llx.StringData(""), // Not in API response
+			"id":          llx.IntData(label.ID),
+			"name":        llx.StringData(label.Name),
+			"color":       llx.StringData(label.Color),
+			"textColor":   llx.StringData(label.TextColor),
+			"description": llx.StringData(label.Description),
+			// The SDK's Label struct does not model description_html, so we have
+			// no value to report. Null says "unknown"; an empty string would
+			// claim, for every label on every project, that no HTML
+			// description exists.
+			"descriptionHtml":        llx.NilData,
 			"openIssuesCount":        llx.IntData(label.OpenIssuesCount),
 			"closedIssuesCount":      llx.IntData(label.ClosedIssuesCount),
 			"openMergeRequestsCount": llx.IntData(label.OpenMergeRequestsCount),
@@ -2038,8 +2073,16 @@ func newMqlGitlabPipelineFromDetail(runtime *plugin.Runtime, pl *gitlab.Pipeline
 	// We already hold the full detail payload, so seed the cache and mark it
 	// resolved. This spares the lazy accessors (user(), duration(), …) a
 	// redundant GetPipeline when they're read off a package-file pipeline.
-	pipeline.details = pl
-	pipeline.detailsOnce.Do(func() {})
+	//
+	// The write has to happen *inside* the Once: CreateResource can hand back
+	// a cached pipeline that another goroutine is already reading through
+	// loadDetails, and a bare assignment carries no happens-before edge with
+	// the write in there. Doing it here also clears a stale error from an
+	// earlier failed fetch, which the payload we hold now supersedes.
+	pipeline.detailsOnce.Do(func() {
+		pipeline.details = pl
+		pipeline.detailsErr = nil
+	})
 	return pipeline, nil
 }
 

--- a/providers/gitlab/resources/gitlab_project.go
+++ b/providers/gitlab/resources/gitlab_project.go
@@ -1188,12 +1188,10 @@ func createMilestoneResource(runtime *plugin.Runtime, milestone *gitlab.Mileston
 	milestoneInfo["startDate"] = llx.TimeDataPtr(isoTimePtr(milestone.StartDate))
 	milestoneInfo["dueDate"] = llx.TimeDataPtr(isoTimePtr(milestone.DueDate))
 
-	// Handle expired field (pointer to bool)
-	if milestone.Expired != nil {
-		milestoneInfo["expired"] = llx.BoolData(*milestone.Expired)
-	} else {
-		milestoneInfo["expired"] = llx.BoolData(false)
-	}
+	// A nil Expired means GitLab did not report the flag, which is not the
+	// same as reporting "not expired" — flattening it to false invents a
+	// value the API never sent. BoolDataPtr maps nil to a real MQL null.
+	milestoneInfo["expired"] = llx.BoolDataPtr(milestone.Expired)
 
 	mqlMilestone, err := CreateResource(runtime, "gitlab.project.milestone", milestoneInfo)
 	if err != nil {
@@ -1776,12 +1774,10 @@ func (p *mqlGitlabProject) milestones() ([]any, error) {
 		milestoneInfo["startDate"] = llx.TimeDataPtr(isoTimePtr(milestone.StartDate))
 		milestoneInfo["dueDate"] = llx.TimeDataPtr(isoTimePtr(milestone.DueDate))
 
-		// Handle expired field (pointer to bool)
-		if milestone.Expired != nil {
-			milestoneInfo["expired"] = llx.BoolData(*milestone.Expired)
-		} else {
-			milestoneInfo["expired"] = llx.BoolData(false)
-		}
+		// A nil Expired means GitLab did not report the flag, which is not the
+		// same as reporting "not expired" — flattening it to false invents a
+		// value the API never sent. BoolDataPtr maps nil to a real MQL null.
+		milestoneInfo["expired"] = llx.BoolDataPtr(milestone.Expired)
 
 		mqlMilestone, err := CreateResource(p.MqlRuntime, "gitlab.project.milestone", milestoneInfo)
 		if err != nil {

--- a/providers/gitlab/resources/gitlab_registries.go
+++ b/providers/gitlab/resources/gitlab_registries.go
@@ -25,10 +25,6 @@ func (t *mqlGitlabProjectContainerRegistryRepositoryTag) id() (string, error) {
 	return "gitlab.project.containerRegistryRepository.tag/" + t.Path.Data + ":" + t.Name.Data, nil
 }
 
-func (p *mqlGitlabProjectContainerExpirationPolicy) id() (string, error) {
-	return "gitlab.project.containerExpirationPolicy/" + strconv.FormatInt(p.containerExpirationProjectID, 10), nil
-}
-
 func (r *mqlGitlabProjectContainerRegistryProtectionRule) id() (string, error) {
 	return "gitlab.project.containerRegistryProtectionRule/" + strconv.FormatInt(r.Id.Data, 10), nil
 }
@@ -78,7 +74,13 @@ func (p *mqlGitlabProject) containerRegistryRepositories() ([]any, error) {
 	page := int64(1)
 	for {
 		repos, resp, err := conn.Client().ContainerRegistry.ListProjectRegistryRepositories(projectID,
-			&gitlab.ListProjectRegistryRepositoriesOptions{ListOptions: gitlab.ListOptions{Page: page, PerPage: 50}})
+			&gitlab.ListProjectRegistryRepositoriesOptions{
+				ListOptions: gitlab.ListOptions{Page: page, PerPage: 50},
+				// GitLab omits tags_count unless it is requested, and the SDK
+				// models it as a plain int64 — without this every repository
+				// reports tagsCount: 0.
+				TagsCount: gitlab.Ptr(true),
+			})
 		if err != nil {
 			if resp != nil && (resp.StatusCode == 403 || resp.StatusCode == 404) {
 				return []any{}, nil
@@ -91,7 +93,7 @@ func (p *mqlGitlabProject) containerRegistryRepositories() ([]any, error) {
 		}
 		page = resp.NextPage
 	}
-	return containerReposToMqlResources(p.MqlRuntime, all, p.Id.Data)
+	return containerReposToMqlResources(p.MqlRuntime, all, p.Id.Data, true)
 }
 
 func (g *mqlGitlabGroup) containerRegistryRepositories() ([]any, error) {
@@ -114,14 +116,14 @@ func (g *mqlGitlabGroup) containerRegistryRepositories() ([]any, error) {
 		}
 		page = resp.NextPage
 	}
-	return containerReposToMqlResources(g.MqlRuntime, all, 0)
+	return containerReposToMqlResources(g.MqlRuntime, all, 0, false)
 }
 
 // containerReposToMqlResources maps SDK RegistryRepository values to MQL
 // resources. When parentProjectID is 0 (group rollup), the per-row ProjectID
 // is used; otherwise the parent project's ID overrides — both are correct
 // since the SDK populates ProjectID consistently.
-func containerReposToMqlResources(runtime *plugin.Runtime, repos []*gitlab.RegistryRepository, parentProjectID int64) ([]any, error) {
+func containerReposToMqlResources(runtime *plugin.Runtime, repos []*gitlab.RegistryRepository, parentProjectID int64, hasTagsCount bool) ([]any, error) {
 	out := make([]any, 0, len(repos))
 	for _, r := range repos {
 		ownerProjectID := parentProjectID
@@ -132,6 +134,14 @@ func containerReposToMqlResources(runtime *plugin.Runtime, repos []*gitlab.Regis
 		if r.Status != nil {
 			status = string(*r.Status)
 		}
+		// The group-level list endpoint has no tags_count parameter in the
+		// SDK's options struct, so we cannot ask for the value there. Report
+		// null rather than the decoded zero, which would claim every
+		// repository in the group holds no tags.
+		tagsCount := llx.NilData
+		if hasTagsCount {
+			tagsCount = llx.IntData(r.TagsCount)
+		}
 		args := map[string]*llx.RawData{
 			"id":                     llx.IntData(r.ID),
 			"name":                   llx.StringData(r.Name),
@@ -139,7 +149,7 @@ func containerReposToMqlResources(runtime *plugin.Runtime, repos []*gitlab.Regis
 			"location":               llx.StringData(r.Location),
 			"createdAt":              llx.TimeDataPtr(r.CreatedAt),
 			"cleanupPolicyStartedAt": llx.TimeDataPtr(r.CleanupPolicyStartedAt),
-			"tagsCount":              llx.IntData(r.TagsCount),
+			"tagsCount":              tagsCount,
 			"status":                 llx.StringData(status),
 		}
 		res, err := CreateResource(runtime, "gitlab.project.containerRegistryRepository", args)
@@ -235,6 +245,11 @@ func (p *mqlGitlabProject) containerExpirationPolicy() (*mqlGitlabProjectContain
 		return nil, nil
 	}
 	args := map[string]*llx.RawData{
+		// Pass the key explicitly rather than letting id() derive it from
+		// containerExpirationProjectID: that field is assigned after
+		// CreateResource returns, so id() always saw 0 and every project's
+		// policy collapsed onto one cache entry.
+		"__id":            llx.StringData(projectScopedID("gitlab.project.containerExpirationPolicy", p.Id.Data)),
 		"enabled":         llx.BoolData(policy.Enabled),
 		"cadence":         llx.StringData(policy.Cadence),
 		"keepN":           llx.IntData(int64(policy.KeepN)),

--- a/providers/gitlab/resources/gitlab_settings.go
+++ b/providers/gitlab/resources/gitlab_settings.go
@@ -14,7 +14,12 @@ import (
 // initGitlabSettings fetches instance-level application settings.
 // Requires an admin-scoped token; returns a permission error otherwise.
 func initGitlabSettings(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 0 {
+	// gitlab.settings is a singleton with no lookup key, so the only reason to
+	// skip the fetch is that a caller already handed us the full field set.
+	// The threshold has to allow for the implicit __id arg — every other init
+	// in this provider uses > 2 for the same reason. At > 0 a single incidental
+	// arg skipped the fetch entirely and left all 33 fields unset.
+	if len(args) > 2 {
 		return args, nil, nil
 	}
 

--- a/providers/gitlab/resources/gitlab_test.go
+++ b/providers/gitlab/resources/gitlab_test.go
@@ -12,26 +12,6 @@ import (
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
-func TestMapAccessLevelToRole(t *testing.T) {
-	tests := []struct {
-		accessLevel int
-		want        string
-	}{
-		{10, "Guest"},
-		{20, "Reporter"},
-		{30, "Developer"},
-		{40, "Maintainer"},
-		{50, "Owner"},
-		{0, "Unknown"},
-		{15, "Unknown"},
-		{60, "Unknown"},
-		{-1, "Unknown"},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, mapAccessLevelToRole(tt.accessLevel), "accessLevel=%d", tt.accessLevel)
-	}
-}
-
 func TestGroupsToDicts(t *testing.T) {
 	t.Run("maps fields and skips nil entries", func(t *testing.T) {
 		groups := []*gitlab.Group{

--- a/providers/gitlab/resources/gitlab_user.go
+++ b/providers/gitlab/resources/gitlab_user.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -30,7 +31,11 @@ var gitlabUserScopeWarn sync.Once
 // from the *gitlab.User they already have, so externalIdentities() doesn't need
 // to call GetUser at all - eliminating an N+1 across N members.
 type mqlGitlabUserInternal struct {
-	fetched         bool
+	// fetched is atomic because the unlocked fast-path read below races the
+	// locked writes otherwise: llx resolves fields in separate goroutines, so
+	// the nineteen accessors that funnel through fetchUser can run
+	// concurrently on the same resource.
+	fetched         atomic.Bool
 	user            *gitlab.User
 	cacheIdentities []*gitlab.UserIdentity
 	lock            sync.Mutex
@@ -90,7 +95,7 @@ func initGitlabUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 	}
 	mqlUser := res.(*mqlGitlabUser)
 	mqlUser.user = user
-	mqlUser.fetched = true
+	mqlUser.fetched.Store(true)
 	return args, mqlUser, nil
 }
 
@@ -102,12 +107,12 @@ func initGitlabUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 // lastSignInAt, ...) are returning zero values rather than reflecting actual
 // state.
 func (u *mqlGitlabUser) fetchUser() (*gitlab.User, error) {
-	if u.fetched {
+	if u.fetched.Load() {
 		return u.user, nil
 	}
 	u.lock.Lock()
 	defer u.lock.Unlock()
-	if u.fetched {
+	if u.fetched.Load() {
 		return u.user, nil
 	}
 	conn := u.MqlRuntime.Connection.(*connection.GitLabConnection)
@@ -118,13 +123,13 @@ func (u *mqlGitlabUser) fetchUser() (*gitlab.User, error) {
 				log.Warn().Int("status", resp.StatusCode).
 					Msg("gitlab token cannot read /users/:id; admin-scoped user fields (isAdmin, isAuditor, lastSignInAt, ...) will return zero values")
 			})
-			u.fetched = true
+			u.fetched.Store(true)
 			return nil, nil
 		}
 		return nil, err
 	}
 	u.user = user
-	u.fetched = true
+	u.fetched.Store(true)
 	return u.user, nil
 }
 
@@ -297,11 +302,6 @@ func (u *mqlGitlabUser) sharedRunnersMinutesLimit() (int64, error) {
 	return user.SharedRunnersMinutesLimit, nil
 }
 
-// id function for gitlab.user.externalIdentity
-func (i *mqlGitlabUserExternalIdentity) id() (string, error) {
-	return "gitlab.user.externalIdentity/" + i.Provider.Data + "/" + i.ExternUID.Data, nil
-}
-
 // mqlGitlabUserExternalIdentityInternal carries the parent user ID so the
 // `user()` accessor can resolve back to the typed gitlab.user resource.
 type mqlGitlabUserExternalIdentityInternal struct {
@@ -347,6 +347,11 @@ func (u *mqlGitlabUser) externalIdentities() ([]any, error) {
 			continue
 		}
 		identityInfo := map[string]*llx.RawData{
+			// The owning user belongs in the key: provider+externUID alone
+			// aliases whenever a provider reports an empty extern_uid, and the
+			// userID assigned just below would then repoint the first user's
+			// identity resource at this one.
+			"__id":      llx.StringData(userScopedID("gitlab.user.externalIdentity", u.Id.Data, identity.Provider, identity.ExternUID)),
 			"provider":  llx.StringData(identity.Provider),
 			"externUID": llx.StringData(identity.ExternUID),
 		}


### PR DESCRIPTION
Static bug review of the gitlab provider (v13.5.3, ~5.7k hand-written LOC). Every finding below was confirmed against the source, the generated `.lr.go`, or the GitLab SDK before being fixed.

## The dominant defect: `__id` collisions across parents

The runtime caches on `resourceName + "\x00" + __id`, and `CreateResource` returns the **cached** instance on a key hit — silently discarding the data it was just handed:

```go
id := name + "\x00" + mqlId
if x, ok := runtime.Resources.Get(id); ok {
    return x, nil
}
```

`gitlab.group.projects` materializes every project in one runtime, and `ListAllGroupMembers` returns inherited members, so this is reachable from ordinary queries — not exotic ones.

| Resource | Old `__id` | Collided |
|---|---|---|
| `project.approvalSetting` | *(empty — no `id()`, no `__id`)* | **always** |
| `project.containerExpirationPolicy` | `.../0` | **always** |
| `group.samlGroupLink` | `.../0/<provider>/<name>` | **always** |
| `member` | user id, unscoped | any group tree |
| `project.protectedBranch` | branch name | every `main` |
| `project.variable` / `group.variable` | `key/envScope` | shared secret names |
| `project.release` | tag name | every `v1.0.0` |
| `project.file` | repo path | every `README.md` |
| `project.codeowners` + `.rule` | path / `line/pattern` | always / every `1/*` |
| `user.externalIdentity` | `provider/externUID` | empty `extern_uid` |

`containerExpirationPolicy` and `samlGroupLink` are the Internal-field-ordering trap: `id()` read a field assigned *after* `CreateResource` returned, so it was always `0`. `project.file` and `containerExpirationPolicy` then wrote their parent id onto the **cached** resource, repointing another project's resource — `file.content()` would fetch the wrong repository.

All now pass an explicit `__id` (which wins over `id()`), built through shared `projectScopedID` / `groupScopedID` / `userScopedID` helpers. The superseded `id()` methods are removed rather than left behind as landmines for future call sites.

The two protected-branch producers also shared a key while populating **different field sets** (the approval-rule path omitted the three access-level lists). They now go through one constructor, so a branch is complete whichever path built it.

## Fabricated data

- **`release.commit` / `release.evidences` failed for 100% of releases.** Both embedded `*time.Time` in a `dict`; llx's `dict2primitive` accepts only JSON-native values and errors on anything else. A nil `*time.Time` doesn't help — the interface is non-nil, so it hits the same branch. Now RFC3339 strings via a `dictTime` helper.
- **`member.isUsingSeat` was always `false`** — GitLab omits `is_using_seat` unless `show_seat_info=true` is sent, and the SDK models it as a plain `bool`.
- **`containerRegistryRepository.tagsCount` was always `0`** — same shape. Now requested on the project path; the group rollup endpoint has no such parameter, so it reports **null** there rather than a fabricated zero.
- **`label.descriptionHtml` was hardcoded `""`.** The SDK genuinely doesn't model the field, so it now reports null and is marked `@maturity("deprecated")`.
- **CODEOWNERS sections with default owners were misparsed.** `[Database] @dba-team` is documented GitLab syntax, but the header regex anchored `\s*$` right after the brackets. The line fell through to the rule branch, emitting a phantom rule whose pattern was the literal `[Database]` *and* leaving section state on the previous section — so every rule after it reported the wrong `required`/`optional` flag. Patterns with no owners now inherit the section defaults.
- **`mapAccessLevelToRole` was missing levels 0, 5, 15, 60**, so an instance admin was indistinguishable from a no-access user. The existing test asserted the gap as correct and has been replaced.

## Pagination

`group.memberRoles` fetched a single page. GitLab defaults to `per_page=20`, and the SDK gives this endpoint no options struct — it now drives `gitlab.WithNext(resp)`, which two siblings in the same files already did for the identical shape. **This was the only truncation**; the other 40+ list calls (including both nested pairs) already paginate correctly.

## Init / null handling

- `gitlab.namespace(id:)` and `gitlab.project(fullPath:)` ignored the selector, fetched the **connection's own** namespace/project, and then overwrote the caller's argument with that object's value — returning authoritative-looking data for something else entirely.
- `initGitlabSettings` used `len(args) > 0` where every sibling uses `> 2` (to allow for the implicit `__id`), so any incidental arg skipped the fetch and left all 33 fields unset.
- Milestone `startDate`/`dueDate` were left **unset** rather than null when absent, surfacing as `primitive with no type information` instead of a clean null.

## Discovery

- **Child configs were cloned without `inventory.WithoutDiscovery()`** (github does this at all five of its clone sites), so every discovered asset re-ran the entire discovery walk — the likely cause of rate-limiting on large groups.
- `subgroups` and `descendant_groups` were concatenated with no dedupe; descendants are a strict superset, so **every direct subgroup was discovered twice** and its project list walked twice.
- The "skip subgroup discovery" guard tested `Group.Name`, which never contains a `/` — it never fired. It also passed `Group.Path` (the leaf slug) to the subgroup endpoints, where GitLab resolves it at the **root namespace**, potentially walking an unrelated top-level group.
- `findSubgroup` matched on display name (so a group renamed away from its slug was unreachable) and dropped everything past the second path segment — `--group a/b/c` silently resolved `a/b`. A full path is a valid group id, so the whole traversal is gone.
- Projects **shared** into a group were attributed to the sharing group, producing a second disjoint platform id for the same repository — scanned and reported twice.
- CLI-targeted projects got platform id `.../group/0/project/<id>` (the `// TODO fix 0`) because `ParseCLI` never sets `group-id`, splitting a project's history from its discovery-scanned self.
- Repo-relative POSIX paths went through `path/filepath`, which rewrites separators on Windows.
- `DiscoverSubAndDescendantGroupsForGroup` could never return an error, making the callers' error handling dead code; a 403 yielded a silently partial tree at `Debug` level. Now warns, and errors when nothing could be read at all.

## Robustness

- `fetchUser`'s double-check used a plain `bool` racing its locked writes (llx resolves fields in parallel goroutines) → `atomic.Bool`.
- The pipeline detail cache was seeded **outside** its `sync.Once`, so it carried no happens-before edge with the write inside `loadDetails`, and a stale `detailsErr` survived.
- Runner-detail and CODEOWNERS fetches now degrade on permission denials instead of failing the field for every shared runner / mid-group-scan.
- The vulnerability GraphQL paths treated a null `data.project` / `data.group` container as "no vulnerabilities" — a vacuous pass for a project we never read.

## Tests

The gap mapped almost exactly onto the findings: `groupsToDicts` is the one dict converter with a test, and it's the one that was correct.

- **id-builder cross-parent uniqueness** — the single highest-value test; it covers 11 of the findings. It also caught a flaw in this PR's own first cut, where a group id of 10 and a project id of 10 both produced `gitlab.member/10/<user>`; the key now names the parent kind.
- **dict JSON-native contract** mirroring `dict2primitive`'s allow-list, over all nine dict converters — the guard that would have caught the release break.
- CODEOWNERS default-owner section forms, including that section state advances past such a header.
- The corrected access-level map, asserting every real level maps to a distinct name.
- Discovery path helpers (`isSubgroup`, `iacDir`, `isHiddenPath`, `isDockerfile`, `isKustomization`).
- `connection_test.go` is replaced — it was gated behind a `debugtest` tag and called `New`/`Identifier`, which no longer exist, so it never compiled.

`go test -race ./...`, `go vet`, and `gofmt -l` are clean; `go.mod` is unchanged. No `.lr.versions` bump: only doc comments and a `@maturity` marker changed, which per the contributor guide doesn't bump versions.

## Deliberately not changed

- **Admin-only user fields on a non-admin token.** `IsAdmin`/`TwoFactorEnabled`/`Identities` are non-pointer types in the SDK, so an omitted key decodes to `false`/`[]` indistinguishably from a real value, and the existing warning only fires on 403/404 — which isn't what GitLab returns here. Distinguishing absent from false needs live confirmation of the actual response shape first.
- **403 degradation across ~17 remaining accessors.** Surfacing a real permission error so the user learns their token is under-scoped is defensible; the inconsistency with the 28 sites that degrade is worth a deliberate product call rather than a blanket change here.
- **Typed refs for `runner.projects`/`groups` and `samlGroupLink.memberRoleId`.** These shipped as `[]string`/`int`, so replacing them needs the deprecate-and-add treatment plus `.lr.versions` entries — a separate change.
