### PR TITLE
🐛 gcp: guard projectId before building the parent service in resource inits

### DIFF
--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -402,6 +402,12 @@ func initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[strin
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.alloydbService.cluster requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.alloydbService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/apikeys.go
+++ b/providers/gcp/resources/apikeys.go
@@ -236,6 +236,12 @@ func initGcpProjectApiKey(runtime *plugin.Runtime, args map[string]*llx.RawData)
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.apiKey requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": args["projectId"],
 	})

--- a/providers/gcp/resources/artifactregistry.go
+++ b/providers/gcp/resources/artifactregistry.go
@@ -213,6 +213,12 @@ func initGcpProjectArtifactRegistryServiceRepository(runtime *plugin.Runtime, ar
 		return nil, nil, errors.New("artifact registry repository init requires a \"name\" argument")
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.artifactRegistryService.repository requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.artifactRegistryService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -71,6 +71,12 @@ func initGcpProjectBigtableServiceInstance(runtime *plugin.Runtime, args map[str
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.bigtableService.instance requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.bigtableService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -423,6 +423,12 @@ func initGcpProjectCloudFunction(runtime *plugin.Runtime, args map[string]*llx.R
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.cloudFunction requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
 		"id": args["projectId"],
 	})

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -119,6 +119,12 @@ func initGcpProjectCloudRunServiceService(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.cloudRunService.service requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.cloudRunService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
@@ -182,6 +188,12 @@ func initGcpProjectCloudRunServiceJob(runtime *plugin.Runtime, args map[string]*
 		} else {
 			return nil, nil, errors.New("no asset identifier found")
 		}
+	}
+
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.cloudRunService.job requires a \"projectId\" argument")
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.cloudRunService", map[string]*llx.RawData{

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -406,6 +406,17 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// The instance is matched by (region, name, projectId); without all three we
+	// can't do the lookup. This has to run before the parent computeService is
+	// built: a missing projectId reaches CreateResource as a nil *llx.RawData and
+	// the generated setter dereferences it, panicking before any later guard runs.
+	if args["region"] == nil || args["name"] == nil || args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.instance requires region, name, and projectId")
+	}
+	wantRegion := args["region"]
+	wantName := args["name"]
+	wantProjectId := args["projectId"]
+
 	// Try to find the instance in the MQL cache first
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
@@ -417,16 +428,6 @@ func initGcpProjectComputeServiceInstance(runtime *plugin.Runtime, args map[stri
 	instances := computeSvc.GetInstances()
 	if instances.Error != nil {
 		return nil, nil, instances.Error
-	}
-
-	// The instance is matched by (region, name, projectId); without all three we
-	// can't do the lookup. Return an error rather than dereferencing a nil arg
-	// (which would panic) or falling through to build a husk with unset fields.
-	wantRegion := args["region"]
-	wantName := args["name"]
-	wantProjectId := args["projectId"]
-	if wantRegion == nil || wantName == nil || wantProjectId == nil {
-		return nil, nil, errors.New("gcp.project.computeService.instance requires region, name, and projectId")
 	}
 
 	for _, inst := range instances.Data {
@@ -1403,6 +1404,12 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// Guard before building the parent: a missing projectId would nil-deref
+	// (and blow the type assertion) rather than return an error.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.firewall requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
 		"projectId": llx.StringData(args["projectId"].Value.(string)),
 	})
@@ -1643,6 +1650,12 @@ func initGcpProjectComputeServiceImage(runtime *plugin.Runtime, args map[string]
 		} else {
 			return nil, nil, errors.New("no asset identifier found")
 		}
+	}
+
+	// Guard before building the parent: a missing projectId would nil-deref
+	// (and blow the type assertion) rather than return an error.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.image requires a \"projectId\" argument")
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
@@ -2022,6 +2035,12 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 	}
 
 	// Try to find the network in the MQL cache first
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.network requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
@@ -2207,6 +2226,12 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 	}
 
 	// Try to find the subnetwork in the MQL cache first
