### PR TITLE
feat(fex): add label and mime_type to File evidence

### DIFF
--- a/providers-sdk/v1/upstream/fex/fex.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex.pb.go
@@ -2325,12 +2325,12 @@ type File struct {
 	Md5 string `protobuf:"bytes,3,opt,name=md5,proto3" json:"md5,omitempty"`
 	// SHA256 hash of file
 	Sha256 string `protobuf:"bytes,4,opt,name=sha256,proto3" json:"sha256,omitempty"`
-	// Optional. Human-readable label or identifier for this file evidence, used
-	// when a finding carries several file evidences or when a UI needs a title for
-	// the document rather than a raw path.
+	// Optional. Human-readable label or identifier for this file evidence,
+	// used when a finding carries several file evidences, or when a UI needs
+	// a title for the document rather than a raw path.
 	Label string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
-	// Optional. MIME / content type of the file (e.g. "application/json",
-	// "text/plain"), so consumers can interpret or render `contents` correctly.
+	// Optional. MIME / content type of the file (e.g. "application/json"), so
+	// consumers can interpret or render `contents` correctly.
 	MimeType string `protobuf:"bytes,6,opt,name=mime_type,json=mimeType,proto3" json:"mime_type,omitempty"`
 	// Optional. File content.
 	Contents      string `protobuf:"bytes,20,opt,name=contents,proto3" json:"contents,omitempty"`

--- a/providers-sdk/v1/upstream/fex/fex.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex.pb.go
@@ -2325,6 +2325,13 @@ type File struct {
 	Md5 string `protobuf:"bytes,3,opt,name=md5,proto3" json:"md5,omitempty"`
 	// SHA256 hash of file
 	Sha256 string `protobuf:"bytes,4,opt,name=sha256,proto3" json:"sha256,omitempty"`
+	// Optional. Human-readable label or identifier for this file evidence, used
+	// when a finding carries several file evidences or when a UI needs a title for
+	// the document rather than a raw path.
+	Label string `protobuf:"bytes,5,opt,name=label,proto3" json:"label,omitempty"`
+	// Optional. MIME / content type of the file (e.g. "application/json",
+	// "text/plain"), so consumers can interpret or render `contents` correctly.
+	MimeType string `protobuf:"bytes,6,opt,name=mime_type,json=mimeType,proto3" json:"mime_type,omitempty"`
 	// Optional. File content.
 	Contents      string `protobuf:"bytes,20,opt,name=contents,proto3" json:"contents,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -2385,6 +2392,20 @@ func (x *File) GetMd5() string {
 func (x *File) GetSha256() string {
 	if x != nil {
 		return x.Sha256
+	}
+	return ""
+}
+
+func (x *File) GetLabel() string {
+	if x != nil {
+		return x.Label
+	}
+	return ""
+}
+
+func (x *File) GetMimeType() string {
+	if x != nil {
+		return x.MimeType
 	}
 	return ""
 }
@@ -4120,12 +4141,14 @@ const file_fex_proto_rawDesc = "" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\t\n" +
-	"\adetails\"t\n" +
+	"\adetails\"\xa7\x01\n" +
 	"\x04File\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x10\n" +
 	"\x03md5\x18\x03 \x01(\tR\x03md5\x12\x16\n" +
-	"\x06sha256\x18\x04 \x01(\tR\x06sha256\x12\x1a\n" +
+	"\x06sha256\x18\x04 \x01(\tR\x06sha256\x12\x14\n" +
+	"\x05label\x18\x05 \x01(\tR\x05label\x12\x1b\n" +
+	"\tmime_type\x18\x06 \x01(\tR\bmimeType\x12\x1a\n" +
 	"\bcontents\x18\x14 \x01(\tR\bcontents\"\xab\x01\n" +
 	"\x04User\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +

--- a/providers-sdk/v1/upstream/fex/fex.proto
+++ b/providers-sdk/v1/upstream/fex/fex.proto
@@ -423,6 +423,13 @@ message File {
   string md5 = 3;
   // SHA256 hash of file
   string sha256 = 4;
+  // Optional. Human-readable label or identifier for this file evidence, used
+  // when a finding carries several file evidences or when a UI needs a title for
+  // the document rather than a raw path.
+  string label = 5;
+  // Optional. MIME / content type of the file (e.g. "application/json",
+  // "text/plain"), so consumers can interpret or render `contents` correctly.
+  string mime_type = 6;
   // Optional. File content.
   string contents = 20;
 }

--- a/providers-sdk/v1/upstream/fex/fex.proto
+++ b/providers-sdk/v1/upstream/fex/fex.proto
@@ -423,12 +423,12 @@ message File {
   string md5 = 3;
   // SHA256 hash of file
   string sha256 = 4;
-  // Optional. Human-readable label or identifier for this file evidence, used
-  // when a finding carries several file evidences or when a UI needs a title for
-  // the document rather than a raw path.
+  // Optional. Human-readable label or identifier for this file evidence,
+  // used when a finding carries several file evidences, or when a UI needs
+  // a title for the document rather than a raw path.
   string label = 5;
-  // Optional. MIME / content type of the file (e.g. "application/json",
-  // "text/plain"), so consumers can interpret or render `contents` correctly.
+  // Optional. MIME / content type of the file (e.g. "application/json"), so
+  // consumers can interpret or render `contents` correctly.
   string mime_type = 6;
   // Optional. File content.
   string contents = 20;

--- a/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
+++ b/providers-sdk/v1/upstream/fex/fex_vtproto.pb.go
@@ -2017,6 +2017,20 @@ func (m *File) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0xa2
 	}
+	if len(m.MimeType) > 0 {
+		i -= len(m.MimeType)
+		copy(dAtA[i:], m.MimeType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MimeType)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.Label) > 0 {
+		i -= len(m.Label)
+		copy(dAtA[i:], m.Label)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Label)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.Sha256) > 0 {
 		i -= len(m.Sha256)
 		copy(dAtA[i:], m.Sha256)
@@ -4226,6 +4240,14 @@ func (m *File) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.Sha256)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.Label)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.MimeType)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -10124,6 +10146,70 @@ func (m *File) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.Sha256 = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Label", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Label = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MimeType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MimeType = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		case 20:
 			if wireType != 2 {


### PR DESCRIPTION
## What

Add two optional fields to the FEX `File` evidence message:

- **`label`** (field 5) — a human-readable label/identifier for the file evidence. Useful when a finding carries several file evidences, or when a UI needs a title for the document rather than a raw path.
- **`mime_type`** (field 6) — the MIME/content type (e.g. `application/json`, `text/plain`) so consumers can interpret or render `contents` correctly.

## Why

`File` evidence can already carry inline document `contents`, but there was no way to name it or declare its type — so a consumer receiving a `contents` blob couldn't tell what it is or how to render it. These two fields make an attached document self-describing.

## How

- Extended `providers-sdk/v1/upstream/fex/fex.proto` `File` message (new fields use free tag numbers 5/6; `contents` remains 20).
- Regenerated `fex.pb.go` and `fex_vtproto.pb.go` via `go generate`.

Both fields are optional and backward compatible (new field numbers, no reuse), so existing producers/consumers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)