### PR TITLE
🐛 remove the cap on the output of `run`

### DIFF
--- a/apps/mql/cmd/plugin.go
+++ b/apps/mql/cmd/plugin.go
@@ -176,6 +176,10 @@ func (c *mqlPlugin) RunQuery(conf *run.RunQueryConfig, runtime *providers.Runtim
 		shellOptions = append(shellOptions, shell.WithOnClose(onCloseHandler))
 		shellOptions = append(shellOptions, shell.WithFeatures(conf.Features))
 		shellOptions = append(shellOptions, shell.WithOutput(out))
+		// `run` is meant for non-interactive/scripted use, so we don't cap the
+		// output like the interactive shell does. Users piping or processing the
+		// full result set should get everything.
+		shellOptions = append(shellOptions, shell.WithMaxLines(0))
 
 		if upstreamConfig != nil {
 			shellOptions = append(shellOptions, shell.WithUpstreamConfig(upstreamConfig))


### PR DESCRIPTION
It makes no sense to cap the output of run. Scan and shell are a different story, but run should be printing what it has.