+	// Guard before building the parent: a missing projectId would nil-deref
+	// (and blow the type assertion) rather than return an error.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.subnetwork requires a \"projectId\" argument")
+	}
+
 	obj, err := NewResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
 		"projectId": llx.StringData(args["projectId"].Value.(string)),
 	})

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -843,6 +843,12 @@ func initGcpProjectDataprocServiceCluster(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.dataprocService.cluster requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.dataprocService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 		"enabled":   llx.BoolData(true),

--- a/providers/gcp/resources/firestore.go
+++ b/providers/gcp/resources/firestore.go
@@ -65,6 +65,12 @@ func initGcpProjectFirestoreServiceDatabase(runtime *plugin.Runtime, args map[st
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.firestoreService.database requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.firestoreService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -85,6 +85,12 @@ func initGcpProjectGkeServiceCluster(runtime *plugin.Runtime, args map[string]*l
 		}
 	}
 
+	// Guard before building the parent: a missing projectId would nil-deref
+	// (and blow the type assertion) rather than return an error.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.gkeService.cluster requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.gkeService", map[string]*llx.RawData{
 		"projectId": llx.StringData(args["projectId"].Value.(string)),
 	})

--- a/providers/gcp/resources/init_guard_test.go
+++ b/providers/gcp/resources/init_guard_test.go
@@ -1,0 +1,142 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitGuardsProjectIdBeforeParentConstruction guards a whole class of
+// scan-crashing panic.
+//
+// Most init functions resolve their resource by first building the parent
+// service from args["projectId"]:
+//
+//	CreateResource(runtime, "gcp.project.pubsubService", map[string]*llx.RawData{
+//	    "projectId": args["projectId"],
+//	})
+//
+// A map lookup for an absent key yields a nil *llx.RawData, and the generated
+// setter dereferences it unconditionally. So a partial query such as
+// `gcp.project.pubsubService.topic(name: "x")` panics inside the provider
+// instead of returning an error -- and because the executor runs blocks in
+// goroutines, that panic is unrecoverable and takes down the whole scan.
+//
+// A nil-guard placed *after* the parent construction is dead code. This test
+// walks the package's own source and fails when any init function reaches a
+// CreateResource/NewResource carrying args["projectId"] without having checked
+// it first.
+func TestInitGuardsProjectIdBeforeParentConstruction(t *testing.T) {
+	fset := token.NewFileSet()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		{
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "init") {
+					continue
+				}
+
+				guardPos := token.NoPos
+				violation := token.NoPos
+
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					switch node := n.(type) {
+					case *ast.BinaryExpr:
+						// args["projectId"] == nil  (or != nil)
+						if isArgsIndex(node.X, "projectId") && isNilIdent(node.Y) && !guardPos.IsValid() {
+							guardPos = node.Pos()
+						}
+					case *ast.CallExpr:
+						name := calleeName(node.Fun)
+						if name != "CreateResource" && name != "NewResource" {
+							return true
+						}
+						if !callCarriesProjectIdArg(node) {
+							return true
+						}
+						if !guardPos.IsValid() || guardPos > node.Pos() {
+							if !violation.IsValid() {
+								violation = node.Pos()
+							}
+						}
+					}
+					return true
+				})
+
+				if violation.IsValid() {
+					t.Errorf("%s: %s passes args[\"projectId\"] into %s before any nil-guard; "+
+						"a partial query would panic the provider. Move the guard above the call.",
+						fset.Position(violation), fn.Name.Name, "CreateResource/NewResource")
+				}
+			}
+		}
+	}
+}
+
+// isArgsIndex reports whether e is the expression args["<key>"].
+func isArgsIndex(e ast.Expr, key string) bool {
+	idx, ok := e.(*ast.IndexExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := idx.X.(*ast.Ident)
+	if !ok || ident.Name != "args" {
+		return false
+	}
+	lit, ok := idx.Index.(*ast.BasicLit)
+	return ok && lit.Kind == token.STRING && strings.Trim(lit.Value, `"`) == key
+}
+
+func isNilIdent(e ast.Expr) bool {
+	ident, ok := e.(*ast.Ident)
+	return ok && ident.Name == "nil"
+}
+
+func calleeName(e ast.Expr) string {
+	switch f := e.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	}
+	return ""
+}
+
+// callCarriesProjectIdArg reports whether any argument of the call references
+// args["projectId"], directly or inside a composite literal.
+func callCarriesProjectIdArg(call *ast.CallExpr) bool {
+	found := false
+	for _, arg := range call.Args {
+		ast.Inspect(arg, func(n ast.Node) bool {
+			if isArgsIndex(exprOf(n), "projectId") {
+				found = true
+				return false
+			}
+			return true
+		})
+	}
+	return found
+}
+
+func exprOf(n ast.Node) ast.Expr {
+	e, _ := n.(ast.Expr)
+	return e
+}

