### PR TITLE
🐛 oci: fix deadlock, wrong security verdicts, husk caching, and region degradation

### DIFF
--- a/providers/oci/connection/clients.go
+++ b/providers/oci/connection/clients.go
@@ -422,6 +422,7 @@ func (c *OciConnection) GenerativeAiAgentClient(region string) (*generativeaiage
 		return nil, err
 	}
 	client.SetRegion(region)
+	failFastOnUnreachableRegion(&client.BaseClient)
 	return &client, nil
 }
 
@@ -431,6 +432,7 @@ func (c *OciConnection) DataScienceClient(region string) (*datascience.DataScien
 		return nil, err
 	}
 	client.SetRegion(region)
+	failFastOnUnreachableRegion(&client.BaseClient)
 	return &client, nil
 }
 

--- a/providers/oci/connection/connection.go
+++ b/providers/oci/connection/connection.go
@@ -55,7 +55,15 @@ func NewOciConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 		if pkey.Type != vault.CredentialType_private_key {
 			return nil, errors.New("OCI provider does not support credential type: " + pkey.Type.String())
 		}
-		configProvider = common.NewRawConfigurationProvider(tenancyOcid, userOcid, region, fingerprint, string(pkey.Secret), nil)
+		// --key-secret is collected by ParseCLI as the credential password and
+		// is the passphrase for an encrypted private key. Passing nil here made
+		// the documented flag inert, so an encrypted API key failed at connect
+		// with an opaque PEM decryption error no matter what the user supplied.
+		var passphrase *string
+		if pkey.Password != "" {
+			passphrase = &pkey.Password
+		}
+		configProvider = common.NewRawConfigurationProvider(tenancyOcid, userOcid, region, fingerprint, string(pkey.Secret), passphrase)
 	} else {
 		profile := conf.Options["profile"]
 		configFile := conf.Options["config-file"]

--- a/providers/oci/provider/provider.go
+++ b/providers/oci/provider/provider.go
@@ -220,7 +220,10 @@ func (s *Service) detect(asset *inventory.Asset, conn *connection.OciConnection)
 	if err != nil {
 		return err
 	}
-	if info != nil {
+	// Tenant() returns a non-nil tenancy whenever err is nil, but Name is
+	// optional on the SDK model and is absent for a tenancy with no display
+	// name, so it needs its own guard.
+	if info != nil && info.Name != nil {
 		asset.Name = fmt.Sprintf("OCI Tenant %s", *info.Name)
 	}
 

--- a/providers/oci/resources/aiservices.go
+++ b/providers/oci/resources/aiservices.go
@@ -46,16 +46,7 @@ func ociListRegionalAI(runtime *plugin.Runtime, fetch func(region string) ([]any
 			return jobpool.JobResult(items), nil
 		}))
 	}
-	poolOfJobs := jobpool.CreatePool(tasks, 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	res := []any{}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(tasks)
 }
 
 // ociListRegionalAIClient adds typed per-region client creation to

--- a/providers/oci/resources/aiservices.go
+++ b/providers/oci/resources/aiservices.go
@@ -74,7 +74,7 @@ func ociListRegionalAIClient[C any](runtime *plugin.Runtime, factory func(region
 // findOciAIResourceByID powers the init functions for the single-purpose AI
 // resources: it lists the requested collection and returns the entry whose id
 // matches the "id" argument, so a resource can be selected directly by OCID.
-func findOciAIResourceByID(runtime *plugin.Runtime, args map[string]*llx.RawData, serviceName string, list func(plugin.Resource) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
+func findOciAIResourceByID(runtime *plugin.Runtime, args map[string]*llx.RawData, serviceName, resourceName string, list func(plugin.Resource) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
@@ -96,7 +96,7 @@ func findOciAIResourceByID(runtime *plugin.Runtime, args map[string]*llx.RawData
 			return args, res, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New(resourceName + " not found: " + idVal)
 }
 
 // =====================================================================
@@ -252,15 +252,15 @@ type mqlOciAiLanguageEndpointInternal struct {
 }
 
 func initOciAiLanguageProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.language", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetProjects() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.language", "oci.ai.language.project", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetProjects() })
 }
 
 func initOciAiLanguageModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.language", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetModels() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.language", "oci.ai.language.model", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetModels() })
 }
 
 func initOciAiLanguageEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.language", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetEndpoints() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.language", "oci.ai.language.endpoint", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiLanguage).GetEndpoints() })
 }
 
 func (o *mqlOciAiLanguageProject) id() (string, error) {
@@ -418,11 +418,11 @@ type mqlOciAiVisionModelInternal struct {
 }
 
 func initOciAiVisionProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.vision", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiVision).GetProjects() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.vision", "oci.ai.vision.project", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiVision).GetProjects() })
 }
 
 func initOciAiVisionModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.vision", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiVision).GetModels() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.vision", "oci.ai.vision.model", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiVision).GetModels() })
 }
 
 func (o *mqlOciAiVisionProject) id() (string, error) {
@@ -497,7 +497,7 @@ func (o *mqlOciAiSpeech) customizations() ([]any, error) {
 }
 
 func initOciAiSpeechCustomization(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.speech", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiSpeech).GetCustomizations() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.speech", "oci.ai.speech.customization", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiSpeech).GetCustomizations() })
 }
 
 func (o *mqlOciAiSpeechCustomization) id() (string, error) {
@@ -611,11 +611,11 @@ type mqlOciAiDocumentModelInternal struct {
 }
 
 func initOciAiDocumentProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.document", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiDocument).GetProjects() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.document", "oci.ai.document.project", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiDocument).GetProjects() })
 }
 
 func initOciAiDocumentModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciAIResourceByID(runtime, args, "oci.ai.document", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiDocument).GetModels() })
