### PR TITLE
feat(languages): requirements.txt SBOM extractor

### DIFF
--- a/providers/os/resources/languages/python/requirements/extractor.go
+++ b/providers/os/resources/languages/python/requirements/extractor.go
@@ -1,0 +1,70 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package requirements
+
+import (
+	"io"
+
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages/python"
+)
+
+var (
+	_ languages.Extractor = (*Extractor)(nil)
+	_ languages.Bom       = (*requirementsTxt)(nil)
+)
+
+// Extractor parses a requirements.txt file (the pip/`pip freeze` format) into a
+// languages.Bom of Python packages.
+type Extractor struct{}
+
+func (e *Extractor) Name() string {
+	return "requirements"
+}
+
+func (e *Extractor) Parse(r io.Reader, filename string) (languages.Bom, error) {
+	reqs, err := ParseRequirementsTxt(r)
+	if err != nil {
+		return nil, err
+	}
+
+	bom := &requirementsTxt{reqs: reqs}
+	if filename != "" {
+		bom.evidence = append(bom.evidence, filename)
+	}
+	return bom, nil
+}
+
+// requirementsTxt is a languages.Bom over a parsed requirements.txt.
+type requirementsTxt struct {
+	reqs     []Requirement
+	evidence []string
+}
+
+// Root returns nil — requirements.txt has no root project entry.
+func (l *requirementsTxt) Root() *languages.Package { return nil }
+
+// Direct returns nil — requirements.txt does not distinguish direct from
+// transitive (a `pip freeze` lists the whole flattened set).
+func (l *requirementsTxt) Direct() languages.Packages { return nil }
+
+// Transitive returns every pinned requirement. Entries without a pinned version
+// (an unconstrained `flask`, or a range like `flask>=2`) are skipped: an SBOM
+// component needs a concrete version, and requirements.txt does not resolve one.
+func (l *requirementsTxt) Transitive() languages.Packages {
+	var packages languages.Packages
+	for _, req := range l.reqs {
+		if req.Name == "" || req.Version == "" {
+			continue
+		}
+		packages = append(packages, &languages.Package{
+			Name:         req.Name,
+			Version:      req.Version,
+			Purl:         python.NewPackageUrl(req.Name, req.Version),
+			Cpes:         python.NewCpes(req.Name, req.Version),
+			EvidenceList: python.NewEvidenceList(l.evidence),
+		})
+	}
+	return packages
+}

--- a/providers/os/resources/languages/python/requirements/extractor_test.go
+++ b/providers/os/resources/languages/python/requirements/extractor_test.go
@@ -1,0 +1,46 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package requirements
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractor(t *testing.T) {
+	const reqs = `# a pip freeze style requirements.txt
+blinker==1.9.0
+Flask==3.1.3
+requests==2.32.5
+werkzeug[watchdog]==3.1.3
+unpinned-package
+ranged>=2.0
+-e git+https://example.com/repo.git#egg=editable
+--index-url https://pypi.org/simple
+`
+
+	bom, err := (&Extractor{}).Parse(strings.NewReader(reqs), "requirements.txt")
+	require.NoError(t, err)
+
+	pkgs := bom.Transitive()
+
+	// Pinned packages are extracted with a purl and file evidence; unpinned and
+	// ranged entries (no concrete version) and option/URL lines are skipped.
+	flask := pkgs.Find("Flask")
+	require.NotNil(t, flask)
+	assert.Equal(t, "3.1.3", flask.Version)
+	assert.Equal(t, "pkg:pypi/flask@3.1.3", flask.Purl)
+	require.Len(t, flask.EvidenceList, 1)
+	assert.Equal(t, "requirements.txt", flask.EvidenceList[0].Value)
+
+	// extras don't break the name/version
+	assert.NotNil(t, pkgs.Find("werkzeug"))
+
+	assert.Nil(t, pkgs.Find("unpinned-package"), "unpinned entry skipped")
+	assert.Nil(t, pkgs.Find("ranged"), "ranged (no pinned version) skipped")
+	assert.Equal(t, 4, len(pkgs), "blinker, Flask, requests, werkzeug")
+}


### PR DESCRIPTION
## Problem

The `languages` extractors cover the modern Python lockfiles (`poetry.lock`, `Pipfile.lock`, `uv.lock`, `pdm.lock`) but **not plain `requirements.txt`** — the pip / `pip freeze` format that is still the most common Python dependency file. A consumer that walks `languages.Extractor`s (e.g. xgrep's SBOM/SCA) therefore produces an empty SBOM for a pip-based project.

Surfaced by an xgrep cross-ecosystem SBOM comparison vs syft: go/rust/ruby/.NET matched exactly, but a `requirements.txt` project yielded 0 packages from xgrep while syft found the full set.

## Change

Expose the **existing** `ParseRequirementsTxt` parser as a `languages.Extractor` (mirroring `poetrylock.Extractor`), so it plugs into the same extractor registry as the lockfile parsers:

- `Extractor.Parse` → a `languages.Bom` whose `Transitive()` yields one package per **pinned** requirement (pypi purl + CPEs + file evidence).
- Unpinned (`flask`) and ranged (`flask>=2`) entries are skipped — an SBOM component needs a concrete version, and `requirements.txt` doesn't resolve one. Option lines (`-r`, `--index-url`) and URL/editable installs are skipped by the underlying parser.

No new parsing logic — just the Extractor/Bom wrapper. Additive; other parsers untouched. Full `languages` suite green.