### PR TITLE
🐛 Treat aws:SourceOwner as a principal-scoping condition

### DIFF
--- a/providers/aws/resources/aws_iam_policy_statement_test.go
+++ b/providers/aws/resources/aws_iam_policy_statement_test.go
@@ -59,6 +59,11 @@ func TestStatementsAllowPublic(t *testing.T) {
 	// A condition that does NOT scope the principal (region) leaves the grant
 	// effectively public — this is the behaviour shared with allowsPublicAccess.
 	regionCondition := map[string]any{"StringEquals": map[string]any{"aws:RequestedRegion": "us-east-1"}}
+	// The AWS-generated default SNS topic policy: a wildcard principal pinned to
+	// the owning account with aws:SourceOwner. Every default topic carries it.
+	sourceOwnerCondition := map[string]any{"StringEquals": map[string]any{"AWS:SourceOwner": "123456789012"}}
+	// A wildcard aws:SourceOwner pins nothing and stays public.
+	wildcardSourceOwnerCondition := map[string]any{"StringEquals": map[string]any{"AWS:SourceOwner": "*"}}
 
 	newStmt := func(effect string, principals map[string]any, conditions any) *mqlAwsIamPolicyStatement {
 		return &mqlAwsIamPolicyStatement{
@@ -76,6 +81,8 @@ func TestStatementsAllowPublic(t *testing.T) {
 		{"public, no conditions", []any{newStmt("Allow", wildcard, nil)}, true},
 		{"public scoped by source condition", []any{newStmt("Allow", wildcard, scopingCondition)}, false},
 		{"public with non-scoping region condition", []any{newStmt("Allow", wildcard, regionCondition)}, true},
+		{"default sns topic policy scoped by source owner", []any{newStmt("Allow", wildcard, sourceOwnerCondition)}, false},
+		{"public with wildcard source owner", []any{newStmt("Allow", wildcard, wildcardSourceOwnerCondition)}, true},
 		{"wildcard but denied", []any{newStmt("Deny", wildcard, nil)}, false},
 		{"specific principal", []any{newStmt("Allow", specific, nil)}, false},
 		{"no statements", []any{}, false},

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -719,8 +719,8 @@ func hasWildcardPrincipal(principals any) bool {
 }
 
 // hasSourceScopingCondition reports whether a statement condition map scopes
-// access with a non-wildcard aws:SourceArn, aws:SourceAccount, or
-// aws:PrincipalOrgID value.
+// access with a non-wildcard aws:SourceArn, aws:SourceAccount,
+// aws:SourceOwner, or aws:PrincipalOrgID value.
 func hasSourceScopingCondition(conditions any) bool {
 	m, ok := conditions.(map[string]any)
 	if !ok {
@@ -740,9 +740,13 @@ func hasSourceScopingCondition(conditions any) bool {
 	return false
 }
 
+// isSourceScopingKey reports whether a condition key pins a wildcard principal
+// to a specific caller. aws:SourceOwner is the account-ID form SNS uses, and is
+// what the AWS-generated default topic policy carries; it scopes a grant
+// exactly as aws:SourceAccount does.
 func isSourceScopingKey(key string) bool {
 	switch strings.ToLower(key) {
-	case "aws:sourcearn", "aws:sourceaccount", "aws:principalorgid":
+	case "aws:sourcearn", "aws:sourceaccount", "aws:sourceowner", "aws:principalorgid":
 		return true
 	}
 	return false


### PR DESCRIPTION
Follow-up to #9433, which surfaced this while live-testing SNS discovery.

### The bug

`isSourceScopingKey` (`providers/aws/resources/aws_lambda.go`) recognizes `aws:SourceArn`, `aws:SourceAccount`, and `aws:PrincipalOrgID`, but not **`aws:SourceOwner`** — the account-ID form SNS uses.

The policy AWS generates for every new SNS topic looks like this:

```json
{
  "Sid": "__default_statement_ID",
  "Effect": "Allow",
  "Principal": { "AWS": "*" },
  "Action": [ "SNS:Publish", "SNS:Subscribe", "..." ],
  "Resource": "arn:aws:sns:us-east-1:<account>:<topic>",
  "Condition": {
    "StringEquals": { "AWS:SourceOwner": "<account>" }
  }
}
```

A wildcard principal pinned to the owning account — not public. But because the condition key wasn't recognized as scoping, `isPublic` returned `true` for it. That is a false positive on essentially every SNS topic in every account.

### Blast radius

`hasSourceScopingCondition` is deliberately shared, so the missing key affected more than SNS:

- `aws.lambda.function.allowsPublicAccess`
- `isPublic` on `aws.sns.topic`, `aws.sqs.queue`, `aws.kms.key`, and `aws.ecr.repository` (all via `statementsAllowPublic` → `resourceIsPublic`)

### Why this direction is safe

Adding a recognized scoping key can only move a verdict from public to not-public, so the risk to weigh is a false *negative*. `aws:SourceOwner` takes an account ID and pins the grant to that account, exactly as `aws:SourceAccount` does, so it cannot mask a genuinely public policy. A wildcard `aws:SourceOwner` value still reads as public through the existing `conditionValueIsWildcard` check, and there is a test for that.

### Scope

Deliberately one key — the one reproduced against a live topic. Other candidates that arguably scope a wildcard principal (`aws:PrincipalAccount`, `aws:PrincipalArn`, `aws:PrincipalOrgPaths`, `kms:CallerAccount`) are left alone; widening a security predicate trades false positives for false negatives, so that seems worth deciding deliberately rather than bundling here.

### Tests

Two cases added to `TestStatementsAllowPublic`, using the real-world `AWS:SourceOwner` casing to also cover the key-lowercasing path:

- default SNS topic policy scoped by source owner → not public
- wildcard `aws:SourceOwner` value → still public

### Verification

Against a live account, a topic carrying the default policy reports `isPublic: false` after the change (`true` before it), with the wildcard principal and the `AWS:SourceOwner` condition both visible in `policyStatements`. The temporary topic used for the check has been deleted. Full `providers/aws` suite passes.
