### PR TITLE
✨ Discover SNS topics and SQS queues as assets

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -114,6 +114,8 @@ Notes:
 				resources.DiscoveryBatchJobDefinitions,
 				resources.DiscoveryDirectoryServiceDirectories,
 				resources.DiscoveryDocumentDBInstances,
+				resources.DiscoverySnsTopics,
+				resources.DiscoverySqsQueues,
 				resources.DiscoveryVPCs,
 			},
 			Flags: []plugin.Flag{

--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -141,6 +141,10 @@ func getServiceName(platformName string) string {
 		return "ds"
 	case "aws-documentdb-instance":
 		return "documentdb"
+	case "aws-sns-topic":
+		return "sns"
+	case "aws-sqs-queue":
+		return "sqs"
 	}
 	return "other"
 }

--- a/providers/aws/connection/platforms.go
+++ b/providers/aws/connection/platforms.go
@@ -64,6 +64,8 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "aws-batch-jobdefinition", Title: "AWS Batch Job Definition", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-directoryservice-directory", Title: "AWS Directory Service Directory", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-documentdb-instance", Title: "AWS DocumentDB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sns-topic", Title: "AWS SNS Topic", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-sqs-queue", Title: "AWS SQS Queue", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 }
 
 var platformsByName = plugin.PlatformsByName(Platforms)