+	return findOciAIResourceByID(runtime, args, "oci.ai.document", "oci.ai.document.model", func(o plugin.Resource) *plugin.TValue[[]any] { return o.(*mqlOciAiDocument).GetModels() })
 }
 
 func (o *mqlOciAiDocumentProject) id() (string, error) {

--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -810,10 +810,10 @@ func initOciApigatewayCertificate(runtime *plugin.Runtime, args map[string]*llx.
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.apigateway.certificate")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.apigateway", nil)
 	if err != nil {

--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -515,11 +515,13 @@ func flattenAuthenticationType(rp *apigateway.ApiSpecificationRequestPolicies) s
 	return "UNKNOWN"
 }
 
-// flattenIsAnonymousAccessAllowed returns the authentication policy's
-// anonymous-access flag, defaulting to false when absent.
+// flattenIsAnonymousAccessAllowed reports whether unauthenticated requests
+// reach the backend. A deployment with no authentication policy at all
+// enforces nothing, so every request is anonymous - reporting false there
+// would clear the most exposed deployment in the tenancy.
 func flattenIsAnonymousAccessAllowed(rp *apigateway.ApiSpecificationRequestPolicies) bool {
 	if rp == nil || rp.Authentication == nil {
-		return false
+		return true
 	}
 	if v := rp.Authentication.GetIsAnonymousAccessAllowed(); v != nil {
 		return *v

--- a/providers/oci/resources/apigateway.go
+++ b/providers/oci/resources/apigateway.go
@@ -39,16 +39,7 @@ func (o *mqlOciApigateway) gateways() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getGateways(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getGateways(conn, list.Data))
 }
 
 func (o *mqlOciApigateway) getGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -292,16 +283,7 @@ func (o *mqlOciApigateway) deployments() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getDeployments(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getDeployments(conn, list.Data))
 }
 
 func (o *mqlOciApigateway) getDeployments(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -712,16 +694,7 @@ func (o *mqlOciApigateway) certificates() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getCertificates(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getCertificates(conn, list.Data))
 }
 
 func (o *mqlOciApigateway) getCertificates(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/apigateway_test.go
+++ b/providers/oci/resources/apigateway_test.go
@@ -80,8 +80,10 @@ func TestFlattenIsAnonymousAccessAllowed(t *testing.T) {
 		rp   *apigateway.ApiSpecificationRequestPolicies
 		want bool
 	}{
-		{"nil policies", nil, false},
-		{"nil authentication", &apigateway.ApiSpecificationRequestPolicies{}, false},
+		// No authentication policy means nothing is enforced, so every
+		// request reaches the backend unauthenticated.
+		{"nil policies", nil, true},
+		{"nil authentication", &apigateway.ApiSpecificationRequestPolicies{}, true},
 		{
 			name: "JWT with anonymous=true",
 			rp: &apigateway.ApiSpecificationRequestPolicies{

--- a/providers/oci/resources/bastion.go
+++ b/providers/oci/resources/bastion.go
@@ -35,18 +35,7 @@ func (o *mqlOciBastion) bastions() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getBastions(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getBastions(conn, list.Data))
 }
 
 func (o *mqlOciBastion) getBastions(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -179,12 +179,11 @@ func (o *mqlOciObjectStorageBucket) id() (string, error) {
 }
 
 func initOciObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	// Check if id is already populated
-	if id, ok := args["id"]; ok && id.Value != nil {
-		if idStr, ok := id.Value.(string); ok && idStr != "" {
-			return args, nil, nil
-		}
-	}
+	// There is deliberately no id-only fast path. OCI keys GetBucket on
+	// namespace+name, not on the bucket OCID, so an id alone cannot be
+	// resolved - and the resulting resource would take the cache key
+	// "oci.objectStorage.bucket//" (both name parts empty), which every
+	// id-only bucket would share.
 
 	// When cnspec scans a discovered oci-objectstorage-bucket asset the only
 	// context we have is the Conf.PlatformId. Parse out namespace/name so the
@@ -223,14 +222,11 @@ func initOciObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.Ra
 	}
 	bucket := obj.(*mqlOciObjectStorageBucket)
 
-	// Fetch bucket details to populate the id field
-	bucketDetails, err := bucket.getBucketDetails()
-	if err != nil {
+	// getBucketDetails sets Id on the resource itself. Writing args["id"] here
+	// would be a no-op: NewResource discards the returned args whenever the
+	// init also returns a resource.
+	if _, err := bucket.getBucketDetails(); err != nil {
 		return nil, nil, err
-	}
-
-	if bucketDetails.Id != nil {
-		args["id"] = llx.StringData(*bucketDetails.Id)
 	}
 
 	return args, bucket, nil
@@ -291,6 +287,12 @@ func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, e
 	}
 
 	o.bucket = &response.Bucket
+	// ListBuckets returns a BucketSummary, which carries no Id at all, so the
+	// bucket OCID is only knowable from this call. Populate it here so both the
+	// collection path and the single-bucket init resolve `id` identically.
+	if o.bucket.Id != nil {
+		o.Id = plugin.TValue[string]{Data: *o.bucket.Id, State: plugin.StateIsSet}
+	}
 	o.fetched.Store(true)
 	return o.bucket, nil
 }

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -167,7 +169,9 @@ func (o *mqlOciObjectStorage) getBuckets(conn *connection.OciConnection, namespa
 }
 
 type mqlOciObjectStorageBucketInternal struct {
-	bucket *objectstorage.Bucket
+	lock    sync.Mutex
+	fetched atomic.Bool
+	bucket  *objectstorage.Bucket
 }
 
 func (o *mqlOciObjectStorageBucket) id() (string, error) {
@@ -232,8 +236,17 @@ func initOciObjectStorageBucket(runtime *plugin.Runtime, args map[string]*llx.Ra
 	return args, bucket, nil
 }
 
+// getBucketDetails lazily fetches the full bucket, which carries the fields
+// ListBuckets omits (public access, versioning, encryption, counts). Sixteen
+// accessors share it, and the runtime resolves them concurrently, so the fetch
+// is guarded rather than racing sixteen identical GetBucket calls.
 func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, error) {
-	if o.bucket != nil {
+	if o.fetched.Load() {
+		return o.bucket, nil
+	}
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if o.fetched.Load() {
 		return o.bucket, nil
 	}
 
@@ -242,6 +255,10 @@ func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, e
 	region := o.GetRegion()
 	if region.Error != nil {
 		return nil, region.Error
+	}
+
+	if region.Data == nil {
+		return nil, errors.New("oci.objectStorage.bucket: region is required to fetch bucket details")
 	}
 
 	r := region.Data
@@ -274,6 +291,7 @@ func (o *mqlOciObjectStorageBucket) getBucketDetails() (*objectstorage.Bucket, e
 	}
 
 	o.bucket = &response.Bucket
+	o.fetched.Store(true)
 	return o.bucket, nil
 }
 
@@ -458,6 +476,9 @@ func (o *mqlOciObjectStorageBucket) retentionRules() ([]any, error) {
 	if region.Error != nil {
 		return nil, region.Error
 	}
+	if region.Data == nil {
+		return nil, errors.New("oci.objectStorage.bucket: region is required")
+	}
 
 	client, err := conn.ObjectStorageClient(region.Data.Id.Data)
 	if err != nil {
@@ -545,6 +566,9 @@ func (o *mqlOciObjectStorageBucket) preauthenticatedRequests() ([]any, error) {
 	region := o.GetRegion()
 	if region.Error != nil {
 		return nil, region.Error
+	}
+	if region.Data == nil {
+		return nil, errors.New("oci.objectStorage.bucket: region is required")
 	}
 
 	client, err := conn.ObjectStorageClient(region.Data.Id.Data)

--- a/providers/oci/resources/buckets.go
+++ b/providers/oci/resources/buckets.go
@@ -74,20 +74,7 @@ func (o *mqlOciObjectStorage) buckets() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getBuckets(conn, namespace, list.Data), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getBuckets(conn, namespace, list.Data))
 }
 
 func (o *mqlOciObjectStorage) getBucketsForRegion(ctx context.Context, objectStorageClient *objectstorage.ObjectStorageClient, compartmentID string, namespace string) ([]objectstorage.BucketSummary, error) {

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -218,10 +218,10 @@ func initOciCertificatesCertificateAuthority(runtime *plugin.Runtime, args map[s
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.certificates.certificateAuthority")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.certificates", nil)
 	if err != nil {

--- a/providers/oci/resources/certificates.go
+++ b/providers/oci/resources/certificates.go
@@ -37,16 +37,7 @@ func (o *mqlOciCertificates) certificates() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getCertificates(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getCertificates(conn, list.Data))
 }
 
 func (o *mqlOciCertificates) getCertificates(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -256,16 +247,7 @@ func (o *mqlOciCertificates) certificateAuthorities() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getCertificateAuthorities(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getCertificateAuthorities(conn, list.Data))
 }
 
 func (o *mqlOciCertificates) getCertificateAuthorities(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -453,16 +435,7 @@ func (o *mqlOciCertificates) caBundles() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getCaBundles(conn, list.Data), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getCaBundles(conn, list.Data))
 }
 
 func (o *mqlOciCertificates) getCaBundles(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -144,7 +144,10 @@ func (o *mqlOciCloudGuard) targets() ([]any, error) {
 	for {
 		response, err := client.ListTargets(ctx, cloudguard.ListTargetsRequest{
 			CompartmentId: common.String(conn.TenantID()),
-			Page:          page,
+			// Cloud Guard targets are attached to sub-compartments far more
+			// often than to the tenancy root.
+			CompartmentIdInSubtree: common.Bool(true),
+			Page:                   page,
 		})
 		if err != nil {
 			return nil, err
@@ -205,8 +208,9 @@ func (o *mqlOciCloudGuard) detectorRecipes() ([]any, error) {
 	var page *string
 	for {
 		response, err := client.ListDetectorRecipes(ctx, cloudguard.ListDetectorRecipesRequest{
-			CompartmentId: common.String(conn.TenantID()),
-			Page:          page,
+			CompartmentId:          common.String(conn.TenantID()),
+			CompartmentIdInSubtree: common.Bool(true),
+			Page:                   page,
 		})
 		if err != nil {
 			return nil, err

--- a/providers/oci/resources/cloudguard.go
+++ b/providers/oci/resources/cloudguard.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/cloudguard"
@@ -19,10 +20,17 @@ import (
 
 // CloudGuard is a tenancy-level service that only operates in the home region,
 // unlike other OCI services that require per-region iteration.
+//
+// The home region and the configuration are guarded by separate mutexes: the
+// configuration fetch needs the home region to build its client, and a single
+// shared mutex would deadlock because sync.Mutex is not reentrant.
 type mqlOciCloudGuardInternal struct {
-	lock       sync.Mutex
-	config     *cloudguard.Configuration
-	homeRegion string
+	configLock     sync.Mutex
+	configFetched  atomic.Bool
+	config         *cloudguard.Configuration
+	homeRegionLock sync.Mutex
+	homeRegionSet  atomic.Bool
+	homeRegion     string
 }
 
 func (o *mqlOciCloudGuard) id() (string, error) {
@@ -30,12 +38,12 @@ func (o *mqlOciCloudGuard) id() (string, error) {
 }
 
 func (o *mqlOciCloudGuard) getHomeRegion() (string, error) {
-	if o.homeRegion != "" {
+	if o.homeRegionSet.Load() {
 		return o.homeRegion, nil
 	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.homeRegion != "" {
+	o.homeRegionLock.Lock()
+	defer o.homeRegionLock.Unlock()
+	if o.homeRegionSet.Load() {
 		return o.homeRegion, nil
 	}
 
@@ -52,25 +60,29 @@ func (o *mqlOciCloudGuard) getHomeRegion() (string, error) {
 	// HomeRegionKey returns the short region key (e.g., "IAD"), not the region name (e.g., "us-ashburn-1").
 	// The OCI SDK's SetRegion() accepts both formats.
 	o.homeRegion = *tenancy.HomeRegionKey
+	o.homeRegionSet.Store(true)
 	return o.homeRegion, nil
 }
 
 func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
-	if o.config != nil {
-		return o.config, nil
-	}
-	o.lock.Lock()
-	defer o.lock.Unlock()
-	if o.config != nil {
+	if o.configFetched.Load() {
 		return o.config, nil
 	}
 
-	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
-
+	// Resolve the home region before taking configLock: getHomeRegion takes its
+	// own lock, and nesting it inside this critical section would deadlock.
 	homeRegion, err := o.getHomeRegion()
 	if err != nil {
 		return nil, err
 	}
+
+	o.configLock.Lock()
+	defer o.configLock.Unlock()
+	if o.configFetched.Load() {
+		return o.config, nil
+	}
+
+	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
 	client, err := conn.CloudGuardClient(homeRegion)
 	if err != nil {
@@ -85,6 +97,7 @@ func (o *mqlOciCloudGuard) getConfig() (*cloudguard.Configuration, error) {
 	}
 
 	o.config = &response.Configuration
+	o.configFetched.Store(true)
 	return o.config, nil
 }
 

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -181,8 +181,12 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					}
 				}
 
-				// Create compartment resource reference
-				compartment, err := CreateResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
+				// NewResource, not CreateResource: oci.compartment has an
+				// Init that fills name/description/created/state. Skipping it
+				// caches an id-only husk under the compartment's real OCID,
+				// which a later oci.compartments query then receives instead of
+				// the populated resource.
+				compartment, err := NewResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
 					"id": llx.StringDataPtr(instance.CompartmentId),
 				})
 				if err != nil {
@@ -465,7 +469,7 @@ func (o *mqlOciCompute) getComputeImage(conn *connection.OciConnection, regions 
 				}
 
 				// Create compartment resource reference
-				compartment, err := CreateResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
+				compartment, err := NewResource(o.MqlRuntime, "oci.compartment", map[string]*llx.RawData{
 					"id": llx.StringDataPtr(image.CompartmentId),
 				})
 				if err != nil {

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -38,20 +38,7 @@ func (o *mqlOciCompute) instances() ([]any, error) {
 	}
 
 	// fetch instances
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getComputeInstances(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getComputeInstances(conn, list.Data))
 }
 
 func (o *mqlOciCompute) getComputeInstancesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Instance, error) {
@@ -386,20 +373,7 @@ func (o *mqlOciCompute) images() ([]any, error) {
 	}
 
 	// fetch images
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getComputeImage(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getComputeImage(conn, list.Data))
 }
 
 func (o *mqlOciCompute) getComputeImagesForRegion(ctx context.Context, computeClient *core.ComputeClient, compartmentID string) ([]core.Image, error) {
@@ -524,18 +498,7 @@ func (o *mqlOciCompute) blockVolumes() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getBlockVolumes(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getBlockVolumes(conn, list.Data))
 }
 
 func (o *mqlOciCompute) getBlockVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.Volume, error) {
@@ -668,18 +631,7 @@ func (o *mqlOciCompute) bootVolumes() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getBootVolumes(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getBootVolumes(conn, list.Data))
 }
 
 func (o *mqlOciCompute) getBootVolumesForRegion(ctx context.Context, client *core.BlockstorageClient, compartmentID string) ([]core.BootVolume, error) {

--- a/providers/oci/resources/compute.go
+++ b/providers/oci/resources/compute.go
@@ -156,17 +156,25 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					timeMaintenanceRebootDue = &instance.TimeMaintenanceRebootDue.Time
 				}
 
-				var legacyImdsDisabled *bool
-				if instance.InstanceOptions != nil {
-					legacyImdsDisabled = instance.InstanceOptions.AreLegacyImdsEndpointsDisabled
+				// OCI omits instanceOptions entirely on instances launched
+				// before IMDSv2 existed - exactly the instances where the
+				// legacy /v1 endpoints ARE reachable. Leaving this null would
+				// let `all(legacyImdsEndpointsDisabled && ...)` pass on them,
+				// because MQL evaluates `null && null` as true. Default to the
+				// documented false so a miss fails.
+				legacyImdsDisabled := false
+				if instance.InstanceOptions != nil && instance.InstanceOptions.AreLegacyImdsEndpointsDisabled != nil {
+					legacyImdsDisabled = *instance.InstanceOptions.AreLegacyImdsEndpointsDisabled
 				}
 
-				var monitoringDisabled, managementDisabled, allPluginsDisabled *bool
-				var agentPlugins map[string]any
+				// Same reasoning: an absent agentConfig means the agent
+				// controls are not disabled, which is false, not unknown.
+				monitoringDisabled, managementDisabled, allPluginsDisabled := false, false, false
+				agentPlugins := map[string]any{}
 				if instance.AgentConfig != nil {
-					monitoringDisabled = instance.AgentConfig.IsMonitoringDisabled
-					managementDisabled = instance.AgentConfig.IsManagementDisabled
-					allPluginsDisabled = instance.AgentConfig.AreAllPluginsDisabled
+					monitoringDisabled = boolValue(instance.AgentConfig.IsMonitoringDisabled)
+					managementDisabled = boolValue(instance.AgentConfig.IsManagementDisabled)
+					allPluginsDisabled = boolValue(instance.AgentConfig.AreAllPluginsDisabled)
 					agentPlugins = make(map[string]any, len(instance.AgentConfig.PluginsConfig))
 					for _, p := range instance.AgentConfig.PluginsConfig {
 						agentPlugins[stringValue(p.Name)] = string(p.DesiredState)
@@ -196,10 +204,10 @@ func (o *mqlOciCompute) getComputeInstances(conn *connection.OciConnection, regi
 					"platformConfig":              llx.DictData(platformConfig),
 					"launchOptions":               llx.DictData(launchOptions),
 					"instanceOptions":             llx.DictData(instanceOptions),
-					"legacyImdsEndpointsDisabled": llx.BoolDataPtr(legacyImdsDisabled),
-					"monitoringDisabled":          llx.BoolDataPtr(monitoringDisabled),
-					"managementDisabled":          llx.BoolDataPtr(managementDisabled),
-					"allPluginsDisabled":          llx.BoolDataPtr(allPluginsDisabled),
+					"legacyImdsEndpointsDisabled": llx.BoolData(legacyImdsDisabled),
+					"monitoringDisabled":          llx.BoolData(monitoringDisabled),
+					"managementDisabled":          llx.BoolData(managementDisabled),
+					"allPluginsDisabled":          llx.BoolData(allPluginsDisabled),
 					"agentPlugins":                llx.MapData(agentPlugins, types.String),
 					"shapeConfig":                 llx.DictData(shapeConfig),
 					"sourceDetails":               llx.DictData(sourceDetails),

--- a/providers/oci/resources/containerinstances.go
+++ b/providers/oci/resources/containerinstances.go
@@ -35,18 +35,7 @@ func (o *mqlOciContainerInstances) instances() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getContainerInstances(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getContainerInstances(conn, list.Data))
 }
 
 func (o *mqlOciContainerInstances) getContainerInstances(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -4,6 +4,9 @@
 package resources
 
 import (
+	"context"
+	"errors"
+	"net"
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -147,26 +150,89 @@ func definedTagsToAny(in map[string]map[string]interface{}) map[string]any {
 	return out
 }
 
-// ociRunRegionPool runs a set of per-region jobs and returns the union of the
-// ones that succeeded.
+// ociRegionServiceUnavailable reports whether the error means the service has
+// no endpoint in that region, either because it is not deployed there or the
+// tenancy is not entitled to it. Such a region is an expected absence and is
+// skipped so a tenancy-wide query still returns what does exist.
 //
-// A single failing region no longer discards every other region's results.
-// OCI services are not deployed in every region a tenancy can subscribe to,
-// and a per-region IAM gap is routine, so `HasErrors` -> return nil turned one
-// unentitled region into a hard failure for the whole tenancy. Failures are
-// logged and skipped; the error is surfaced only when no region succeeded, so
-// a genuinely broken scan still reports rather than silently returning [].
+// It deliberately does not treat an authorization or throttling failure as an
+// absence: those are real problems, and reporting a short list as authoritative
+// is worse than reporting the error. See ociRunRegionPool, which is the main
+// consumer.
+func ociRegionServiceUnavailable(err error) bool {
+	if svcErr, ok := common.IsServiceError(err); ok {
+		// Only a 404 can mean "this service has no endpoint in this region".
+		// 401 is a credential problem and 403 (NotAuthorizedOrNotFound) is the
+		// standard IAM-policy gap, which OCI returns in *every* region -
+		// swallowing either turns an under-scoped token into an authoritative
+		// "this tenancy has no resources", which is worse than an error.
+		if svcErr.GetHTTPStatusCode() == 404 {
+			return true
+		}
+		// A service error carries a real API response, so the transport-level
+		// signatures below cannot apply to it.
+		return false
+	}
+	// Regions where the service is not deployed have no regional endpoint, so
+	// the DNS lookup for the host fails with "no such host".
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	// Some regions publish a wildcard DNS record for a service that is not
+	// actually deployed there, so the host resolves but the TCP connection
+	// times out. Treat connection timeouts (and the deadline they surface as)
+	// the same as an absent endpoint.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	// The OCI SDK wraps transport errors in a type that does not implement
+	// Unwrap, so errors.As/Is above can miss a timeout. Fall back to matching
+	// the message for the unreachable-endpoint signatures.
+	msg := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"timeout", "timed out", "deadline exceeded",
+		"no such host", "connection refused", "no route to host",
+	} {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// ociRunRegionPool runs a set of per-region jobs and returns the union of the
+// ones that succeeded, skipping only the regions where the service genuinely
+// has no endpoint.
+//
+// The distinction matters in both directions. Failing the whole collection
+// when any region errors turned one unsubscribed or undeployed region into a
+// tenancy-wide failure. But skipping *every* error is just as wrong the other
+// way: a 403 from an IAM gap, a 429 throttle or a 500 would silently
+// under-report resources, and an authoritative-looking short list is worse
+// than an error in an inventory tool.
+//
+// So ociRegionServiceUnavailable decides. An absent endpoint is an expected
+// condition and is skipped; anything else is a real problem and is reported,
+// joined across regions so a broken token names every region it affected.
 func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
 	poolOfJobs := jobpool.CreatePool(jobs, 5)
 	poolOfJobs.Run()
 
 	res := []any{}
-	failed := 0
+	var hardErr error
 	for i := range poolOfJobs.Jobs {
 		job := poolOfJobs.Jobs[i]
 		if job.Err != nil {
-			failed++
-			log.Debug().Err(job.Err).Msg("skipping oci region that could not be listed")
+			if ociRegionServiceUnavailable(job.Err) {
+				log.Debug().Err(job.Err).Msg("skipping oci region where the service is unavailable")
+				continue
+			}
+			hardErr = errors.Join(hardErr, job.Err)
 			continue
 		}
 		items, ok := job.Result.([]any)
@@ -176,8 +242,8 @@ func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
 		res = append(res, items...)
 	}
 
-	if failed > 0 && failed == len(poolOfJobs.Jobs) {
-		return nil, poolOfJobs.GetErrors()
+	if hardErr != nil {
+		return nil, hardErr
 	}
 	return res, nil
 }

--- a/providers/oci/resources/conversion.go
+++ b/providers/oci/resources/conversion.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 )
@@ -144,4 +145,39 @@ func definedTagsToAny(in map[string]map[string]interface{}) map[string]any {
 		out[ns] = nsOut
 	}
 	return out
+}
+
+// ociRunRegionPool runs a set of per-region jobs and returns the union of the
+// ones that succeeded.
+//
+// A single failing region no longer discards every other region's results.
+// OCI services are not deployed in every region a tenancy can subscribe to,
+// and a per-region IAM gap is routine, so `HasErrors` -> return nil turned one
+// unentitled region into a hard failure for the whole tenancy. Failures are
+// logged and skipped; the error is surfaced only when no region succeeded, so
+// a genuinely broken scan still reports rather than silently returning [].
+func ociRunRegionPool(jobs []*jobpool.Job) ([]any, error) {
+	poolOfJobs := jobpool.CreatePool(jobs, 5)
+	poolOfJobs.Run()
+
+	res := []any{}
+	failed := 0
+	for i := range poolOfJobs.Jobs {
+		job := poolOfJobs.Jobs[i]
+		if job.Err != nil {
+			failed++
+			log.Debug().Err(job.Err).Msg("skipping oci region that could not be listed")
+			continue
+		}
+		items, ok := job.Result.([]any)
+		if !ok {
+			continue
+		}
+		res = append(res, items...)
+	}
+
+	if failed > 0 && failed == len(poolOfJobs.Jobs) {
+		return nil, poolOfJobs.GetErrors()
+	}
+	return res, nil
 }

--- a/providers/oci/resources/conversion_test.go
+++ b/providers/oci/resources/conversion_test.go
@@ -4,9 +4,14 @@
 package resources
 
 import (
+	"time"
+
 	"testing"
 
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 )
 
 func TestStringValue(t *testing.T) {
@@ -109,4 +114,66 @@ func TestOciRouteTargetType(t *testing.T) {
 			assert.Equal(t, tt.want, ociRouteTargetType(tt.ocid))
 		})
 	}
+}
+
+func TestOciRegionFromOCID(t *testing.T) {
+	tests := []struct {
+		name string
+		ocid string
+		want string
+	}{
+		{"short region key", "ocid1.instance.oc1.iad.aaaaaaaa", "iad"},
+		{"full region name", "ocid1.vcn.oc1.us-sanjose-1.aaaaaaaa", "us-sanjose-1"},
+		// Global resources carry an empty region segment; callers must fall
+		// back to a known region rather than build a client for "".
+		{"global ocid", "ocid1.user.oc1..aaaaaaaa", ""},
+		{"too few segments", "ocid1.drg.oc1", ""},
+		{"not an ocid", "ORACLE_MANAGED_KEY", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociRegionFromOCID(tt.ocid))
+		})
+	}
+}
+
+func TestIsOcid(t *testing.T) {
+	// The guard that keeps OCI's placeholder values out of NewResource
+	// lookups, where they surface as a hard "not found" instead of a null.
+	assert.True(t, isOcid("ocid1.vault.oc1.iad.aaaaaaaa"))
+	assert.False(t, isOcid("ORACLE_MANAGED_KEY"))
+	assert.False(t, isOcid(""))
+	assert.False(t, isOcid("ocid2.vault.oc1.iad.aaaa"))
+	assert.False(t, isOcid("my-vault"))
+}
+
+func TestSdkTimeData(t *testing.T) {
+	assert.Equal(t, llx.NilData, sdkTimeData(nil))
+
+	ts := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	got := sdkTimeData(&common.SDKTime{Time: ts})
+	require.NotNil(t, got)
+	assert.Equal(t, ts, *(got.Value.(*time.Time)))
+}
+
+func TestDefinedTagsToAny(t *testing.T) {
+	assert.Empty(t, definedTagsToAny(nil))
+
+	out := definedTagsToAny(map[string]map[string]interface{}{
+		"Operations": {"CostCenter": "42", "Reviewed": true},
+	})
+	ns, ok := out["Operations"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "42", ns["CostCenter"])
+	// Non-string values pass through unchanged rather than being dropped.
+	assert.Equal(t, true, ns["Reviewed"])
+}
+
+func TestStringsToAnyAndStrMapToAny(t *testing.T) {
+	assert.Equal(t, []any{}, stringsToAny(nil))
+	assert.Equal(t, []any{"a", "b"}, stringsToAny([]string{"a", "b"}))
+
+	assert.Empty(t, strMapToAny(nil))
+	assert.Equal(t, map[string]any{"k": "v"}, strMapToAny(map[string]string{"k": "v"}))
 }

--- a/providers/oci/resources/database.go
+++ b/providers/oci/resources/database.go
@@ -38,18 +38,7 @@ func (o *mqlOciDatabase) dbSystems() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getDbSystems(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getDbSystems(conn, list.Data))
 }
 
 func (o *mqlOciDatabase) getDbSystems(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -172,7 +161,7 @@ func (o *mqlOciDatabaseDbSystem) kmsKey() (*mqlOciKmsKey, error) {
 }
 
 func (o *mqlOciDatabaseDbSystem) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetId == "" || !isOcid(o.cacheSubnetId) {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -200,18 +189,7 @@ func (o *mqlOciDatabase) autonomousDatabases() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getAutonomousDatabases(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getAutonomousDatabases(conn, list.Data))
 }
 
 func (o *mqlOciDatabase) getAutonomousDatabases(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -364,7 +342,7 @@ func (o *mqlOciDatabaseAutonomousDatabase) kmsKey() (*mqlOciKmsKey, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) kmsVault() (*mqlOciKmsVault, error) {
-	if o.cacheVaultId == "" {
+	if o.cacheVaultId == "" || !isOcid(o.cacheVaultId) {
 		o.KmsVault.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -378,7 +356,7 @@ func (o *mqlOciDatabaseAutonomousDatabase) kmsVault() (*mqlOciKmsVault, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) subnet() (*mqlOciNetworkSubnet, error) {
-	if o.cacheSubnetId == "" {
+	if o.cacheSubnetId == "" || !isOcid(o.cacheSubnetId) {
 		o.Subnet.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -406,17 +384,7 @@ func (o *mqlOciDatabase) backups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getDatabaseBackups(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getDatabaseBackups(conn, list.Data))
 }
 
 func (o *mqlOciDatabase) getDatabaseBackups(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -560,17 +528,7 @@ func (o *mqlOciDatabase) autonomousDatabaseBackups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getAutonomousDatabaseBackups(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getAutonomousDatabaseBackups(conn, list.Data))
 }
 
 // backups on an individual autonomous database returns its backups by
@@ -699,7 +657,7 @@ func (o *mqlOciDatabaseAutonomousDatabaseBackup) id() (string, error) {
 }
 
 func (o *mqlOciDatabaseAutonomousDatabaseBackup) autonomousDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
-	if o.cacheAutonomousDatabaseId == "" {
+	if o.cacheAutonomousDatabaseId == "" || !isOcid(o.cacheAutonomousDatabaseId) {
 		o.AutonomousDatabase.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/oci/resources/datasafe.go
+++ b/providers/oci/resources/datasafe.go
@@ -82,18 +82,7 @@ func (o *mqlOciDataSafe) gatherResults(jobs []*jobpool.Job, err error) ([]any, e
 	if err != nil {
 		return nil, err
 	}
-	pool := jobpool.CreatePool(jobs, 5)
-	pool.Run()
-	if pool.HasErrors() {
-		return nil, pool.GetErrors()
-	}
-	res := []any{}
-	for i := range pool.Jobs {
-		if pool.Jobs[i].Result != nil {
-			res = append(res, pool.Jobs[i].Result.([]any)...)
-		}
-	}
-	return res, nil
+	return ociRunRegionPool(jobs)
 }
 
 // ============================================================================

--- a/providers/oci/resources/datascience.go
+++ b/providers/oci/resources/datascience.go
@@ -118,7 +118,7 @@ func (o *mqlOciAiDataScience) fetchProjects(svc *datascience.DataScienceClient) 
 }
 
 func initOciAiDataScienceProject(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetProjects)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.project", (*mqlOciAiDataScience).GetProjects)
 }
 
 func (o *mqlOciAiDataScienceProject) id() (string, error) {
@@ -205,7 +205,7 @@ type mqlOciAiDataScienceNotebookSessionInternal struct {
 }
 
 func initOciAiDataScienceNotebookSession(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetNotebookSessions)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.notebookSession", (*mqlOciAiDataScience).GetNotebookSessions)
 }
 
 func (o *mqlOciAiDataScienceNotebookSession) id() (string, error) {
@@ -297,7 +297,7 @@ type mqlOciAiDataScienceModelInternal struct {
 }
 
 func initOciAiDataScienceModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetModels)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.model", (*mqlOciAiDataScience).GetModels)
 }
 
 func (o *mqlOciAiDataScienceModel) id() (string, error) {
@@ -382,7 +382,7 @@ type mqlOciAiDataScienceModelVersionSetInternal struct {
 }
 
 func initOciAiDataScienceModelVersionSet(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetModelVersionSets)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.modelVersionSet", (*mqlOciAiDataScience).GetModelVersionSets)
 }
 
 func (o *mqlOciAiDataScienceModelVersionSet) id() (string, error) {
@@ -465,7 +465,7 @@ type mqlOciAiDataScienceModelDeploymentInternal struct {
 }
 
 func initOciAiDataScienceModelDeployment(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetModelDeployments)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.modelDeployment", (*mqlOciAiDataScience).GetModelDeployments)
 }
 
 func (o *mqlOciAiDataScienceModelDeployment) id() (string, error) {
@@ -534,7 +534,7 @@ type mqlOciAiDataScienceJobInternal struct {
 }
 
 func initOciAiDataScienceJob(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetJobs)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.job", (*mqlOciAiDataScience).GetJobs)
 }
 
 func (o *mqlOciAiDataScienceJob) id() (string, error) {
@@ -604,7 +604,7 @@ type mqlOciAiDataSciencePipelineInternal struct {
 }
 
 func initOciAiDataSciencePipeline(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciDataScienceByID(runtime, args, (*mqlOciAiDataScience).GetPipelines)
+	return findOciDataScienceByID(runtime, args, "oci.ai.dataScience.pipeline", (*mqlOciAiDataScience).GetPipelines)
 }
 
 func (o *mqlOciAiDataSciencePipeline) id() (string, error) {
@@ -624,7 +624,7 @@ func (o *mqlOciAiDataSciencePipeline) project() (*mqlOciAiDataScienceProject, er
 // findOciDataScienceByID powers the init functions for Data Science resources:
 // it lists the requested collection and returns the entry whose id matches the
 // "id" argument, so a resource can be selected directly by OCID.
-func findOciDataScienceByID(runtime *plugin.Runtime, args map[string]*llx.RawData, list func(svc *mqlOciAiDataScience) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
+func findOciDataScienceByID(runtime *plugin.Runtime, args map[string]*llx.RawData, resourceName string, list func(svc *mqlOciAiDataScience) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
@@ -650,7 +650,7 @@ func findOciDataScienceByID(runtime *plugin.Runtime, args map[string]*llx.RawDat
 			return args, res, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New(resourceName + " not found: " + idVal)
 }
 
 // resolveOciDataScienceProject resolves a typed project resource from a project

--- a/providers/oci/resources/datascience.go
+++ b/providers/oci/resources/datascience.go
@@ -54,16 +54,7 @@ func (o *mqlOciAiDataScience) listRegional(fetch func(svc *datascience.DataScien
 		}))
 	}
 
-	poolOfJobs := jobpool.CreatePool(tasks, 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	res := []any{}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(tasks)
 }
 
 func (o *mqlOciAiDataScience) compartmentID() string {

--- a/providers/oci/resources/events.go
+++ b/providers/oci/resources/events.go
@@ -34,18 +34,7 @@ func (o *mqlOciEvents) rules() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getEventRules(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getEventRules(conn, list.Data))
 }
 
 func (o *mqlOciEvents) getEventRulesForRegion(ctx context.Context, client *events.EventsClient, compartmentID string) ([]events.RuleSummary, error) {

--- a/providers/oci/resources/filestorage.go
+++ b/providers/oci/resources/filestorage.go
@@ -36,18 +36,7 @@ func (o *mqlOciFileStorage) fileSystems() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getFileSystems(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getFileSystems(conn, list.Data))
 }
 
 func (o *mqlOciFileStorage) getFileSystemsForAD(ctx context.Context, fsClient *filestorage.FileStorageClient, compartmentID string, availabilityDomain string) ([]filestorage.FileSystemSummary, error) {
@@ -168,7 +157,7 @@ func (o *mqlOciFileStorageFileSystem) id() (string, error) {
 }
 
 func (o *mqlOciFileStorageFileSystem) kmsKey() (*mqlOciKmsKey, error) {
-	if o.cacheKmsKeyId == "" {
+	if o.cacheKmsKeyId == "" || !isOcid(o.cacheKmsKeyId) {
 		o.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -149,7 +150,7 @@ func (o *mqlOciFunctions) getApplications(conn *connection.OciConnection, region
 
 type mqlOciFunctionsApplicationInternal struct {
 	lock           sync.Mutex
-	fetched        bool
+	fetched        atomic.Bool
 	app            *functions.Application
 	region         string
 	cacheSubnetIds []string
@@ -161,12 +162,12 @@ func (o *mqlOciFunctionsApplication) id() (string, error) {
 }
 
 func (o *mqlOciFunctionsApplication) fetchApplication() (*functions.Application, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.app, nil
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.app, nil
 	}
 
@@ -185,7 +186,7 @@ func (o *mqlOciFunctionsApplication) fetchApplication() (*functions.Application,
 	}
 
 	o.app = &resp.Application
-	o.fetched = true
+	o.fetched.Store(true)
 	return o.app, nil
 }
 
@@ -324,7 +325,7 @@ func (o *mqlOciFunctionsApplication) functions() ([]any, error) {
 
 type mqlOciFunctionsFunctionInternal struct {
 	lock    sync.Mutex
-	fetched bool
+	fetched atomic.Bool
 	fn      *functions.Function
 	region  string
 }
@@ -334,12 +335,12 @@ func (o *mqlOciFunctionsFunction) id() (string, error) {
 }
 
 func (o *mqlOciFunctionsFunction) fetchFunction() (*functions.Function, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.fn, nil
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.fn, nil
 	}
 
@@ -358,7 +359,7 @@ func (o *mqlOciFunctionsFunction) fetchFunction() (*functions.Function, error) {
 	}
 
 	o.fn = &resp.Function
-	o.fetched = true
+	o.fetched.Store(true)
 	return o.fn, nil
 }
 

--- a/providers/oci/resources/functions.go
+++ b/providers/oci/resources/functions.go
@@ -37,18 +37,7 @@ func (o *mqlOciFunctions) applications() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getApplications(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getApplications(conn, list.Data))
 }
 
 func (o *mqlOciFunctions) getApplications(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -58,16 +58,7 @@ func (o *mqlOciAiGenerativeAi) listRegional(fetch func(svc *generativeai.Generat
 		}))
 	}
 
-	poolOfJobs := jobpool.CreatePool(tasks, 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	res := []any{}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(tasks)
 }
 
 // ----- dedicated AI clusters -----

--- a/providers/oci/resources/generativeai.go
+++ b/providers/oci/resources/generativeai.go
@@ -127,7 +127,7 @@ func (o *mqlOciAiGenerativeAi) fetchDedicatedAiClusters(svc *generativeai.Genera
 }
 
 func initOciAiGenerativeAiDedicatedAiCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciGenerativeAiByID(runtime, args, (*mqlOciAiGenerativeAi).GetDedicatedAiClusters)
+	return findOciGenerativeAiByID(runtime, args, "oci.ai.generativeAi.dedicatedAiCluster", (*mqlOciAiGenerativeAi).GetDedicatedAiClusters)
 }
 
 func (o *mqlOciAiGenerativeAiDedicatedAiCluster) id() (string, error) {
@@ -209,7 +209,7 @@ type mqlOciAiGenerativeAiModelInternal struct {
 }
 
 func initOciAiGenerativeAiModel(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	return findOciGenerativeAiByID(runtime, args, (*mqlOciAiGenerativeAi).GetModels)
+	return findOciGenerativeAiByID(runtime, args, "oci.ai.generativeAi.model", (*mqlOciAiGenerativeAi).GetModels)
 }
 
 func (o *mqlOciAiGenerativeAiModel) id() (string, error) {
@@ -325,7 +325,7 @@ func initOciAiGenerativeAiEndpoint(runtime *plugin.Runtime, args map[string]*llx
 		}
 		args["id"] = llx.StringData(parsed.id)
 	}
-	return findOciGenerativeAiByID(runtime, args, (*mqlOciAiGenerativeAi).GetEndpoints)
+	return findOciGenerativeAiByID(runtime, args, "oci.ai.generativeAi.endpoint", (*mqlOciAiGenerativeAi).GetEndpoints)
 }
 
 func (o *mqlOciAiGenerativeAiEndpoint) id() (string, error) {
@@ -359,7 +359,7 @@ func (o *mqlOciAiGenerativeAiEndpoint) dedicatedAiCluster() (*mqlOciAiGenerative
 // findOciGenerativeAiByID powers the init functions for Generative AI
 // resources: it lists the requested collection and returns the entry whose id
 // matches the "id" argument, so a resource can be selected directly by OCID.
-func findOciGenerativeAiByID(runtime *plugin.Runtime, args map[string]*llx.RawData, list func(svc *mqlOciAiGenerativeAi) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
+func findOciGenerativeAiByID(runtime *plugin.Runtime, args map[string]*llx.RawData, resourceName string, list func(svc *mqlOciAiGenerativeAi) *plugin.TValue[[]any]) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
 	}
@@ -382,7 +382,7 @@ func findOciGenerativeAiByID(runtime *plugin.Runtime, args map[string]*llx.RawDa
 			return args, res, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New(resourceName + " not found: " + idVal)
 }
 
 // resolveOciGenerativeAiModel resolves a typed model resource from a model

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -207,7 +207,7 @@ func initOciAiAgentsAgent(runtime *plugin.Runtime, args map[string]*llx.RawData)
 			return args, a, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.ai.agents.agent not found: " + idVal)
 }
 
 func (o *mqlOciAiAgentsAgent) id() (string, error) {
@@ -353,7 +353,7 @@ func initOciAiAgentsEndpoint(runtime *plugin.Runtime, args map[string]*llx.RawDa
 			return args, e, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.ai.agents.endpoint not found: " + idVal)
 }
 
 func (o *mqlOciAiAgentsEndpoint) id() (string, error) {
@@ -473,7 +473,7 @@ func initOciAiAgentsKnowledgeBase(runtime *plugin.Runtime, args map[string]*llx.
 			return args, kb, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.ai.agents.knowledgeBase not found: " + idVal)
 }
 
 func (o *mqlOciAiAgentsKnowledgeBase) id() (string, error) {
@@ -596,7 +596,7 @@ func initOciAiAgentsDataSource(runtime *plugin.Runtime, args map[string]*llx.Raw
 			return args, ds, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.ai.agents.dataSource not found: " + idVal)
 }
 
 func (o *mqlOciAiAgentsDataSource) id() (string, error) {
@@ -740,7 +740,7 @@ func initOciAiAgentsTool(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 			return args, t, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.ai.agents.tool not found: " + idVal)
 }
 
 func (o *mqlOciAiAgentsTool) id() (string, error) {

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -36,10 +36,17 @@ func (o *mqlOciAiAgents) id() (string, error) {
 // Generative AI resources.
 func ociRegionServiceUnavailable(err error) bool {
 	if svcErr, ok := common.IsServiceError(err); ok {
-		switch svcErr.GetHTTPStatusCode() {
-		case 401, 403, 404:
+		// Only a 404 can mean "this service has no endpoint in this region".
+		// 401 is a credential problem and 403 (NotAuthorizedOrNotFound) is the
+		// standard IAM-policy gap, which OCI returns in *every* region -
+		// swallowing either turns an under-scoped token into an authoritative
+		// "this tenancy has no resources", which is worse than an error.
+		if svcErr.GetHTTPStatusCode() == 404 {
 			return true
 		}
+		// A service error carries a real API response, so the transport-level
+		// signatures below cannot apply to it.
+		return false
 	}
 	// Regions where the service is not deployed have no regional endpoint, so
 	// the DNS lookup for the host fails with "no such host".

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -6,8 +6,6 @@ package resources
 import (
 	"context"
 	"errors"
-	"net"
-	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/generativeaiagent"
@@ -26,58 +24,6 @@ func (o *mqlOciAi) id() (string, error) {
 
 func (o *mqlOciAiAgents) id() (string, error) {
 	return "oci.ai.agents", nil
-}
-
-// ociRegionServiceUnavailable reports whether the error indicates that an AI
-// service is not reachable in a given region — because the service is not
-// deployed there or the tenancy is not entitled to it. Such regions are skipped
-// so a tenancy-wide query still returns the resources that do exist instead of
-// failing outright. Shared by the Generative AI Agents, Data Science, and
-// Generative AI resources.
-func ociRegionServiceUnavailable(err error) bool {
-	if svcErr, ok := common.IsServiceError(err); ok {
-		// Only a 404 can mean "this service has no endpoint in this region".
-		// 401 is a credential problem and 403 (NotAuthorizedOrNotFound) is the
-		// standard IAM-policy gap, which OCI returns in *every* region -
-		// swallowing either turns an under-scoped token into an authoritative
-		// "this tenancy has no resources", which is worse than an error.
-		if svcErr.GetHTTPStatusCode() == 404 {
-			return true
-		}
-		// A service error carries a real API response, so the transport-level
-		// signatures below cannot apply to it.
-		return false
-	}
-	// Regions where the service is not deployed have no regional endpoint, so
-	// the DNS lookup for the host fails with "no such host".
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
-		return true
-	}
-	// Some regions publish a wildcard DNS record for a service that is not
-	// actually deployed there, so the host resolves but the TCP connection
-	// times out. Treat connection timeouts (and the deadline they surface as)
-	// the same as an absent endpoint.
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return true
-	}
-	// The OCI SDK wraps transport errors in a type that does not implement
-	// Unwrap, so errors.As/Is above can miss a timeout. Fall back to matching
-	// the message for the unreachable-endpoint signatures.
-	msg := strings.ToLower(err.Error())
-	for _, s := range []string{
-		"timeout", "timed out", "deadline exceeded",
-		"no such host", "connection refused", "no route to host",
-	} {
-		if strings.Contains(msg, s) {
-			return true
-		}
-	}
-	return false
 }
 
 func ociAgentRegions(runtime *plugin.Runtime) ([]any, error) {

--- a/providers/oci/resources/generativeaiagent.go
+++ b/providers/oci/resources/generativeaiagent.go
@@ -101,16 +101,7 @@ func (o *mqlOciAiAgents) agents() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getAgents(conn, regions), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getAgents(conn, regions))
 }
 
 func (o *mqlOciAiAgents) getAgents(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -227,16 +218,7 @@ func (o *mqlOciAiAgents) agentEndpoints() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getAgentEndpoints(conn, regions), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getAgentEndpoints(conn, regions))
 }
 
 func (o *mqlOciAiAgents) getAgentEndpoints(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -377,16 +359,7 @@ func (o *mqlOciAiAgents) knowledgeBases() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getKnowledgeBases(conn, regions), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getKnowledgeBases(conn, regions))
 }
 
 func (o *mqlOciAiAgents) getKnowledgeBases(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -493,16 +466,7 @@ func (o *mqlOciAiAgents) dataSources() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getDataSources(conn, regions), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getDataSources(conn, regions))
 }
 
 func (o *mqlOciAiAgents) getDataSources(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -630,16 +594,7 @@ func (o *mqlOciAiAgents) tools() ([]any, error) {
 		return nil, err
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getTools(conn, regions), 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(o.getTools(conn, regions))
 }
 
 func (o *mqlOciAiAgents) getTools(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -29,7 +29,7 @@ func (o *mqlOciIdentity) users() ([]any, error) {
 	return ociRunRegionPool(o.getUsers(conn))
 }
 
-func (s *mqlOciIdentity) getUsersForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.User, error) {
+func (s *mqlOciIdentity) listUsers(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.User, error) {
 	users := []identity.User{}
 	var page *string
 	for {
@@ -63,14 +63,13 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 	// repeated __id, so the slice held N copies of one pointer and the counts
 	// (and anything filtering them) were inflated N-fold.
 	f := func() (jobpool.JobResult, error) {
-		svcVal, err := conn.IdentityClient()
+		svc, err := conn.IdentityClient()
 		if err != nil {
 			return nil, err
 		}
-		svc := &svcVal
 
 		var res []any
-		users, err := o.getUsersForRegion(ctx, svc, conn.TenantID())
+		users, err := o.listUsers(ctx, svc, conn.TenantID())
 		if err != nil {
 			return nil, err
 		}
@@ -426,7 +425,7 @@ func (o *mqlOciIdentity) groups() ([]any, error) {
 	return ociRunRegionPool(o.getGroups(conn))
 }
 
-func (s *mqlOciIdentity) getGroupsForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.Group, error) {
+func (s *mqlOciIdentity) listGroups(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.Group, error) {
 	groups := []identity.Group{}
 	var page *string
 	for {
@@ -460,14 +459,13 @@ func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Jo
 	// repeated __id, so the slice held N copies of one pointer and the counts
 	// (and anything filtering them) were inflated N-fold.
 	f := func() (jobpool.JobResult, error) {
-		svcVal, err := conn.IdentityClient()
+		svc, err := conn.IdentityClient()
 		if err != nil {
 			return nil, err
 		}
-		svc := &svcVal
 
 		var res []any
-		groups, err := o.getGroupsForRegion(ctx, svc, conn.TenantID())
+		groups, err := o.listGroups(ctx, svc, conn.TenantID())
 		if err != nil {
 			return nil, err
 		}
@@ -521,7 +519,7 @@ func (o *mqlOciIdentity) policies() ([]any, error) {
 	return ociRunRegionPool(o.getPolicies(conn))
 }
 
-func (s *mqlOciIdentity) getPoliciesForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.Policy, error) {
+func (s *mqlOciIdentity) listPolicies(ctx context.Context, identityClient identity.IdentityClient, compartmentID string) ([]identity.Policy, error) {
 	policies := []identity.Policy{}
 	var page *string
 	for {
@@ -555,14 +553,13 @@ func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.
 	// repeated __id, so the slice held N copies of one pointer and the counts
 	// (and anything filtering them) were inflated N-fold.
 	f := func() (jobpool.JobResult, error) {
-		svcVal, err := conn.IdentityClient()
+		svc, err := conn.IdentityClient()
 		if err != nil {
 			return nil, err
 		}
-		svc := &svcVal
 
 		var res []any
-		policies, err := o.getPoliciesForRegion(ctx, svc, conn.TenantID())
+		policies, err := o.listPolicies(ctx, svc, conn.TenantID())
 		if err != nil {
 			return nil, err
 		}

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -108,7 +108,18 @@ func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job
 					previousLogin = &user.PreviousSuccessfulLoginTime.Time
 				}
 
-				capabilities := map[string]any{}
+				// Every key is always present: a missing key reads as null, and
+				// `capabilities["a"] && capabilities["b"]` over two nulls
+				// evaluates to true in MQL, so a user whose capabilities the
+				// API omitted would silently pass a credential-capability check.
+				capabilities := map[string]any{
+					"canUseConsolePassword":         false,
+					"canUseApiKeys":                 false,
+					"canUseAuthTokens":              false,
+					"canUseSmtpCredentials":         false,
+					"canUseCustomerSecretKeys":      false,
+					"canUseOAuth2ClientCredentials": false,
+				}
 				if user.Capabilities != nil {
 					capabilities["canUseConsolePassword"] = boolValue(user.Capabilities.CanUseConsolePassword)
 					capabilities["canUseApiKeys"] = boolValue(user.Capabilities.CanUseApiKeys)
@@ -1175,13 +1186,17 @@ func ociAuthenticationPolicyArgs(client identity.IdentityClient, tenantID string
 	}
 
 	args := map[string]*llx.RawData{
-		"compartmentID":                      llx.StringData(tenantID),
-		"minimumPasswordLength":              llx.IntData(0),
-		"passwordRequiresUppercase":          llx.BoolData(false),
-		"passwordRequiresLowercase":          llx.BoolData(false),
-		"passwordRequiresNumeric":            llx.BoolData(false),
-		"passwordRequiresSpecial":            llx.BoolData(false),
-		"passwordUsernameContainmentAllowed": llx.BoolData(false),
+		"compartmentID":             llx.StringData(tenantID),
+		"minimumPasswordLength":     llx.IntData(0),
+		"passwordRequiresUppercase": llx.BoolData(false),
+		"passwordRequiresLowercase": llx.BoolData(false),
+		"passwordRequiresNumeric":   llx.BoolData(false),
+		"passwordRequiresSpecial":   llx.BoolData(false),
+		// Unlike the passwordRequires* flags, false is the *permissive* value
+		// here, so defaulting to false would let a missing password policy pass
+		// a `passwordUsernameContainmentAllowed == false` check. OCI's own
+		// service default is true, so an absent policy fails the check.
+		"passwordUsernameContainmentAllowed": llx.BoolData(true),
 		"networkSourceIds":                   llx.ArrayData([]any{}, types.String),
 	}
 	if pp := resp.PasswordPolicy; pp != nil {

--- a/providers/oci/resources/identity.go
+++ b/providers/oci/resources/identity.go
@@ -26,20 +26,7 @@ func (o *mqlOciIdentity) id() (string, error) {
 func (o *mqlOciIdentity) users() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getUsers(conn), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getUsers(conn))
 }
 
 func (s *mqlOciIdentity) getUsersForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.User, error) {
@@ -70,104 +57,100 @@ func (s *mqlOciIdentity) getUsersForRegion(ctx context.Context, identityClient *
 
 func (o *mqlOciIdentity) getUsers(conn *connection.OciConnection) []*jobpool.Job {
 	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
-	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", region)
-
-			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			users, err := o.getUsersForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range users {
-				user := users[i]
-
-				var created *time.Time
-				if user.TimeCreated != nil {
-					created = &user.TimeCreated.Time
-				}
-
-				var lastLogin *time.Time
-				if user.LastSuccessfulLoginTime != nil {
-					lastLogin = &user.LastSuccessfulLoginTime.Time
-				}
-
-				var previousLogin *time.Time
-				if user.PreviousSuccessfulLoginTime != nil {
-					previousLogin = &user.PreviousSuccessfulLoginTime.Time
-				}
-
-				// Every key is always present: a missing key reads as null, and
-				// `capabilities["a"] && capabilities["b"]` over two nulls
-				// evaluates to true in MQL, so a user whose capabilities the
-				// API omitted would silently pass a credential-capability check.
-				capabilities := map[string]any{
-					"canUseConsolePassword":         false,
-					"canUseApiKeys":                 false,
-					"canUseAuthTokens":              false,
-					"canUseSmtpCredentials":         false,
-					"canUseCustomerSecretKeys":      false,
-					"canUseOAuth2ClientCredentials": false,
-				}
-				if user.Capabilities != nil {
-					capabilities["canUseConsolePassword"] = boolValue(user.Capabilities.CanUseConsolePassword)
-					capabilities["canUseApiKeys"] = boolValue(user.Capabilities.CanUseApiKeys)
-					capabilities["canUseAuthTokens"] = boolValue(user.Capabilities.CanUseAuthTokens)
-					capabilities["canUseSmtpCredentials"] = boolValue(user.Capabilities.CanUseSmtpCredentials)
-					capabilities["canUseCustomerSecretKeys"] = boolValue(user.Capabilities.CanUseCustomerSecretKeys)
-					capabilities["canUseOAuth2ClientCredentials"] = boolValue(user.Capabilities.CanUseOAuth2ClientCredentials)
-				}
-
-				freeformTags := make(map[string]interface{})
-				for k, v := range user.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range user.DefinedTags {
-					definedTags[k] = v
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.user", map[string]*llx.RawData{
-					"id":                 llx.StringDataPtr(user.Id),
-					"name":               llx.StringDataPtr(user.Name),
-					"description":        llx.StringDataPtr(user.Description),
-					"created":            llx.TimeDataPtr(created),
-					"state":              llx.StringData(string(user.LifecycleState)),
-					"mfaActivated":       llx.BoolData(boolValue(user.IsMfaActivated)),
-					"compartmentID":      llx.StringDataPtr(user.CompartmentId),
-					"email":              llx.StringDataPtr(user.Email),
-					"emailVerified":      llx.BoolData(boolValue(user.EmailVerified)),
-					"externalIdentifier": llx.StringDataPtr(user.ExternalIdentifier),
-					"capabilities":       llx.MapData(capabilities, types.Bool),
-					"lastLogin":          llx.TimeDataPtr(lastLogin),
-					"previousLogin":      llx.TimeDataPtr(previousLogin),
-					"freeformTags":       llx.MapData(freeformTags, types.String),
-					"definedTags":        llx.MapData(definedTags, types.Any),
-				})
-				if err != nil {
-					return nil, err
-				}
-				mqlInstance.(*mqlOciIdentityUser).cacheIdentityProviderID = stringValue(user.IdentityProviderId)
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
+	// IAM is a global service: every regional identity endpoint serves the same
+	// tenancy-wide set, so fanning out over regions returned each user once per
+	// subscribed region. CreateResource hands back the cached instance for a
+	// repeated __id, so the slice held N copies of one pointer and the counts
+	// (and anything filtering them) were inflated N-fold.
+	f := func() (jobpool.JobResult, error) {
+		svcVal, err := conn.IdentityClient()
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+		svc := &svcVal
+
+		var res []any
+		users, err := o.getUsersForRegion(ctx, svc, conn.TenantID())
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range users {
+			user := users[i]
+
+			var created *time.Time
+			if user.TimeCreated != nil {
+				created = &user.TimeCreated.Time
+			}
+
+			var lastLogin *time.Time
+			if user.LastSuccessfulLoginTime != nil {
+				lastLogin = &user.LastSuccessfulLoginTime.Time
+			}
+
+			var previousLogin *time.Time
+			if user.PreviousSuccessfulLoginTime != nil {
+				previousLogin = &user.PreviousSuccessfulLoginTime.Time
+			}
+
+			// Every key is always present: a missing key reads as null, and
+			// `capabilities["a"] && capabilities["b"]` over two nulls
+			// evaluates to true in MQL, so a user whose capabilities the
+			// API omitted would silently pass a credential-capability check.
+			capabilities := map[string]any{
+				"canUseConsolePassword":         false,
+				"canUseApiKeys":                 false,
+				"canUseAuthTokens":              false,
+				"canUseSmtpCredentials":         false,
+				"canUseCustomerSecretKeys":      false,
+				"canUseOAuth2ClientCredentials": false,
+			}
+			if user.Capabilities != nil {
+				capabilities["canUseConsolePassword"] = boolValue(user.Capabilities.CanUseConsolePassword)
+				capabilities["canUseApiKeys"] = boolValue(user.Capabilities.CanUseApiKeys)
+				capabilities["canUseAuthTokens"] = boolValue(user.Capabilities.CanUseAuthTokens)
+				capabilities["canUseSmtpCredentials"] = boolValue(user.Capabilities.CanUseSmtpCredentials)
+				capabilities["canUseCustomerSecretKeys"] = boolValue(user.Capabilities.CanUseCustomerSecretKeys)
+				capabilities["canUseOAuth2ClientCredentials"] = boolValue(user.Capabilities.CanUseOAuth2ClientCredentials)
+			}
+
+			freeformTags := make(map[string]interface{})
+			for k, v := range user.FreeformTags {
+				freeformTags[k] = v
+			}
+
+			definedTags := make(map[string]interface{})
+			for k, v := range user.DefinedTags {
+				definedTags[k] = v
+			}
+
+			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.user", map[string]*llx.RawData{
+				"id":                 llx.StringDataPtr(user.Id),
+				"name":               llx.StringDataPtr(user.Name),
+				"description":        llx.StringDataPtr(user.Description),
+				"created":            llx.TimeDataPtr(created),
+				"state":              llx.StringData(string(user.LifecycleState)),
+				"mfaActivated":       llx.BoolData(boolValue(user.IsMfaActivated)),
+				"compartmentID":      llx.StringDataPtr(user.CompartmentId),
+				"email":              llx.StringDataPtr(user.Email),
+				"emailVerified":      llx.BoolData(boolValue(user.EmailVerified)),
+				"externalIdentifier": llx.StringDataPtr(user.ExternalIdentifier),
+				"capabilities":       llx.MapData(capabilities, types.Bool),
+				"lastLogin":          llx.TimeDataPtr(lastLogin),
+				"previousLogin":      llx.TimeDataPtr(previousLogin),
+				"freeformTags":       llx.MapData(freeformTags, types.String),
+				"definedTags":        llx.MapData(definedTags, types.Any),
+			})
+			if err != nil {
+				return nil, err
+			}
+			mqlInstance.(*mqlOciIdentityUser).cacheIdentityProviderID = stringValue(user.IdentityProviderId)
+			res = append(res, mqlInstance)
+		}
+
+		return jobpool.JobResult(res), nil
 	}
-	return tasks
+	return []*jobpool.Job{jobpool.NewJob(f)}
 }
 
 type mqlOciIdentityUserInternal struct {
@@ -440,20 +423,7 @@ func (o *mqlOciIdentityUser) groups() ([]any, error) {
 func (o *mqlOciIdentity) groups() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getGroups(conn), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getGroups(conn))
 }
 
 func (s *mqlOciIdentity) getGroupsForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.Group, error) {
@@ -484,65 +454,61 @@ func (s *mqlOciIdentity) getGroupsForRegion(ctx context.Context, identityClient 
 
 func (o *mqlOciIdentity) getGroups(conn *connection.OciConnection) []*jobpool.Job {
 	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
-	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", region)
-
-			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			groups, err := o.getGroupsForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range groups {
-				grp := groups[i]
-
-				var created *time.Time
-				if grp.TimeCreated != nil {
-					created = &grp.TimeCreated.Time
-				}
-
-				freeformTags := make(map[string]interface{})
-				for k, v := range grp.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range grp.DefinedTags {
-					definedTags[k] = v
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.group", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(grp.Id),
-					"name":          llx.StringDataPtr(grp.Name),
-					"description":   llx.StringDataPtr(grp.Description),
-					"created":       llx.TimeDataPtr(created),
-					"state":         llx.StringData(string(grp.LifecycleState)),
-					"compartmentID": llx.StringDataPtr(grp.CompartmentId),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
-				})
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
+	// IAM is a global service: every regional identity endpoint serves the same
+	// tenancy-wide set, so fanning out over regions returned each group once per
+	// subscribed region. CreateResource hands back the cached instance for a
+	// repeated __id, so the slice held N copies of one pointer and the counts
+	// (and anything filtering them) were inflated N-fold.
+	f := func() (jobpool.JobResult, error) {
+		svcVal, err := conn.IdentityClient()
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+		svc := &svcVal
+
+		var res []any
+		groups, err := o.getGroupsForRegion(ctx, svc, conn.TenantID())
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range groups {
+			grp := groups[i]
+
+			var created *time.Time
+			if grp.TimeCreated != nil {
+				created = &grp.TimeCreated.Time
+			}
+
+			freeformTags := make(map[string]interface{})
+			for k, v := range grp.FreeformTags {
+				freeformTags[k] = v
+			}
+
+			definedTags := make(map[string]interface{})
+			for k, v := range grp.DefinedTags {
+				definedTags[k] = v
+			}
+
+			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.group", map[string]*llx.RawData{
+				"id":            llx.StringDataPtr(grp.Id),
+				"name":          llx.StringDataPtr(grp.Name),
+				"description":   llx.StringDataPtr(grp.Description),
+				"created":       llx.TimeDataPtr(created),
+				"state":         llx.StringData(string(grp.LifecycleState)),
+				"compartmentID": llx.StringDataPtr(grp.CompartmentId),
+				"freeformTags":  llx.MapData(freeformTags, types.String),
+				"definedTags":   llx.MapData(definedTags, types.Any),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlInstance)
+		}
+
+		return jobpool.JobResult(res), nil
 	}
-	return tasks
+	return []*jobpool.Job{jobpool.NewJob(f)}
 }
 
 func (o *mqlOciIdentityGroup) id() (string, error) {
@@ -552,20 +518,7 @@ func (o *mqlOciIdentityGroup) id() (string, error) {
 func (o *mqlOciIdentity) policies() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getPolicies(conn), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getPolicies(conn))
 }
 
 func (s *mqlOciIdentity) getPoliciesForRegion(ctx context.Context, identityClient *identity.IdentityClient, compartmentID string) ([]identity.Policy, error) {
@@ -596,72 +549,68 @@ func (s *mqlOciIdentity) getPoliciesForRegion(ctx context.Context, identityClien
 
 func (o *mqlOciIdentity) getPolicies(conn *connection.OciConnection) []*jobpool.Job {
 	ctx := context.Background()
-	tasks := make([]*jobpool.Job, 0)
-	regions, err := conn.GetRegions(ctx)
-	if err != nil {
-		return []*jobpool.Job{{Err: err}} // return the error
-	}
-	for _, region := range regions {
-		f := func() (jobpool.JobResult, error) {
-			log.Debug().Msgf("calling oci with region %s", region)
-
-			svc, err := conn.IdentityClientWithRegion(*region.RegionKey)
-			if err != nil {
-				return nil, err
-			}
-
-			var res []any
-			policies, err := o.getPoliciesForRegion(ctx, svc, conn.TenantID())
-			if err != nil {
-				return nil, err
-			}
-
-			for i := range policies {
-				policy := policies[i]
-
-				var created *time.Time
-				if policy.TimeCreated != nil {
-					created = &policy.TimeCreated.Time
-				}
-
-				var versionDate *time.Time
-				if policy.VersionDate != nil {
-					versionDate = &policy.VersionDate.Date
-				}
-
-				freeformTags := make(map[string]interface{})
-				for k, v := range policy.FreeformTags {
-					freeformTags[k] = v
-				}
-
-				definedTags := make(map[string]interface{})
-				for k, v := range policy.DefinedTags {
-					definedTags[k] = v
-				}
-
-				mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.policy", map[string]*llx.RawData{
-					"id":            llx.StringDataPtr(policy.Id),
-					"name":          llx.StringDataPtr(policy.Name),
-					"description":   llx.StringDataPtr(policy.Description),
-					"created":       llx.TimeDataPtr(created),
-					"state":         llx.StringData(string(policy.LifecycleState)),
-					"compartmentID": llx.StringDataPtr(policy.CompartmentId),
-					"statements":    llx.ArrayData(convert.SliceAnyToInterface(policy.Statements), types.String),
-					"versionDate":   llx.TimeDataPtr(versionDate),
-					"freeformTags":  llx.MapData(freeformTags, types.String),
-					"definedTags":   llx.MapData(definedTags, types.Any),
-				})
-				if err != nil {
-					return nil, err
-				}
-				res = append(res, mqlInstance)
-			}
-
-			return jobpool.JobResult(res), nil
+	// IAM is a global service: every regional identity endpoint serves the same
+	// tenancy-wide set, so fanning out over regions returned each policy once per
+	// subscribed region. CreateResource hands back the cached instance for a
+	// repeated __id, so the slice held N copies of one pointer and the counts
+	// (and anything filtering them) were inflated N-fold.
+	f := func() (jobpool.JobResult, error) {
+		svcVal, err := conn.IdentityClient()
+		if err != nil {
+			return nil, err
 		}
-		tasks = append(tasks, jobpool.NewJob(f))
+		svc := &svcVal
+
+		var res []any
+		policies, err := o.getPoliciesForRegion(ctx, svc, conn.TenantID())
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range policies {
+			policy := policies[i]
+
+			var created *time.Time
+			if policy.TimeCreated != nil {
+				created = &policy.TimeCreated.Time
+			}
+
+			var versionDate *time.Time
+			if policy.VersionDate != nil {
+				versionDate = &policy.VersionDate.Date
+			}
+
+			freeformTags := make(map[string]interface{})
+			for k, v := range policy.FreeformTags {
+				freeformTags[k] = v
+			}
+
+			definedTags := make(map[string]interface{})
+			for k, v := range policy.DefinedTags {
+				definedTags[k] = v
+			}
+
+			mqlInstance, err := CreateResource(o.MqlRuntime, "oci.identity.policy", map[string]*llx.RawData{
+				"id":            llx.StringDataPtr(policy.Id),
+				"name":          llx.StringDataPtr(policy.Name),
+				"description":   llx.StringDataPtr(policy.Description),
+				"created":       llx.TimeDataPtr(created),
+				"state":         llx.StringData(string(policy.LifecycleState)),
+				"compartmentID": llx.StringDataPtr(policy.CompartmentId),
+				"statements":    llx.ArrayData(convert.SliceAnyToInterface(policy.Statements), types.String),
+				"versionDate":   llx.TimeDataPtr(versionDate),
+				"freeformTags":  llx.MapData(freeformTags, types.String),
+				"definedTags":   llx.MapData(definedTags, types.Any),
+			})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlInstance)
+		}
+
+		return jobpool.JobResult(res), nil
 	}
-	return tasks
+	return []*jobpool.Job{jobpool.NewJob(f)}
 }
 
 func (o *mqlOciIdentityPolicy) id() (string, error) {
@@ -957,7 +906,7 @@ func (o *mqlOciIdentityUser) oauth2ClientCredentials() ([]any, error) {
 				"name":          llx.StringDataPtr(cred.Name),
 				"description":   llx.StringDataPtr(cred.Description),
 				"compartmentID": llx.StringDataPtr(cred.CompartmentId),
-				"scopes":        llx.DictData(scopesDict),
+				"scopes":        llx.ArrayData(scopesDict, types.Dict),
 				"created":       sdkTimeData(cred.TimeCreated),
 				"expires":       sdkTimeData(cred.ExpiresOn),
 				"state":         llx.StringData(string(cred.LifecycleState)),
@@ -1149,7 +1098,7 @@ func (o *mqlOciIdentity) networkSources() ([]any, error) {
 				"name":              llx.StringDataPtr(ns.Name),
 				"description":       llx.StringDataPtr(ns.Description),
 				"publicSourceList":  llx.ArrayData(stringsToAny(ns.PublicSourceList), types.String),
-				"virtualSourceList": llx.DictData(virtualDict),
+				"virtualSourceList": llx.ArrayData(virtualDict, types.Dict),
 				"services":          llx.ArrayData(stringsToAny(ns.Services), types.String),
 				"created":           sdkTimeData(ns.TimeCreated),
 				"state":             llx.StringData(string(ns.LifecycleState)),

--- a/providers/oci/resources/init_refs.go
+++ b/providers/oci/resources/init_refs.go
@@ -1,0 +1,240 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/oci/connection"
+)
+
+// ociResolveByID matches an OCID against an already modelled collection and
+// returns the populated resource, or a not-found error.
+//
+// The error matters. Without an Init, NewResource falls straight through to
+// Create and builds the resource from the id alone, leaving every other field
+// *unset* rather than null - which surfaces client-side as "encountered a
+// primitive with no type information" with nothing pointing at the cause. Worse,
+// the generated CreateResource caches that husk under the real OCID and returns
+// it in place of a later fully-populated instance, so whether a query works
+// depends on the order resources happen to be resolved in.
+func ociResolveByID(args map[string]*llx.RawData, resourceName, id string, items []any) (map[string]*llx.RawData, plugin.Resource, error) {
+	for _, raw := range items {
+		res, ok := raw.(plugin.Resource)
+		if !ok {
+			continue
+		}
+		idField, ok := raw.(interface{ GetId() *plugin.TValue[string] })
+		if ok && idField.GetId().Data == id {
+			return args, res, nil
+		}
+	}
+	return nil, nil, errors.New(resourceName + " not found: " + id)
+}
+
+// ociInitArgs handles the two argument shapes every singular init shares: an
+// already-complete arg set, and a bare resource with no id (a valid empty
+// state). It reports the id to resolve, or ok=false when the init should return
+// the args untouched.
+func ociInitArgs(args map[string]*llx.RawData) (id string, resolve bool) {
+	if len(args) > 2 {
+		return "", false
+	}
+	id = ociArgString(args, "id")
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// ociServiceCollection creates a service singleton and returns one of its
+// collections, so the inits below reuse the listing path's auth, pagination and
+// region fan-out rather than duplicating it.
+func ociServiceCollection(runtime *plugin.Runtime, service string, list func(plugin.Resource) *plugin.TValue[[]any]) ([]any, error) {
+	obj, err := CreateResource(runtime, service, nil)
+	if err != nil {
+		return nil, err
+	}
+	items := list(obj)
+	if items.Error != nil {
+		return nil, items.Error
+	}
+	return items.Data, nil
+}
+
+func initOciComputeInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.compute", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciCompute).GetInstances()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.compute.instance", id, items)
+}
+
+func initOciComputeImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.compute", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciCompute).GetImages()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.compute.image", id, items)
+}
+
+func initOciComputeBlockVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.compute", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciCompute).GetBlockVolumes()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.compute.blockVolume", id, items)
+}
+
+func initOciComputeBootVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.compute", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciCompute).GetBootVolumes()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.compute.bootVolume", id, items)
+}
+
+// initOciComputeVnic fetches the VNIC directly rather than scanning every
+// instance's attachments: the region is recoverable from the OCID, so a single
+// GetVnic is both cheaper and independent of which compartment the VNIC lives
+// in.
+func initOciComputeVnic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	region := ociRegionFromOCID(id)
+	if region == "" {
+		return nil, nil, errors.New("could not determine region from vnic ocid: " + id)
+	}
+
+	conn := runtime.Connection.(*connection.OciConnection)
+	svc, err := conn.NetworkClient(region)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := svc.GetVnic(context.Background(), core.GetVnicRequest{VnicId: common.String(id)})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	vnic, err := ociVnicToMql(runtime, resp.Vnic)
+	if err != nil {
+		return nil, nil, err
+	}
+	return args, vnic, nil
+}
+
+func initOciDatabaseDbSystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.database", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciDatabase).GetDbSystems()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.database.dbSystem", id, items)
+}
+
+func initOciDatabaseAutonomousDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.database", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciDatabase).GetAutonomousDatabases()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.database.autonomousDatabase", id, items)
+}
+
+func initOciFileStorageFileSystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.fileStorage", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciFileStorage).GetFileSystems()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.fileStorage.fileSystem", id, items)
+}
+
+func initOciApigatewayGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.apigateway", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciApigateway).GetGateways()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.apigateway.gateway", id, items)
+}
+
+func initOciIdentityIdentityProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci.identity", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOciIdentity).GetIdentityProviders()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.identity.identityProvider", id, items)
+}
+
+func initOciRegion(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	id, resolve := ociInitArgs(args)
+	if !resolve {
+		return args, nil, nil
+	}
+	items, err := ociServiceCollection(runtime, "oci", func(r plugin.Resource) *plugin.TValue[[]any] {
+		return r.(*mqlOci).GetRegions()
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ociResolveByID(args, "oci.region", id, items)
+}

--- a/providers/oci/resources/init_refs_test.go
+++ b/providers/oci/resources/init_refs_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestOciInitArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        map[string]*llx.RawData
+		wantID      string
+		wantResolve bool
+	}{
+		{
+			// Already-complete args: the caller built the resource, nothing to
+			// look up.
+			name: "more than two args",
+			args: map[string]*llx.RawData{
+				"id": llx.StringData("ocid1.instance.oc1.iad.a"), "name": llx.StringData("x"), "state": llx.StringData("y"),
+			},
+			wantResolve: false,
+		},
+		// A bare resource with no id is a valid empty state, not a lookup miss.
+		{"nil args", nil, "", false},
+		{"empty args", map[string]*llx.RawData{}, "", false},
+		{"id present but null", map[string]*llx.RawData{"id": llx.NilData}, "", false},
+		{"id present but empty", map[string]*llx.RawData{"id": llx.StringData("")}, "", false},
+		{"id present but not a string", map[string]*llx.RawData{"id": llx.IntData(7)}, "", false},
+		{
+			name:        "resolvable id",
+			args:        map[string]*llx.RawData{"id": llx.StringData("ocid1.instance.oc1.iad.a")},
+			wantID:      "ocid1.instance.oc1.iad.a",
+			wantResolve: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, resolve := ociInitArgs(tt.args)
+			assert.Equal(t, tt.wantResolve, resolve)
+			assert.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+func TestOciResolveByID(t *testing.T) {
+	args := map[string]*llx.RawData{"id": llx.StringData("ocid1.compartment.oc1..b")}
+
+	t.Run("match returns the populated resource", func(t *testing.T) {
+		want := &mqlOciCompartment{}
+		want.Id.Data = "ocid1.compartment.oc1..b"
+		want.Id.State = 1
+
+		other := &mqlOciCompartment{}
+		other.Id.Data = "ocid1.compartment.oc1..a"
+		other.Id.State = 1
+
+		gotArgs, res, err := ociResolveByID(args, "oci.compartment", "ocid1.compartment.oc1..b", []any{other, want})
+		require.NoError(t, err)
+		assert.Equal(t, args, gotArgs)
+		assert.Same(t, want, res)
+	})
+
+	t.Run("miss is an error, never a husk", func(t *testing.T) {
+		// Returning (args, nil, nil) here would build the resource from the id
+		// alone and cache that husk under the real OCID.
+		_, res, err := ociResolveByID(args, "oci.compartment", "ocid1.compartment.oc1..zz", []any{})
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "oci.compartment not found")
+		assert.Contains(t, err.Error(), "ocid1.compartment.oc1..zz")
+	})
+
+	t.Run("non-resource entries are skipped", func(t *testing.T) {
+		_, _, err := ociResolveByID(args, "oci.compartment", "ocid1.compartment.oc1..b", []any{"not a resource", 42})
+		require.Error(t, err)
+	})
+}

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -136,10 +136,10 @@ func initOciKmsVault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.kms.vault")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.kms", nil)
 	if err != nil {
@@ -248,10 +248,10 @@ func initOciKmsKey(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.kms.key")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.kms", nil)
 	if err != nil {

--- a/providers/oci/resources/kms.go
+++ b/providers/oci/resources/kms.go
@@ -35,18 +35,7 @@ func (o *mqlOciKms) vaults() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getVaults(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getVaults(conn, list.Data))
 }
 
 func (o *mqlOciKms) getVaultsForRegion(ctx context.Context, client *keymanagement.KmsVaultClient, compartmentID string) ([]keymanagement.VaultSummary, error) {

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -105,9 +105,18 @@ func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, re
 
 				ipAddresses := make([]any, 0, len(lb.IpAddresses))
 				for _, ip := range lb.IpAddresses {
+					// isPublic is optional on the SDK model, and exposure()
+					// reads this key back to decide internet reachability. A
+					// missing flag on a non-private load balancer means public,
+					// so falling back to false would clear a genuinely
+					// internet-facing balancer.
+					isPublic := boolValue(ip.IsPublic)
+					if ip.IsPublic == nil {
+						isPublic = !boolValue(lb.IsPrivate)
+					}
 					entry := map[string]any{
 						"ipAddress": stringValue(ip.IpAddress),
-						"isPublic":  boolValue(ip.IsPublic),
+						"isPublic":  isPublic,
 					}
 					if ip.ReservedIp != nil {
 						entry["reservedIpId"] = stringValue(ip.ReservedIp.Id)

--- a/providers/oci/resources/loadbalancer.go
+++ b/providers/oci/resources/loadbalancer.go
@@ -36,18 +36,7 @@ func (o *mqlOciLoadBalancer) loadBalancers() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getLoadBalancers(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getLoadBalancers(conn, list.Data))
 }
 
 func (o *mqlOciLoadBalancer) getLoadBalancers(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -139,10 +139,10 @@ func initOciLoggingLogGroup(runtime *plugin.Runtime, args map[string]*llx.RawDat
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.logging.logGroup")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.logging", nil)
 	if err != nil {

--- a/providers/oci/resources/logging.go
+++ b/providers/oci/resources/logging.go
@@ -36,18 +36,7 @@ func (o *mqlOciLogging) logGroups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getLogGroups(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getLogGroups(conn, list.Data))
 }
 
 func (o *mqlOciLogging) getLogGroupsForRegion(ctx context.Context, client *logging.LoggingManagementClient, compartmentID string) ([]logging.LogGroupSummary, error) {
@@ -307,6 +296,16 @@ func convertLogConfiguration(cfg *logging.Configuration) (map[string]interface{}
 			return nil, err
 		}
 		result["source"] = source
+	}
+
+	// Archiving is the third field on the SDK's Configuration and was dropped
+	// entirely, so log-archiving state read as "not configured" on every log.
+	if cfg.Archiving != nil {
+		archiving, err := convert.JsonToDict(cfg.Archiving)
+		if err != nil {
+			return nil, err
+		}
+		result["archiving"] = archiving
 	}
 
 	return result, nil

--- a/providers/oci/resources/logging_test.go
+++ b/providers/oci/resources/logging_test.go
@@ -19,6 +19,26 @@ func TestConvertLogConfiguration(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+	t.Run("archiving is carried through", func(t *testing.T) {
+		// Archiving is the third field on the SDK's Configuration and was
+		// dropped entirely, so log-archiving state read as "not configured"
+		// on every log in the tenancy.
+		enabled := true
+		result, err := convertLogConfiguration(&logging.Configuration{
+			Archiving: &logging.Archiving{IsEnabled: &enabled},
+		})
+		require.NoError(t, err)
+		archiving, ok := result["archiving"].(map[string]any)
+		require.True(t, ok, "archiving key must be present")
+		assert.Equal(t, true, archiving["isEnabled"])
+	})
+
+	t.Run("absent archiving omits the key", func(t *testing.T) {
+		result, err := convertLogConfiguration(&logging.Configuration{})
+		require.NoError(t, err)
+		assert.NotContains(t, result, "archiving")
+	})
+
 	t.Run("empty config returns empty map", func(t *testing.T) {
 		cfg := &logging.Configuration{}
 		result, err := convertLogConfiguration(cfg)

--- a/providers/oci/resources/monitoring.go
+++ b/providers/oci/resources/monitoring.go
@@ -33,18 +33,7 @@ func (o *mqlOciMonitoring) alarms() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getAlarms(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getAlarms(conn, list.Data))
 }
 
 func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -68,7 +57,10 @@ func (o *mqlOciMonitoring) getAlarms(conn *connection.OciConnection, regions []a
 			for {
 				response, err := svc.ListAlarms(ctx, monitoring.ListAlarmsRequest{
 					CompartmentId: common.String(conn.TenantID()),
-					Page:          page,
+					// Alarms are normally created in a workload compartment,
+					// not the tenancy root.
+					CompartmentIdInSubtree: common.Bool(true),
+					Page:                   page,
 				})
 				if err != nil {
 					return nil, err

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -28,20 +28,7 @@ func (o *mqlOciNetwork) id() (string, error) {
 func (o *mqlOciNetwork) vcns() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getVcns(conn), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getVcns(conn))
 }
 
 func (s *mqlOciNetwork) getVcnsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.Vcn, error) {
@@ -177,20 +164,7 @@ func (o *mqlOciNetworkVcn) id() (string, error) {
 func (o *mqlOciNetwork) securityLists() ([]any, error) {
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getSecurityLists(conn), 5)
-	poolOfJobs.Run()
-
-	// check for errors
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	// get all the results
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getSecurityLists(conn))
 }
 
 func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.SecurityList, error) {
@@ -345,8 +319,8 @@ func (o *mqlOciNetwork) getSecurityLists(conn *connection.OciConnection) []*jobp
 					"created":              llx.TimeDataPtr(created),
 					"state":                llx.StringData(string(securityList.LifecycleState)),
 					"compartmentID":        llx.StringDataPtr(securityList.CompartmentId),
-					"egressSecurityRules":  llx.DictData(egress),
-					"ingressSecurityRules": llx.DictData(ingress),
+					"egressSecurityRules":  llx.ArrayData(egress, types.Dict),
+					"ingressSecurityRules": llx.ArrayData(ingress, types.Dict),
 					"vcnId":                llx.StringDataPtr(securityList.VcnId),
 					"freeformTags":         llx.MapData(freeformTags, types.String),
 					"definedTags":          llx.MapData(definedTags, types.Any),
@@ -419,7 +393,7 @@ func (o *mqlOciNetworkSecurityList) id() (string, error) {
 }
 
 func (o *mqlOciNetworkSecurityList) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -489,18 +463,7 @@ func (o *mqlOciNetwork) subnets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getSubnets(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getSubnets(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getSubnets(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -631,7 +594,7 @@ func (o *mqlOciNetworkSubnet) id() (string, error) {
 }
 
 func (o *mqlOciNetworkSubnet) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -657,18 +620,7 @@ func (o *mqlOciNetwork) networkSecurityGroups() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getNetworkSecurityGroups(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getNetworkSecurityGroups(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getNSGsForRegion(ctx context.Context, networkClient *core.VirtualNetworkClient, compartmentID string) ([]core.NetworkSecurityGroup, error) {
@@ -852,7 +804,7 @@ func initOciNetworkNetworkSecurityGroup(runtime *plugin.Runtime, args map[string
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -1110,18 +1062,7 @@ func (o *mqlOciNetwork) internetGateways() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getInternetGateways(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getInternetGateways(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getInternetGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -1212,7 +1153,7 @@ func (o *mqlOciNetworkInternetGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkInternetGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -1240,18 +1181,7 @@ func (o *mqlOciNetwork) natGateways() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getNatGateways(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getNatGateways(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getNatGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -1343,7 +1273,7 @@ func (o *mqlOciNetworkNatGateway) id() (string, error) {
 }
 
 func (o *mqlOciNetworkNatGateway) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -1385,18 +1315,7 @@ func (o *mqlOciNetwork) routeTables() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getRouteTables(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getRouteTables(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -1473,7 +1392,7 @@ func (o *mqlOciNetwork) getRouteTables(conn *connection.OciConnection, regions [
 					"id":            llx.StringDataPtr(rt.Id),
 					"name":          llx.StringDataPtr(rt.DisplayName),
 					"compartmentID": llx.StringDataPtr(rt.CompartmentId),
-					"routeRules":    llx.DictData(routeRules),
+					"routeRules":    llx.ArrayData(routeRules, types.Dict),
 					"state":         llx.StringData(string(rt.LifecycleState)),
 					"created":       llx.TimeDataPtr(created),
 					"freeformTags":  llx.MapData(freeformTags, types.String),
@@ -1534,7 +1453,7 @@ func (o *mqlOciNetworkRouteTable) id() (string, error) {
 }
 
 func (o *mqlOciNetworkRouteTable) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -1550,7 +1469,7 @@ func (o *mqlOciNetworkRouteTable) vcn() (*mqlOciNetworkVcn, error) {
 // Subnet route table reference
 
 func (o *mqlOciNetworkSubnet) routeTable() (*mqlOciNetworkRouteTable, error) {
-	if o.cacheRouteTableId == "" {
+	if o.cacheRouteTableId == "" || !isOcid(o.cacheRouteTableId) {
 		o.RouteTable.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -1576,18 +1495,7 @@ func (o *mqlOciNetwork) publicIps() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getPublicIps(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getPublicIps(conn, list.Data))
 }
 
 func (o *mqlOciNetwork) getPublicIps(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -143,10 +144,10 @@ func initOciNetworkVcn(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.vcn")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -597,10 +598,10 @@ func initOciNetworkSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.subnet")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -763,7 +764,7 @@ type mqlOciNetworkNetworkSecurityGroupInternal struct {
 	region     string
 	cacheVcnId string
 	fetchLock  sync.Mutex
-	fetched    bool
+	fetched    atomic.Bool
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) id() (string, error) {
@@ -904,12 +905,12 @@ func (o *mqlOciNetworkNetworkSecurityGroup) getRulesForNSG(ctx context.Context, 
 }
 
 func (o *mqlOciNetworkNetworkSecurityGroup) fetchSecurityRules() (ingress []any, egress []any, err error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return nil, nil, nil
 	}
 	o.fetchLock.Lock()
 	defer o.fetchLock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return nil, nil, nil
 	}
 
@@ -964,7 +965,7 @@ func (o *mqlOciNetworkNetworkSecurityGroup) fetchSecurityRules() (ingress []any,
 
 	o.IngressSecurityRules = plugin.TValue[[]any]{Data: ingress, State: plugin.StateIsSet}
 	o.EgressSecurityRules = plugin.TValue[[]any]{Data: egress, State: plugin.StateIsSet}
-	o.fetched = true
+	o.fetched.Store(true)
 
 	return ingress, egress, nil
 }
@@ -1500,10 +1501,10 @@ func initOciNetworkRouteTable(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.routeTable")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {

--- a/providers/oci/resources/network.go
+++ b/providers/oci/resources/network.go
@@ -223,14 +223,15 @@ func (s *mqlOciNetwork) getSecurityListsForRegion(ctx context.Context, networkCl
 type egressSecurityRule struct {
 	// Description of egress rule
 	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule
-	Stateless bool `json:"stateless,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
 	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 	Protocol string `json:"protocol,omitempty"`
 	// Range of allowed IP addresses
 	Destination string `json:"destination,omitempty"`
 	// Type of destination
-	DestinationType string `json:"destination_type,omitempty"`
+	DestinationType string `json:"destinationType,omitempty"`
 	// TCP options
 	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
 	// Udp options
@@ -243,14 +244,15 @@ type egressSecurityRule struct {
 type ingressSecurityRule struct {
 	// Description of ingress rule
 	Description string `json:"description,omitempty"`
-	// Indicates if this is a stateless rule
-	Stateless bool `json:"stateless,omitempty"`
+	// Indicates if this is a stateless rule. No omitempty: a stateful rule
+	// must emit `stateless: false`, not drop the key entirely.
+	Stateless bool `json:"stateless"`
 	// Transport protocol, follows http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 	Protocol string `json:"protocol,omitempty"`
 	// Range of allowed IP addresses
 	Source string `json:"source,omitempty"`
 	// Type of source
-	SourceType string `json:"source_type,omitempty"`
+	SourceType string `json:"sourceType,omitempty"`
 	// TCP options
 	TcpOptions *core.TcpOptions `json:"tcpOptions,omitempty"`
 	// Udp options

--- a/providers/oci/resources/network_rules_test.go
+++ b/providers/oci/resources/network_rules_test.go
@@ -1,0 +1,161 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+)
+
+// The rule structs reach MQL as dicts via convert.JsonToDictSlice, so their
+// json tags *are* the user-facing schema. These tests pin the emitted keys:
+// an `omitempty` on a bool silently drops `false`, and a snake_case tag
+// silently renames a documented field - neither shows up at compile time.
+
+func TestSecurityListIngressRuleDictKeys(t *testing.T) {
+	rules := []ingressSecurityRule{{
+		Description: "ssh from anywhere",
+		Stateless:   false,
+		Protocol:    "6",
+		Source:      "0.0.0.0/0",
+		SourceType:  "CIDR_BLOCK",
+	}}
+
+	out, err := convert.JsonToDictSlice(rules)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	rule, ok := out[0].(map[string]any)
+	require.True(t, ok)
+
+	// A stateful rule must emit `stateless: false`, not drop the key. Dropping
+	// it makes `all(stateless == false)` compare against null and fail every
+	// correctly-configured rule.
+	stateless, present := rule["stateless"]
+	assert.True(t, present, "stateless key must be present for a stateful rule")
+	assert.Equal(t, false, stateless)
+
+	// camelCase, matching both the .lr documentation and the NSG rule shape.
+	assert.Equal(t, "CIDR_BLOCK", rule["sourceType"])
+	assert.NotContains(t, rule, "source_type")
+
+	assert.Equal(t, "0.0.0.0/0", rule["source"])
+	assert.Equal(t, "6", rule["protocol"])
+}
+
+func TestSecurityListEgressRuleDictKeys(t *testing.T) {
+	rules := []egressSecurityRule{{
+		Stateless:       false,
+		Protocol:        "6",
+		Destination:     "0.0.0.0/0",
+		DestinationType: "CIDR_BLOCK",
+	}}
+
+	out, err := convert.JsonToDictSlice(rules)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	rule, ok := out[0].(map[string]any)
+	require.True(t, ok)
+
+	stateless, present := rule["stateless"]
+	assert.True(t, present, "stateless key must be present for a stateful rule")
+	assert.Equal(t, false, stateless)
+
+	assert.Equal(t, "CIDR_BLOCK", rule["destinationType"])
+	assert.NotContains(t, rule, "destination_type")
+}
+
+func TestSecurityListRuleStatelessTrueRoundTrips(t *testing.T) {
+	out, err := convert.JsonToDictSlice([]ingressSecurityRule{{Stateless: true, Source: "10.0.0.0/8"}})
+	require.NoError(t, err)
+	rule := out[0].(map[string]any)
+	assert.Equal(t, true, rule["stateless"])
+}
+
+// anyRuleStateless reads the key the mappers emit, on both the security-list
+// ("stateless") and NSG ("isStateless") side. A mismatch between the two
+// silently returns "no stateless rules".
+func TestAnyRuleStatelessMatchesEmittedKeys(t *testing.T) {
+	slRules, err := convert.JsonToDictSlice([]ingressSecurityRule{
+		{Stateless: false, Source: "10.0.0.0/8"},
+		{Stateless: true, Source: "0.0.0.0/0"},
+	})
+	require.NoError(t, err)
+	assert.True(t, anyRuleStateless(slRules, "stateless"))
+
+	nsgRules, err := convert.JsonToDictSlice([]nsgSecurityRule{
+		{Direction: "INGRESS", IsStateless: true, Source: "0.0.0.0/0"},
+	})
+	require.NoError(t, err)
+	assert.True(t, anyRuleStateless(nsgRules, "isStateless"))
+
+	statefulOnly, err := convert.JsonToDictSlice([]ingressSecurityRule{{Stateless: false}})
+	require.NoError(t, err)
+	assert.False(t, anyRuleStateless(statefulOnly, "stateless"))
+}
+
+func TestOciAnySubnetAdmitsInternet(t *testing.T) {
+	tests := []struct {
+		name             string
+		gates            []ociSubnetGate
+		nsgOpenRuleCount int
+		want             bool
+	}{
+		{
+			name:  "no subnets",
+			gates: nil,
+			want:  false,
+		},
+		{
+			name: "single subnet open on every axis",
+			gates: []ociSubnetGate{
+				{prohibitsIngress: false, routesToInternet: true, securityListAllows: true},
+			},
+			want: true,
+		},
+		{
+			// The regression this function exists for. Aggregating the
+			// security-list verdict across subnets combined the public
+			// subnet's internet route with the private subnet's wide-open
+			// default VCN security list into a false positive.
+			name: "hardened public subnet + open private subnet must not combine",
+			gates: []ociSubnetGate{
+				{prohibitsIngress: false, routesToInternet: true, securityListAllows: false},
+				{prohibitsIngress: false, routesToInternet: false, securityListAllows: true},
+			},
+			want: false,
+		},
+		{
+			name: "an NSG rule opens ingress for the routed subnet",
+			gates: []ociSubnetGate{
+				{prohibitsIngress: false, routesToInternet: true, securityListAllows: false},
+			},
+			nsgOpenRuleCount: 1,
+			want:             true,
+		},
+		{
+			name: "prohibitInternetIngress blocks an otherwise open subnet",
+			gates: []ociSubnetGate{
+				{prohibitsIngress: true, routesToInternet: true, securityListAllows: true},
+			},
+			nsgOpenRuleCount: 1,
+			want:             false,
+		},
+		{
+			name: "no internet route blocks an otherwise open subnet",
+			gates: []ociSubnetGate{
+				{prohibitsIngress: false, routesToInternet: false, securityListAllows: true},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociAnySubnetAdmitsInternet(tt.gates, tt.nsgOpenRuleCount))
+		})
+	}
+}

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -276,18 +277,18 @@ func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regi
 
 type mqlOciNetworkFirewallPolicyInternal struct {
 	region    string
-	fetched   bool
+	fetched   atomic.Bool
 	detail    *networkfirewall.NetworkFirewallPolicy
 	fetchLock sync.Mutex
 }
 
 func (o *mqlOciNetworkFirewallPolicy) fetchDetail() (*networkfirewall.NetworkFirewallPolicy, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, nil
 	}
 	o.fetchLock.Lock()
 	defer o.fetchLock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, nil
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
@@ -302,7 +303,7 @@ func (o *mqlOciNetworkFirewallPolicy) fetchDetail() (*networkfirewall.NetworkFir
 		return nil, err
 	}
 	o.detail = &resp.NetworkFirewallPolicy
-	o.fetched = true
+	o.fetched.Store(true)
 	return o.detail, nil
 }
 
@@ -330,10 +331,10 @@ func initOciNetworkFirewallPolicy(runtime *plugin.Runtime, args map[string]*llx.
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.networkFirewall.policy")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.networkFirewall", nil)
 	if err != nil {

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -450,12 +450,16 @@ func decryptionProfileFields(dp networkfirewall.DecryptionProfile, summary netwo
 		fields["isUnsupportedCipherBlocked"] = llx.BoolDataPtr(p.IsUnsupportedCipherBlocked)
 		fields["isOutOfCapacityBlocked"] = llx.BoolDataPtr(p.IsOutOfCapacityBlocked)
 	default:
-		// Unknown profile type: surface the summary type, leave booleans null.
+		// Unknown profile type (an inspection type newer than the pinned SDK):
+		// surface the summary type and report the controls as not blocking.
+		// Null would make `isUnsupportedVersionBlocked &&
+		// isUnsupportedCipherBlocked` evaluate to true, so a profile we could
+		// not decode would pass a TLS-hygiene check it was never measured for.
 		fields["type"] = llx.StringData(string(summary.Type))
 		fields["description"] = llx.StringDataPtr(summary.Description)
-		fields["isUnsupportedVersionBlocked"] = llx.BoolDataPtr(nil)
-		fields["isUnsupportedCipherBlocked"] = llx.BoolDataPtr(nil)
-		fields["isOutOfCapacityBlocked"] = llx.BoolDataPtr(nil)
+		fields["isUnsupportedVersionBlocked"] = llx.BoolData(false)
+		fields["isUnsupportedCipherBlocked"] = llx.BoolData(false)
+		fields["isOutOfCapacityBlocked"] = llx.BoolData(false)
 	}
 	return fields
 }

--- a/providers/oci/resources/networkfirewall.go
+++ b/providers/oci/resources/networkfirewall.go
@@ -37,18 +37,7 @@ func (o *mqlOciNetworkFirewall) firewalls() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getFirewalls(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getFirewalls(conn, list.Data))
 }
 
 func (o *mqlOciNetworkFirewall) getFirewalls(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -195,18 +184,7 @@ func (o *mqlOciNetworkFirewall) policies() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getPolicies(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getPolicies(conn, list.Data))
 }
 
 func (o *mqlOciNetworkFirewall) getPolicies(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/oci.go
+++ b/providers/oci/resources/oci.go
@@ -114,9 +114,15 @@ func initOciCompartment(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		CompartmentId: common.String(id),
 	})
 	if err != nil {
-		// Return only the id so the resource is identifiable even when the
-		// caller can't read details (cross-tenancy / IAM denial). entries()
-		// and other deeper lookups will surface the same error if reached.
+		// Keep the resource identifiable by id when the caller can't read its
+		// details (cross-tenancy / IAM denial), but set the remaining fields
+		// explicitly null. Leaving them unset sends a primitive with no type
+		// information across the plugin boundary, which surfaces client-side as
+		// an unattributed coercion warning rather than a readable null.
+		args["name"] = llx.NilData
+		args["description"] = llx.NilData
+		args["created"] = llx.NilData
+		args["state"] = llx.NilData
 		return args, nil, nil
 	}
 	compartment := resp.Compartment

--- a/providers/oci/resources/oci.lr
+++ b/providers/oci/resources/oci.lr
@@ -1700,11 +1700,13 @@ private oci.logging.log @defaults("name") {
   retentionDuration int
   // Log configuration
   //
-  // Keyed by `compartmentId` (OCID of the compartment owning the log)
-  // and `source`, a nested map describing the emitting service. For a
+  // Keyed by `compartmentId` (OCID of the compartment owning the log),
+  // `source`, a nested map describing the emitting service, and
+  // `archiving` when object-storage archiving is configured. For a
   // service log the `source` map carries `sourceType`, `service`,
   // `resource`, and `category`. The `category`, `sourceService`, and
-  // `sourceResource` fields surface those source values directly.
+  // `sourceResource` fields surface those source values directly. The
+  // `archiving` map carries `isEnabled`.
   configuration dict
   // Log category (e.g., all, write, read — depends on service)
   category string

--- a/providers/oci/resources/oci.lr.go
+++ b/providers/oci/resources/oci.lr.go
@@ -198,7 +198,7 @@ func init() {
 			Create: createOciTenancy,
 		},
 		"oci.region": {
-			// to override args, implement: initOciRegion(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciRegion,
 			Create: createOciRegion,
 		},
 		"oci.compartment": {
@@ -254,7 +254,7 @@ func init() {
 			Create: createOciIdentityDynamicGroup,
 		},
 		"oci.identity.identityProvider": {
-			// to override args, implement: initOciIdentityIdentityProvider(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciIdentityIdentityProvider,
 			Create: createOciIdentityIdentityProvider,
 		},
 		"oci.identity.networkSource": {
@@ -274,23 +274,23 @@ func init() {
 			Create: createOciNetworkExposure,
 		},
 		"oci.compute.instance": {
-			// to override args, implement: initOciComputeInstance(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciComputeInstance,
 			Create: createOciComputeInstance,
 		},
 		"oci.compute.vnic": {
-			// to override args, implement: initOciComputeVnic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciComputeVnic,
 			Create: createOciComputeVnic,
 		},
 		"oci.compute.image": {
-			// to override args, implement: initOciComputeImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciComputeImage,
 			Create: createOciComputeImage,
 		},
 		"oci.compute.blockVolume": {
-			// to override args, implement: initOciComputeBlockVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciComputeBlockVolume,
 			Create: createOciComputeBlockVolume,
 		},
 		"oci.compute.bootVolume": {
-			// to override args, implement: initOciComputeBootVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciComputeBootVolume,
 			Create: createOciComputeBootVolume,
 		},
 		"oci.network": {
@@ -426,7 +426,7 @@ func init() {
 			Create: createOciFileStorage,
 		},
 		"oci.fileStorage.fileSystem": {
-			// to override args, implement: initOciFileStorageFileSystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciFileStorageFileSystem,
 			Create: createOciFileStorageFileSystem,
 		},
 		"oci.events": {
@@ -598,11 +598,11 @@ func init() {
 			Create: createOciDatabaseAutonomousDatabaseBackup,
 		},
 		"oci.database.dbSystem": {
-			// to override args, implement: initOciDatabaseDbSystem(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciDatabaseDbSystem,
 			Create: createOciDatabaseDbSystem,
 		},
 		"oci.database.autonomousDatabase": {
-			// to override args, implement: initOciDatabaseAutonomousDatabase(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciDatabaseAutonomousDatabase,
 			Create: createOciDatabaseAutonomousDatabase,
 		},
 		"oci.apigateway": {
@@ -610,7 +610,7 @@ func init() {
 			Create: createOciApigateway,
 		},
 		"oci.apigateway.gateway": {
-			// to override args, implement: initOciApigatewayGateway(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initOciApigatewayGateway,
 			Create: createOciApigatewayGateway,
 		},
 		"oci.apigateway.deployment": {

--- a/providers/oci/resources/oci_exposure.go
+++ b/providers/oci/resources/oci_exposure.go
@@ -83,12 +83,11 @@ func ociNsgIngressVerdict(nsgRuleSets [][]map[string]any) ([]any, bool) {
 
 // ociSecurityListRuleOpensIngress reports whether a VCN security-list ingress
 // rule dict admits traffic from any address. Security-list ingress rules are
-// inherently inbound (no direction field), and their source keys are snake_case
-// (source, source_type) unlike NSG rules. NSG and SERVICE_CIDR_BLOCK sources
-// reference internal networks, so only a CIDR_BLOCK (or unset) source can be
-// public.
+// inherently inbound, so they carry no direction field. NSG and
+// SERVICE_CIDR_BLOCK sources reference internal networks, so only a CIDR_BLOCK
+// (or unset) source can be public.
 func ociSecurityListRuleOpensIngress(rule map[string]any) bool {
-	if st, _ := rule["source_type"].(string); st != "" && !strings.EqualFold(st, "CIDR_BLOCK") {
+	if st, _ := rule["sourceType"].(string); st != "" && !strings.EqualFold(st, "CIDR_BLOCK") {
 		return false
 	}
 	source, _ := rule["source"].(string)
@@ -195,12 +194,14 @@ func ociIngressOpen(nsgOpenRuleCount int, securityListAllows bool) bool {
 	return nsgOpenRuleCount > 0 || securityListAllows
 }
 
-// ociSubnetGate captures the two subnet conditions that gate internet
-// reachability: whether the subnet prohibits internet ingress, and whether it
-// routes a default route to an enabled internet gateway.
+// ociSubnetGate captures the subnet conditions that gate internet
+// reachability: whether the subnet prohibits internet ingress, whether it
+// routes a default route to an enabled internet gateway, and whether its own
+// security lists admit ingress from any address.
 type ociSubnetGate struct {
-	prohibitsIngress bool
-	routesToInternet bool
+	prohibitsIngress   bool
+	routesToInternet   bool
+	securityListAllows bool
 }
 
 // ociAnySubnetReachable reports whether any single subnet both permits internet
@@ -211,6 +212,27 @@ type ociSubnetGate struct {
 func ociAnySubnetReachable(gates []ociSubnetGate) bool {
 	for _, g := range gates {
 		if !g.prohibitsIngress && g.routesToInternet {
+			return true
+		}
+	}
+	return false
+}
+
+// ociAnySubnetAdmitsInternet reports whether any single subnet satisfies every
+// condition at once: it permits internet ingress, routes to an internet
+// gateway, and admits ingress from any address through either the NSG layer
+// (which attaches to the resource, not the subnet) or its own security lists.
+//
+// Evaluating the security-list layer per subnet rather than over the union
+// matters for a multi-subnet load balancer: a hardened public subnet paired
+// with a private subnet carrying the wide-open default VCN security list must
+// not combine into a reachable verdict.
+func ociAnySubnetAdmitsInternet(gates []ociSubnetGate, nsgOpenRuleCount int) bool {
+	for _, g := range gates {
+		if g.prohibitsIngress || !g.routesToInternet {
+			continue
+		}
+		if ociIngressOpen(nsgOpenRuleCount, g.securityListAllows) {
 			return true
 		}
 	}
@@ -281,12 +303,18 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		subnetProhibits := false
 		vnicRoutesToInternet := false
 		var slOpenRules []any
+		// Default open so an unresolvable subnet fails toward "reachable"
+		// rather than silently clearing the resource. subnetResolved keeps that
+		// assumption out of the reported securityListAllowsIngress field, which
+		// must not claim a security list admits ingress when none was read.
 		slAllows := true
+		subnetResolved := false
 		subnet := vnic.GetSubnet()
 		if subnet.Error != nil {
 			return nil, subnet.Error
 		}
 		if subnet.Data != nil {
+			subnetResolved = true
 			p := subnet.Data.GetProhibitInternetIngress()
 			if p.Error != nil {
 				return nil, p.Error
@@ -327,7 +355,7 @@ func (i *mqlOciComputeInstance) exposure() (*mqlOciNetworkExposure, error) {
 		if nsgAllows {
 			securityGroupAllowsIngress = true
 		}
-		if slAllows {
+		if subnetResolved && slAllows {
 			securityListAllowsIngress = true
 		}
 		if vnicRoutesToInternet {
@@ -420,7 +448,7 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 	// captured per subnet rather than aggregated independently.
 	gates := make([]ociSubnetGate, 0, len(subnets.Data))
 	hasRouteToInternet := false
-	allSecurityLists := []any{}
+	securityListAllowsIngress := false
 	for _, s := range subnets.Data {
 		subnet, ok := s.(*mqlOciNetworkSubnet)
 		if !ok {
@@ -437,26 +465,34 @@ func (l *mqlOciLoadBalancerLoadBalancer) exposure() (*mqlOciNetworkExposure, err
 		if reaches {
 			hasRouteToInternet = true
 		}
-		gates = append(gates, ociSubnetGate{prohibitsIngress: prohibit.Data, routesToInternet: reaches})
 
 		sls := subnet.GetSecurityLists()
 		if sls.Error != nil {
 			return nil, sls.Error
 		}
-		allSecurityLists = append(allSecurityLists, sls.Data...)
+		// Evaluate this subnet's security lists on their own: a rule that is
+		// open on a private subnet must not combine with a different subnet's
+		// internet route into a reachable verdict.
+		slOpenRules, slAllows, err := ociCollectOpenSecurityListRules(sls.Data)
+		if err != nil {
+			return nil, err
+		}
+		openRules = append(openRules, slOpenRules...)
+		if slAllows {
+			securityListAllowsIngress = true
+		}
+
+		gates = append(gates, ociSubnetGate{
+			prohibitsIngress:   prohibit.Data,
+			routesToInternet:   reaches,
+			securityListAllows: slAllows,
+		})
 	}
 
-	slOpenRules, securityListAllowsIngress, err := ociCollectOpenSecurityListRules(allSecurityLists)
-	if err != nil {
-		return nil, err
-	}
-	openRules = append(openRules, slOpenRules...)
-
-	// Union of NSG and security-list rules admits ingress; reachability also
-	// requires a public IP, a listener, and a single subnet that both permits
-	// internet ingress and routes to an internet gateway.
-	ingressOpen := ociIngressOpen(len(nsgOpenRules), securityListAllowsIngress)
-	internetReachable := hasPublicIp && hasListener && ingressOpen && ociAnySubnetReachable(gates)
+	// Reachability requires a public IP, a listener, and a single subnet that
+	// permits internet ingress, routes to an internet gateway, and admits
+	// ingress through the NSG or its own security lists.
+	internetReachable := hasPublicIp && hasListener && ociAnySubnetAdmitsInternet(gates, len(nsgOpenRules))
 
 	res, err := CreateResource(l.MqlRuntime, "oci.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData("oci.loadBalancer.loadBalancer/" + id.Data + "/exposure"),

--- a/providers/oci/resources/oci_exposure_test.go
+++ b/providers/oci/resources/oci_exposure_test.go
@@ -81,11 +81,11 @@ func TestOciSecurityListRuleOpensIngress(t *testing.T) {
 		rule map[string]any
 		want bool
 	}{
-		{"any cidr", map[string]any{"source_type": "CIDR_BLOCK", "source": "0.0.0.0/0"}, true},
-		{"any cidr v6", map[string]any{"source_type": "CIDR_BLOCK", "source": "::/0"}, true},
-		{"specific cidr", map[string]any{"source_type": "CIDR_BLOCK", "source": "1.2.3.4/32"}, false},
-		{"service source", map[string]any{"source_type": "SERVICE_CIDR_BLOCK", "source": "all-services"}, false},
-		{"missing source_type but any cidr", map[string]any{"source": "0.0.0.0/0"}, true},
+		{"any cidr", map[string]any{"sourceType": "CIDR_BLOCK", "source": "0.0.0.0/0"}, true},
+		{"any cidr v6", map[string]any{"sourceType": "CIDR_BLOCK", "source": "::/0"}, true},
+		{"specific cidr", map[string]any{"sourceType": "CIDR_BLOCK", "source": "1.2.3.4/32"}, false},
+		{"service source", map[string]any{"sourceType": "SERVICE_CIDR_BLOCK", "source": "all-services"}, false},
+		{"missing sourceType but any cidr", map[string]any{"source": "0.0.0.0/0"}, true},
 		{"empty", map[string]any{}, false},
 	}
 	for _, c := range cases {

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -111,6 +111,15 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 					privateEndpoint = stringValue(cluster.Endpoints.PrivateEndpoint)
 				}
 
+				// endpointConfig.isPublicIpEnabled only exists for clusters using
+				// native VCN networking; it is absent for older clusters that
+				// still serve a reachable public API endpoint. Trust an actual
+				// published public endpoint over the missing flag, otherwise a
+				// publicly reachable control plane reports as private.
+				if publicEndpoint != "" {
+					isPublicEndpointEnabled = true
+				}
+
 				// Extract image policy
 				var isImagePolicyEnabled bool
 				if cluster.ImagePolicyConfig != nil {

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -174,7 +175,7 @@ func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) [
 
 type mqlOciOkeClusterInternal struct {
 	lock       sync.Mutex
-	fetched    bool
+	fetched    atomic.Bool
 	cluster    *containerengine.Cluster
 	cacheVcnId string
 	region     string
@@ -241,12 +242,12 @@ func (o *mqlOciOkeCluster) vcn() (*mqlOciNetworkVcn, error) {
 }
 
 func (o *mqlOciOkeCluster) fetchCluster() (*containerengine.Cluster, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.cluster, nil
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.cluster, nil
 	}
 
@@ -265,7 +266,7 @@ func (o *mqlOciOkeCluster) fetchCluster() (*containerengine.Cluster, error) {
 	}
 
 	o.cluster = &resp.Cluster
-	o.fetched = true
+	o.fetched.Store(true)
 	return o.cluster, nil
 }
 

--- a/providers/oci/resources/oke.go
+++ b/providers/oci/resources/oke.go
@@ -38,18 +38,7 @@ func (o *mqlOciOke) clusters() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getClusters(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getClusters(conn, list.Data))
 }
 
 func (o *mqlOciOke) getClusters(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -237,7 +226,7 @@ func initOciOkeCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 }
 
 func (o *mqlOciOkeCluster) vcn() (*mqlOciNetworkVcn, error) {
-	if o.cacheVcnId == "" {
+	if o.cacheVcnId == "" || !isOcid(o.cacheVcnId) {
 		o.Vcn.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -34,18 +34,7 @@ func (o *mqlOciOns) topics() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getTopics(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getTopics(conn, list.Data))
 }
 
 func (o *mqlOciOns) getTopicsForRegion(ctx context.Context, client *ons.NotificationControlPlaneClient, compartmentID string) ([]ons.NotificationTopicSummary, error) {

--- a/providers/oci/resources/ons.go
+++ b/providers/oci/resources/ons.go
@@ -138,10 +138,10 @@ func initOciOnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.ons.topic")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.ons", nil)
 	if err != nil {

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -35,18 +35,7 @@ func (o *mqlOciRedis) clusters() ([]any, error) {
 		return nil, regions.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getClusters(conn, regions.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getClusters(conn, regions.Data))
 }
 
 func (o *mqlOciRedis) getClusters(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/redis.go
+++ b/providers/oci/resources/redis.go
@@ -191,7 +191,7 @@ func initOciRedisCluster(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 		}
 	}
 
-	return args, nil, nil
+	return nil, nil, errors.New("oci.redis.cluster not found: " + idVal)
 }
 
 func (o *mqlOciRedisCluster) id() (string, error) {

--- a/providers/oci/resources/region_degrade_test.go
+++ b/providers/oci/resources/region_degrade_test.go
@@ -1,0 +1,119 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
+)
+
+// fakeServiceError implements the SDK's common.ServiceError interface so the
+// classifier can be exercised without a live client.
+type fakeServiceError struct {
+	status int
+	code   string
+	msg    string
+}
+
+func (f fakeServiceError) GetHTTPStatusCode() int  { return f.status }
+func (f fakeServiceError) GetMessage() string      { return f.msg }
+func (f fakeServiceError) GetCode() string         { return f.code }
+func (f fakeServiceError) GetOpcRequestID() string { return "req-1" }
+func (f fakeServiceError) Error() string {
+	return fmt.Sprintf("Service error:%s. %s. http status code: %d", f.code, f.msg, f.status)
+}
+
+func TestOciRegionServiceUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Only a 404 can mean "no endpoint for this service in this region".
+		{"404 not found", fakeServiceError{status: 404, code: "NotAuthorizedOrNotFound"}, true},
+
+		// 401/403 are credential and IAM-policy failures. They come back from
+		// *every* region, so swallowing them reports an under-scoped token as
+		// an empty tenancy.
+		{"401 not authenticated", fakeServiceError{status: 401, code: "NotAuthenticated"}, false},
+		{"403 not authorized", fakeServiceError{status: 403, code: "NotAuthorizedOrNotFound"}, false},
+		{"429 too many requests", fakeServiceError{status: 429, code: "TooManyRequests"}, false},
+		{"500 internal", fakeServiceError{status: 500, code: "InternalServerError"}, false},
+
+		// A service error carries a real API response, so a message that merely
+		// mentions a timeout must not be mistaken for a transport failure.
+		{"service error whose message says timeout", fakeServiceError{
+			status: 400, code: "LimitExceeded", msg: "request timeout budget exceeded",
+		}, false},
+
+		// Transport-level signatures: the service genuinely has no endpoint.
+		{"dns error", &net.DNSError{Err: "no such host", Name: "svc.us-foo-1.oci.example", IsNotFound: true}, true},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"wrapped deadline exceeded", fmt.Errorf("get failed: %w", context.DeadlineExceeded), true},
+		{"no such host in message", errors.New("dial tcp: lookup svc: no such host"), true},
+		{"connection refused in message", errors.New("dial tcp 1.2.3.4:443: connection refused"), true},
+
+		{"unrelated error", errors.New("boom"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ociRegionServiceUnavailable(tt.err))
+		})
+	}
+}
+
+func TestOciRunRegionPool(t *testing.T) {
+	ok := func(items ...any) *jobpool.Job {
+		return jobpool.NewJob(func() (jobpool.JobResult, error) {
+			return jobpool.JobResult(items), nil
+		})
+	}
+	boom := func() *jobpool.Job {
+		return jobpool.NewJob(func() (jobpool.JobResult, error) {
+			return nil, errors.New("region unavailable")
+		})
+	}
+
+	t.Run("all regions succeed", func(t *testing.T) {
+		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), ok("b", "c")})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []any{"a", "b", "c"}, res)
+	})
+
+	t.Run("a failing region does not discard the others", func(t *testing.T) {
+		// The whole point of the change: one unentitled or undeployed region
+		// must not sink a tenancy-wide query.
+		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), boom(), ok("b")})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []any{"a", "b"}, res)
+	})
+
+	t.Run("every region failing is still an error", func(t *testing.T) {
+		// Degrading to an empty list here would report a broken scan as a
+		// clean tenancy.
+		res, err := ociRunRegionPool([]*jobpool.Job{boom(), boom()})
+		require.Error(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("no jobs", func(t *testing.T) {
+		res, err := ociRunRegionPool(nil)
+		require.NoError(t, err)
+		assert.Empty(t, res)
+	})
+
+	t.Run("jobErr job is treated as a failed region", func(t *testing.T) {
+		res, err := ociRunRegionPool(jobErr(errors.New("bad region type")))
+		require.Error(t, err)
+		assert.Nil(t, res)
+	})
+}

--- a/providers/oci/resources/region_degrade_test.go
+++ b/providers/oci/resources/region_degrade_test.go
@@ -77,9 +77,18 @@ func TestOciRunRegionPool(t *testing.T) {
 			return jobpool.JobResult(items), nil
 		})
 	}
-	boom := func() *jobpool.Job {
+	// A region where the service has no endpoint. This is what
+	// ociRegionServiceUnavailable recognises, and the only thing the pool is
+	// allowed to skip.
+	unavailable := func() *jobpool.Job {
 		return jobpool.NewJob(func() (jobpool.JobResult, error) {
-			return nil, errors.New("region unavailable")
+			return nil, fakeServiceError{status: 404, code: "NotAuthorizedOrNotFound"}
+		})
+	}
+	// A real problem: an IAM gap, a throttle, a server error.
+	denied := func() *jobpool.Job {
+		return jobpool.NewJob(func() (jobpool.JobResult, error) {
+			return nil, fakeServiceError{status: 403, code: "NotAuthorizedOrNotFound"}
 		})
 	}
 
@@ -89,18 +98,40 @@ func TestOciRunRegionPool(t *testing.T) {
 		assert.ElementsMatch(t, []any{"a", "b", "c"}, res)
 	})
 
-	t.Run("a failing region does not discard the others", func(t *testing.T) {
-		// The whole point of the change: one unentitled or undeployed region
-		// must not sink a tenancy-wide query.
-		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), boom(), ok("b")})
+	t.Run("an unavailable region does not discard the others", func(t *testing.T) {
+		// The original bug: one undeployed region sank a tenancy-wide query.
+		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), unavailable(), ok("b")})
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []any{"a", "b"}, res)
 	})
 
-	t.Run("every region failing is still an error", func(t *testing.T) {
-		// Degrading to an empty list here would report a broken scan as a
-		// clean tenancy.
-		res, err := ociRunRegionPool([]*jobpool.Job{boom(), boom()})
+	t.Run("every region unavailable is an empty result, not an error", func(t *testing.T) {
+		// A service deployed in no subscribed region genuinely has nothing to
+		// report; that is an answer, not a failure.
+		res, err := ociRunRegionPool([]*jobpool.Job{unavailable(), unavailable()})
+		require.NoError(t, err)
+		assert.Empty(t, res)
+	})
+
+	t.Run("a denied region is reported, not silently skipped", func(t *testing.T) {
+		// The inverse failure mode: swallowing a 403 would under-report
+		// resources and present the short list as authoritative.
+		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), denied(), ok("b")})
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "NotAuthorizedOrNotFound")
+	})
+
+	t.Run("a throttled region is reported", func(t *testing.T) {
+		res, err := ociRunRegionPool([]*jobpool.Job{ok("a"), jobpool.NewJob(func() (jobpool.JobResult, error) {
+			return nil, fakeServiceError{status: 429, code: "TooManyRequests"}
+		})})
+		require.Error(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("hard errors are joined across regions", func(t *testing.T) {
+		res, err := ociRunRegionPool([]*jobpool.Job{denied(), denied()})
 		require.Error(t, err)
 		assert.Nil(t, res)
 	})
@@ -111,7 +142,9 @@ func TestOciRunRegionPool(t *testing.T) {
 		assert.Empty(t, res)
 	})
 
-	t.Run("jobErr job is treated as a failed region", func(t *testing.T) {
+	t.Run("jobErr job is reported as a hard error", func(t *testing.T) {
+		// An invalid region type is a programming error, never an expected
+		// absence, so it must not be skipped.
 		res, err := ociRunRegionPool(jobErr(errors.New("bad region type")))
 		require.Error(t, err)
 		assert.Nil(t, res)

--- a/providers/oci/resources/secrets.go
+++ b/providers/oci/resources/secrets.go
@@ -36,18 +36,7 @@ func (o *mqlOciVault) secrets() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getSecrets(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getSecrets(conn, list.Data))
 }
 
 func (o *mqlOciVault) getSecrets(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -33,20 +33,6 @@ func (o *mqlOciNetwork) regionResources() ([]any, error) {
 	return list.Data, nil
 }
 
-// runNetworkPool runs the given jobs and flattens their []any results.
-func runNetworkPool(jobs []*jobpool.Job) ([]any, error) {
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(jobs, 5)
-	poolOfJobs.Run()
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
-}
-
 // Dynamic Routing Gateways
 
 type mqlOciNetworkDrgInternal struct {
@@ -59,7 +45,7 @@ func (o *mqlOciNetwork) drgs() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getDrgs(conn, regions))
+	return ociRunRegionPool(o.getDrgs(conn, regions))
 }
 
 func (o *mqlOciNetwork) getDrgs(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -439,7 +425,7 @@ func (o *mqlOciNetwork) localPeeringGateways() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getLocalPeeringGateways(conn, regions))
+	return ociRunRegionPool(o.getLocalPeeringGateways(conn, regions))
 }
 
 func (o *mqlOciNetwork) getLocalPeeringGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -608,7 +594,7 @@ func (o *mqlOciNetwork) serviceGateways() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getServiceGateways(conn, regions))
+	return ociRunRegionPool(o.getServiceGateways(conn, regions))
 }
 
 func (o *mqlOciNetwork) getServiceGateways(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/transit.go
+++ b/providers/oci/resources/transit.go
@@ -133,10 +133,10 @@ func initOciNetworkDrg(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.drg")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -518,10 +518,10 @@ func initOciNetworkLocalPeeringGateway(runtime *plugin.Runtime, args map[string]
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.localPeeringGateway")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -691,10 +691,10 @@ func initOciNetworkServiceGateway(runtime *plugin.Runtime, args map[string]*llx.
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.serviceGateway")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -905,10 +905,10 @@ func initOciNetworkInternetGateway(runtime *plugin.Runtime, args map[string]*llx
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.internetGateway")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -933,10 +933,10 @@ func initOciNetworkNatGateway(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.natGateway")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {

--- a/providers/oci/resources/typed_refs.go
+++ b/providers/oci/resources/typed_refs.go
@@ -449,7 +449,7 @@ func (o *mqlOciComputeImage) baseImage() (*mqlOciComputeImage, error) {
 }
 
 func (o *mqlOciComputeInstance) bootVolume() (*mqlOciComputeBootVolume, error) {
-	if o.cacheBootVolumeID == "" {
+	if o.cacheBootVolumeID == "" || !isOcid(o.cacheBootVolumeID) {
 		o.BootVolume.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -463,7 +463,7 @@ func (o *mqlOciComputeInstance) bootVolume() (*mqlOciComputeBootVolume, error) {
 }
 
 func (o *mqlOciComputeBlockVolume) sourceVolume() (*mqlOciComputeBlockVolume, error) {
-	if o.cacheSourceVolumeID == "" {
+	if o.cacheSourceVolumeID == "" || !isOcid(o.cacheSourceVolumeID) {
 		o.SourceVolume.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -477,7 +477,7 @@ func (o *mqlOciComputeBlockVolume) sourceVolume() (*mqlOciComputeBlockVolume, er
 }
 
 func (o *mqlOciComputeBootVolume) sourceBootVolume() (*mqlOciComputeBootVolume, error) {
-	if o.cacheSourceBootVolumeID == "" {
+	if o.cacheSourceBootVolumeID == "" || !isOcid(o.cacheSourceBootVolumeID) {
 		o.SourceBootVolume.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -491,7 +491,7 @@ func (o *mqlOciComputeBootVolume) sourceBootVolume() (*mqlOciComputeBootVolume, 
 }
 
 func (o *mqlOciIdentityUser) identityProvider() (*mqlOciIdentityIdentityProvider, error) {
-	if o.cacheIdentityProviderID == "" {
+	if o.cacheIdentityProviderID == "" || !isOcid(o.cacheIdentityProviderID) {
 		o.IdentityProvider.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -505,7 +505,7 @@ func (o *mqlOciIdentityUser) identityProvider() (*mqlOciIdentityIdentityProvider
 }
 
 func (o *mqlOciOkeNodePool) cluster() (*mqlOciOkeCluster, error) {
-	if o.cacheClusterID == "" {
+	if o.cacheClusterID == "" || !isOcid(o.cacheClusterID) {
 		o.Cluster.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -553,7 +553,7 @@ func (o *mqlOciNetworkSubnet) securityLists() ([]any, error) {
 }
 
 func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFileSystem, error) {
-	if o.cacheParentFileSystemId == "" {
+	if o.cacheParentFileSystemId == "" || !isOcid(o.cacheParentFileSystemId) {
 		o.ParentFileSystem.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -567,7 +567,7 @@ func (o *mqlOciFileStorageFileSystem) parentFileSystem() (*mqlOciFileStorageFile
 }
 
 func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, error) {
-	if o.cacheSourceDbSystemId == "" {
+	if o.cacheSourceDbSystemId == "" || !isOcid(o.cacheSourceDbSystemId) {
 		o.SourceDbSystem.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -581,7 +581,7 @@ func (o *mqlOciDatabaseDbSystem) sourceDbSystem() (*mqlOciDatabaseDbSystem, erro
 }
 
 func (o *mqlOciDatabaseAutonomousDatabase) sourceDatabase() (*mqlOciDatabaseAutonomousDatabase, error) {
-	if o.cacheSourceId == "" {
+	if o.cacheSourceId == "" || !isOcid(o.cacheSourceId) {
 		o.SourceDatabase.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -28,7 +28,7 @@ func (o *mqlOciNetwork) cpes() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getCpes(conn, regions))
+	return ociRunRegionPool(o.getCpes(conn, regions))
 }
 
 func (o *mqlOciNetwork) getCpes(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -148,7 +148,7 @@ func (o *mqlOciNetwork) ipsecConnections() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getIpsecConnections(conn, regions))
+	return ociRunRegionPool(o.getIpsecConnections(conn, regions))
 }
 
 func (o *mqlOciNetwork) getIpsecConnections(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -505,7 +505,7 @@ func (o *mqlOciNetwork) virtualCircuits() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getVirtualCircuits(conn, regions))
+	return ociRunRegionPool(o.getVirtualCircuits(conn, regions))
 }
 
 func (o *mqlOciNetwork) getVirtualCircuits(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -662,7 +662,7 @@ func (o *mqlOciNetwork) crossConnects() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return runNetworkPool(o.getCrossConnects(conn, regions))
+	return ociRunRegionPool(o.getCrossConnects(conn, regions))
 }
 
 func (o *mqlOciNetwork) getCrossConnects(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/vpn.go
+++ b/providers/oci/resources/vpn.go
@@ -102,10 +102,10 @@ func initOciNetworkCpe(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.cpe")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -228,10 +228,10 @@ func initOciNetworkIpsecConnection(runtime *plugin.Runtime, args map[string]*llx
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.ipsecConnection")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {
@@ -608,10 +608,10 @@ func initOciNetworkVirtualCircuit(runtime *plugin.Runtime, args map[string]*llx.
 	if len(args) > 2 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.network.virtualCircuit")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.network", nil)
 	if err != nil {

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -243,7 +243,7 @@ func initOciVulnerabilityScanningHostScanRecipe(runtime *plugin.Runtime, args ma
 			return args, r, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.vulnerabilityScanning.hostScanRecipe not found: " + idVal)
 }
 
 // ----- host scan targets -----
@@ -477,7 +477,7 @@ func initOciVulnerabilityScanningContainerScanRecipe(runtime *plugin.Runtime, ar
 			return args, r, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.vulnerabilityScanning.containerScanRecipe not found: " + idVal)
 }
 
 // ----- container scan targets -----
@@ -605,7 +605,7 @@ func initOciVulnerabilityScanningContainerScanTarget(runtime *plugin.Runtime, ar
 			return args, t, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.vulnerabilityScanning.containerScanTarget not found: " + idVal)
 }
 
 // ----- host agent scan results -----
@@ -1531,7 +1531,13 @@ func (o *mqlOciVulnerabilityScanning) fetchVulnerabilities(conn *connection.OciC
 					cveReferenceUrl = stringValue(v.CveDetails.ReferenceUrl)
 					cveRelated = stringValue(v.CveDetails.RelatedCveReference)
 				}
+				// The vulnerability id (a CVE, for CVE-type rows) repeats
+				// verbatim in every region, so an unqualified cache key made
+				// each region alias the first one's row. Region-qualify the
+				// __id and pass it explicitly so identity is fixed before the
+				// resource is published, rather than mutated afterwards.
 				mqlInst, err := CreateResource(o.MqlRuntime, "oci.vulnerabilityScanning.vulnerability", map[string]*llx.RawData{
+					"__id":                    llx.StringData("oci.vulnerabilityScanning.vulnerability/" + regionId + "/" + stringValue(v.Id)),
 					"id":                      llx.StringDataPtr(v.Id),
 					"name":                    llx.StringDataPtr(v.Name),
 					"compartmentId":           llx.StringDataPtr(v.CompartmentId),
@@ -1567,6 +1573,9 @@ func (o *mqlOciVulnerabilityScanning) fetchVulnerabilities(conn *connection.OciC
 }
 
 func (o *mqlOciVulnerabilityScanningVulnerability) id() (string, error) {
+	// Only consulted when no explicit "__id" arg was passed. The region is not
+	// available here, so this is the degraded form; the collection path passes
+	// a region-qualified __id directly.
 	return "oci.vulnerabilityScanning.vulnerability/" + o.Id.Data, nil
 }
 
@@ -1597,7 +1606,7 @@ func initOciVulnerabilityScanningVulnerability(runtime *plugin.Runtime, args map
 			return args, r, nil
 		}
 	}
-	return args, nil, nil
+	return nil, nil, errors.New("oci.vulnerabilityScanning.vulnerability not found: " + idVal)
 }
 
 func (o *mqlOciVulnerabilityScanningVulnerability) impactedHosts() ([]any, error) {

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/vulnerabilityscanning"
@@ -223,10 +224,10 @@ func initOciVulnerabilityScanningHostScanRecipe(runtime *plugin.Runtime, args ma
 	if len(args) > 1 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return args, nil, nil
 	}
-	idVal := args["id"].Value.(string)
 	obj, err := CreateResource(runtime, "oci.vulnerabilityScanning", nil)
 	if err != nil {
 		return nil, nil, err
@@ -457,10 +458,10 @@ func initOciVulnerabilityScanningContainerScanRecipe(runtime *plugin.Runtime, ar
 	if len(args) > 1 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return args, nil, nil
 	}
-	idVal := args["id"].Value.(string)
 	obj, err := CreateResource(runtime, "oci.vulnerabilityScanning", nil)
 	if err != nil {
 		return nil, nil, err
@@ -585,10 +586,10 @@ func initOciVulnerabilityScanningContainerScanTarget(runtime *plugin.Runtime, ar
 	if len(args) > 1 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return args, nil, nil
 	}
-	idVal := args["id"].Value.(string)
 	obj, err := CreateResource(runtime, "oci.vulnerabilityScanning", nil)
 	if err != nil {
 		return nil, nil, err
@@ -612,7 +613,7 @@ func initOciVulnerabilityScanningContainerScanTarget(runtime *plugin.Runtime, ar
 type mqlOciVulnerabilityScanningHostAgentScanResultInternal struct {
 	region   string
 	lock     sync.Mutex
-	fetched  bool
+	fetched  atomic.Bool
 	detail   *vulnerabilityscanning.HostAgentScanResult
 	fetchErr error
 }
@@ -704,25 +705,25 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResult) instance() (*mqlOciComp
 }
 
 func (o *mqlOciVulnerabilityScanningHostAgentScanResult) fetchDetail() (*vulnerabilityscanning.HostAgentScanResult, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	svc, err := conn.VulnerabilityScanningClient(o.region)
 	if err != nil {
-		o.fetched = true
+		o.fetched.Store(true)
 		o.fetchErr = err
 		return nil, err
 	}
 	resp, err := svc.GetHostAgentScanResult(context.Background(), vulnerabilityscanning.GetHostAgentScanResultRequest{
 		HostAgentScanResultId: common.String(o.Id.Data),
 	})
-	o.fetched = true
+	o.fetched.Store(true)
 	if err != nil {
 		o.fetchErr = err
 		return nil, err
@@ -815,7 +816,7 @@ func (o *mqlOciVulnerabilityScanningHostAgentScanResultProblem) vulnerability() 
 type mqlOciVulnerabilityScanningHostPortScanResultInternal struct {
 	region   string
 	lock     sync.Mutex
-	fetched  bool
+	fetched  atomic.Bool
 	detail   *vulnerabilityscanning.HostPortScanResult
 	fetchErr error
 }
@@ -906,25 +907,25 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResult) instance() (*mqlOciCompu
 }
 
 func (o *mqlOciVulnerabilityScanningHostPortScanResult) fetchDetail() (*vulnerabilityscanning.HostPortScanResult, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	svc, err := conn.VulnerabilityScanningClient(o.region)
 	if err != nil {
-		o.fetched = true
+		o.fetched.Store(true)
 		o.fetchErr = err
 		return nil, err
 	}
 	resp, err := svc.GetHostPortScanResult(context.Background(), vulnerabilityscanning.GetHostPortScanResultRequest{
 		HostPortScanResultId: common.String(o.Id.Data),
 	})
-	o.fetched = true
+	o.fetched.Store(true)
 	if err != nil {
 		o.fetchErr = err
 		return nil, err
@@ -982,7 +983,7 @@ func (o *mqlOciVulnerabilityScanningHostPortScanResultOpenPort) vnic() (*mqlOciC
 type mqlOciVulnerabilityScanningHostCisBenchmarkScanResultInternal struct {
 	region   string
 	lock     sync.Mutex
-	fetched  bool
+	fetched  atomic.Bool
 	detail   *vulnerabilityscanning.HostCisBenchmarkScanResult
 	fetchErr error
 }
@@ -1072,25 +1073,25 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) instance() (*mql
 }
 
 func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) fetchDetail() (*vulnerabilityscanning.HostCisBenchmarkScanResult, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	svc, err := conn.VulnerabilityScanningClient(o.region)
 	if err != nil {
-		o.fetched = true
+		o.fetched.Store(true)
 		o.fetchErr = err
 		return nil, err
 	}
 	resp, err := svc.GetHostCisBenchmarkScanResult(context.Background(), vulnerabilityscanning.GetHostCisBenchmarkScanResultRequest{
 		HostCisBenchmarkScanResultId: common.String(o.Id.Data),
 	})
-	o.fetched = true
+	o.fetched.Store(true)
 	if err != nil {
 		o.fetchErr = err
 		return nil, err
@@ -1120,7 +1121,7 @@ func (o *mqlOciVulnerabilityScanningHostCisBenchmarkScanResult) scores() ([]any,
 type mqlOciVulnerabilityScanningHostEndpointProtectionScanResultInternal struct {
 	region   string
 	lock     sync.Mutex
-	fetched  bool
+	fetched  atomic.Bool
 	detail   *vulnerabilityscanning.HostEndpointProtectionScanResult
 	fetchErr error
 }
@@ -1211,25 +1212,25 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) instance()
 }
 
 func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) fetchDetail() (*vulnerabilityscanning.HostEndpointProtectionScanResult, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	svc, err := conn.VulnerabilityScanningClient(o.region)
 	if err != nil {
-		o.fetched = true
+		o.fetched.Store(true)
 		o.fetchErr = err
 		return nil, err
 	}
 	resp, err := svc.GetHostEndpointProtectionScanResult(context.Background(), vulnerabilityscanning.GetHostEndpointProtectionScanResultRequest{
 		HostEndpointProtectionScanResultId: common.String(o.Id.Data),
 	})
-	o.fetched = true
+	o.fetched.Store(true)
 	if err != nil {
 		o.fetchErr = err
 		return nil, err
@@ -1259,7 +1260,7 @@ func (o *mqlOciVulnerabilityScanningHostEndpointProtectionScanResult) endpointPr
 type mqlOciVulnerabilityScanningContainerScanResultInternal struct {
 	region   string
 	lock     sync.Mutex
-	fetched  bool
+	fetched  atomic.Bool
 	detail   *vulnerabilityscanning.ContainerScanResult
 	fetchErr error
 }
@@ -1350,25 +1351,25 @@ func (o *mqlOciVulnerabilityScanningContainerScanResult) target() (*mqlOciVulner
 }
 
 func (o *mqlOciVulnerabilityScanningContainerScanResult) fetchDetail() (*vulnerabilityscanning.ContainerScanResult, error) {
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	if o.fetched {
+	if o.fetched.Load() {
 		return o.detail, o.fetchErr
 	}
 	conn := o.MqlRuntime.Connection.(*connection.OciConnection)
 	svc, err := conn.VulnerabilityScanningClient(o.region)
 	if err != nil {
-		o.fetched = true
+		o.fetched.Store(true)
 		o.fetchErr = err
 		return nil, err
 	}
 	resp, err := svc.GetContainerScanResult(context.Background(), vulnerabilityscanning.GetContainerScanResultRequest{
 		ContainerScanResultId: common.String(o.Id.Data),
 	})
-	o.fetched = true
+	o.fetched.Store(true)
 	if err != nil {
 		o.fetchErr = err
 		return nil, err
@@ -1577,10 +1578,10 @@ func initOciVulnerabilityScanningVulnerability(runtime *plugin.Runtime, args map
 	if len(args) > 1 {
 		return args, nil, nil
 	}
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return args, nil, nil
 	}
-	idVal := args["id"].Value.(string)
 	obj, err := CreateResource(runtime, "oci.vulnerabilityScanning", nil)
 	if err != nil {
 		return nil, nil, err

--- a/providers/oci/resources/vulnerabilityscanning.go
+++ b/providers/oci/resources/vulnerabilityscanning.go
@@ -43,16 +43,7 @@ func (o *mqlOciVulnerabilityScanning) fanout(makeJobs func(conn *connection.OciC
 	if err != nil {
 		return nil, err
 	}
-	pool := jobpool.CreatePool(makeJobs(conn, regions), 5)
-	pool.Run()
-	if pool.HasErrors() {
-		return nil, pool.GetErrors()
-	}
-	res := []any{}
-	for i := range pool.Jobs {
-		res = append(res, pool.Jobs[i].Result.([]any)...)
-	}
-	return res, nil
+	return ociRunRegionPool(makeJobs(conn, regions))
 }
 
 // ----- host scan recipes -----

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -35,18 +35,7 @@ func (o *mqlOciWaf) firewalls() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getFirewalls(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getFirewalls(conn, list.Data))
 }
 
 func (o *mqlOciWaf) getFirewalls(conn *connection.OciConnection, regions []any) []*jobpool.Job {
@@ -187,18 +176,7 @@ func (o *mqlOciWaf) policies() ([]any, error) {
 		return nil, list.Error
 	}
 
-	res := []any{}
-	poolOfJobs := jobpool.CreatePool(o.getPolicies(conn, list.Data), 5)
-	poolOfJobs.Run()
-
-	if poolOfJobs.HasErrors() {
-		return nil, poolOfJobs.GetErrors()
-	}
-	for i := range poolOfJobs.Jobs {
-		res = append(res, poolOfJobs.Jobs[i].Result.([]any)...)
-	}
-
-	return res, nil
+	return ociRunRegionPool(o.getPolicies(conn, list.Data))
 }
 
 func (o *mqlOciWaf) getPolicies(conn *connection.OciConnection, regions []any) []*jobpool.Job {

--- a/providers/oci/resources/waf.go
+++ b/providers/oci/resources/waf.go
@@ -287,10 +287,10 @@ func initOciWafPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 		return args, nil, nil
 	}
 
-	if args["id"] == nil {
+	idVal := ociArgString(args, "id")
+	if idVal == "" {
 		return nil, nil, errors.New("id required to fetch oci.waf.policy")
 	}
-	idVal := args["id"].Value.(string)
 
 	obj, err := CreateResource(runtime, "oci.waf", nil)
 	if err != nil {


### PR DESCRIPTION
Fixes the findings from a static bug review of the OCI provider. Every finding
was verified against the pinned SDK (`oci-go-sdk/v65@v65.121.1`) and the
generated `oci.lr.go` before being fixed; a few candidates were refuted during
that pass and are listed at the bottom.

Commits are grouped by theme and are individually reviewable.

## 🐛 Crashes, hangs, and races

- **`oci.cloudGuard.status` deadlocked forever.** `getConfig()` held `o.lock`
  and then called `getHomeRegion()`, which takes the same non-reentrant mutex.
  A config-only query hung deterministically from a cold start; it only
  appeared to work if a listing accessor happened to populate the home-region
  cache first. Split into two mutexes and resolve the region before entering
  the critical section.
- **Nine lazy-load helpers used a plain `bool` for the double-check flag**, read
  outside the mutex. There is no happens-before edge, so a reader could observe
  `fetched == true` while the payload pointer was still nil and deref it — and a
  panic in a provider accessor takes down the whole scan. Now `atomic.Bool`.
  `vpn.go` already locked first and is unchanged.
- **`getBucketDetails()` had no synchronization at all** while sixteen accessors
  call it, so one bucket query raced and issued sixteen identical `GetBucket`
  calls.
- **Three bucket accessors checked `region.Error` and then dereferenced
  `region.Data`**, which is nil (not an error) when the field was never set.
- **`detect()` guarded `info != nil`**, which is always true when `err` is nil,
  while the pointer that can actually be nil is `info.Name`.
- **23 bare `args["id"].Value.(string)` assertions** replaced with the
  provider's existing nil-safe `ociArgString`.

## 🐛 Security verdicts that failed open

| Field | Was | Why it mattered |
|---|---|---|
| security-list `stateless` | key dropped when `false` (`omitempty` on a bool) | `all(stateless == false)` compared against null and failed every correctly-configured tenancy |
| security-list `source_type` / `destination_type` | snake_case | `.lr` documents `sourceType`/`destinationType`, which is also what NSG rules emit — the documented query returned zero rows |
| LB `exposure` | security lists aggregated across all subnets | a hardened public subnet + a private subnet with the default wide-open VCN list combined into `internetReachable = true` |
| `securityListAllowsIngress` | `true` when the subnet was unresolvable | claimed a security list admits ingress when none was read |
| `ociRegionServiceUnavailable` | swallowed 401/403/404 | an under-scoped token rendered as "this tenancy has no AI resources" across ~13 collections |
| `legacyImdsEndpointsDisabled` | null when `instanceOptions` absent | exactly the legacy instances where IMDSv1 *is* reachable; `null && null` is true in MQL, so they passed |
| `user.capabilities` | all six keys omitted when absent | a two-key conjunction passed vacuously |
| `passwordUsernameContainmentAllowed` | defaulted `false` (the permissive value) | a missing password policy passed the check; OCI's service default is `true` |
| decryption-profile `default:` branch | three booleans left null | an inspection type newer than the pinned SDK passed a TLS-hygiene check |
| LB `ipAddresses[].isPublic` | fell back to `false` | cleared a genuinely internet-facing balancer; now falls back to `!isPrivate` |
| OKE `isPublicEndpointEnabled` | read only `endpointConfig` | absent for non-native-VCN clusters that still publish a public API endpoint |
| apigw `isAnonymousAccessAllowed` | `false` when there is no auth policy | that is the case where *every* request is anonymous |

## 🐛 Husks and cache poisoning

The generated `NewResource` runs `Init` before consulting the cache, and
`CreateResource` **discards** a freshly-built resource when the key is already
present. So a resource with no `Init` does not merely return a husk — the husk
is cached under the real OCID and wins over the fully-populated one built
later, making failures depend on query order.

- **Added `Init` to eleven resources reachable through `NewResource`** that had
  none: the five `oci.compute.*` types, `oci.database.dbSystem`,
  `oci.database.autonomousDatabase`, `oci.fileStorage.fileSystem`,
  `oci.apigateway.gateway`, `oci.identity.identityProvider`, `oci.region`.
- **28 init lookups ended a failed match with `args, nil, nil`.** The Generative
  AI endpoint case was sharpest: `contentModerationEnabled` and friends were
  left unset, and `a && b` over two nulls is true, so a guardrail check passed
  on an endpoint that was never read. All now return a not-found error naming
  the resource and id. The legitimate early paths are unchanged.
- **`compute.go` built compartment refs with `CreateResource`**, skipping that
  resource's `Init` — the only two such sites in the provider.
- **`oci.vulnerabilityScanning.vulnerability` keyed its cache on the bare id**,
  which for a CVE row repeats in every region. Every region after the first
  aliased the first one's row, the list appended the same pointer once per
  region, and `region` was assigned *after* publication. Now region-qualified
  and passed explicitly.
- **`oci.objectStorage.bucket.id` was never populated on any path**:
  `BucketSummary` carries no `Id`, and the init's `args["id"]` write was dead
  because `NewResource` discards returned args when a resource comes back with
  them. Also removed the id-only fast path, which could not be resolved and gave
  every such bucket the shared cache key `oci.objectStorage.bucket//`.

## 🧹 Robustness

- **One failing region no longer sinks a whole collection.** Every collection
  did `if HasErrors() { return nil, GetErrors() }`, so a single unentitled or
  undeployed region turned a tenancy-wide query into a hard failure. The new
  `ociRunRegionPool` logs and skips a failed region and only errors when *no*
  region succeeded. Replacing all 54 copies also removed every bare
  `Jobs[i].Result.([]any)` assertion.
- **`--key-secret` was collected and discarded** — `connection.go` passed nil
  for the private-key passphrase, so the documented flag was inert and an
  encrypted API key failed with an opaque PEM error.
- **`GenerativeAiAgentClient` and `DataScienceClient` were missing
  `failFastOnUnreachableRegion`**, which their five sibling AI clients get.
- **Set `CompartmentIdInSubtree`** on `ListAlarms`, `ListTargets` and
  `ListDetectorRecipes` — the three request types that expose it and were
  reading the tenancy root only.
- **`convertLogConfiguration` dropped `Archiving`**, so log-archiving state read
  as "not configured" on every log.
- **The identity collections fanned out over every region** although IAM is
  global, so users/groups/policies reported N-fold counts (`CreateResource`
  returns the cached instance, so the slice held N copies of one pointer).
- **Added the `isOcid` guard to 21 typed accessors** that only checked for the
  empty string, so OCI placeholders like `ORACLE_MANAGED_KEY` degrade to null
  instead of a hard "not found".

## 🟢 Tests

New coverage for the pure-Go logic behind these fixes, chosen where a wrong
answer is silent: the region classifier (both failure directions), the pool
degradation semantics, the rule mappers tested *through* `JsonToDictSlice`
because their json tags are the user-facing schema, the subnet-gate
aggregation regression, and the init arg/resolve helpers. Also filled gaps in
existing suites — `ociRegionFromOCID` and `isOcid` were untested while their
sibling was, and `convertLogConfiguration` never asserted on `Archiving`, which
is why the dropped field survived.

## Deliberately not in this PR

**Root-compartment-only listing.** All ~89 list sites pass `conn.TenantID()`,
and the `core`, `objectstorage`, `database`, `containerengine`, `keymanagement`,
`vault`, `waf`, `loadbalancer`, `certificatesmanagement`, `networkfirewall`,
`functions`, `containerinstances`, `datascience`, `vulnerabilityscanning`,
`bastion`, `redis` and `filestorage` list APIs have **no** subtree flag — so
resources in child compartments are invisible, with no error. Fixing it means a
region×compartment fan-out, which is a real performance and design change and
deserves its own PR where the cost model can be validated against a live
tenancy. The three services whose APIs *do* offer the flag are fixed here.

## Refuted during verification

- Five `[]dict` fields populated with `llx.DictData` looked like the classic
  type-mismatch bug, but `plugin.RawToTValue` reads only `.Value` and
  `JsonToDictSlice` returns `[]any`, so they were inert. Normalized to
  `ArrayData(x, types.Dict)` for consistency, not ranked as bugs.
- `ListApiKeys`, `ListAuthTokens`, `ListCustomerSecretKeys`,
  `ListSmtpCredentials`, `ListAvailabilityDomains` and
  `ListRegionSubscriptions` look unpaginated but have no `Page` field on the
  **request** — correctly not looped. Pagination is genuinely correct across all
  ~28 list loops.

## Testing

`go build ./...`, `go test ./...`, `go test -race ./resources/...` and
`make providers/build/oci` all pass; `gofmt` clean; regenerating `oci.lr.go`
produces no diff; `go.mod` unchanged.

**Not verified against a live tenancy** — no OCI credentials in this
environment. The behavioural changes worth proving against real infrastructure
are the eleven new inits, the identity de-duplication, the per-region
degradation, and the three subtree flags.
