### PR TITLE
fix(languages): strip quotes from CocoaPods pod names

### DIFF
--- a/providers/os/resources/languages/swift/podfilelock/extractor.go
+++ b/providers/os/resources/languages/swift/podfilelock/extractor.go
@@ -94,6 +94,14 @@ func parsePodEntry(s string) podEntry {
 
 	// Remove trailing colon (pods with sub-dependencies)
 	s = strings.TrimSuffix(s, ":")
+	s = strings.TrimSpace(s)
+
+	// CocoaPods wraps a pod spec in double quotes when the name contains special
+	// characters, e.g. `"Artsy+UIColors (3.1.0)"`. Strip the surrounding quotes so
+	// the name doesn't keep a stray leading `"`.
+	if len(s) >= 2 && strings.HasPrefix(s, `"`) && strings.HasSuffix(s, `"`) {
+		s = s[1 : len(s)-1]
+	}
 
 	// Find "(version)"
 	openParen := strings.LastIndex(s, "(")

--- a/providers/os/resources/languages/swift/podfilelock/extractor_test.go
+++ b/providers/os/resources/languages/swift/podfilelock/extractor_test.go
@@ -45,3 +45,20 @@ func TestPodfileLockExtractor(t *testing.T) {
 	require.NotNil(t, p)
 	assert.Equal(t, "5.0.1", p.Version)
 }
+
+func TestParsePodEntryQuotedName(t *testing.T) {
+	// CocoaPods quotes names with special characters; the quotes must be stripped.
+	e := parsePodEntry(`"Artsy+UIColors (3.1.0)"`)
+	assert.Equal(t, "Artsy+UIColors", e.Name)
+	assert.Equal(t, "3.1.0", e.Version)
+
+	// A quoted name with a trailing colon (has sub-dependencies).
+	e = parsePodEntry(`"Artsy+UIFonts (3.1.3)":`)
+	assert.Equal(t, "Artsy+UIFonts", e.Name)
+	assert.Equal(t, "3.1.3", e.Version)
+
+	// Unquoted names are unchanged.
+	e = parsePodEntry("Alamofire (5.8.1)")
+	assert.Equal(t, "Alamofire", e.Name)
+	assert.Equal(t, "5.8.1", e.Version)
+}


### PR DESCRIPTION
## Problem

CocoaPods wraps a pod spec in double quotes when the name contains special characters, e.g.:

```
PODS:
  - "Artsy+UIColors (3.1.0)"
  - "Artsy+UIFonts (3.1.3)"
```

`parsePodEntry` didn't strip the surrounding quotes, so the extracted name kept a stray leading `"` — producing a malformed name (`"Artsy+UIColors`) and purl (`pkg:cocoapods/%22Artsy+UIColors@3.1.0`).

Surfaced by a cross-tool SBOM comparison on a real `Podfile.lock` (artsy/eidolon): 5 of 50 pods had the quote artifact.

## Change

Strip the wrapping double quotes in `parsePodEntry` before parsing the `name (version)` spec. Unquoted names are unaffected.

Test covers quoted names (with and without a trailing `:` for pods that have sub-dependencies) and the unchanged unquoted path.