### PR TITLE
feat(languages): tag conan build_requires as dev scope

### DIFF
--- a/providers/os/resources/languages/cpp/conanlock/extractor.go
+++ b/providers/os/resources/languages/cpp/conanlock/extractor.go
@@ -92,25 +92,30 @@ func (l *conanLock) parseV1() languages.Packages {
 func (l *conanLock) parseV2() languages.Packages {
 	var packages languages.Packages
 
-	allRefs := make([]string, 0, len(l.Requires)+len(l.BuildRequires)+len(l.PythonRequires))
-	allRefs = append(allRefs, l.Requires...)
-	allRefs = append(allRefs, l.BuildRequires...)
-	allRefs = append(allRefs, l.PythonRequires...)
-
-	for _, ref := range allRefs {
-		parsed, ok := parseConanReference(ref)
-		if !ok {
-			log.Warn().Str("ref", ref).Msg("cannot parse conan reference")
-			continue
+	add := func(refs []string, scope string) {
+		for _, ref := range refs {
+			parsed, ok := parseConanReference(ref)
+			if !ok {
+				log.Warn().Str("ref", ref).Msg("cannot parse conan reference")
+				continue
+			}
+			packages = append(packages, &languages.Package{
+				Name:         parsed.Name,
+				Version:      parsed.Version,
+				Purl:         cpp.NewPackageUrl(parsed.Name, parsed.Version),
+				EvidenceList: cpp.NewEvidenceList(l.evidence),
+				Scope:        scope,
+			})
 		}
-
-		packages = append(packages, &languages.Package{
-			Name:         parsed.Name,
-			Version:      parsed.Version,
-			Purl:         cpp.NewPackageUrl(parsed.Name, parsed.Version),
-			EvidenceList: cpp.NewEvidenceList(l.evidence),
-		})
 	}
+
+	// `requires` are runtime/production dependencies; `build_requires` and
+	// `python_requires` are build-time tooling (compilers, cmake, conan
+	// extensions) that isn't in the produced artifact — reported as dev scope so
+	// consumers can drop them from a production view.
+	add(l.Requires, languages.PackageScopeProd)
+	add(l.BuildRequires, languages.PackageScopeDev)
+	add(l.PythonRequires, languages.PackageScopeDev)
 
 	return packages
 }

--- a/providers/os/resources/languages/cpp/conanlock/extractor_test.go
+++ b/providers/os/resources/languages/cpp/conanlock/extractor_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/resources/languages"
 )
 
 func TestParseV1(t *testing.T) {
@@ -56,14 +57,18 @@ func TestParseV2(t *testing.T) {
 	require.NotNil(t, boost)
 	assert.Equal(t, "1.84.0", boost.Version)
 	assert.Equal(t, "pkg:conan/boost@1.84.0", boost.Purl)
+	assert.Equal(t, languages.PackageScopeProd, boost.Scope, "requires are production")
 
+	// build_requires and python_requires are build-time tooling → dev scope
 	cmake := pkgs.Find("cmake")
 	require.NotNil(t, cmake)
 	assert.Equal(t, "3.28.1", cmake.Version)
+	assert.Equal(t, languages.PackageScopeDev, cmake.Scope)
 
 	conanTools := pkgs.Find("conan-tools")
 	require.NotNil(t, conanTools)
 	assert.Equal(t, "1.0.0", conanTools.Version)
+	assert.Equal(t, languages.PackageScopeDev, conanTools.Scope)
 }
 
 func TestParseConanReference(t *testing.T) {


### PR DESCRIPTION
## Problem

`conan.lock` (v2) separates runtime dependencies (`requires`) from build-time tooling (`build_requires`, `python_requires` — compilers, cmake, conan extensions), and the extractor already reads all three — but emits them **without a scope**. A consumer applying a production-scope default can't drop the build tooling and over-reports.

Surfaced by a cross-ecosystem SBOM comparison against syft: a `conan.lock` with 6 runtime deps plus `cmake`/`ninja` build tools reported **8** where syft's production view shows **6**.

## Change

Tag `requires` as `PackageScopeProd` and `build_requires`/`python_requires` as `PackageScopeDev` (v2 path). Coverage is unchanged — this only labels what's already extracted, so a consumer can filter build-time deps out. Matches how the npm/pnpm/composer parsers already report scope.

Test asserts `boost` (prod) vs `cmake`/`conan-tools` (dev). Full `languages` suite green.