--- a/providers/gcp/resources/init_guard_test.go
+++ b/providers/gcp/resources/init_guard_test.go
@@ -60,8 +60,12 @@ func TestInitGuardsProjectIdBeforeParentConstruction(t *testing.T) {
 				ast.Inspect(fn.Body, func(n ast.Node) bool {
 					switch node := n.(type) {
 					case *ast.BinaryExpr:
-						// args["projectId"] == nil  (or != nil)
-						if isArgsIndex(node.X, "projectId") && isNilIdent(node.Y) && !guardPos.IsValid() {
+						// args["projectId"] == nil / != nil, either operand order.
+						// Matching only the left-hand form would let a reversed
+						// `nil == args["projectId"]` silently bypass the detector.
+						guarded := (isArgsIndex(node.X, "projectId") && isNilIdent(node.Y)) ||
+							(isArgsIndex(node.Y, "projectId") && isNilIdent(node.X))
+						if guarded && !guardPos.IsValid() {
 							guardPos = node.Pos()
 						}
 					case *ast.CallExpr:

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -69,6 +69,14 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 		}
 	}
 
+	// The keyring is matched by (name, location, projectId); without all three we
+	// can't do the lookup. This has to run before the parent kmsService is built:
+	// a missing projectId reaches CreateResource as a nil *llx.RawData and the
+	// generated setter dereferences it, panicking before any later guard runs.
+	if args["name"] == nil || args["location"] == nil || args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.kmsService.keyring requires name, location, and projectId")
+	}
+
 	// Create the parent KMS service and find the specific keyring
 	obj, err := CreateResource(runtime, "gcp.project.kmsService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
@@ -80,13 +88,6 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 	keyrings := kmsSvc.GetKeyrings()
 	if keyrings.Error != nil {
 		return nil, nil, keyrings.Error
-	}
-
-	// The keyring is matched by (name, location, projectId); without all three we
-	// can't do the lookup. Return an error rather than dereferencing a nil arg
-	// (which would panic) or falling through to build a husk with unset fields.
-	if args["name"] == nil || args["location"] == nil || args["projectId"] == nil {
-		return nil, nil, errors.New("gcp.project.kmsService.keyring requires name, location, and projectId")
 	}
 
 	// Find the matching keyring

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -596,6 +596,12 @@ func initGcpProjectLoggingserviceBucket(runtime *plugin.Runtime, args map[string
 	// Use NewResource so initGcpProjectLoggingservice runs and sets serviceEnabled;
 	// CreateResource would skip init and leave serviceEnabled=false, making
 	// GetBuckets() short-circuit to empty even when logging is enabled.
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.loggingservice.bucket requires a \"projectId\" argument")
+	}
+
 	obj, err := NewResource(runtime, "gcp.project.loggingservice", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -112,6 +112,12 @@ func initGcpProjectPubsubServiceTopic(runtime *plugin.Runtime, args map[string]*
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.pubsubService.topic requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.pubsubService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
@@ -188,6 +194,12 @@ func initGcpProjectPubsubServiceSubscription(runtime *plugin.Runtime, args map[s
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.pubsubService.subscription requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.pubsubService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
@@ -259,6 +271,12 @@ func initGcpProjectPubsubServiceSnapshot(runtime *plugin.Runtime, args map[strin
 		} else {
 			return nil, nil, errors.New("no asset identifier found")
 		}
+	}
+
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.pubsubService.snapshot requires a \"projectId\" argument")
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.pubsubService", map[string]*llx.RawData{

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -104,6 +104,12 @@ func initGcpProjectRedisServiceInstance(runtime *plugin.Runtime, args map[string
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.redisService.instance requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.redisService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})
@@ -509,6 +515,12 @@ func initGcpProjectRedisServiceCluster(runtime *plugin.Runtime, args map[string]
 		} else {
 			return nil, nil, errors.New("no asset identifier found")
 		}
+	}
+
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.redisService.cluster requires a \"projectId\" argument")
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.redisService", map[string]*llx.RawData{

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -225,6 +225,12 @@ func initGcpProjectSecretmanagerServiceSecret(runtime *plugin.Runtime, args map[
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.secretmanagerService.secret requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.secretmanagerService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/spanner.go
+++ b/providers/gcp/resources/spanner.go
@@ -71,6 +71,12 @@ func initGcpProjectSpannerServiceInstance(runtime *plugin.Runtime, args map[stri
 		}
 	}
 
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.spannerService.instance requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.spannerService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -61,6 +61,12 @@ func initGcpProjectSqlServiceInstance(runtime *plugin.Runtime, args map[string]*
 	}
 
 	// Create the parent SQL service and find the specific instance
+	// Guard before building the parent: CreateResource hands args["projectId"]
+	// to the generated setter, which dereferences it, so nil panics the provider.
+	if args["projectId"] == nil {
+		return nil, nil, errors.New("gcp.project.sqlService.instance requires a \"projectId\" argument")
+	}
+
 	obj, err := CreateResource(runtime, "gcp.project.sqlService", map[string]*llx.RawData{
 		"projectId": args["projectId"],
 	})


### PR DESCRIPTION
## Summary

Live verification of #9403 against a real GCP project found that the partial-arg
init guards it added **run too late to do their job**, so the panics that PR set
out to fix are all still reachable.

Every one of these inits resolves its resource by first constructing the parent
service from `args["projectId"]`:

```go
obj, err := CreateResource(runtime, "gcp.project.pubsubService", map[string]*llx.RawData{
    "projectId": args["projectId"],
})
```

A map lookup for an absent key yields a **nil `*llx.RawData`**, and the generated
setter dereferences it unconditionally. The panic therefore happens on *that*
line, before the nil-guard sitting below it ever executes. The guard was dead
code.

Because the executor runs blocks in goroutines, the panic is unrecoverable: one
such query takes down the **whole scan**, not just the one field.

## Reproduced live

Against a real project, every one of these panicked the provider on a name-only
query:

```
$ mql run gcp project <project> -c 'gcp.project.pubsubService.topic(name: "nope")'
rpc error: code = Internal desc = panic in provider GetData:
runtime error: invalid memory address or nil pointer dereference

  resources.initGcpProjectPubsubServiceTopic (pubsub.go:116)
  resources.CreateResource -> createGcpProjectPubsubService -> SetAllData -> SetData
```

Confirmed panicking pre-fix: `kmsService.keyring`, `computeService.instance`,
`computeService.network`, `pubsubService.topic`, `redisService.instance`,
`redisService.cluster`, `spannerService.instance`, `secretmanagerService.secret`,
`bigtableService.instance`, `firestoreService.database`,
`alloydbService.cluster`, `dataprocService.cluster`.

## What changed

- **Moved** the `projectId` check above the parent construction in the two inits
  #9403 reordered incorrectly: `kms.go` keyring and `compute.go` instance.
- **Added** the missing check at the other 19 sites (alloydb, apikeys,
  artifactregistry, bigtable, cloudrun service + job, cloud_functions, compute
  network, dataproc, firestore, logging bucket, pubsub topic + subscription +
  snapshot, redis instance + cluster, secretmanager, spanner, sql).
- Four of those — `compute` firewall/image/subnetwork and `gke` cluster — are
  **pre-existing and worse**: they call
  `llx.StringData(args["projectId"].Value.(string))`, which is both a nil deref
  *and* an unchecked type assertion.

`dns.go` was already correct and is untouched.

## Test

`TestInitGuardsProjectIdBeforeParentConstruction` walks the package's own AST and
fails when any `init*` reaches a `CreateResource`/`NewResource` carrying
`args["projectId"]` without having checked it first.

This test is what earned its keep: a hand-audited first pass fixed 17 sites and
**missed the four pre-existing ones**, which the test caught immediately.

## Verification

Provider rebuilt and re-run against the same live project — every previously
panicking query now returns a clean, descriptive error, and typed cross-resource
traversal (`sourceDiskRef`, `config.topic`, `autoscalingPolicyRef`,
`backupVault`) still resolves, confirming the guards do not break the
`NewResource` cross-ref paths that legitimately pass `projectId`.

Full provider test suite green; `gofmt` clean. No schema change, so no
`.lr.versions` entry; the permission set is unchanged.
