### PR TITLE
feat(languages): tag composer dev/prod dependency scope

### DIFF
--- a/providers/os/resources/languages/php/composerlock/extractor.go
+++ b/providers/os/resources/languages/php/composerlock/extractor.go
@@ -48,24 +48,25 @@ func (l *composerLock) Root() *languages.Package {
 func (l *composerLock) Direct() languages.Packages {
 	var direct languages.Packages
 	for _, pkg := range l.Packages {
-		direct = append(direct, makePackage(pkg, l.evidence))
+		direct = append(direct, makePackage(pkg, l.evidence, languages.PackageScopeProd))
 	}
 	return direct
 }
 
-// Transitive returns all packages (production + dev).
+// Transitive returns all packages: the "packages" section as production scope
+// and "packages-dev" as development scope (composer.lock separates the two).
 func (l *composerLock) Transitive() languages.Packages {
 	var all languages.Packages
 	for _, pkg := range l.Packages {
-		all = append(all, makePackage(pkg, l.evidence))
+		all = append(all, makePackage(pkg, l.evidence, languages.PackageScopeProd))
 	}
 	for _, pkg := range l.PackagesDev {
-		all = append(all, makePackage(pkg, l.evidence))
+		all = append(all, makePackage(pkg, l.evidence, languages.PackageScopeDev))
 	}
 	return all
 }
 
-func makePackage(pkg composerPackage, evidence []string) *languages.Package {
+func makePackage(pkg composerPackage, evidence []string, scope string) *languages.Package {
 	// Note: License and Description are available in composer.lock but not yet
 	// exposed via the php.package MQL resource. When license support is added
 	// to the .lr schema, populate them here.
@@ -75,5 +76,6 @@ func makePackage(pkg composerPackage, evidence []string) *languages.Package {
 		Purl:         php.NewPackageUrl(pkg.Name, pkg.Version),
 		Cpes:         php.NewCpes(pkg.Name, pkg.Version),
 		EvidenceList: php.NewEvidenceList(evidence),
+		Scope:        scope,
 	}
 }

--- a/providers/os/resources/languages/php/composerlock/extractor_test.go
+++ b/providers/os/resources/languages/php/composerlock/extractor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
 	"go.mondoo.com/mql/v13/sbom"
 )
 
@@ -39,9 +40,10 @@ func TestComposerLockExtractor(t *testing.T) {
 	// Dev packages should NOT be in direct
 	assert.Nil(t, direct.Find("phpunit/phpunit"))
 
-	// Transitive = all packages
+	// Transitive = all packages, scoped: "packages" → prod, "packages-dev" → dev.
 	transitive := info.Transitive()
 	assert.Equal(t, 5, len(transitive))
-	assert.NotNil(t, transitive.Find("phpunit/phpunit"))
-	assert.NotNil(t, transitive.Find("mockery/mockery"))
+	assert.Equal(t, languages.PackageScopeProd, transitive.Find("monolog/monolog").Scope)
+	assert.Equal(t, languages.PackageScopeDev, transitive.Find("phpunit/phpunit").Scope)
+	assert.Equal(t, languages.PackageScopeDev, transitive.Find("mockery/mockery").Scope)
 }


### PR DESCRIPTION
## Problem

`composer.lock` separates production (`packages`) from development (`packages-dev`), and the extractor already reads both — but emits them **without a scope**. A consumer that applies a production-scope default therefore can't drop dev packages and over-reports.

Found by a cross-ecosystem SBOM comparison against syft on a real **symfony/demo** `composer.lock`: the extractor's output has **153** packages (99 prod + 54 dev) where syft's production view shows **99** — the 54 extras are dev tooling (`phpunit`, `xdebug-handler`, doctrine test bundles).

## Change

Tag `packages` as `PackageScopeProd` and `packages-dev` as `PackageScopeDev` (thread a scope through `makePackage`), matching how the npm/pnpm parsers already report scope. Coverage is unchanged — this only labels what's already extracted, so a consumer can filter dev out.

Test updated to assert `monolog` (prod) vs `phpunit`/`mockery` (dev) scope. Full `languages` suite green.