--- a/providers/aws/connection/platforms_test.go
+++ b/providers/aws/connection/platforms_test.go
@@ -27,7 +27,7 @@ var discoveryPlatformNames = []string{
 	"aws-opensearch-domain", "aws-rds-dbcluster", "aws-rds-dbinstance", "aws-redshift-cluster",
 	"aws-route53-hostedzone", "aws-s3-bucket", "aws-sagemaker-notebookinstance",
 	"aws-sagemaker-processingjob", "aws-sagemaker-trainingjob", "aws-secretsmanager-secret",
-	"aws-security-group", "aws-ssm-instance", "aws-vpc",
+	"aws-security-group", "aws-sns-topic", "aws-sqs-queue", "aws-ssm-instance", "aws-vpc",
 }
 
 func TestPlatformCatalogComplete(t *testing.T) {
@@ -65,6 +65,10 @@ func TestGetPlatformForObjectParity(t *testing.T) {
 	assert.Equal(t, "aws-object", p.Kind)
 	assert.Equal(t, "aws", p.Runtime)
 	assert.Equal(t, []string{"aws", acc, "s3"}, p.TechnologyUrlSegments)
+
+	// messaging objects resolve to their own service segment, not the "other" fallback
+	assert.Equal(t, []string{"aws", acc, "sns"}, GetPlatformForObject("aws-sns-topic", acc).TechnologyUrlSegments)
+	assert.Equal(t, []string{"aws", acc, "sqs"}, GetPlatformForObject("aws-sqs-queue", acc).TechnologyUrlSegments)
 
 	// an unknown object name falls back to a generic AWS object
 	u := GetPlatformForObject("aws-brand-new-thing", acc)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -1752,7 +1752,7 @@ func init() {
 			Create: createAwsSns,
 		},
 		"aws.sns.topic": {
-			// to override args, implement: initAwsSnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsSnsTopic,
 			Create: createAwsSnsTopic,
 		},
 		"aws.sns.subscription": {
@@ -2760,7 +2760,7 @@ func init() {
 			Create: createAwsSqs,
 		},
 		"aws.sqs.queue": {
-			// to override args, implement: initAwsSqsQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAwsSqsQueue,
 			Create: createAwsSqsQueue,
 		},
 		"aws.rds": {

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.50.3",
-  "generated_at": "2026-07-25T13:09:40-07:00",
+  "generated_at": "2026-07-25T14:16:51-07:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -881,6 +881,7 @@
     "sns:ListTagsForResource",
     "sns:ListTopics",
     "sqs:GetQueueAttributes",
+    "sqs:GetQueueUrl",
     "sqs:ListQueueTags",
     "sqs:ListQueues",
     "ssm:DescribeAssociation",
@@ -6402,6 +6403,12 @@
       "permission": "sqs:GetQueueAttributes",
       "service": "sqs",
       "action": "GetQueueAttributes",
+      "source_file": "aws_sqs.go"
+    },
+    {
+      "permission": "sqs:GetQueueUrl",
+      "service": "sqs",
+      "action": "GetQueueUrl",
       "source_file": "aws_sqs.go"
     },
     {

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -50,22 +50,35 @@ func (a *mqlAwsSns) topics() ([]any, error) {
 	return res, nil
 }
 
-func (a *mqlAwsSnsTopic) init(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+// initAwsSnsTopic resolves a single SNS topic. Topics are keyed by ARN, and
+// every topic API call needs the region that ARN carries, so the region is
+// always derived from it. When the resource is requested for a discovered
+// asset (aws-sns-topic platform) no args are passed and the ARN comes from the
+// connection's asset identifier.
+func initAwsSnsTopic(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if len(args) > 2 {
 		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+			args["arn"] = llx.StringData(assetArn)
+		}
 	}
 
 	if args["arn"] == nil {
 		return nil, nil, errors.New("arn required to fetch sns topic")
 	}
-	arnVal := args["arn"].Value.(string)
-	arn, err := arn.Parse(arnVal)
+	arnVal, ok := args["arn"].Value.(string)
+	if !ok {
+		return nil, nil, errors.New("wrong type for 'arn' in aws.sns.topic initialization, it must be a string")
+	}
+	parsedArn, err := arn.Parse(arnVal)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	args["arn"] = llx.StringData(arnVal)
-	args["region"] = llx.StringData(arn.Region)
+	args["region"] = llx.StringData(parsedArn.Region)
 	return args, nil, nil
 }
 

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,6 +31,105 @@ func (a *mqlAwsSqs) id() (string, error) {
 
 func (a *mqlAwsSqsQueue) id() (string, error) {
 	return a.Url.Data, nil
+}
+
+// sqsQueueName returns the queue name carried by an SQS queue URL, which is
+// always its last path segment. For
+// "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue" that is
+// "MyQueue".
+func sqsQueueName(queueURL string) string {
+	if i := strings.LastIndex(queueURL, "/"); i >= 0 {
+		return queueURL[i+1:]
+	}
+	return queueURL
+}
+
+// regionFromSqsQueueURL returns the region encoded in an SQS queue URL host.
+// It covers the standard "sqs.<region>.amazonaws.com" host, its FIPS
+// "sqs-fips.<region>.amazonaws.com" variant, and the legacy
+// "<region>.queue.amazonaws.com" host. It returns "" when the host carries no
+// region, such as the region-less legacy "queue.amazonaws.com".
+func regionFromSqsQueueURL(queueURL string) string {
+	u, err := url.Parse(queueURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(u.Hostname(), ".")
+	if len(parts) < 3 {
+		return ""
+	}
+	switch {
+	case parts[0] == "sqs" || parts[0] == "sqs-fips":
+		return parts[1]
+	case parts[1] == "queue":
+		return parts[0]
+	}
+	return ""
+}
+
+// initAwsSqsQueue resolves a single SQS queue. Queues are keyed by their URL,
+// which is also what every queue API call takes. A queue requested by ARN
+// alone (from a discovered aws-sqs-queue asset, or from another resource that
+// only holds the ARN) is resolved through GetQueueUrl using the queue name and
+// owner account the ARN carries.
+func initAwsSqsQueue(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+
+	if len(args) == 0 {
+		if assetArn := getAssetIdentifier(runtime); assetArn != "" {
+			args["arn"] = llx.StringData(assetArn)
+		}
+	}
+
+	// A URL already identifies the queue, so only the region it implies is
+	// still missing.
+	if args["url"] != nil {
+		if args["region"] == nil {
+			queueURL, ok := args["url"].Value.(string)
+			if !ok {
+				return nil, nil, fmt.Errorf("wrong type for 'url' in aws.sqs.queue initialization, it must be a string")
+			}
+			region := regionFromSqsQueueURL(queueURL)
+			if region == "" {
+				return nil, nil, fmt.Errorf("unable to determine region from sqs queue url %q", queueURL)
+			}
+			args["region"] = llx.StringData(region)
+		}
+		return args, nil, nil
+	}
+
+	if args["arn"] == nil {
+		return nil, nil, fmt.Errorf("arn or url required to fetch sqs queue")
+	}
+	arnVal, ok := args["arn"].Value.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("wrong type for 'arn' in aws.sqs.queue initialization, it must be a string")
+	}
+	parsedArn, err := arn.Parse(arnVal)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := runtime.Connection.(*connection.AwsConnection)
+	svc := conn.Sqs(parsedArn.Region)
+	resp, err := svc.GetQueueUrl(context.Background(), &sqs.GetQueueUrlInput{
+		QueueName:              aws.String(parsedArn.Resource),
+		QueueOwnerAWSAccountId: aws.String(parsedArn.AccountID),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	// Returning here without a URL would leave the resource with an empty
+	// __id, so treat a missing URL as a lookup failure.
+	if resp.QueueUrl == nil || *resp.QueueUrl == "" {
+		return nil, nil, fmt.Errorf("aws.sqs.queue with arn %q not found", arnVal)
+	}
+
+	args["url"] = llx.StringDataPtr(resp.QueueUrl)
+	args["region"] = llx.StringData(parsedArn.Region)
+	return args, nil, nil
 }
 
 func (a *mqlAwsSqs) queues() ([]any, error) {

--- a/providers/aws/resources/aws_sqs_test.go
+++ b/providers/aws/resources/aws_sqs_test.go
@@ -1,0 +1,52 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSqsQueueName(t *testing.T) {
+	tests := []struct {
+		name     string
+		queueURL string
+		expected string
+	}{
+		{"standard url", "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue", "MyQueue"},
+		{"fifo queue", "https://sqs.eu-west-1.amazonaws.com/123456789012/MyQueue.fifo", "MyQueue.fifo"},
+		{"china partition", "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/MyQueue", "MyQueue"},
+		{"legacy host", "https://us-east-1.queue.amazonaws.com/123456789012/MyQueue", "MyQueue"},
+		{"no path separator", "MyQueue", "MyQueue"},
+		{"empty", "", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, sqsQueueName(test.queueURL))
+		})
+	}
+}
+
+func TestRegionFromSqsQueueURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		queueURL string
+		expected string
+	}{
+		{"standard url", "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue", "us-east-1"},
+		{"fips url", "https://sqs-fips.us-gov-west-1.amazonaws.com/123456789012/MyQueue", "us-gov-west-1"},
+		{"china partition", "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/MyQueue", "cn-north-1"},
+		{"legacy host", "https://us-east-1.queue.amazonaws.com/123456789012/MyQueue", "us-east-1"},
+		{"region-less legacy host", "https://queue.amazonaws.com/123456789012/MyQueue", ""},
+		{"unrecognized host", "https://example.com/123456789012/MyQueue", ""},
+		{"not a url", "MyQueue", ""},
+		{"empty", "", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, regionFromSqsQueueURL(test.queueURL))
+		})
+	}
+}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -82,6 +82,8 @@ const (
 	DiscoveryBatchJobDefinitions         = "batch-jobdefinitions"
 	DiscoveryDirectoryServiceDirectories = "directoryservice-directories"
 	DiscoveryDocumentDBInstances         = "documentdb-instances"
+	DiscoverySnsTopics                   = "sns-topics"
+	DiscoverySqsQueues                   = "sqs-queues"
 )
 
 var AllAPIResources = []string{
@@ -137,6 +139,8 @@ var AllAPIResources = []string{
 	DiscoveryBatchJobDefinitions,
 	DiscoveryDirectoryServiceDirectories,
 	DiscoveryDocumentDBInstances,
+	DiscoverySnsTopics,
+	DiscoverySqsQueues,
 }
 
 var Auto = append(
@@ -1764,6 +1768,80 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 				awsObject: awsObject{
 					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
 					id: f.Arn.Data, service: "documentdb", objectType: "instance",
+				},
+			}
+			assetList = append(assetList, MqlObjectToAsset(accountId, obj, conn))
+		}
+	case DiscoverySnsTopics:
+		res, err := NewResource(runtime, "aws.sns", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+
+		s := res.(*mqlAwsSns)
+
+		topics := s.GetTopics()
+		if topics == nil {
+			return assetList, nil
+		}
+		if topics.Error != nil {
+			return nil, topics.Error
+		}
+
+		for i := range topics.Data {
+			f := topics.Data[i].(*mqlAwsSnsTopic)
+
+			// The resource segment of an SNS topic ARN is the bare topic name.
+			topicArn, err := arn.Parse(f.Arn.Data)
+			if err != nil {
+				log.Error().Err(err).Str("arn", f.Arn.Data).Msg("unable to parse sns topic arn")
+				continue
+			}
+
+			tags := mapStringInterfaceToStringString(f.GetTags().Data)
+			obj := mqlObject{
+				name: topicArn.Resource, labels: tags,
+				awsObject: awsObject{
+					account: accountId, region: f.Region.Data, arn: f.Arn.Data,
+					id: f.Arn.Data, service: "sns", objectType: "topic",
+				},
+			}
+			assetList = append(assetList, MqlObjectToAsset(accountId, obj, conn))
+		}
+	case DiscoverySqsQueues:
+		res, err := NewResource(runtime, "aws.sqs", map[string]*llx.RawData{})
+		if err != nil {
+			return nil, err
+		}
+
+		s := res.(*mqlAwsSqs)
+
+		queues := s.GetQueues()
+		if queues == nil {
+			return assetList, nil
+		}
+		if queues.Error != nil {
+			return nil, queues.Error
+		}
+
+		for i := range queues.Data {
+			f := queues.Data[i].(*mqlAwsSqsQueue)
+
+			// Queues are listed by URL only; the ARN comes from the queue
+			// attributes, so skip any queue whose attributes are unreadable
+			// rather than emitting an asset with no platform id.
+			queueArn := f.GetArn()
+			if queueArn.Error != nil {
+				log.Error().Err(queueArn.Error).Str("url", f.Url.Data).Msg("unable to fetch sqs queue arn")
+				continue
+			}
+
+			tags := mapStringInterfaceToStringString(f.GetTags().Data)
+			obj := mqlObject{
+				name: sqsQueueName(f.Url.Data), labels: tags,
+				awsObject: awsObject{
+					account: accountId, region: f.Region.Data, arn: queueArn.Data,
+					id: queueArn.Data, service: "sqs", objectType: "queue",
 				},
 			}
 			assetList = append(assetList, MqlObjectToAsset(accountId, obj, conn))

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -301,6 +301,14 @@ func getPlatformName(awsObject awsObject) string {
 		if awsObject.objectType == "directory" {
 			return "aws-directoryservice-directory"
 		}
+	case "sns":
+		if awsObject.objectType == "topic" {
+			return "aws-sns-topic"
+		}
+	case "sqs":
+		if awsObject.objectType == "queue" {
+			return "aws-sqs-queue"
+		}
 	}
 	return ""
 }

--- a/providers/aws/resources/discovery_test.go
+++ b/providers/aws/resources/discovery_test.go
@@ -64,6 +64,8 @@ func TestAllResolvedResources(t *testing.T) {
 		DiscoveryBatchJobDefinitions,
 		DiscoveryDirectoryServiceDirectories,
 		DiscoveryDocumentDBInstances,
+		DiscoverySnsTopics,
+		DiscoverySqsQueues,
 		DiscoveryInstances,
 		DiscoverySSMInstances,
 		DiscoveryECR,
@@ -123,6 +125,8 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoveryBatchJobDefinitions,
 		DiscoveryDirectoryServiceDirectories,
 		DiscoveryDocumentDBInstances,
+		DiscoverySnsTopics,
+		DiscoverySqsQueues,
 	}
 	require.ElementsMatch(t, expected, Auto)
 }


### PR DESCRIPTION
Adds `sns-topics` and `sqs-queues` discovery targets so SNS topics and SQS queues are surfaced as their own assets, plus the platform detection and resource inits needed to scan each one individually.

### Discovery

- New `DiscoverySnsTopics` (`sns-topics`) and `DiscoverySqsQueues` (`sqs-queues`) targets, wired into `AllAPIResources` (and so into `Auto` / `All`) and the provider's discovery flag list.
- SNS assets are named after the topic name carried in the ARN's resource segment.
- SQS queues are listed by URL only, so the ARN comes from the queue attributes. A queue whose attributes are unreadable is skipped with a log line rather than emitted as an asset with no platform ID.

### Detection

- `aws-sns-topic` and `aws-sqs-queue` added to the static platform catalog.
- `sns` / `sqs` technology URL segments, so neither falls into the `other` bucket.
- `(service, objectType)` → platform-name mapping for `sns/topic` and `sqs/queue`.
- Both names added to the `platforms_test.go` cross-check, with assertions on their URL segments.

### `aws.sns.topic` init

The topic's region is derived from its ARN, and the ARN comes from the asset identifier when the resource is requested for a discovered topic asset.

This replaces a `(*mqlAwsSnsTopic) init` **method** that was never registered — the generator only picks up free `initAwsSnsTopic` functions, so the method was dead code (the linter flagged it as unused). The practical effect: every topic reached by ARN alone — `aws.sns.subscription.topic`, `aws.cloudtrail.trail.snsTopic`, `aws.config.deliverychannel.snsTopic`, and the other typed refs — was constructed with an empty `region`, which is the region every SNS API call on that topic then used.

### `aws.sqs.queue` init

Queues are keyed by their URL, which is also what every queue API call takes. A queue requested by ARN alone (a discovered asset, or another resource holding only the ARN) resolves its URL through `GetQueueUrl` from the queue name and owner account in the ARN. A URL supplied without a region has the region read off the URL host — handling the standard, FIPS, and legacy host forms.

Adds `sqs:GetQueueUrl` to the permissions manifest.

### Tests

Unit tests for the two new pure-Go URL helpers (`sqsQueueName`, `regionFromSqsQueueURL`), covering the standard, FIPS, China-partition, legacy, and region-less hosts.

### Verification

Run against a live account:

- `aws.sqs.queues` and `aws.sns.topics` return their rows.
- `--discover sqs-queues` / `--discover sns-topics` emit assets with the expected names, `aws-sqs-queue` / `aws-sns-topic` platforms, and well-formed platform IDs.
- Querying `aws.sqs.queue` and `aws.sns.topic` with no args against each discovered asset resolves through the new inits and returns real field data.

SQS was checked against two pre-existing queues; SNS against one temporary topic, which has been deleted.

### Noted, not fixed here

`isPublic` returns `true` for any SNS topic carrying the AWS-generated default policy. That policy uses a wildcard principal scoped by an `AWS:SourceOwner` condition, but `isSourceScopingKey` (`aws_lambda.go`) only recognizes `aws:sourcearn`, `aws:sourceaccount`, and `aws:principalorgid`. Pre-existing and out of scope for this PR, but worth fixing separately — discovering topics as assets makes the false positive far more visible.
