### PR TITLE
🐛 aws: fix cache-key collisions, hard failures, and wrong security verdicts

### DIFF
--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -150,9 +150,16 @@ func IsMacieNotEnabledError(err error) bool {
 		if respErr.HTTPStatusCode() == 401 && strings.Contains(respErr.Error(), "AccessDeniedException: Macie is not enabled") {
 			return true
 		}
-		// Also catch general access denied cases for Macie
+		// Also catch general access denied cases for Macie, but only when the
+		// message actually names Macie. Matching a bare AccessDenied swallowed
+		// genuine macie2:* permission gaps and reported them as "Macie is not
+		// enabled", so every Macie resource degraded to empty and any
+		// data-classification policy passed vacuously.
 		if (respErr.HTTPStatusCode() == 400 || respErr.HTTPStatusCode() == 401 || respErr.HTTPStatusCode() == 403) &&
-			(strings.Contains(respErr.Error(), "AccessDeniedException") || strings.Contains(respErr.Error(), "AccessDenied")) {
+			(strings.Contains(respErr.Error(), "AccessDeniedException") || strings.Contains(respErr.Error(), "AccessDenied")) &&
+			(strings.Contains(respErr.Error(), "Macie is not enabled") ||
+				strings.Contains(respErr.Error(), "Macie isn't enabled") ||
+				strings.Contains(respErr.Error(), "not enabled for your account")) {
 			return true
 		}
 		// GetClassificationExportConfiguration / GetAutomatedDiscoveryConfiguration

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2401,7 +2401,7 @@ private aws.iam.user @defaults("arn name createdAt") {
   // Time when password was last used
   passwordLastUsed time
   // Tags for the IAM user
-  tags map[string]string
+  tags() map[string]string
   // Infrastructure-management system that owns this user
   //
   // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the user is unmanaged or managed by a tool that leaves no recognizable tag.
@@ -2467,7 +2467,7 @@ private aws.iam.instanceProfile @defaults("instanceProfileId instanceProfileName
   // Name of the instance profile
   instanceProfileName string
   // Tags for the instance profile
-  tags map[string]string
+  tags() map[string]string
   // Role attached to the instanceProfile
   iamRoles() []aws.iam.role
 }
@@ -2604,7 +2604,7 @@ private aws.iam.role @defaults("arn name") {
   // Description of the role
   description string
   // Tags associated with the role
-  tags map[string]string
+  tags() map[string]string
   // Time when the role was created
   createdAt time
   // Policy document that grants an entity permission to assume the role
@@ -11729,10 +11729,14 @@ private aws.s3.bucket @defaults("name location public") {
   // Whether the bucket allows public access
   //
   // True when the bucket policy or an access control grant exposes the bucket
-  // to everyone (the AllUsers or AuthenticatedUsers groups). Returns false
-  // whenever any Block Public Access setting is on, since that access is then
-  // blocked regardless of the policy or ACLs. Read the four `blockPublic*`
-  // fields to see the underlying settings.
+  // to everyone (the AllUsers or AuthenticatedUsers groups) and the relevant
+  // Block Public Access setting does not neutralize it. `restrictPublicBuckets`
+  // suppresses a public policy and `ignorePublicAcls` suppresses a public ACL;
+  // `blockPublicAcls` and `blockPublicPolicy` only reject new public grants and
+  // therefore do not change the answer for grants that already exist. Null when
+  // neither the policy nor the ACL could be read, so an under-scoped token is
+  // distinguishable from a bucket that is verified private. Read the four
+  // `blockPublic*` fields to see the underlying settings.
   public() bool
   // List of CORS information for the bucket
   cors() []aws.s3.bucket.corsrule
@@ -17211,7 +17215,7 @@ aws.ec2 {
 private aws.ec2.eip @defaults("publicIp attached privateIpAddress") {
   // Public IP address of the EIP
   publicIp string
-  // Whether the Elastic IP is associated with an instance (false if no allocationId is present)
+  // Whether the Elastic IP is associated with a network interface or instance
   attached bool
   // EC2 instance associated with the EIP
   instance() aws.ec2.instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -88410,7 +88410,9 @@ func (c *mqlAwsIamUser) GetPasswordLastUsed() *plugin.TValue[*time.Time] {
 }
 
 func (c *mqlAwsIamUser) GetTags() *plugin.TValue[map[string]any] {
-	return &c.Tags
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 func (c *mqlAwsIamUser) GetManagedBy() *plugin.TValue[string] {
@@ -88652,7 +88654,9 @@ func (c *mqlAwsIamInstanceProfile) GetInstanceProfileName() *plugin.TValue[strin
 }
 
 func (c *mqlAwsIamInstanceProfile) GetTags() *plugin.TValue[map[string]any] {
-	return &c.Tags
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 func (c *mqlAwsIamInstanceProfile) GetIamRoles() *plugin.TValue[[]any] {
@@ -88691,7 +88695,12 @@ func createAwsIamLoginProfile(runtime *plugin.Runtime, args map[string]*llx.RawD
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.iam.loginProfile", res.__id)
@@ -88859,7 +88868,12 @@ func createAwsIamPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 		return res, err
 	}
 
-	// to override __id implement: id() (string, error)
+	if res.__id == "" {
+		res.__id, err = res.id()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if runtime.HasRecording {
 		args, err = runtime.ResourceFromRecording("aws.iam.policy", res.__id)
@@ -89204,7 +89218,9 @@ func (c *mqlAwsIamRole) GetDescription() *plugin.TValue[string] {
 }
 
 func (c *mqlAwsIamRole) GetTags() *plugin.TValue[map[string]any] {
-	return &c.Tags
+	return plugin.GetOrCompute[map[string]any](&c.Tags, func() (map[string]any, error) {
+		return c.tags()
+	})
 }
 
 func (c *mqlAwsIamRole) GetCreatedAt() *plugin.TValue[*time.Time] {

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -494,16 +494,19 @@
     "iam:ListGroupPolicies",
     "iam:ListGroups",
     "iam:ListGroupsForUser",
+    "iam:ListInstanceProfileTags",
     "iam:ListInstanceProfiles",
     "iam:ListMFADevices",
     "iam:ListOpenIDConnectProviders",
     "iam:ListPolicies",
     "iam:ListPolicyVersions",
     "iam:ListRolePolicies",
+    "iam:ListRoleTags",
     "iam:ListRoles",
     "iam:ListSAMLProviders",
     "iam:ListServerCertificates",
     "iam:ListUserPolicies",
+    "iam:ListUserTags",
     "iam:ListUsers",
     "iam:ListVirtualMFADevices",
     "identitystore:ListGroups",
@@ -3994,6 +3997,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:ListInstanceProfileTags",
+      "service": "iam",
+      "action": "ListInstanceProfileTags",
+      "source_file": "aws_iam.go"
+    },
+    {
       "permission": "iam:ListInstanceProfiles",
       "service": "iam",
       "action": "ListInstanceProfiles",
@@ -4030,6 +4039,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:ListRoleTags",
+      "service": "iam",
+      "action": "ListRoleTags",
+      "source_file": "aws_iam.go"
+    },
+    {
       "permission": "iam:ListRoles",
       "service": "iam",
       "action": "ListRoles",
@@ -4051,6 +4066,12 @@
       "permission": "iam:ListUserPolicies",
       "service": "iam",
       "action": "ListUserPolicies",
+      "source_file": "aws_iam.go"
+    },
+    {
+      "permission": "iam:ListUserTags",
+      "service": "iam",
+      "action": "ListUserTags",
       "source_file": "aws_iam.go"
     },
     {

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -96,7 +96,10 @@ func (a *mqlAwsAccount) organization() (*mqlAwsOrganization, error) {
 			"masterAccountArn":   llx.StringDataPtr(org.Organization.MasterAccountArn),
 			"masterAccountEmail": llx.StringDataPtr(org.Organization.MasterAccountEmail),
 		})
-	return res.(*mqlAwsOrganization), err
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAwsOrganization), nil
 }
 
 func (a *mqlAwsOrganization) accounts() ([]any, error) {

--- a/providers/aws/resources/aws_apprunner.go
+++ b/providers/aws/resources/aws_apprunner.go
@@ -495,8 +495,12 @@ func (a *mqlAwsApprunner) getAutoScalingConfigurations(conn *connection.AwsConne
 
 			var nextToken *string
 			for {
+				// LatestOnly defaults to true server-side when the field is
+				// omitted, which hid every non-latest revision -- including
+				// revisions that services are actively pinned to.
 				resp, err := svc.ListAutoScalingConfigurations(ctx, &apprunner.ListAutoScalingConfigurationsInput{
-					NextToken: nextToken,
+					NextToken:  nextToken,
+					LatestOnly: false,
 				})
 				if err != nil {
 					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
@@ -973,7 +977,12 @@ func (a *mqlAwsApprunner) getObservabilityConfigurations(conn *connection.AwsCon
 
 			var nextToken *string
 			for {
-				resp, err := svc.ListObservabilityConfigurations(ctx, &apprunner.ListObservabilityConfigurationsInput{NextToken: nextToken})
+				// See the note on ListAutoScalingConfigurations: LatestOnly defaults to
+				// true when omitted.
+				resp, err := svc.ListObservabilityConfigurations(ctx, &apprunner.ListObservabilityConfigurationsInput{
+					NextToken:  nextToken,
+					LatestOnly: false,
+				})
 				if err != nil {
 					if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
 						log.Debug().Str("region", region).Msg("error accessing region for App Runner ListObservabilityConfigurations")

--- a/providers/aws/resources/aws_billing.go
+++ b/providers/aws/resources/aws_billing.go
@@ -16,6 +16,7 @@ import (
 	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/types"
 )
@@ -334,6 +335,13 @@ func (a *mqlAwsBilling) monthToDateCost() (float64, error) {
 	if err := a.fetchMonthToDate(); err != nil {
 		return 0, err
 	}
+	// Cost Explorer is denied by default for member accounts and any role
+	// without ce:*. Reporting 0.0 there is indistinguishable from a genuinely
+	// idle account and makes spend thresholds pass vacuously.
+	if a.mtdUnavailable {
+		a.MonthToDateCost.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
 	return a.mtdTotal, nil
 }
 
@@ -350,6 +358,10 @@ func (a *mqlAwsBilling) costsByService() (map[string]any, error) {
 func (a *mqlAwsBilling) lastMonthCost() (float64, error) {
 	if err := a.fetchLastMonth(); err != nil {
 		return 0, err
+	}
+	if a.lastMonthUnavailable {
+		a.LastMonthCost.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
 	}
 	return a.lastMonthTotal, nil
 }
@@ -368,12 +380,20 @@ func (a *mqlAwsBilling) last30DaysCost() (float64, error) {
 	if err := a.fetchLast30Days(); err != nil {
 		return 0, err
 	}
+	if a.last30Unavailable {
+		a.Last30DaysCost.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
 	return a.last30Total, nil
 }
 
 func (a *mqlAwsBilling) forecastedMonthCost() (float64, error) {
 	if err := a.fetchForecast(); err != nil {
 		return 0, err
+	}
+	if a.forecastUnavailable {
+		a.ForecastedMonthCost.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
 	}
 	return a.forecastAmount, nil
 }

--- a/providers/aws/resources/aws_codeartifact.go
+++ b/providers/aws/resources/aws_codeartifact.go
@@ -192,7 +192,11 @@ func (a *mqlAwsCodeartifactDomain) id() (string, error) {
 }
 
 func initAwsCodeartifactDomain(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
-	if len(args) > 2 {
+	// Only skip the lookup when the caller already supplied the identity we
+	// would resolve. repository.domain() passes name+owner+region (3 args), so a
+	// bare `len(args) > 2` fast path skipped the fetch and produced a husk whose
+	// id() (the unset arn) was empty, aliasing every repository's domain.
+	if args["arn"] != nil {
 		return args, nil, nil
 	}
 	name := rawStringArg(args["name"])

--- a/providers/aws/resources/aws_detective.go
+++ b/providers/aws/resources/aws_detective.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/detective"
 	detectivetypes "github.com/aws/aws-sdk-go-v2/service/detective/types"
@@ -152,7 +153,9 @@ func newMqlAwsDetectiveGraphMember(runtime *plugin.Runtime, region string, m det
 			entry["volumeUsageInBytes"] = *info.VolumeUsageInBytes
 		}
 		if info.VolumeUsageUpdateTime != nil {
-			entry["volumeUsageUpdateTime"] = *info.VolumeUsageUpdateTime
+			// dict values must be JSON-native; a time.Time fails conversion at
+			// query time with "unsupported child type: time.Time".
+			entry["volumeUsageUpdateTime"] = info.VolumeUsageUpdateTime.Format(time.RFC3339)
 		}
 		volumeUsage[string(pkg)] = entry
 	}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -76,7 +76,11 @@ func initAwsEc2Eip(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 
 	if len(address.Addresses) > 0 {
 		add := address.Addresses[0]
-		attached := add.AllocationId != nil
+		// AssociationId, not AllocationId: AllocationId is the allocation handle
+		// present on every VPC Elastic IP whether or not it is associated (it was
+		// only absent for EC2-Classic, retired in 2022), so keying on it made
+		// `attached` unconditionally true and `where(attached == false)` empty.
+		attached := add.AssociationId != nil
 		args["publicIp"] = llx.StringDataPtr(add.PublicIp)
 		args["attached"] = llx.BoolData(attached) // this is false if allocationId is null and true otherwise
 		args["networkInterfaceId"] = llx.StringDataPtr(add.NetworkInterfaceId)
@@ -195,7 +199,11 @@ func (a *mqlAwsEc2) getEIPs(conn *connection.AwsConnection) []*jobpool.Job {
 					continue
 				}
 
-				attached := add.AllocationId != nil
+				// AssociationId, not AllocationId: AllocationId is the allocation handle
+				// present on every VPC Elastic IP whether or not it is associated (it was
+				// only absent for EC2-Classic, retired in 2022), so keying on it made
+				// `attached` unconditionally true and `where(attached == false)` empty.
+				attached := add.AssociationId != nil
 				args := map[string]*llx.RawData{
 					"publicIp":                llx.StringDataPtr(add.PublicIp),
 					"attached":                llx.BoolData(attached), // this is false if allocationId is null and true otherwise
@@ -793,8 +801,14 @@ func initAwsEc2Keypair(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "InvalidKeyPair.NotFound" {
 				log.Warn().Msgf("key %s does not exist in %s region", n, r)
-				args["fingerprint"] = llx.StringData("")
-				args["type"] = llx.StringData("")
+				// A deleted keypair is a legitimate empty state, but it still
+				// needs a unique cache key: id() falls back to arn, which this
+				// path leaves empty, so every deleted keypair in the account
+				// aliased to whichever one resolved first. Unknown attributes
+				// are null rather than "" so they read as unknown, not empty.
+				args["__id"] = llx.StringData("aws.ec2.keypair/" + r + "/" + n)
+				args["fingerprint"] = llx.NilData
+				args["type"] = llx.NilData
 				args["tags"] = llx.MapData(map[string]any{}, types.String)
 				args["arn"] = llx.StringData("")
 				args["createdAt"] = llx.NilData
@@ -817,8 +831,10 @@ func initAwsEc2Keypair(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 
 		return args, nil, nil
 	}
-	args["fingerprint"] = llx.StringData("")
-	args["type"] = llx.StringData("")
+	// Same as the InvalidKeyPair.NotFound path above: unique key, null unknowns.
+	args["__id"] = llx.StringData("aws.ec2.keypair/" + r + "/" + n)
+	args["fingerprint"] = llx.NilData
+	args["type"] = llx.NilData
 	args["tags"] = llx.MapData(map[string]any{}, types.String)
 	args["arn"] = llx.StringData("")
 	args["createdAt"] = llx.NilData
@@ -1981,6 +1997,9 @@ func initAwsEc2Image(runtime *plugin.Runtime, args map[string]*llx.RawData) (map
 		return nil, nil, err
 	}
 	resource := strings.Split(arn.Resource, "/")
+	if len(resource) < 2 {
+		return nil, nil, fmt.Errorf("not a valid ec2 image arn %q", arnVal)
+	}
 	conn := runtime.Connection.(*connection.AwsConnection)
 	svc := conn.Ec2(arn.Region)
 	ctx := context.Background()
@@ -2308,11 +2327,19 @@ func (a *mqlAwsEc2Instance) id() (string, error) {
 
 func (a *mqlAwsEc2Instance) vpc() (*mqlAwsVpc, error) {
 	vpcArn := a.VpcArn
-	if vpcArn.State == plugin.StateIsNull {
-		return nil, errors.New("ec2 instance has no vpc associated with it")
-	} else if vpcArn.Error != nil {
+	if vpcArn.Error != nil {
 		return nil, vpcArn.Error
-	} else {
+	}
+	// RawToTValue stamps a nil value as StateIsNull|StateIsSet, so the old
+	// `State == plugin.StateIsNull` comparison could never match. Instances
+	// without a VPC (terminated instances drop VpcId) therefore fell through
+	// with arn:"" and triggered an account-wide VPC scan that ended in a
+	// misleading "vpc does not exist" error. A missing VPC is a null field.
+	if !vpcArn.IsSet() || vpcArn.IsNull() || vpcArn.Data == "" {
+		a.Vpc.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	{
 		res, err := NewResource(a.MqlRuntime, "aws.vpc", map[string]*llx.RawData{"arn": llx.StringData(vpcArn.Data)})
 		if err != nil {
 			return nil, err
@@ -4082,13 +4109,17 @@ func initAwsEc2Launchtemplate(runtime *plugin.Runtime, args map[string]*llx.RawD
 	svc := conn.Ec2(region)
 	resp, err := svc.DescribeLaunchTemplates(context.Background(), input)
 	if err != nil {
+		// Falling through with `args, nil, nil` built a husk: args holds only
+		// region plus id/name, arn is never set, so id() returned "" and every
+		// unresolvable launch template shared the empty cache key while its
+		// other fields stayed unset (not null).
 		if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
-			return args, nil, nil
+			return nil, nil, errors.Wrap(err, "could not access aws ec2 launch template")
 		}
 		return nil, nil, err
 	}
 	if len(resp.LaunchTemplates) == 0 {
-		return args, nil, nil
+		return nil, nil, errors.New("aws ec2 launch template does not exist")
 	}
 	mqlLt, err := buildLaunchTemplateResource(runtime, region, conn.AccountId(), resp.LaunchTemplates[0])
 	if err != nil {

--- a/providers/aws/resources/aws_ecs.go
+++ b/providers/aws/resources/aws_ecs.go
@@ -314,8 +314,12 @@ func (a *mqlAwsEcsCluster) containerInstances() ([]any, error) {
 		}
 		nextToken = containerInstances.NextToken
 	}
-	if len(allContainerInstanceArns) > 0 {
-		containerInstancesDetail, err := svc.DescribeContainerInstances(ctx, &ecsservice.DescribeContainerInstancesInput{Cluster: &clustera, ContainerInstances: allContainerInstanceArns, Include: []ecstypes.ContainerInstanceField{ecstypes.ContainerInstanceFieldTags}})
+	// DescribeContainerInstances accepts at most 100 entries per request, so a
+	// cluster with more registered instances than that used to fail the call
+	// outright -- and the error was only logged, so the cluster reported zero
+	// container instances.
+	for _, batch := range slicesx.Batch(allContainerInstanceArns, 100) {
+		containerInstancesDetail, err := svc.DescribeContainerInstances(ctx, &ecsservice.DescribeContainerInstancesInput{Cluster: &clustera, ContainerInstances: batch, Include: []ecstypes.ContainerInstanceField{ecstypes.ContainerInstanceFieldTags}})
 		if err == nil {
 			for _, ci := range containerInstancesDetail.ContainerInstances {
 				versionInfo, err := convert.JsonToDict(ci.VersionInfo)
@@ -916,7 +920,7 @@ func createTaskDefinitionResource(runtime *plugin.Runtime, region string, td *ec
 	// Create volumes
 	volumes := []any{}
 	for i := range td.Volumes {
-		mqlVolume, err := createVolumeResource(runtime, region, &td.Volumes[i])
+		mqlVolume, err := createVolumeResource(runtime, region, convert.ToValue(td.TaskDefinitionArn), &td.Volumes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -1212,11 +1216,16 @@ func createContainerDefinitionResource(runtime *plugin.Runtime, taskDefArn strin
 		})
 }
 
-func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.Volume) (any, error) {
+// createVolumeResource builds one task-definition volume. taskDefArn qualifies
+// every cache key below: volume names are unique only within a single task
+// definition revision, so keying on the bare name collapses same-named volumes
+// (data, tmp, config) across every revision in the account onto the first one.
+func createVolumeResource(runtime *plugin.Runtime, region string, taskDefArn string, vol *ecstypes.Volume) (any, error) {
 	volName := ""
 	if vol.Name != nil {
 		volName = *vol.Name
 	}
+	volKey := taskDefArn + "/volume/" + volName
 
 	// Create EFS volume configuration
 	var efsVolConfig any
@@ -1246,7 +1255,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 			iam := string(efsConfig.AuthorizationConfig.Iam)
 			mqlAuthConfig, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig",
 				map[string]*llx.RawData{
-					"__id":          llx.StringData(volName + "/efs/auth"),
+					"__id":          llx.StringData(volKey + "/efs/auth"),
 					"accessPointId": llx.StringData(accessPointId),
 					"iam":           llx.StringData(iam),
 				})
@@ -1258,7 +1267,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 			// Create empty authorization config
 			mqlAuthConfig, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig",
 				map[string]*llx.RawData{
-					"__id":          llx.StringData(volName + "/efs/auth"),
+					"__id":          llx.StringData(volKey + "/efs/auth"),
 					"accessPointId": llx.StringData(""),
 					"iam":           llx.StringData(""),
 				})
@@ -1275,7 +1284,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		}
 		mqlEfsConfig, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":                  llx.StringData(volName + "/efs"),
+				"__id":                  llx.StringData(volKey + "/efs"),
 				"fileSystemId":          llx.StringData(fileSystemId),
 				"rootDirectory":         llx.StringData(rootDirectory),
 				"transitEncryption":     llx.StringData(transitEncryption),
@@ -1292,7 +1301,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		// Create empty authorization config for empty EFS config
 		emptyAuthConfig, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration.authorizationConfig",
 			map[string]*llx.RawData{
-				"__id":          llx.StringData(volName + "/efs/auth"),
+				"__id":          llx.StringData(volKey + "/efs/auth"),
 				"accessPointId": llx.StringData(""),
 				"iam":           llx.StringData(""),
 			})
@@ -1301,7 +1310,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		}
 		mqlEfsConfig, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":                  llx.StringData(volName + "/efs"),
+				"__id":                  llx.StringData(volKey + "/efs"),
 				"fileSystemId":          llx.StringData(""),
 				"rootDirectory":         llx.StringData(""),
 				"transitEncryption":     llx.StringData(""),
@@ -1323,7 +1332,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		}
 		mqlHost, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.host",
 			map[string]*llx.RawData{
-				"__id":       llx.StringData(volName + "/host"),
+				"__id":       llx.StringData(volKey + "/host"),
 				"sourcePath": llx.StringData(sourcePath),
 			})
 		if err != nil {
@@ -1334,7 +1343,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		// Create empty host config
 		mqlHost, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.host",
 			map[string]*llx.RawData{
-				"__id":       llx.StringData(volName + "/host"),
+				"__id":       llx.StringData(volKey + "/host"),
 				"sourcePath": llx.StringData(""),
 			})
 		if err != nil {
@@ -1370,7 +1379,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		}
 		mqlDocker, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.dockerVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":          llx.StringData(volName + "/docker"),
+				"__id":          llx.StringData(volKey + "/docker"),
 				"scope":         llx.StringData(scope),
 				"autoprovision": llx.BoolData(autoprovision),
 				"driver":        llx.StringData(driver),
@@ -1385,7 +1394,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		// Create empty docker config
 		mqlDocker, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.dockerVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":          llx.StringData(volName + "/docker"),
+				"__id":          llx.StringData(volKey + "/docker"),
 				"scope":         llx.StringData(""),
 				"autoprovision": llx.BoolData(false),
 				"driver":        llx.StringData(""),
@@ -1420,7 +1429,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 		}
 		mqlS3files, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.s3filesVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":                  llx.StringData(volName + "/s3files"),
+				"__id":                  llx.StringData(volKey + "/s3files"),
 				"fileSystemArn":         llx.StringData(fileSystemArn),
 				"accessPointArn":        llx.StringData(accessPointArn),
 				"rootDirectory":         llx.StringData(rootDirectory),
@@ -1433,7 +1442,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 	} else {
 		mqlS3files, err := CreateResource(runtime, "aws.ecs.taskDefinition.volume.s3filesVolumeConfiguration",
 			map[string]*llx.RawData{
-				"__id":                  llx.StringData(volName + "/s3files"),
+				"__id":                  llx.StringData(volKey + "/s3files"),
 				"fileSystemArn":         llx.StringData(""),
 				"accessPointArn":        llx.StringData(""),
 				"rootDirectory":         llx.StringData(""),
@@ -1465,7 +1474,7 @@ func createVolumeResource(runtime *plugin.Runtime, region string, vol *ecstypes.
 
 	return CreateResource(runtime, "aws.ecs.taskDefinition.volume",
 		map[string]*llx.RawData{
-			"__id":                       llx.StringData(volName),
+			"__id":                       llx.StringData(volKey),
 			"name":                       llx.StringData(volName),
 			"efsVolumeConfiguration":     llx.ResourceData(efsVolConfigResource, "aws.ecs.taskDefinition.volume.efsVolumeConfiguration"),
 			"host":                       llx.ResourceData(hostConfigResource, "aws.ecs.taskDefinition.volume.host"),
@@ -1776,7 +1785,7 @@ func (a *mqlAwsEcsTaskDefinition) volumes() ([]any, error) {
 	}
 	volumes := []any{}
 	for i := range td.Volumes {
-		mqlVolume, err := createVolumeResource(a.MqlRuntime, a.Region.Data, &td.Volumes[i])
+		mqlVolume, err := createVolumeResource(a.MqlRuntime, a.Region.Data, a.Arn.Data, &td.Volumes[i])
 		if err != nil {
 			return nil, err
 		}
@@ -1896,8 +1905,10 @@ func (a *mqlAwsEcsTaskDefinitionVolume) s3filesVolumeConfiguration() (*mqlAwsEcs
 	return a.S3filesVolumeConfiguration.Data, nil
 }
 
+// id returns the task-definition-qualified cache key set at construction.
+// `name` alone is unique only within one task definition revision.
 func (a *mqlAwsEcsTaskDefinitionVolume) id() (string, error) {
-	return a.Name.Data, nil
+	return a.__id, nil
 }
 
 func (a *mqlAwsEcsTaskDefinitionEphemeralStorage) id() (string, error) {

--- a/providers/aws/resources/aws_efs.go
+++ b/providers/aws/resources/aws_efs.go
@@ -146,7 +146,13 @@ func (a *mqlAwsEfsFilesystem) kmsKey() (*mqlAwsKmsKey, error) {
 		mqlKeyResource, err := NewResource(a.MqlRuntime, "aws.kms.key", map[string]*llx.RawData{
 			"arn": llx.StringDataPtr(a.cacheKmsKeyID),
 		})
-		return mqlKeyResource.(*mqlAwsKmsKey), err
+		// initAwsKmsKey returns (nil, err) on an unparseable ARN or a denied
+		// DescribeKey; asserting on the nil interface would panic and, because
+		// blocks run in goroutines, take down the whole scan.
+		if err != nil {
+			return nil, err
+		}
+		return mqlKeyResource.(*mqlAwsKmsKey), nil
 	}
 	a.KmsKey.State = plugin.StateIsSet | plugin.StateIsNull
 

--- a/providers/aws/resources/aws_elb.go
+++ b/providers/aws/resources/aws_elb.go
@@ -1019,10 +1019,11 @@ func isV1LoadBalancerArn(a string) bool {
 	if err != nil {
 		return false
 	}
-	if strings.Contains(arnVal.Resource, "classic") {
-		return true
-	}
-	return false
+	// Must be a prefix match on the synthesized classic path. A substring match
+	// also caught ALB/NLB ARNs whose *name* contains "classic"
+	// (loadbalancer/app/prod-classic-api/...), dispatching them to the v1 API:
+	// listeners() then returned [] and enforcesTls() passed vacuously.
+	return strings.HasPrefix(arnVal.Resource, "loadbalancer/classic/")
 }
 
 func elbv2TagsToMap(tags []elbtypes.Tag) map[string]any {

--- a/providers/aws/resources/aws_elb_test.go
+++ b/providers/aws/resources/aws_elb_test.go
@@ -51,3 +51,28 @@ func TestListenerForwardTargetGroupsNoForwardAction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+// TestIsV1LoadBalancerArn guards the classic-vs-v2 dispatch. A substring match
+// on "classic" also caught ALB/NLB ARNs whose *name* contains it, sending them
+// to the v1 API: listeners() then returned an empty list and enforcesTls()
+// passed vacuously on an unencrypted ALB.
+func TestIsV1LoadBalancerArn(t *testing.T) {
+	tests := []struct {
+		name string
+		arn  string
+		want bool
+	}{
+		{"classic", "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/classic/my-elb", true},
+		{"alb named classic-migration", "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/classic-migration-alb/50dc", false},
+		{"alb named prod-classic-api", "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/app/prod-classic-api/abc", false},
+		{"nlb", "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/net/my-nlb/abc", false},
+		{"gwlb", "arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/gwy/my-gwlb/abc", false},
+		{"not an arn", "my-elb", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isV1LoadBalancerArn(tt.arn))
+		})
+	}
+}

--- a/providers/aws/resources/aws_foundation_helpers_test.go
+++ b/providers/aws/resources/aws_foundation_helpers_test.go
@@ -166,3 +166,63 @@ func TestHasSourceScopingCondition(t *testing.T) {
 		})
 	}
 }
+
+// TestIsRestrictingConditionOperator pins which IAM condition operators narrow
+// a grant. Negated forms and Null widen it: StringNotEquals on
+// aws:PrincipalOrgID means "allow everyone OUTSIDE my org" and Null means
+// "allow principals for which the key is absent", both strictly worse than an
+// unconditional public grant.
+func TestIsRestrictingConditionOperator(t *testing.T) {
+	restricting := []string{
+		"StringEquals", "stringequals", "StringLike", "StringEqualsIgnoreCase",
+		"ArnEquals", "ArnLike",
+		"StringEqualsIfExists", "ForAnyValue:StringEquals", "ForAllValues:StringLike",
+	}
+	for _, op := range restricting {
+		assert.True(t, isRestrictingConditionOperator(op), "expected %q to restrict", op)
+	}
+
+	widening := []string{
+		"StringNotEquals", "StringNotLike", "ArnNotEquals", "ArnNotLike",
+		"Null", "NotIpAddress", "DateLessThan", "Bool",
+	}
+	for _, op := range widening {
+		assert.False(t, isRestrictingConditionOperator(op), "expected %q not to restrict", op)
+	}
+}
+
+// TestHasSourceScopingConditionOperators covers the operator gate and the
+// widened scoping-key set. Before the gate, a negated operator on a scoping key
+// read as "scoped" and the resource reported not-public.
+func TestHasSourceScopingConditionOperators(t *testing.T) {
+	cond := func(op, key, val string) any {
+		return map[string]any{op: map[string]any{key: val}}
+	}
+
+	t.Run("restricting operators scope the grant", func(t *testing.T) {
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "aws:PrincipalOrgID", "o-myorg")))
+		assert.True(t, hasSourceScopingCondition(cond("ArnLike", "aws:SourceArn", "arn:aws:sns:us-east-1:1:t")))
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "aws:SourceAccount", "111111111111")))
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "aws:SourceOwner", "111111111111")))
+	})
+
+	t.Run("newly recognized scoping keys", func(t *testing.T) {
+		// the shape AWS's own service-linked KMS grants carry
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "kms:CallerAccount", "111111111111")))
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "aws:SourceVpce", "vpce-123")))
+		assert.True(t, hasSourceScopingCondition(cond("StringEquals", "aws:PrincipalAccount", "111111111111")))
+	})
+
+	t.Run("negated and Null operators do not scope", func(t *testing.T) {
+		assert.False(t, hasSourceScopingCondition(cond("StringNotEquals", "aws:PrincipalOrgID", "o-myorg")))
+		assert.False(t, hasSourceScopingCondition(cond("ArnNotLike", "aws:SourceArn", "arn:aws:sns:us-east-1:1:t")))
+		assert.False(t, hasSourceScopingCondition(cond("Null", "aws:PrincipalOrgID", "true")))
+	})
+
+	t.Run("wildcard values and unrelated keys do not scope", func(t *testing.T) {
+		assert.False(t, hasSourceScopingCondition(cond("StringEquals", "aws:SourceArn", "*")))
+		assert.False(t, hasSourceScopingCondition(cond("StringEquals", "s3:x-amz-acl", "public-read")))
+		assert.False(t, hasSourceScopingCondition(nil))
+		assert.False(t, hasSourceScopingCondition("not-a-map"))
+	})
+}

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -100,9 +100,13 @@ func (a *mqlAwsIam) credentialReport() ([]any, error) {
 			}
 		}
 
-		// if we have an error and it is not 500 we generate a report
+		// if we have an error and it is not 500 we generate a report.
+		// ReportExpired (410) needs the same treatment as ReportNotPresent:
+		// AWS expires cached credential reports and the only way forward is to
+		// regenerate. Without this branch the whole credentialReport field --
+		// and every root-MFA / key-rotation check built on it -- hard-errors.
 		if errors.As(err, &ae) {
-			if ae.ErrorCode() == "ReportNotPresent" {
+			if code := ae.ErrorCode(); code == "ReportNotPresent" || code == "ReportExpired" {
 				// generate a new report
 				_, err := svc.GenerateCredentialReport(ctx, &iam.GenerateCredentialReportInput{})
 				if err != nil {
@@ -341,6 +345,77 @@ func (a *mqlAwsIam) users() ([]any, error) {
 	return res, nil
 }
 
+// tags for IAM users/roles/instance profiles must be fetched separately: the
+// ListUsers / ListRoles / ListInstanceProfiles responses explicitly omit Tags
+// (the SDK documents this on each operation), so the collection path used to
+// report {} for every principal while the single-object path returned the real
+// tags. Fetching lazily keeps queries that don't select tags free of the call.
+// The init paths (GetUser/GetRole/GetInstanceProfile) already populate the
+// field eagerly, so GetOrCompute short-circuits and these never fire there.
+
+func (a *mqlAwsIamUser) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	userName := a.Name.Data
+	res := []iamtypes.Tag{}
+	paginator := iam.NewListUserTagsPaginator(svc, &iam.ListUserTagsInput{UserName: &userName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return map[string]any{}, nil
+			}
+			return nil, err
+		}
+		res = append(res, page.Tags...)
+	}
+	return iamTagsToMap(res), nil
+}
+
+func (a *mqlAwsIamRole) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	roleName := a.Name.Data
+	res := []iamtypes.Tag{}
+	paginator := iam.NewListRoleTagsPaginator(svc, &iam.ListRoleTagsInput{RoleName: &roleName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return map[string]any{}, nil
+			}
+			return nil, err
+		}
+		res = append(res, page.Tags...)
+	}
+	return iamTagsToMap(res), nil
+}
+
+func (a *mqlAwsIamInstanceProfile) tags() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	name := a.InstanceProfileName.Data
+	res := []iamtypes.Tag{}
+	paginator := iam.NewListInstanceProfileTagsPaginator(svc, &iam.ListInstanceProfileTagsInput{InstanceProfileName: &name})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				return map[string]any{}, nil
+			}
+			return nil, err
+		}
+		res = append(res, page.Tags...)
+	}
+	return iamTagsToMap(res), nil
+}
+
 func iamTagsToMap(tags []iamtypes.Tag) map[string]any {
 	return tagsToMap(tags, func(t iamtypes.Tag) *string { return t.Key }, func(t iamtypes.Tag) *string { return t.Value })
 }
@@ -382,7 +457,6 @@ func (a *mqlAwsIam) createInstanceProfile(instanceProfile *iamtypes.InstanceProf
 			"instanceProfileId":   llx.StringDataPtr(instanceProfile.InstanceProfileId),
 			"instanceProfileName": llx.StringDataPtr(instanceProfile.InstanceProfileName),
 			// "roles":               llx.MapDataPtr(instanceProfile.Roles),
-			"tags": llx.MapData(iamTagsToMap(instanceProfile.Tags), types.String),
 		},
 	)
 	if err != nil {
@@ -427,7 +501,6 @@ func (a *mqlAwsIam) createIamUser(usr *iamtypes.User) (plugin.Resource, error) {
 			"name":             llx.StringDataPtr(usr.UserName),
 			"createdAt":        llx.TimeDataPtr(usr.CreateDate),
 			"passwordLastUsed": llx.TimeDataPtr(usr.PasswordLastUsed),
-			"tags":             llx.MapData(iamTagsToMap(usr.Tags), types.String),
 			"path":             llx.StringDataPtr(usr.Path),
 		},
 	)
@@ -568,7 +641,6 @@ func (a *mqlAwsIam) mqlPolicies(policies []iamtypes.Policy) ([]any, error) {
 				"arn":             llx.StringDataPtr(policy.Arn),
 				"policyId":        llx.StringDataPtr(policy.PolicyId),
 				"name":            llx.StringDataPtr(policy.PolicyName),
-				"description":     llx.StringDataPtr(policy.Description),
 				"isAttachable":    llx.BoolData(policy.IsAttachable),
 				"attachmentCount": llx.IntDataDefault(policy.AttachmentCount, 0),
 				"createdAt":       llx.TimeDataPtr(policy.CreateDate),
@@ -670,7 +742,6 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 					"id":                       llx.StringDataPtr(role.RoleId),
 					"name":                     llx.StringDataPtr(role.RoleName),
 					"description":              llx.StringDataPtr(role.Description),
-					"tags":                     llx.MapData(iamTagsToMap(role.Tags), types.String),
 					"createdAt":                llx.TimeDataPtr(role.CreateDate),
 					"assumeRolePolicyDocument": llx.MapData(policyDocumentMap, types.Any),
 					"maxSessionDuration":       llx.IntDataDefault(role.MaxSessionDuration, 3600),
@@ -720,7 +791,13 @@ func (a *mqlAwsIam) groups() ([]any, error) {
 func (p *mqlAwsIamUsercredentialreportentry) id() (string, error) {
 	props := p.Properties.Data
 
-	userid := props["arn"].(string)
+	// The credential report is a hand-parsed CSV; a ragged row yields a map
+	// without "arn". A bare assertion here panics inside an executor goroutine
+	// and takes the whole scan with it.
+	userid, ok := props["arn"].(string)
+	if !ok {
+		return "", errors.New("aws iam credential report entry has no arn")
+	}
 
 	return "aws/iam/credentialreport/" + userid, nil
 }
@@ -897,9 +974,13 @@ func (a *mqlAwsIamUsercredentialreportentry) user() (*mqlAwsIamUser, error) {
 		return nil, errors.New("root user does not exist")
 	}
 
+	userName, ok := props["user"].(string)
+	if !ok {
+		return nil, errors.New("aws iam credential report entry has no user")
+	}
 	mqlUser, err := NewResource(a.MqlRuntime, ResourceAwsIamUser,
 		map[string]*llx.RawData{
-			"name": llx.StringData(props["user"].(string)),
+			"name": llx.StringData(userName),
 		},
 	)
 	if err != nil {
@@ -1289,6 +1370,13 @@ type mqlAwsIamPolicyInternal struct {
 	cachedVersions  []iamtypes.PolicyVersion
 	versionsFetched atomic.Bool
 	versionsLock    sync.Mutex
+}
+
+// id keys the resource on the policy ARN. Without it every aws.iam.policy
+// shares the empty cache key, so CreateResource returns the first-created
+// policy for every subsequent one.
+func (a *mqlAwsIamPolicy) id() (string, error) {
+	return a.Arn.Data, nil
 }
 
 func (a *mqlAwsIamPolicy) loadPolicy(arn string) (*iamtypes.Policy, error) {
@@ -1747,28 +1835,26 @@ func (a *mqlAwsIamRole) id() (string, error) {
 }
 
 func (a *mqlAwsIamRole) permissionsBoundary() (*mqlAwsIamPolicy, error) {
-	// roles() populates permissionsBoundaryArn directly from ListRoles, so prefer
-	// the cached value to avoid an extra GetRole per role. Only fall back to
-	// GetRole when this resource was constructed via NewResource without eager
-	// population (in which case the field's state flag will not be set).
-	boundaryArn := ""
-	if a.PermissionsBoundaryArn.IsSet() {
-		boundaryArn = a.PermissionsBoundaryArn.Data
-	} else {
-		conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-		svc := conn.Iam("")
-		ctx := context.Background()
-
-		roleName := a.Name.Data
-		resp, err := svc.GetRole(ctx, &iam.GetRoleInput{RoleName: &roleName})
+	// ListRoles explicitly does not return PermissionsBoundary (see the SDK docs
+	// on ListRoles), so roles() always wrote "" into permissionsBoundaryArn.
+	// Because llx.StringData("") still marks the field StateIsSet, gating on
+	// PermissionsBoundaryArn.IsSet() made the GetRole fallback unreachable and
+	// every role reported "no permissions boundary". Track provenance with a
+	// dedicated flag instead, exactly as aws.iam.user does.
+	if !a.permissionsBoundaryArnSet {
+		// getRoleDetails memoizes GetRole, so this shares one call with
+		// lastUsedAt/lastUsedRegion instead of issuing a second one.
+		resp, err := a.getRoleDetails()
 		if err != nil {
 			return nil, err
 		}
-		if resp.Role != nil && resp.Role.PermissionsBoundary != nil {
-			boundaryArn = convert.ToValue(resp.Role.PermissionsBoundary.PermissionsBoundaryArn)
+		if resp != nil && resp.Role != nil && resp.Role.PermissionsBoundary != nil {
+			a.permissionsBoundaryArn = convert.ToValue(resp.Role.PermissionsBoundary.PermissionsBoundaryArn)
 		}
-		a.PermissionsBoundaryArn = plugin.TValue[string]{Data: boundaryArn, State: plugin.StateIsSet}
+		a.permissionsBoundaryArnSet = true
+		a.PermissionsBoundaryArn = plugin.TValue[string]{Data: a.permissionsBoundaryArn, State: plugin.StateIsSet}
 	}
+	boundaryArn := a.permissionsBoundaryArn
 
 	if boundaryArn == "" {
 		a.PermissionsBoundary.State = plugin.StateIsNull | plugin.StateIsSet
@@ -1787,6 +1873,11 @@ type mqlAwsIamRoleInternal struct {
 	cachedRole  *iam.GetRoleOutput
 	roleFetched bool
 	roleLock    sync.Mutex
+	// permissionsBoundaryArn/-Set mirror the aws.iam.user pattern: ListRoles
+	// never returns PermissionsBoundary, so the eager value is meaningless and
+	// only a GetRole-sourced value may be trusted.
+	permissionsBoundaryArn    string
+	permissionsBoundaryArnSet bool
 }
 
 // getRoleDetails fetches and memoizes the full role via GetRole. The account-wide
@@ -2230,6 +2321,7 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	}
 
 	o, err := CreateResource(a.MqlRuntime, ResourceAwsIamLoginProfile, map[string]*llx.RawData{
+		"__id":                  llx.StringData(a.Arn.Data + "/loginProfile"),
 		"createdAt":             llx.TimeData(*date),
 		"passwordResetRequired": llx.BoolData(profile.LoginProfile.PasswordResetRequired),
 	})
@@ -2241,14 +2333,12 @@ func (a *mqlAwsIamUser) loginProfile() (*mqlAwsIamLoginProfile, error) {
 	return a.loginProfileCache, nil
 }
 
-func (a *mqlAwsIamLoginProfile) init() (string, error) {
-	date := a.CreatedAt.Data
-	if date == nil {
-		return "", nil
-	}
-	// Note: the precision of AWS logins is in seconds. Current AWS docs don't
-	// specify a precision. Using seconds is reasonable.
-	return strconv.FormatInt(date.Unix(), 10), nil
+// id returns the user-qualified cache key set at construction. This was
+// previously named `init`, which the code generator never registers, so the
+// resource had an empty __id and every user shared one login profile. Keying on
+// the creation timestamp would also collide for users created in the same second.
+func (a *mqlAwsIamLoginProfile) id() (string, error) {
+	return a.__id, nil
 }
 
 func initAwsIamInstanceProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -239,7 +239,14 @@ func (a *mqlAwsSnsTopic) policyStatements() ([]any, error) {
 }
 
 func (a *mqlAwsSqsQueue) policyStatements() ([]any, error) {
-	return policyStatementsFromDict(a.MqlRuntime, a.Arn.Data, a.GetPolicy())
+	// aws.sqs.queue.arn is a computed field; reading a.Arn.Data directly yields
+	// "" unless something already resolved it, which made every queue's
+	// statements share the cache key "/statement/N".
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	return policyStatementsFromDict(a.MqlRuntime, arn.Data, a.GetPolicy())
 }
 
 func (a *mqlAwsEcrRepository) policyStatements() ([]any, error) {
@@ -278,6 +285,17 @@ func (a *mqlAwsIamPolicyStatement) hasPublicPrincipal() (bool, error) {
 	if !strings.EqualFold(effect.Data, "Allow") {
 		return false, nil
 	}
+	// An Allow with NotPrincipal grants everyone *except* the listed principals,
+	// so it is public by construction. Only Principal was consulted before, so
+	// `{"Effect":"Allow","NotPrincipal":{...}}` on a bucket read as not-public.
+	notPrincipals := a.GetNotPrincipals()
+	if notPrincipals.Error != nil {
+		return false, notPrincipals.Error
+	}
+	if len(notPrincipals.Data) > 0 {
+		return true, nil
+	}
+
 	principals := a.GetPrincipals()
 	if principals.Error != nil {
 		return false, principals.Error

--- a/providers/aws/resources/aws_iam_policy_statement_test.go
+++ b/providers/aws/resources/aws_iam_policy_statement_test.go
@@ -100,3 +100,95 @@ func TestStatementsAllowPublic(t *testing.T) {
 		})
 	}
 }
+
+// TestPolicyStatementHasPublicPrincipalNotPrincipal covers Allow + NotPrincipal,
+// which grants everyone *except* the listed principals and is therefore public
+// by construction. Only Principal was consulted before, so a bucket policy of
+// this shape reported not-public.
+func TestPolicyStatementHasPublicPrincipalNotPrincipal(t *testing.T) {
+	tests := []struct {
+		name          string
+		effect        string
+		principals    map[string]any
+		notPrincipals map[string]any
+		want          bool
+	}{
+		{
+			name:          "allow with notPrincipal is public",
+			effect:        "Allow",
+			notPrincipals: map[string]any{"AWS": []any{"arn:aws:iam::111111111111:role/Admin"}},
+			want:          true,
+		},
+		{
+			name:          "deny with notPrincipal is not public",
+			effect:        "Deny",
+			notPrincipals: map[string]any{"AWS": []any{"arn:aws:iam::111111111111:role/Admin"}},
+			want:          false,
+		},
+		{
+			name:          "empty notPrincipal falls back to principal",
+			effect:        "Allow",
+			principals:    map[string]any{"AWS": []any{"arn:aws:iam::111111111111:root"}},
+			notPrincipals: map[string]any{},
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := &mqlAwsIamPolicyStatement{
+				Effect:        setString(tt.effect),
+				Principals:    setMap(tt.principals),
+				NotPrincipals: setMap(tt.notPrincipals),
+			}
+			got, err := stmt.hasPublicPrincipal()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestStatementsAllowPublicNegatedCondition covers the operator gate through
+// the public-facing predicate: a wildcard principal scoped by a *negated*
+// operator is not scoped at all, and must still report public.
+func TestStatementsAllowPublicNegatedCondition(t *testing.T) {
+	wildcard := map[string]any{"AWS": []any{"*"}}
+
+	tests := []struct {
+		name      string
+		condition map[string]any
+		want      bool
+	}{
+		{
+			name:      "StringEquals on a scoping key is scoped",
+			condition: map[string]any{"StringEquals": map[string]any{"aws:PrincipalOrgID": "o-123"}},
+			want:      false,
+		},
+		{
+			name:      "StringNotEquals on a scoping key is NOT scoped",
+			condition: map[string]any{"StringNotEquals": map[string]any{"aws:PrincipalOrgID": "o-123"}},
+			want:      true,
+		},
+		{
+			name:      "Null on a scoping key is NOT scoped",
+			condition: map[string]any{"Null": map[string]any{"aws:PrincipalOrgID": "true"}},
+			want:      true,
+		},
+		{
+			name:      "kms:CallerAccount is scoped",
+			condition: map[string]any{"StringEquals": map[string]any{"kms:CallerAccount": "111111111111"}},
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt := &mqlAwsIamPolicyStatement{
+				Effect:     setString("Allow"),
+				Principals: setMap(wildcard),
+				Conditions: setDict(any(tt.condition)),
+			}
+			got, err := statementsAllowPublic([]any{stmt})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/providers/aws/resources/aws_iam_test.go
+++ b/providers/aws/resources/aws_iam_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+// TestIamPolicyCacheKeysAreDistinct is the regression test for the deleted
+// mqlAwsIamPolicy.id(). CreateResource keys the runtime cache on
+// name + "\x00" + MqlID() and returns the *cached* instance on a hit, so a
+// resource with no id() and no explicit __id gave every IAM policy in a scan
+// the empty key -- and every one after the first resolved to the first one's
+// data. A wildcard-Allow check then inspected a single arbitrary policy.
+//
+// This goes through CreateResource rather than asserting the id() formula
+// directly: the previous SageMaker tests asserted the formula and passed while
+// production ids were all empty.
+func TestIamPolicyCacheKeysAreDistinct(t *testing.T) {
+	runtime := testRuntime()
+
+	first, err := CreateResource(runtime, "aws.iam.policy", map[string]*llx.RawData{
+		"arn": llx.StringData("arn:aws:iam::111111111111:policy/first"),
+	})
+	require.NoError(t, err)
+
+	second, err := CreateResource(runtime, "aws.iam.policy", map[string]*llx.RawData{
+		"arn": llx.StringData("arn:aws:iam::111111111111:policy/second"),
+	})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, first.MqlID(), "policy must have a non-empty cache key")
+	assert.NotEqual(t, first.MqlID(), second.MqlID(), "two policies must not share a cache key")
+
+	// The second call must return the second policy, not the cached first one.
+	require.NotSame(t, first, second)
+	assert.Equal(t, "arn:aws:iam::111111111111:policy/second",
+		second.(*mqlAwsIamPolicy).Arn.Data)
+}
+
+// TestIamLoginProfileCacheKeysAreDistinct covers the login profile, whose id
+// method was named `init` -- a name the code generator never registers -- so
+// __id stayed empty and every user reported the first user's console-password
+// profile. Keying on the creation timestamp would also collide for users
+// created within the same second.
+func TestIamLoginProfileCacheKeysAreDistinct(t *testing.T) {
+	runtime := testRuntime()
+
+	alice, err := CreateResource(runtime, "aws.iam.loginProfile", map[string]*llx.RawData{
+		"__id":                  llx.StringData("arn:aws:iam::111111111111:user/alice/loginProfile"),
+		"passwordResetRequired": llx.BoolData(true),
+	})
+	require.NoError(t, err)
+
+	bob, err := CreateResource(runtime, "aws.iam.loginProfile", map[string]*llx.RawData{
+		"__id":                  llx.StringData("arn:aws:iam::111111111111:user/bob/loginProfile"),
+		"passwordResetRequired": llx.BoolData(false),
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, alice.MqlID(), bob.MqlID())
+	assert.True(t, alice.(*mqlAwsIamLoginProfile).PasswordResetRequired.Data)
+	assert.False(t, bob.(*mqlAwsIamLoginProfile).PasswordResetRequired.Data)
+}

--- a/providers/aws/resources/aws_identitycenter.go
+++ b/providers/aws/resources/aws_identitycenter.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
@@ -143,7 +144,7 @@ func (a *mqlAwsIdentitycenterInstance) permissionSets() ([]any, error) {
 
 type mqlAwsIdentitycenterPermissionSetInternal struct {
 	cacheInstanceArn string
-	fetched          bool
+	fetched          atomic.Bool
 	lock             sync.Mutex
 	descResp         *ssoadmin.DescribePermissionSetOutput
 }
@@ -153,12 +154,12 @@ func (a *mqlAwsIdentitycenterPermissionSet) id() (string, error) {
 }
 
 func (a *mqlAwsIdentitycenterPermissionSet) fetchDetail() (*ssoadmin.DescribePermissionSetOutput, error) {
-	if a.fetched {
+	if a.fetched.Load() {
 		return a.descResp, nil
 	}
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	if a.fetched {
+	if a.fetched.Load() {
 		return a.descResp, nil
 	}
 
@@ -175,8 +176,11 @@ func (a *mqlAwsIdentitycenterPermissionSet) fetchDetail() (*ssoadmin.DescribePer
 	if err != nil {
 		return nil, err
 	}
-	a.fetched = true
+	// Publish the value before the flag: a reader on the lock-free fast path
+	// that observes fetched==true must never see a nil descResp, or the
+	// accessors below nil-deref and kill the scan.
 	a.descResp = resp
+	a.fetched.Store(true)
 	return resp, nil
 }
 
@@ -184,6 +188,9 @@ func (a *mqlAwsIdentitycenterPermissionSet) name() (string, error) {
 	resp, err := a.fetchDetail()
 	if err != nil {
 		return "", err
+	}
+	if resp == nil || resp.PermissionSet == nil {
+		return "", nil
 	}
 	return convert.ToValue(resp.PermissionSet.Name), nil
 }
@@ -193,6 +200,9 @@ func (a *mqlAwsIdentitycenterPermissionSet) description() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp == nil || resp.PermissionSet == nil {
+		return "", nil
+	}
 	return convert.ToValue(resp.PermissionSet.Description), nil
 }
 
@@ -200,6 +210,9 @@ func (a *mqlAwsIdentitycenterPermissionSet) sessionDuration() (string, error) {
 	resp, err := a.fetchDetail()
 	if err != nil {
 		return "", err
+	}
+	if resp == nil || resp.PermissionSet == nil {
+		return "", nil
 	}
 	return convert.ToValue(resp.PermissionSet.SessionDuration), nil
 }
@@ -209,6 +222,9 @@ func (a *mqlAwsIdentitycenterPermissionSet) relayState() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if resp == nil || resp.PermissionSet == nil {
+		return "", nil
+	}
 	return convert.ToValue(resp.PermissionSet.RelayState), nil
 }
 
@@ -216,6 +232,9 @@ func (a *mqlAwsIdentitycenterPermissionSet) createdAt() (*time.Time, error) {
 	resp, err := a.fetchDetail()
 	if err != nil {
 		return nil, err
+	}
+	if resp == nil || resp.PermissionSet == nil {
+		return nil, nil
 	}
 	return resp.PermissionSet.CreatedDate, nil
 }

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -22,7 +22,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
-	"go.mondoo.com/mql/v13/providers/aws/resources/awspolicy"
 	"go.mondoo.com/mql/v13/types"
 	"golang.org/x/sync/errgroup"
 )
@@ -673,13 +672,18 @@ func (a *mqlAwsLambdaFunction) policy() (any, error) {
 		}
 		return nil, err
 	}
-	if functionPolicy != nil {
-		var policy lambdaPolicyDocument
-		err = json.Unmarshal([]byte(*functionPolicy.Policy), &policy)
-		if err != nil {
+	if functionPolicy != nil && functionPolicy.Policy != nil {
+		// Unmarshal into a plain any, matching SNS/SQS/ECR. Decoding into a
+		// hand-written struct dropped Condition, NotPrincipal, NotAction and
+		// NotResource, so isPublic/allowsPublicAccess could never see a scoping
+		// condition -- an org-scoped Function URL read as fully public. The
+		// struct also typed Action as a string, so any array-valued Action
+		// failed to unmarshal and errored the whole field.
+		var policyDoc any
+		if err := json.Unmarshal([]byte(*functionPolicy.Policy), &policyDoc); err != nil {
 			return nil, err
 		}
-		return convert.JsonToDict(policy)
+		return policyDoc, nil
 	}
 
 	return nil, nil
@@ -726,7 +730,15 @@ func hasSourceScopingCondition(conditions any) bool {
 	if !ok {
 		return false
 	}
-	for _, opVal := range m {
+	for op, opVal := range m {
+		// The operator decides whether a condition narrows or widens the grant.
+		// StringNotEquals on aws:PrincipalOrgID means "allow everyone OUTSIDE my
+		// org" and Null means "allow principals for which the key is absent" --
+		// both strictly worse than an unconditional public grant, yet the
+		// operator-blind version read them as "scoped" and reported not-public.
+		if !isRestrictingConditionOperator(op) {
+			continue
+		}
 		keys, ok := opVal.(map[string]any)
 		if !ok {
 			continue
@@ -740,13 +752,38 @@ func hasSourceScopingCondition(conditions any) bool {
 	return false
 }
 
+// isRestrictingConditionOperator reports whether an IAM condition operator
+// narrows a grant. Negated forms (StringNotEquals, ArnNotLike, ...) and Null
+// widen it, so a scoping key under one of those must not count as scoped.
+// The ForAllValues:/ForAnyValue: set qualifiers and the IfExists suffix are
+// stripped first; IfExists still restricts when the key is present.
+func isRestrictingConditionOperator(op string) bool {
+	o := strings.ToLower(op)
+	o = strings.TrimPrefix(o, "forallvalues:")
+	o = strings.TrimPrefix(o, "foranyvalue:")
+	o = strings.TrimSuffix(o, "ifexists")
+	switch o {
+	case "stringequals", "stringlike", "stringequalsignorecase",
+		"arnequals", "arnlike":
+		return true
+	}
+	return false
+}
+
 // isSourceScopingKey reports whether a condition key pins a wildcard principal
 // to a specific caller. aws:SourceOwner is the account-ID form SNS uses, and is
 // what the AWS-generated default topic policy carries; it scopes a grant
 // exactly as aws:SourceAccount does.
 func isSourceScopingKey(key string) bool {
 	switch strings.ToLower(key) {
-	case "aws:sourcearn", "aws:sourceaccount", "aws:sourceowner", "aws:principalorgid":
+	case "aws:sourcearn", "aws:sourceaccount", "aws:sourceowner", "aws:principalorgid",
+		// Additional keys that genuinely confine a wildcard principal. Without
+		// these, AWS's own service-linked KMS grants (kms:CallerAccount +
+		// kms:ViaService) and VPC-endpoint-restricted buckets reported public.
+		"aws:principalorgpaths", "aws:principalaccount", "aws:principalarn",
+		"aws:sourceorgid", "aws:sourceorgpaths", "aws:resourceorgid",
+		"aws:sourcevpc", "aws:sourcevpce",
+		"kms:calleraccount":
 		return true
 	}
 	return false
@@ -1402,19 +1439,6 @@ func (a *mqlAwsLambdaFunction) runtimeManagementConfig() (any, error) {
 }
 
 // ==================== Types ====================
-
-type lambdaPolicyDocument struct {
-	Version   string                  `json:"Version,omitempty"`
-	Statement []lambdaPolicyStatement `json:"Statement,omitempty"`
-}
-
-type lambdaPolicyStatement struct {
-	Sid       string              `json:"Sid,omitempty"`
-	Effect    string              `json:"Effect,omitempty"`
-	Action    string              `json:"Action,omitempty"`
-	Resource  string              `json:"Resource,omitempty"`
-	Principal awspolicy.Principal `json:"Principal,omitempty"`
-}
 
 // ==================== Per-Function Versions ====================
 

--- a/providers/aws/resources/aws_rds.go
+++ b/providers/aws/resources/aws_rds.go
@@ -441,7 +441,7 @@ func (a mqlAwsRdsClusterParameterGroup) parameters() ([]any, error) {
 			return nil, err
 		}
 		for _, parameter := range parameters.Parameters {
-			mqlParameter, err := newMqlAwsRdsParameterGroupParameter(a.MqlRuntime, parameter)
+			mqlParameter, err := newMqlAwsRdsParameterGroupParameter(a.MqlRuntime, a.Arn.Data, parameter)
 			if err != nil {
 				return nil, err
 			}
@@ -467,7 +467,7 @@ func (a *mqlAwsRdsParameterGroup) parameters() ([]any, error) {
 			return nil, err
 		}
 		for _, parameter := range parameters.Parameters {
-			mqlParameter, err := newMqlAwsRdsParameterGroupParameter(a.MqlRuntime, parameter)
+			mqlParameter, err := newMqlAwsRdsParameterGroupParameter(a.MqlRuntime, a.Arn.Data, parameter)
 			if err != nil {
 				return nil, err
 			}
@@ -477,7 +477,11 @@ func (a *mqlAwsRdsParameterGroup) parameters() ([]any, error) {
 	return res, nil
 }
 
-func newMqlAwsRdsParameterGroupParameter(runtime *plugin.Runtime, parameter rds_types.Parameter) (*mqlAwsRdsParameterGroupParameter, error) {
+// newMqlAwsRdsParameterGroupParameter builds a single parameter row. groupArn
+// qualifies the cache key: parameter names are unique only within one parameter
+// group, so keying on the bare name collapses every group in the account onto
+// whichever group resolved first.
+func newMqlAwsRdsParameterGroupParameter(runtime *plugin.Runtime, groupArn string, parameter rds_types.Parameter) (*mqlAwsRdsParameterGroupParameter, error) {
 	engineModes := []any{}
 	for _, engineMode := range parameter.SupportedEngineModes {
 		engineModes = append(engineModes, engineMode)
@@ -485,7 +489,7 @@ func newMqlAwsRdsParameterGroupParameter(runtime *plugin.Runtime, parameter rds_
 
 	resource, err := CreateResource(runtime, ResourceAwsRdsParameterGroupParameter,
 		map[string]*llx.RawData{
-			"__id":                 llx.StringDataPtr(parameter.ParameterName),
+			"__id":                 llx.StringData(groupArn + "/parameter/" + convert.ToValue(parameter.ParameterName)),
 			"name":                 llx.StringDataPtr(parameter.ParameterName),
 			"value":                llx.StringDataPtr(parameter.ParameterValue),
 			"allowedValues":        llx.StringDataPtr(parameter.AllowedValues),
@@ -1458,8 +1462,11 @@ func (a *mqlAwsRdsSnapshot) kmsKey() (*mqlAwsKmsKey, error) {
 	return mqlKey.(*mqlAwsKmsKey), nil
 }
 
+// id returns the parent-qualified cache key set at construction. It must not
+// fall back to `target`, which is the backup *location* ("region" for almost
+// every instance) and therefore identical across the whole account.
 func (a *mqlAwsRdsBackupsetting) id() (string, error) {
-	return a.Target.Data, nil
+	return a.__id, nil
 }
 
 type mqlAwsRdsBackupsettingInternal struct {
@@ -1511,6 +1518,7 @@ func (a *mqlAwsRdsDbinstance) backupSettings() ([]any, error) {
 			}
 			mqlRdsBackup, err := CreateResource(a.MqlRuntime, ResourceAwsRdsBackupsetting,
 				map[string]*llx.RawData{
+					"__id":                     llx.StringData(a.Arn.Data + "/backupsetting/" + convert.ToValue(backup.DbiResourceId)),
 					"target":                   llx.StringDataPtr(backup.BackupTarget),
 					"retentionPeriod":          llx.IntDataPtr(backup.BackupRetentionPeriod),
 					"dedicatedLogVolume":       llx.BoolDataPtr(backup.DedicatedLogVolume),
@@ -1562,6 +1570,7 @@ func (a *mqlAwsRdsDbcluster) backupSettings() ([]any, error) {
 			}
 			mqlRdsBackup, err := CreateResource(a.MqlRuntime, ResourceAwsRdsBackupsetting,
 				map[string]*llx.RawData{
+					"__id":                     llx.StringData(a.Arn.Data + "/backupsetting/" + convert.ToValue(backup.DbClusterResourceId)),
 					"target":                   llx.StringDataPtr(backup.DBClusterIdentifier),
 					"retentionPeriod":          llx.IntDataPtr(backup.BackupRetentionPeriod),
 					"dedicatedLogVolume":       llx.NilData,
@@ -1595,11 +1604,17 @@ func (a *mqlAwsRdsSnapshot) attributes() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		if snapshotAttributes == nil || snapshotAttributes.DBClusterSnapshotAttributesResult == nil {
+			return []any{}, nil
+		}
 		return convert.JsonToDictSlice(snapshotAttributes.DBClusterSnapshotAttributesResult.DBClusterSnapshotAttributes)
 	}
 	snapshotAttributes, err := svc.DescribeDBSnapshotAttributes(ctx, &rds.DescribeDBSnapshotAttributesInput{DBSnapshotIdentifier: &snapshotId})
 	if err != nil {
 		return nil, err
+	}
+	if snapshotAttributes == nil || snapshotAttributes.DBSnapshotAttributesResult == nil {
+		return []any{}, nil
 	}
 	return convert.JsonToDictSlice(snapshotAttributes.DBSnapshotAttributesResult.DBSnapshotAttributes)
 }

--- a/providers/aws/resources/aws_s3.go
+++ b/providers/aws/resources/aws_s3.go
@@ -803,93 +803,138 @@ const (
 	s3AllUsersGroup           = "http://acs.amazonaws.com/groups/global/AllUsers"
 )
 
+// s3BucketIsPublic applies AWS's actual Block Public Access semantics to a
+// policy signal and an ACL signal.
+//
+// BlockPublicAcls and BlockPublicPolicy only reject *new* public ACLs and
+// policies; AWS documents that enabling them does not affect grants that
+// already exist. Only IgnorePublicAcls neutralizes an existing public ACL, and
+// only RestrictPublicBuckets neutralizes an existing public policy. Treating
+// any of the four as "not public" reported a world-readable bucket as private
+// whenever, say, BlockPublicAcls was on and a `Principal: "*"` policy was
+// attached -- the standard static-site/CDN configuration.
+func s3BucketIsPublic(pab *s3types.PublicAccessBlockConfiguration, policyIsPublic, aclIsPublic bool) bool {
+	ignorePublicAcls := pab != nil && pab.IgnorePublicAcls != nil && *pab.IgnorePublicAcls
+	restrictPublicBuckets := pab != nil && pab.RestrictPublicBuckets != nil && *pab.RestrictPublicBuckets
+
+	if policyIsPublic && !restrictPublicBuckets {
+		return true
+	}
+	if aclIsPublic && !ignorePublicAcls {
+		return true
+	}
+	return false
+}
+
+// s3PolicyGrantsPublicAccess reports whether any Allow statement names the
+// wildcard principal.
+func s3PolicyGrantsPublicAccess(policy *awspolicy.S3BucketPolicy) bool {
+	if policy == nil {
+		return false
+	}
+	for _, statement := range policy.Statements {
+		if !strings.EqualFold(statement.Effect, "Allow") {
+			continue
+		}
+		if awsPrincipal, ok := statement.Principal["AWS"]; ok {
+			if slices.Contains(awsPrincipal, "*") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// s3GrantsArePublic reports whether any ACL grant targets the AllUsers or
+// AuthenticatedUsers group.
+func s3GrantsArePublic(grants []s3types.Grant) bool {
+	for i := range grants {
+		grant := grants[i]
+		if grant.Grantee == nil {
+			continue
+		}
+		if grant.Grantee.Type == s3types.TypeGroup &&
+			(convert.ToValue(grant.Grantee.URI) == s3AuthenticatedUsersGroup ||
+				convert.ToValue(grant.Grantee.URI) == s3AllUsersGroup) {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *mqlAwsS3Bucket) public() (bool, error) {
+	// markUnknown reports null rather than a confident `false` when neither the
+	// policy nor the ACL could be read. `false` here is indistinguishable from
+	// "verified not public", which is the dangerous direction for an exposure
+	// check on an under-scoped token.
+	markUnknown := func() (bool, error) {
+		a.Public.State = plugin.StateIsSet | plugin.StateIsNull
+		return false, nil
+	}
+
 	region, ok, err := a.bucketRegion()
-	if err != nil || !ok {
+	if err != nil {
 		return false, err
+	}
+	if !ok {
+		return markUnknown()
 	}
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 	bucketname := a.Name.Data
 	svc := conn.S3(region)
 	ctx := context.Background()
 
-	// Check Public Access Block settings first (reuses cached result)
 	accessBlock, err := a.fetchPublicAccessBlock()
 	if err != nil {
 		return false, err
 	}
 
-	notPublic := false
-	if accessBlock != nil {
-		if accessBlock.BlockPublicAcls != nil && *accessBlock.BlockPublicAcls {
-			notPublic = true
-		}
-		if accessBlock.BlockPublicPolicy != nil && *accessBlock.BlockPublicPolicy {
-			notPublic = true
-		}
-		if accessBlock.IgnorePublicAcls != nil && *accessBlock.IgnorePublicAcls {
-			notPublic = true
-		}
-		if accessBlock.RestrictPublicBuckets != nil && *accessBlock.RestrictPublicBuckets {
-			notPublic = true
-		}
-	}
-	if notPublic {
-		return false, nil // Public access is restricted
-	}
+	policyIsPublic := false
+	policyKnown := false
 
-	// Then, use GetBucketPolicyStatus to determine public access
+	// GetBucketPolicyStatus is AWS's own verdict on the policy. A `false` here
+	// is a real answer about the *policy*, but it says nothing about the ACL --
+	// so it must not short-circuit the ACL check below.
 	statusOutput, err := svc.GetBucketPolicyStatus(ctx, &s3.GetBucketPolicyStatusInput{
 		Bucket: &bucketname,
 	})
 	if err != nil && !isS3BucketInaccessible(err) {
 		return false, err
 	}
-	if statusOutput != nil &&
-		statusOutput.PolicyStatus != nil &&
-		statusOutput.PolicyStatus.IsPublic != nil {
-		return *statusOutput.PolicyStatus.IsPublic, nil
+	if statusOutput != nil && statusOutput.PolicyStatus != nil && statusOutput.PolicyStatus.IsPublic != nil {
+		policyIsPublic = *statusOutput.PolicyStatus.IsPublic
+		policyKnown = true
 	}
 
-	// If that didn't work, fetch the bucket policy manually and parse it
-	bucketPolicyResource := a.GetPolicy()
-	if bucketPolicyResource.State == plugin.StateIsSet && bucketPolicyResource.Data != nil {
-		bucketPolicy, err := bucketPolicyResource.Data.parsePolicyDocument()
-		if err != nil {
-			return false, err
-		}
-
-		for _, statement := range bucketPolicy.Statements {
-			if statement.Effect != "Allow" {
-				continue
+	// Fall back to parsing the policy ourselves when the status call was denied.
+	if !policyKnown {
+		bucketPolicyResource := a.GetPolicy()
+		if bucketPolicyResource.State == plugin.StateIsSet && bucketPolicyResource.Data != nil {
+			bucketPolicy, err := bucketPolicyResource.Data.parsePolicyDocument()
+			if err != nil {
+				return false, err
 			}
-			if awsPrincipal, ok := statement.Principal["AWS"]; ok {
-				if slices.Contains(awsPrincipal, "*") {
-					return true, nil
-				}
-			}
+			policyIsPublic = s3PolicyGrantsPublicAccess(bucketPolicy)
+			policyKnown = true
 		}
 	}
 
-	// Finally check for bucket ACLs
+	aclIsPublic := false
+	aclKnown := false
 	acl, err := a.gatherAcl()
 	if err != nil {
 		return false, err
 	}
-	if acl == nil {
-		return false, nil
+	if acl != nil {
+		aclIsPublic = s3GrantsArePublic(acl.Grants)
+		aclKnown = true
 	}
 
-	for i := range acl.Grants {
-		grant := acl.Grants[i]
-		if grant.Grantee == nil {
-			continue
-		}
-		if grant.Grantee.Type == s3types.TypeGroup && (convert.ToValue(grant.Grantee.URI) == s3AuthenticatedUsersGroup || convert.ToValue(grant.Grantee.URI) == s3AllUsersGroup) {
-			return true, nil
-		}
+	if !policyKnown && !aclKnown {
+		return markUnknown()
 	}
-	return false, nil
+
+	return s3BucketIsPublic(accessBlock, policyIsPublic, aclIsPublic), nil
 }
 
 func (a *mqlAwsS3Bucket) cors() ([]any, error) {
@@ -917,6 +962,7 @@ func (a *mqlAwsS3Bucket) cors() ([]any, error) {
 		corsrule := cors.CORSRules[i]
 		mqlBucketCors, err := CreateResource(a.MqlRuntime, "aws.s3.bucket.corsrule",
 			map[string]*llx.RawData{
+				"__id":           llx.StringData(fmt.Sprintf("%s/cors/%d", a.Arn.Data, i)),
 				"name":           llx.StringData(bucketname),
 				"allowedHeaders": llx.ArrayData(toInterfaceArr(corsrule.AllowedHeaders), types.String),
 				"allowedMethods": llx.ArrayData(toInterfaceArr(corsrule.AllowedMethods), types.String),
@@ -1459,6 +1505,7 @@ func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) 
 	}
 
 	args := map[string]*llx.RawData{
+		"__id":                  llx.StringData(a.Arn.Data + "/website"),
 		"errorDocument":         llx.NilData,
 		"indexDocument":         llx.NilData,
 		"redirectAllRequestsTo": llx.NilData,
@@ -1471,6 +1518,7 @@ func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) 
 	}
 	if website.RedirectAllRequestsTo != nil {
 		res, err := CreateResource(a.MqlRuntime, ResourceAwsS3BucketWebsiteConfigurationRedirectAllRequestsToConf, map[string]*llx.RawData{
+			"__id":     llx.StringData(a.Arn.Data + "/website/redirectAllRequestsTo"),
 			"hostname": llx.StringData(convert.ToValue(website.RedirectAllRequestsTo.HostName)),
 			"protocol": llx.StringData(string(website.RedirectAllRequestsTo.Protocol)),
 		})
@@ -1481,10 +1529,12 @@ func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) 
 	}
 
 	routingRules := []any{}
-	for _, rule := range website.RoutingRules {
-		args := map[string]*llx.RawData{}
+	for i, rule := range website.RoutingRules {
+		ruleID := fmt.Sprintf("%s/website/routingRule/%d", a.Arn.Data, i)
+		args := map[string]*llx.RawData{"__id": llx.StringData(ruleID)}
 		if rule.Redirect != nil {
 			redirectRes, err := CreateResource(a.MqlRuntime, ResourceAwsS3BucketWebsiteConfigurationRoutingRuleRedirectConf, map[string]*llx.RawData{
+				"__id":                 llx.StringData(ruleID + "/redirect"),
 				"hostname":             llx.StringData(convert.ToValue(rule.Redirect.HostName)),
 				"httpRedirectCode":     llx.StringData(convert.ToValue(rule.Redirect.HttpRedirectCode)),
 				"protocol":             llx.StringData(string(rule.Redirect.Protocol)),
@@ -1499,6 +1549,7 @@ func (a *mqlAwsS3Bucket) website() (*mqlAwsS3BucketWebsiteConfiguration, error) 
 
 		if rule.Condition != nil {
 			condition, err := CreateResource(a.MqlRuntime, ResourceAwsS3BucketWebsiteConfigurationRoutingRuleConditionConf, map[string]*llx.RawData{
+				"__id":                        llx.StringData(ruleID + "/condition"),
 				"httpErrorCodeReturnedEquals": llx.StringData(convert.ToValue(rule.Condition.HttpErrorCodeReturnedEquals)),
 				"keyPrefixEquals":             llx.StringData(convert.ToValue(rule.Condition.KeyPrefixEquals)),
 			})
@@ -1529,8 +1580,11 @@ func (a *mqlAwsS3BucketGrant) id() (string, error) {
 	return a.Id.Data, nil
 }
 
+// id returns the bucket-and-index qualified cache key set at construction.
+// `name` is the bucket name, which every CORS rule on a bucket shares, so it
+// cannot be the key on its own.
 func (a *mqlAwsS3BucketCorsrule) id() (string, error) {
-	return "s3.bucket.corsrule " + a.Name.Data, nil
+	return a.__id, nil
 }
 
 func (a *mqlAwsS3BucketPolicy) id() (string, error) {

--- a/providers/aws/resources/aws_s3_test.go
+++ b/providers/aws/resources/aws_s3_test.go
@@ -4,15 +4,19 @@
 package resources
 
 import (
+	"encoding/json"
 	"errors"
 	nethttp "net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/aws/resources/awspolicy"
 )
 
 func TestS3BucketArnValidation(t *testing.T) {
@@ -71,4 +75,87 @@ func TestIsS3BucketInaccessible(t *testing.T) {
 			assert.Equal(t, tt.want, isS3BucketInaccessible(tt.err))
 		})
 	}
+}
+
+// pabConfig builds a Block Public Access configuration with all four flags set.
+func pabConfig(blockAcls, blockPolicy, ignoreAcls, restrictBuckets bool) *s3types.PublicAccessBlockConfiguration {
+	return &s3types.PublicAccessBlockConfiguration{
+		BlockPublicAcls:       aws.Bool(blockAcls),
+		BlockPublicPolicy:     aws.Bool(blockPolicy),
+		IgnorePublicAcls:      aws.Bool(ignoreAcls),
+		RestrictPublicBuckets: aws.Bool(restrictBuckets),
+	}
+}
+
+// TestS3BucketIsPublic pins AWS's actual Block Public Access semantics.
+// BlockPublicAcls and BlockPublicPolicy only reject *new* public grants, so
+// they must not suppress one that already exists; only IgnorePublicAcls and
+// RestrictPublicBuckets neutralize existing ACL and policy grants respectively.
+// Treating any of the four as "not public" reported the standard
+// static-site/CDN bucket (blockPublicAcls on, `Principal: "*"` policy) private.
+func TestS3BucketIsPublic(t *testing.T) {
+	tests := []struct {
+		name           string
+		pab            *s3types.PublicAccessBlockConfiguration
+		policyIsPublic bool
+		aclIsPublic    bool
+		want           bool
+	}{
+		{"no pab, nothing public", nil, false, false, false},
+		{"no pab, public policy", nil, true, false, true},
+		{"no pab, public acl", nil, false, true, true},
+
+		{"blockPublicAcls on, public policy still public", pabConfig(true, false, false, false), true, false, true},
+		{"blockPublicPolicy on, public policy still public", pabConfig(false, true, false, false), true, false, true},
+		{"blockPublicAcls+ignorePublicAcls on, public policy still public", pabConfig(true, false, true, false), true, false, true},
+		{"blockPublicAcls on, public acl still public", pabConfig(true, false, false, false), false, true, true},
+
+		{"restrictPublicBuckets suppresses a public policy", pabConfig(false, false, false, true), true, false, false},
+		{"ignorePublicAcls suppresses a public acl", pabConfig(false, false, true, false), false, true, false},
+
+		{"restrictPublicBuckets does not suppress a public acl", pabConfig(false, false, false, true), false, true, true},
+		{"ignorePublicAcls does not suppress a public policy", pabConfig(false, false, true, false), true, false, true},
+
+		{"all four on", pabConfig(true, true, true, true), true, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, s3BucketIsPublic(tt.pab, tt.policyIsPublic, tt.aclIsPublic))
+		})
+	}
+}
+
+func TestS3GrantsArePublic(t *testing.T) {
+	group := func(uri string) s3types.Grant {
+		return s3types.Grant{Grantee: &s3types.Grantee{Type: s3types.TypeGroup, URI: aws.String(uri)}}
+	}
+	assert.False(t, s3GrantsArePublic(nil))
+	assert.False(t, s3GrantsArePublic([]s3types.Grant{{Grantee: nil}}))
+	assert.False(t, s3GrantsArePublic([]s3types.Grant{group("http://acs.amazonaws.com/groups/s3/LogDelivery")}))
+	assert.True(t, s3GrantsArePublic([]s3types.Grant{group(s3AllUsersGroup)}))
+	assert.True(t, s3GrantsArePublic([]s3types.Grant{group(s3AuthenticatedUsersGroup)}))
+	assert.False(t, s3GrantsArePublic([]s3types.Grant{
+		{Grantee: &s3types.Grantee{Type: s3types.TypeCanonicalUser, ID: aws.String("abc")}},
+	}))
+}
+
+func TestS3PolicyGrantsPublicAccess(t *testing.T) {
+	parse := func(t *testing.T, doc string) *awspolicy.S3BucketPolicy {
+		t.Helper()
+		var p awspolicy.S3BucketPolicy
+		require.NoError(t, json.Unmarshal([]byte(doc), &p))
+		return &p
+	}
+
+	assert.False(t, s3PolicyGrantsPublicAccess(nil))
+
+	assert.True(t, s3PolicyGrantsPublicAccess(parse(t, `{"Version":"2012-10-17","Statement":[
+		{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`)))
+
+	assert.False(t, s3PolicyGrantsPublicAccess(parse(t, `{"Version":"2012-10-17","Statement":[
+		{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::111111111111:root"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}]}`)))
+
+	// a wildcard principal under Deny is not a public grant
+	assert.False(t, s3PolicyGrantsPublicAccess(parse(t, `{"Version":"2012-10-17","Statement":[
+		{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"s3:*","Resource":"arn:aws:s3:::b/*"}]}`)))
 }

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -544,6 +544,7 @@ func (a *mqlAwsSagemakerEndpoint) dataCaptureConfig() (*mqlAwsSagemakerEndpointD
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, "aws.sagemaker.endpoint.dataCaptureConfig",
 		map[string]*llx.RawData{
+			"__id":                      llx.StringData(a.Arn.Data + "/dataCaptureConfig"),
 			"enableCapture":             llx.BoolDataPtr(dcc.EnableCapture),
 			"captureStatus":             llx.StringData(string(dcc.CaptureStatus)),
 			"currentSamplingPercentage": llx.IntData(samplingPct),
@@ -717,6 +718,7 @@ func sagemakerBuildProductionVariants(runtime *plugin.Runtime, parentId string, 
 
 		mqlPV, err := CreateResource(runtime, "aws.sagemaker.endpoint.productionVariant",
 			map[string]*llx.RawData{
+				"__id":                 llx.StringData(parentId + "/" + convert.ToValue(v.VariantName)),
 				"variantName":          llx.StringDataPtr(v.VariantName),
 				"currentInstanceCount": llx.IntData(currentCount),
 				"desiredInstanceCount": llx.IntData(desiredCount),
@@ -740,6 +742,7 @@ func sagemakerBuildProductionVariants(runtime *plugin.Runtime, parentId string, 
 		for _, vs := range v.VariantStatus {
 			mqlVS, err := CreateResource(runtime, "aws.sagemaker.endpoint.productionVariant.status",
 				map[string]*llx.RawData{
+					"__id":          llx.StringData(variantId + "/status/" + string(vs.Status)),
 					"status":        llx.StringData(string(vs.Status)),
 					"statusMessage": llx.StringDataPtr(vs.StatusMessage),
 					"startTime":     llx.TimeDataPtr(vs.StartTime),
@@ -1329,9 +1332,10 @@ func (a *mqlAwsSagemakerTrainingjob) secondaryStatusTransitions() ([]any, error)
 		return nil, err
 	}
 	res := make([]any, 0, len(a.cacheSecondaryStatusTransitions))
-	for _, t := range a.cacheSecondaryStatusTransitions {
+	for i, t := range a.cacheSecondaryStatusTransitions {
 		mqlT, err := CreateResource(a.MqlRuntime, "aws.sagemaker.trainingjob.statusTransition",
 			map[string]*llx.RawData{
+				"__id":          llx.StringData(fmt.Sprintf("%s/statusTransition/%d/%s", a.Arn.Data, i, string(t.Status))),
 				"status":        llx.StringData(string(t.Status)),
 				"startTime":     llx.TimeDataPtr(t.StartTime),
 				"endTime":       llx.TimeDataPtr(t.EndTime),
@@ -1352,13 +1356,14 @@ func (a *mqlAwsSagemakerTrainingjob) finalMetrics() ([]any, error) {
 		return nil, err
 	}
 	res := make([]any, 0, len(a.cacheFinalMetrics))
-	for _, m := range a.cacheFinalMetrics {
+	for i, m := range a.cacheFinalMetrics {
 		var value float64
 		if m.Value != nil {
 			value = float64(*m.Value)
 		}
 		mqlM, err := CreateResource(a.MqlRuntime, "aws.sagemaker.trainingjob.metricData",
 			map[string]*llx.RawData{
+				"__id":       llx.StringData(fmt.Sprintf("%s/metric/%d/%s", a.Arn.Data, i, convert.ToValue(m.MetricName))),
 				"metricName": llx.StringDataPtr(m.MetricName),
 				"value":      llx.FloatData(value),
 				"timestamp":  llx.TimeDataPtr(m.Timestamp),
@@ -2816,6 +2821,7 @@ func (a *mqlAwsSagemakerCluster) instanceGroups() ([]any, error) {
 			}
 			mqlITD, err := CreateResource(a.MqlRuntime, "aws.sagemaker.clusterInstanceGroup.instanceTypeDetail",
 				map[string]*llx.RawData{
+					"__id":           llx.StringData(a.Region.Data + "/" + a.Name.Data + "/" + igName + "/instanceTypeDetail/" + string(itd.InstanceType)),
 					"instanceType":   llx.StringData(string(itd.InstanceType)),
 					"currentCount":   llx.IntData(itdCurrentCount),
 					"threadsPerCore": llx.IntData(itdThreadsPerCore),
@@ -2833,6 +2839,7 @@ func (a *mqlAwsSagemakerCluster) instanceGroups() ([]any, error) {
 		}
 		mqlIG, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerClusterInstanceGroup,
 			map[string]*llx.RawData{
+				"__id":                 llx.StringData(a.Region.Data + "/" + a.Name.Data + "/" + convert.ToValue(ig.InstanceGroupName)),
 				"instanceGroupName":    llx.StringDataPtr(ig.InstanceGroupName),
 				"instanceType":         llx.StringData(string(ig.InstanceType)),
 				"region":               llx.StringData(a.Region.Data),
@@ -2929,6 +2936,7 @@ func (a *mqlAwsSagemakerCluster) nodes() ([]any, error) {
 
 			mqlNode, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerClusterNode,
 				map[string]*llx.RawData{
+					"__id":               llx.StringData(a.Region.Data + "/" + clusterName + "/" + convert.ToValue(node.InstanceGroupName) + "/" + convert.ToValue(node.InstanceId)),
 					"instanceId":         llx.StringDataPtr(node.InstanceId),
 					"instanceGroupName":  llx.StringDataPtr(node.InstanceGroupName),
 					"instanceType":       llx.StringData(string(node.InstanceType)),
@@ -3017,6 +3025,7 @@ func (a *mqlAwsSagemakerCluster) restrictedInstanceGroups() ([]any, error) {
 
 		mqlRIG, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerClusterRestrictedInstanceGroup,
 			map[string]*llx.RawData{
+				"__id":                              llx.StringData(a.Region.Data + "/" + a.Name.Data + "/" + convert.ToValue(rig.InstanceGroupName)),
 				"instanceGroupName":                 llx.StringDataPtr(rig.InstanceGroupName),
 				"instanceType":                      llx.StringData(string(rig.InstanceType)),
 				"region":                            llx.StringData(a.Region.Data),
@@ -3322,6 +3331,7 @@ func (a *mqlAwsSagemakerFeatureGroup) featureDefinitions() ([]any, error) {
 	for _, fd := range resp.FeatureDefinitions {
 		mqlFD, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerFeatureDefinition,
 			map[string]*llx.RawData{
+				"__id":           llx.StringData(a.Arn.Data + "/" + convert.ToValue(fd.FeatureName) + "/" + string(fd.FeatureType)),
 				"featureName":    llx.StringDataPtr(fd.FeatureName),
 				"featureType":    llx.StringData(string(fd.FeatureType)),
 				"collectionType": llx.StringData(string(fd.CollectionType)),

--- a/providers/aws/resources/aws_sagemaker_mlops.go
+++ b/providers/aws/resources/aws_sagemaker_mlops.go
@@ -249,6 +249,7 @@ func (a *mqlAwsSagemakerExperiment) source() (*mqlAwsSagemakerExperimentSource, 
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerExperimentSource,
 		map[string]*llx.RawData{
+			"__id":       llx.StringData(a.Arn.Data + "/source"),
 			"sourceArn":  llx.StringDataPtr(a.cacheSourceArn),
 			"sourceType": llx.StringData(a.cacheSourceType),
 		})
@@ -434,6 +435,7 @@ func (a *mqlAwsSagemakerTrial) source() (*mqlAwsSagemakerTrialSource, error) {
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTrialSource,
 		map[string]*llx.RawData{
+			"__id":       llx.StringData(a.Arn.Data + "/source"),
 			"sourceArn":  llx.StringDataPtr(a.cacheSourceArn),
 			"sourceType": llx.StringData(a.cacheSourceType),
 		})
@@ -662,6 +664,7 @@ func (a *mqlAwsSagemakerTrialComponent) fetchDetails() error {
 		}
 		mqlMetric, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTrialComponentMetricSummary,
 			map[string]*llx.RawData{
+				"__id":       llx.StringData(a.Arn.Data + "/metric/" + convert.ToValue(m.MetricName)),
 				"metricName": llx.StringDataPtr(m.MetricName),
 				"sourceArn":  llx.StringDataPtr(m.SourceArn),
 				"min":        llx.FloatData(minVal),
@@ -693,6 +696,7 @@ func (a *mqlAwsSagemakerTrialComponent) source() (*mqlAwsSagemakerTrialComponent
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTrialComponentSource,
 		map[string]*llx.RawData{
+			"__id":       llx.StringData(a.Arn.Data + "/source"),
 			"sourceArn":  llx.StringDataPtr(a.cacheSourceArn),
 			"sourceType": llx.StringData(a.cacheSourceType),
 		})
@@ -864,6 +868,7 @@ func (a *mqlAwsSagemakerProject) fetchDetails() error {
 		for _, p := range resp.ServiceCatalogProvisioningDetails.ProvisioningParameters {
 			mqlParam, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerProjectProvisioningParameter,
 				map[string]*llx.RawData{
+					"__id":  llx.StringData(a.Arn.Data + "/provisioningParam/" + convert.ToValue(p.Key)),
 					"key":   llx.StringDataPtr(p.Key),
 					"value": llx.StringDataPtr(p.Value),
 				})
@@ -894,6 +899,7 @@ func (a *mqlAwsSagemakerProject) serviceCatalogProvisioningDetails() (*mqlAwsSag
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerProjectProvisioningDetails,
 		map[string]*llx.RawData{
+			"__id":                   llx.StringData(a.Arn.Data + "/provisioningDetails"),
 			"productId":              llx.StringData(a.cacheProvisioningProductId),
 			"provisioningArtifactId": llx.StringData(a.cacheProvisioningArtifactId),
 			"pathId":                 llx.StringData(a.cacheProvisioningPathId),
@@ -917,6 +923,7 @@ func (a *mqlAwsSagemakerProject) serviceCatalogProvisionedProductDetails() (*mql
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerProjectProvisionedProductDetails,
 		map[string]*llx.RawData{
+			"__id":                            llx.StringData(a.Arn.Data + "/provisionedProductDetails"),
 			"provisionedProductId":            llx.StringData(a.cacheProvisionedProductId),
 			"provisionedProductStatusMessage": llx.StringData(a.cacheProvisionedProductStatusMessage),
 		})
@@ -1117,6 +1124,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) fetchDetails() error {
 			for _, r := range pr.ContinuousParameterRanges {
 				mqlRange, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobParameterRange,
 					map[string]*llx.RawData{
+						"__id":        llx.StringData(a.Arn.Data + "/parameterRange/" + convert.ToValue(r.Name)),
 						"name":        llx.StringDataPtr(r.Name),
 						"type":        llx.StringData("Continuous"),
 						"minValue":    llx.StringDataPtr(r.MinValue),
@@ -1134,6 +1142,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) fetchDetails() error {
 			for _, r := range pr.IntegerParameterRanges {
 				mqlRange, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobParameterRange,
 					map[string]*llx.RawData{
+						"__id":        llx.StringData(a.Arn.Data + "/parameterRange/" + convert.ToValue(r.Name)),
 						"name":        llx.StringDataPtr(r.Name),
 						"type":        llx.StringData("Integer"),
 						"minValue":    llx.StringDataPtr(r.MinValue),
@@ -1155,6 +1164,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) fetchDetails() error {
 				}
 				mqlRange, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobParameterRange,
 					map[string]*llx.RawData{
+						"__id":        llx.StringData(a.Arn.Data + "/parameterRange/" + convert.ToValue(r.Name)),
 						"name":        llx.StringDataPtr(r.Name),
 						"type":        llx.StringData("Categorical"),
 						"minValue":    llx.StringData(""),
@@ -1215,6 +1225,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) objectiveMetric() (*mqlAwsSagem
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobObjective,
 		map[string]*llx.RawData{
+			"__id":       llx.StringData(a.Arn.Data + "/objective"),
 			"type":       llx.StringData(a.cacheObjectiveType),
 			"metricName": llx.StringData(a.cacheObjectiveMetricName),
 		})
@@ -1232,6 +1243,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) resourceLimits() (*mqlAwsSagema
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobResourceLimits,
 		map[string]*llx.RawData{
+			"__id":                    llx.StringData(a.Arn.Data + "/resourceLimits"),
 			"maxNumberOfTrainingJobs": llx.IntData(a.cacheMaxTrainingJobs),
 			"maxParallelTrainingJobs": llx.IntData(a.cacheMaxParallelJobs),
 			"maxRuntimeInSeconds":     llx.IntData(a.cacheMaxRuntimeInSeconds),
@@ -1257,6 +1269,7 @@ func (a *mqlAwsSagemakerHyperParameterTuningJob) trainingJobStatusCounters() (*m
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerHyperParameterTuningJobStatusCounters,
 		map[string]*llx.RawData{
+			"__id":              llx.StringData(a.Arn.Data + "/statusCounters"),
 			"completed":         llx.IntData(a.cacheCompleted),
 			"inProgress":        llx.IntData(a.cacheInProgress),
 			"retryableError":    llx.IntData(a.cacheRetryableError),
@@ -1573,6 +1586,7 @@ func (a *mqlAwsSagemakerTransformJob) transformInput() (*mqlAwsSagemakerTransfor
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTransformJobInput,
 		map[string]*llx.RawData{
+			"__id":            llx.StringData(a.Arn.Data + "/transformInput"),
 			"s3Uri":           llx.StringData(a.cacheInputS3Uri),
 			"dataSource":      llx.StringData(a.cacheInputDataSource),
 			"contentType":     llx.StringData(a.cacheInputContentType),
@@ -1597,6 +1611,7 @@ func (a *mqlAwsSagemakerTransformJob) transformOutput() (*mqlAwsSagemakerTransfo
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTransformJobOutput,
 		map[string]*llx.RawData{
+			"__id":         llx.StringData(a.Arn.Data + "/transformOutput"),
 			"s3Uri":        llx.StringData(a.cacheOutputS3Uri),
 			"accept":       llx.StringData(a.cacheOutputAccept),
 			"assembleWith": llx.StringData(a.cacheOutputAssembleWith),
@@ -1620,6 +1635,7 @@ func (a *mqlAwsSagemakerTransformJob) transformResources() (*mqlAwsSagemakerTran
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerTransformJobResources,
 		map[string]*llx.RawData{
+			"__id":          llx.StringData(a.Arn.Data + "/transformResources"),
 			"instanceType":  llx.StringData(a.cacheResourceInstanceType),
 			"instanceCount": llx.IntData(a.cacheResourceInstanceCount),
 		})
@@ -1824,6 +1840,7 @@ func (a *mqlAwsSagemakerAutoMLJob) fetchDetails() error {
 		}
 		mqlCh, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerAutoMLJobInputChannel,
 			map[string]*llx.RawData{
+				"__id":                llx.StringData(a.Arn.Data + "/inputChannel/" + convert.ToValue(ch.TargetAttributeName)),
 				"targetAttributeName": llx.StringDataPtr(ch.TargetAttributeName),
 				"contentType":         llx.StringDataPtr(ch.ContentType),
 				"compressionType":     llx.StringData(string(ch.CompressionType)),
@@ -1879,6 +1896,7 @@ func (a *mqlAwsSagemakerAutoMLJob) outputDataConfig() (*mqlAwsSagemakerAutoMLJob
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerAutoMLJobOutputConfig,
 		map[string]*llx.RawData{
+			"__id":  llx.StringData(a.Arn.Data + "/outputConfig"),
 			"s3Uri": llx.StringData(a.cacheOutputS3Uri),
 		})
 	if err != nil {
@@ -1916,6 +1934,7 @@ func (a *mqlAwsSagemakerAutoMLJob) bestCandidate() (*mqlAwsSagemakerAutoMLJobCan
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerAutoMLJobCandidate,
 		map[string]*llx.RawData{
+			"__id":                 llx.StringData(a.Arn.Data + "/bestCandidate"),
 			"candidateName":        llx.StringData(a.cacheCandidateName),
 			"candidateStatus":      llx.StringData(a.cacheCandidateStatus),
 			"objectiveMetricName":  llx.StringData(a.cacheObjMetricName),

--- a/providers/aws/resources/aws_sagemaker_monitoring.go
+++ b/providers/aws/resources/aws_sagemaker_monitoring.go
@@ -168,6 +168,7 @@ func (a *mqlAwsSagemakerEndpointConfig) dataCaptureConfig() (*mqlAwsSagemakerEnd
 
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerEndpointConfigDataCaptureConfig,
 		map[string]*llx.RawData{
+			"__id":                      llx.StringData(a.Arn.Data + "/dataCaptureConfig"),
 			"enableCapture":             llx.BoolDataPtr(dcc.EnableCapture),
 			"initialSamplingPercentage": llx.IntData(samplingPct),
 			"destinationS3Uri":          llx.StringDataPtr(dcc.DestinationS3Uri),
@@ -296,6 +297,7 @@ func (a *mqlAwsSagemakerEndpointConfigProductionVariant) serverlessConfig() (*mq
 	}
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerEndpointConfigServerlessConfig,
 		map[string]*llx.RawData{
+			"__id":                   llx.StringData(a.cacheParentArn + "/productionVariant/" + a.VariantName.Data + "/serverlessConfig"),
 			"memorySizeInMB":         llx.IntData(memSize),
 			"maxConcurrency":         llx.IntData(maxConc),
 			"provisionedConcurrency": llx.IntData(provConc),
@@ -344,6 +346,7 @@ func sagemakerBuildEndpointConfigProductionVariants(runtime *plugin.Runtime, par
 
 		mqlPV, err := CreateResource(runtime, ResourceAwsSagemakerEndpointConfigProductionVariant,
 			map[string]*llx.RawData{
+				"__id":                              llx.StringData(parentArn + "/productionVariant/" + convert.ToValue(v.VariantName)),
 				"variantName":                       llx.StringDataPtr(v.VariantName),
 				"modelName":                         llx.StringDataPtr(v.ModelName),
 				"instanceType":                      llx.StringData(string(v.InstanceType)),
@@ -541,6 +544,7 @@ func (a *mqlAwsSagemakerMonitoringSchedule) scheduleConfig() (*mqlAwsSagemakerMo
 	sc := resp.MonitoringScheduleConfig.ScheduleConfig
 	mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerMonitoringScheduleScheduleConfig,
 		map[string]*llx.RawData{
+			"__id":                  llx.StringData(a.Arn.Data + "/scheduleConfig"),
 			"scheduleExpression":    llx.StringDataPtr(sc.ScheduleExpression),
 			"dataAnalysisStartTime": llx.StringDataPtr(sc.DataAnalysisStartTime),
 			"dataAnalysisEndTime":   llx.StringDataPtr(sc.DataAnalysisEndTime),
@@ -682,6 +686,7 @@ func sagemakerBuildMonitoringJobSubResources(runtime *plugin.Runtime, details mo
 		}
 		mqlRes, err := CreateResource(runtime, ResourceAwsSagemakerMonitoringJobDefinitionAppSpecification,
 			map[string]*llx.RawData{
+				"__id":                            llx.StringData(parentArn + "/appSpecification"),
 				"imageUri":                        llx.StringDataPtr(spec.ImageUri),
 				"containerEntrypoint":             llx.ArrayData(entrypoint, types.String),
 				"containerArguments":              llx.ArrayData(args, types.String),
@@ -703,6 +708,7 @@ func sagemakerBuildMonitoringJobSubResources(runtime *plugin.Runtime, details mo
 		batchDict, _ := convert.JsonToDict(details.JobInput.BatchTransformInput)
 		mqlRes, err := CreateResource(runtime, ResourceAwsSagemakerMonitoringJobDefinitionJobInput,
 			map[string]*llx.RawData{
+				"__id":                llx.StringData(parentArn + "/jobInput"),
 				"endpointInput":       llx.DictData(endpointDict),
 				"batchTransformInput": llx.DictData(batchDict),
 			})
@@ -723,7 +729,9 @@ func sagemakerBuildMonitoringJobSubResources(runtime *plugin.Runtime, details mo
 			outputs = details.OutputConfig.MonitoringOutputs
 		}
 		mqlRes, err := CreateResource(runtime, ResourceAwsSagemakerMonitoringJobDefinitionJobOutputConfig,
-			map[string]*llx.RawData{})
+			map[string]*llx.RawData{
+				"__id": llx.StringData(parentArn + "/jobOutputConfig"),
+			})
 		if err != nil {
 			return nil, err
 		}
@@ -752,6 +760,7 @@ func sagemakerBuildMonitoringJobSubResources(runtime *plugin.Runtime, details mo
 		}
 		mqlRes, err := CreateResource(runtime, ResourceAwsSagemakerMonitoringJobDefinitionJobResources,
 			map[string]*llx.RawData{
+				"__id":           llx.StringData(parentArn + "/jobResources"),
 				"instanceType":   llx.StringData(instanceType),
 				"instanceCount":  llx.IntData(instanceCount),
 				"volumeSizeInGB": llx.IntData(volumeSize),
@@ -781,6 +790,7 @@ func sagemakerBuildMonitoringJobSubResources(runtime *plugin.Runtime, details mo
 		}
 		mqlRes, err := CreateResource(runtime, ResourceAwsSagemakerMonitoringJobDefinitionNetworkConfig,
 			map[string]*llx.RawData{
+				"__id":                                  llx.StringData(parentArn + "/networkConfig"),
 				"enableInterContainerTrafficEncryption": llx.BoolData(enableEncrypt),
 				"enableNetworkIsolation":                llx.BoolData(enableIsolation),
 			})
@@ -839,6 +849,7 @@ func (a *mqlAwsSagemakerMonitoringJobDefinitionJobOutputConfig) monitoringOutput
 		s3Out := output.S3Output
 		mqlRes, err := CreateResource(a.MqlRuntime, ResourceAwsSagemakerMonitoringJobDefinitionMonitoringOutput,
 			map[string]*llx.RawData{
+				"__id":         llx.StringData(fmt.Sprintf("%s/monitoringOutput/%d", a.cacheParentArn, i)),
 				"s3Uri":        llx.StringDataPtr(s3Out.S3Uri),
 				"localPath":    llx.StringDataPtr(s3Out.LocalPath),
 				"s3UploadMode": llx.StringData(string(s3Out.S3UploadMode)),

--- a/providers/aws/resources/aws_test.go
+++ b/providers/aws/resources/aws_test.go
@@ -6,8 +6,10 @@ package resources
 import (
 	"errors"
 	"fmt"
+	nethttp "net/http"
 	"testing"
 
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,5 +77,38 @@ func TestIsServiceNotAvailableInRegionError(t *testing.T) {
 		// not enough — both phrases must be present together.
 		err := fmt.Errorf("operation error EC2: DescribeInstances, https response error StatusCode: 0, request send failed, Get \"https://ec2.amazonaws.com/\": net/http: TLS handshake timeout")
 		assert.False(t, IsServiceNotAvailableInRegionError(err))
+	})
+}
+
+// macieHTTPError builds a Macie-style error carrying an HTTP status code.
+func macieHTTPError(code int, msg string) error {
+	return &smithyhttp.ResponseError{
+		Response: &smithyhttp.Response{Response: &nethttp.Response{StatusCode: code}},
+		Err:      errors.New(msg),
+	}
+}
+
+// TestIsMacieNotEnabledError guards the over-broad branch: matching a bare
+// AccessDenied with no Macie-specific message swallowed genuine macie2:*
+// permission gaps across 15 call sites, so every Macie resource degraded to
+// empty and any data-classification policy passed with nothing to fail on.
+func TestIsMacieNotEnabledError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsMacieNotEnabledError(nil))
+	})
+
+	t.Run("bare permission denial is not a not-enabled signal", func(t *testing.T) {
+		assert.False(t, IsMacieNotEnabledError(macieHTTPError(403,
+			"AccessDeniedException: User is not authorized to perform macie2:ListFindings")))
+	})
+
+	t.Run("401 with Macie message", func(t *testing.T) {
+		assert.True(t, IsMacieNotEnabledError(macieHTTPError(401,
+			"AccessDeniedException: Macie is not enabled")))
+	})
+
+	t.Run("404 with Macie message", func(t *testing.T) {
+		assert.True(t, IsMacieNotEnabledError(macieHTTPError(404,
+			"ResourceNotFoundException: Amazon Macie isn't enabled for your account")))
 	})
 }

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -1193,6 +1193,7 @@ func (a *mqlAwsVpcRoutetable) associations() ([]any, error) {
 			return nil, err
 		}
 		mqlAssoc, err := CreateResource(a.MqlRuntime, ResourceAwsVpcRoutetableAssociation, map[string]*llx.RawData{
+			"__id":                    llx.StringDataPtr(assoc.RouteTableAssociationId),
 			"routeTableAssociationId": llx.StringDataPtr(assoc.RouteTableAssociationId),
 			"associationsState":       llx.DictData(state),
 			"gatewayId":               llx.StringDataPtr(assoc.GatewayId),

--- a/providers/aws/resources/aws_waf.go
+++ b/providers/aws/resources/aws_waf.go
@@ -30,8 +30,11 @@ func wafRegionForScope(scope string) string {
 	return ""
 }
 
+// id includes the scope: aws.waf is parameterized on it, so a constant key made
+// aws.waf(scope: "REGIONAL") return the cached CLOUDFRONT instance (or vice
+// versa) whenever both were queried in one scan.
 func (a *mqlAwsWaf) id() (string, error) {
-	return "aws.waf", nil
+	return "aws.waf/" + a.Scope.Data, nil
 }
 
 // wafTagsForArn lists the tags on a WAF resource, resolving the WAF endpoint
@@ -504,7 +507,7 @@ func (a *mqlAwsWafRulegroup) rules() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		ruleAction, err := createActionResource(a.MqlRuntime, rule.Action, rule.Name)
+		ruleAction, err := createActionResource(a.MqlRuntime, rule.Action, rule.Name, ruleID)
 		if err != nil {
 			return nil, err
 		}
@@ -620,7 +623,7 @@ func (a *mqlAwsWafAcl) rules() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
-		ruleAction, err := createActionResource(a.MqlRuntime, rule.Action, rule.Name)
+		ruleAction, err := createActionResource(a.MqlRuntime, rule.Action, rule.Name, ruleID)
 		if err != nil {
 			return nil, err
 		}
@@ -645,7 +648,7 @@ func (a *mqlAwsWafAcl) rules() ([]any, error) {
 	return rules, nil
 }
 
-func createActionResource(runtime *plugin.Runtime, ruleAction *waftypes.RuleAction, ruleName *string) (plugin.Resource, error) {
+func createActionResource(runtime *plugin.Runtime, ruleAction *waftypes.RuleAction, ruleName *string, ruleID string) (plugin.Resource, error) {
 	var mqlAction plugin.Resource
 	var err error
 
@@ -676,6 +679,7 @@ func createActionResource(runtime *plugin.Runtime, ruleAction *waftypes.RuleActi
 		}
 	}
 	mqlAction, err = CreateResource(runtime, "aws.waf.rule.action", map[string]*llx.RawData{
+		"__id":         llx.StringData(ruleID + "/action"),
 		"ruleName":     llx.StringDataPtr(ruleName),
 		"action":       llx.StringData(action),
 		"responseCode": llx.StringData(responseCode),
@@ -796,6 +800,7 @@ func createStatementResource(runtime *plugin.Runtime, statement *waftypes.Statem
 			var IPSetForwardedIPConfig plugin.Resource
 			if statement.IPSetReferenceStatement.IPSetForwardedIPConfig != nil {
 				IPSetForwardedIPConfig, err = CreateResource(runtime, "aws.waf.rule.statement.ipsetreferencestatement.ipsetforwardedipconfig", map[string]*llx.RawData{
+					"__id":             llx.StringData(mqlStatementID + "/ipsetforwardedipconfig"),
 					"statementID":      llx.StringData(mqlStatementID),
 					"ruleName":         llx.StringDataPtr(ruleName),
 					"headerName":       llx.StringDataPtr(statement.IPSetReferenceStatement.IPSetForwardedIPConfig.HeaderName),
@@ -1034,7 +1039,8 @@ func createFieldToMatchResource(runtime *plugin.Runtime, fieldToMatch *waftypes.
 	}
 	if fieldToMatch.HeaderOrder != nil {
 		target = "HeaderOrder"
-		headerOrder, err = CreateResource(runtime, "aws.waf.rule.fieldtomatch.headerOrder", map[string]*llx.RawData{
+		headerOrder, err = CreateResource(runtime, ResourceAwsWafRuleFieldtomatchHeaderorder, map[string]*llx.RawData{
+			"__id":             llx.StringData(mqlStatementID + "/headerOrder"),
 			"statementID":      llx.StringData(mqlStatementID),
 			"ruleName":         llx.StringDataPtr(ruleName),
 			"overSizeHandling": llx.StringData(string(fieldToMatch.HeaderOrder.OversizeHandling)),
@@ -1061,7 +1067,8 @@ func createFieldToMatchResource(runtime *plugin.Runtime, fieldToMatch *waftypes.
 		if fieldToMatch.Headers.MatchPattern != nil {
 			includeHeaders := convert.SliceAnyToInterface(fieldToMatch.Headers.MatchPattern.IncludedHeaders)
 			excludeHeaders := convert.SliceAnyToInterface(fieldToMatch.Headers.MatchPattern.ExcludedHeaders)
-			matchPattern, err = CreateResource(runtime, "aws.waf.rule.fieldtomatch.jsonbody.matchpattern", map[string]*llx.RawData{
+			matchPattern, err = CreateResource(runtime, ResourceAwsWafRuleFieldtomatchHeadersMatchpattern, map[string]*llx.RawData{
+				"__id":           llx.StringData(mqlStatementID + "/headers/matchPattern"),
 				"statementID":    llx.StringData(mqlStatementID),
 				"ruleName":       llx.StringDataPtr(ruleName),
 				"all":            llx.BoolData(fieldToMatch.Headers.MatchPattern.All != nil),
@@ -1072,10 +1079,11 @@ func createFieldToMatchResource(runtime *plugin.Runtime, fieldToMatch *waftypes.
 				return nil, err
 			}
 		}
-		headers, err = CreateResource(runtime, "aws.waf.rule.fieldtomatch.headers", map[string]*llx.RawData{
+		headers, err = CreateResource(runtime, ResourceAwsWafRuleFieldtomatchHeaders, map[string]*llx.RawData{
+			"__id":             llx.StringData(mqlStatementID + "/headers"),
 			"statementID":      llx.StringData(mqlStatementID),
 			"ruleName":         llx.StringDataPtr(ruleName),
-			"matchPattern":     llx.ResourceData(matchPattern, "aws.waf.rule.fieldtomatch.headers.matchpatern"),
+			"matchPattern":     llx.ResourceData(matchPattern, ResourceAwsWafRuleFieldtomatchHeadersMatchpattern),
 			"overSizeHandling": llx.StringData(string(fieldToMatch.Headers.OversizeHandling)),
 			"matchScope":       llx.StringData(string(fieldToMatch.Headers.MatchScope)),
 		})

--- a/providers/aws/resources/awspolicy/s3bucketpolicy.go
+++ b/providers/aws/resources/awspolicy/s3bucketpolicy.go
@@ -18,9 +18,37 @@ import (
 // see https://aws.amazon.com/blogs/security/back-to-school-understanding-the-iam-policy-grammar/
 
 type S3BucketPolicy struct {
-	Version    string                    `json:"Version"`
-	Id         string                    `json:"Id,omitempty"`
-	Statements []S3BucketPolicyStatement `json:"Statement"`
+	Version    string       `json:"Version"`
+	Id         string       `json:"Id,omitempty"`
+	Statements s3Statements `json:"Statement"`
+}
+
+// s3Statements accepts both shapes the IAM policy grammar allows for
+// `Statement`: an array, and a single bare object. Without the single-object
+// case a legal `{"Statement":{...}}` document failed to unmarshal, so
+// policyStatements/isPublic/hasWildcardAllow errored out on it while the
+// sibling IamPolicyDocument (which already has this unmarshaller) parsed it.
+type s3Statements []S3BucketPolicyStatement
+
+func (v *s3Statements) UnmarshalJSON(b []byte) error {
+	var raw any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if _, isArray := raw.([]any); isArray {
+		var out []S3BucketPolicyStatement
+		if err := json.Unmarshal(b, &out); err != nil {
+			return err
+		}
+		*v = out
+		return nil
+	}
+	var one S3BucketPolicyStatement
+	if err := json.Unmarshal(b, &one); err != nil {
+		return err
+	}
+	*v = []S3BucketPolicyStatement{one}
+	return nil
 }
 
 // the policy statement includes many different aspects including the Not* elements, they are used to exclude

--- a/providers/aws/resources/awspolicy/s3bucketpolicy_test.go
+++ b/providers/aws/resources/awspolicy/s3bucketpolicy_test.go
@@ -73,3 +73,27 @@ func TestPolicyPrincipalArray(t *testing.T) {
 		"Service": {"lambda.amazonaws.com", "logs.amazonaws.com"},
 	}, policy.Statements[0].Principal.Data())
 }
+
+// TestS3BucketPolicySingleObjectStatement covers the single-object Statement
+// shape the IAM policy grammar allows. Without the s3Statements unmarshaller it
+// failed to decode, so policyStatements/isPublic/hasWildcardAllow errored on
+// such documents while the sibling IamPolicyDocument parsed them fine.
+func TestS3BucketPolicySingleObjectStatement(t *testing.T) {
+	var p S3BucketPolicy
+	err := json.Unmarshal([]byte(`{"Version":"2012-10-17","Statement":
+		{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"}}`), &p)
+	require.NoError(t, err)
+	require.Len(t, p.Statements, 1)
+	assert.Equal(t, "Allow", p.Statements[0].Effect)
+	assert.Equal(t, []string{"*"}, p.Statements[0].Principal["AWS"])
+}
+
+func TestS3BucketPolicyArrayStatementStillWorks(t *testing.T) {
+	var p S3BucketPolicy
+	err := json.Unmarshal([]byte(`{"Version":"2012-10-17","Statement":[
+		{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:GetObject","Resource":"arn:aws:s3:::b/*"},
+		{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"s3:PutObject","Resource":"arn:aws:s3:::b/*"}]}`), &p)
+	require.NoError(t, err)
+	require.Len(t, p.Statements, 2)
+	assert.Equal(t, "Deny", p.Statements[1].Effect)
+}

--- a/providers/aws/resources/discovery.go
+++ b/providers/aws/resources/discovery.go
@@ -759,7 +759,10 @@ func discover(runtime *plugin.Runtime, awsAccount *mqlAwsAccount, target string,
 				name: f.Name.Data, labels: map[string]string{},
 				awsObject: awsObject{
 					account: accountId, region: "us-east-1", arn: f.Arn.Data,
-					id: f.Name.Data, service: "dynamodb", objectType: "table",
+					// Distinct from the regular table objectType: a global table
+					// and its us-east-1 replica share a name, so both mapped to
+					// the same platform id and merged into one asset.
+					id: f.Name.Data, service: "dynamodb", objectType: "globaltable",
 				},
 			}
 			assetList = append(assetList, MqlObjectToAsset(accountId, m, conn))


### PR DESCRIPTION
Fixes the critical and high-severity findings from a static bug review of the AWS provider. Every fix below was verified against the source, the generated `aws.lr.go`, and the pinned SDK before being written.

## Why this is one PR

The three groups below are independent, but they share one mechanism and one test story, and several of the `__id` fixes are in files the semantic fixes also touch. Reviewing by group (the three headings) should be straightforward; each bullet is self-contained.

---

## 1. Cache-key (`__id`) collisions

`CreateResource` computes `name + "\x00" + res.MqlID()` and **returns the cached instance on a key hit**. Any resource with a colliding or empty `__id` therefore reports the first-created instance's data for every subsequent one — silently, with no error.

### `aws.iam.policy` had no `id()` at all — an 11-month-old regression

`mqlAwsIamPolicy` has no `id()` method and no call site passed `__id`, so the generated creator kept `res.__id == ""` and every IAM policy in a scan aliased to the first one.

```
f7eb444ec  2025-09-03  Fix a compilation failure in `aws.iam.policies` (#5915)

-func (a *mqlAwsIamPolicy) id() (string, error) {
-	if a == nil { return "", nil }
-	return a.Arn.Data, nil
-}
```

`aws.iam.policies { arn name attachmentCount }` on a 300-policy account returned 300 copies of one policy. `aws.iam.policies.none(statements.any(hasWildcardAllow))` inspected exactly one policy and passed vacuously — and because `versions()`/`statements()` read that one policy's ARN, the statement data was wrong too. Same for `role.attachedPolicies`, `user.attachedPolicies`, `group.attachedPolicies`, and both `permissionsBoundary()` accessors.

### 39 SageMaker sub-resources

Each built `__id` from an `Internal` cache field assigned *after* `CreateResource` returned — but the generated `createXxx` calls `res.id()` inside `Create`. `cache*` fields live on the Internal struct and `SetData` rejects unknown args, so they cannot be passed in; they can only be assigned afterward. All 39 resolved against an empty string, and **22 produced a literally constant key** (`/source`, `/objective`, `/transformInput`, …).

`aws.sagemaker.endpointConfigs { productionVariants { modelName instanceType } }` keyed on `/productionVariant/AllTraffic` — the default variant name — so every endpoint config in the account reported the first one's model and instance type.

Fixed by passing `__id` explicitly at each site. The pattern also pre-existed in the older `aws_sagemaker.go` (10 of the 39), which is where the newer files copied it from.

### The rest

| Resource | Was keyed on | Now |
|---|---|---|
| `aws.rds.backupsetting` | `target` — the backup *location*, `"region"` for nearly every instance | parent ARN + resource id |
| `aws.rds.parameterGroup.parameter` | bare parameter name (shared by cluster **and** instance groups) | group ARN + name |
| `aws.vpc.routetable.association` | nothing (no `id()`, no `__id`) | `RouteTableAssociationId` |
| `aws.s3.bucket.websiteConfiguration` + 4 nested | nothing | bucket ARN + path |
| `aws.s3.bucket.corsrule` | bucket name (all rules on a bucket collide) | bucket ARN + index |
| `aws.waf.rule.action`, `…ipsetforwardedipconfig` | nothing | rule/statement id |
| `aws.iam.loginProfile` | nothing — its id method was named `init`, which the generator never registers | user ARN |
| `aws.ecs.taskDefinition.volume` (+ EFS/host/docker/s3 children) | bare volume name, unique only within one revision | task-definition ARN + name |
| `aws.waf` | the constant `"aws.waf"` | includes `scope`, so `REGIONAL` no longer returns the cached `CLOUDFRONT` instance |

`initAwsCodeartifactDomain`'s `len(args) > 2` fast path skipped the lookup for the exact 3-arg call its own `repository.domain()` makes, producing a shared husk with an empty `__id`.

---

## 2. Hard failures and panics

- **WAF `Headers` / `HeaderOrder`.** The `Headers` branch built a `jsonbody.matchpattern` and passed `includeHeaders`/`excludeHeaders`, which only `headers.matchpattern` declares. `SetData` **returns an error** on unknown fields, so `CreateResource` failed and the error propagated out of `rules()`. `HeaderOrder` used `"…fieldtomatch.headerOrder"`, which matches no factory key (it is all-lowercase). `Headers.MatchPattern` is a **required** SDK member, so this fired on any WAF using header inspection — including most AWS managed rule groups. `aws.waf.rule.fieldtomatch.headers.matchpattern` was declared in the schema and constructed by no code.
- **`aws.detective.graph.member.volumeUsageByDatasourcePackage`** put a `time.Time` into a `dict`. `dict2primitive` accepts only JSON-native values, so this errored at query time for any member that has ever ingested data.
- **Two scan-killing panics.** `efs.filesystem.kmsKey` did `return mqlKeyResource.(*mqlAwsKmsKey), err` with no `if err != nil` first — `initAwsKmsKey` has several `(nil, err)` paths, and asserting on a nil interface panics. `identitycenter` published `fetched = true` *before* `descResp`, so a reader on the lock-free path could get `(nil, nil)` and nil-deref. Both run in executor goroutines, so the panic takes the whole scan, not one query.
- **ECS `DescribeContainerInstances`** was called with the full ARN list past its documented 100-item cap, and the error was only logged — so clusters with >100 registered instances reported **zero**. Now batched via `slicesx.Batch`.
- **`credentialReport`** only regenerated on `ReportNotPresent`, not `ReportExpired` (HTTP 410), so a stale report hard-errored the whole field and every check built on it.
- Nil/bounds guards: `initAwsEc2Image` ARN split, RDS snapshot-attribute results, Lambda policy body, `account.organization`, and the two bare assertions on hand-parsed credential-report CSV values.

---

## 3. Wrong security verdicts

- **`aws.s3.bucket.public`** had three defects. It returned on a *false* policy status, making the ACL grant check unreachable for any bucket with a policy; it treated all four Block Public Access flags as "not public", though AWS documents `BlockPublicAcls`/`BlockPublicPolicy` as rejecting only **new** grants (only `IgnorePublicAcls` and `RestrictPublicBuckets` neutralize existing ones); and it returned a confident `false` when nothing could be read. The decision logic is now a pure `s3BucketIsPublic(pab, policyIsPublic, aclIsPublic)` with a 12-case table test, and an unreadable bucket reports **null**.
- **`aws.ec2.eip.attached`** read `AllocationId` — the allocation handle present on *every* VPC EIP — instead of `AssociationId`. It was unconditionally `true`, so `where(attached == false)` was always empty and "no dangling Elastic IPs" passed vacuously.
- **Lambda resource policies** were decoded into a hand-written struct with no `Condition`, `NotPrincipal`, `NotAction` or `NotResource`, so `isPublic`/`allowsPublicAccess` could not see a scoping condition — an org-scoped Function URL read as fully public. Its `Action string` also failed to unmarshal any array-valued action. Now parsed verbatim, matching SNS/SQS/ECR.
- **`hasSourceScopingCondition` ignored the condition operator.** `StringNotEquals` on `aws:PrincipalOrgID` means *allow everyone outside my org* and `Null` means *allow principals lacking the key* — both worse than an unconditional public grant, both previously read as "scoped" → not public. Now gated on an allowlist of restricting operators. The scoping-key list also missed `kms:CallerAccount`, `aws:SourceVpce`, `aws:PrincipalAccount` and others, which made AWS's own service-linked KMS grants report public.
- **`hasPublicPrincipal` never read `notPrincipals`.** `Allow` + `NotPrincipal` grants everyone except the listed principals — public by construction.
- **`S3BucketPolicy` could not decode a single-object `Statement`**, which the IAM policy grammar allows and the sibling `IamPolicyDocument` already handles.
- **`aws.billing` reported $0.00** when Cost Explorer was denied — the `*Unavailable` flags were written at five sites and read at none. Denied now reads null.
- **IAM `tags` and `role.permissionsBoundary`** were populated from `List*` responses that the SDK explicitly documents as omitting them, so the collection path reported `{}` / no-boundary for every principal while the single-object path returned the truth. Both now resolve lazily (`tags` became a computed accessor; the role boundary uses the memoized `getRoleDetails`, matching the `aws.iam.user` pattern). `aws.iam.policy.description` is likewise `GetPolicy`-only and is no longer pinned to null on the list path.
- **`isV1LoadBalancerArn` substring-matched `"classic"`**, so an ALB named `prod-classic-api` was dispatched to the v1 API by eight accessors — `listeners()` returned `[]` and **`enforcesTls()` passed vacuously on an unencrypted ALB**.
- **`IsMacieNotEnabledError`** matched any 400/401/403 containing `AccessDenied` with no Macie discriminator, so a missing `macie2:*` grant read as "Macie not enabled" across 15 call sites.
- **AppRunner** left `LatestOnly` at its zero value, which the service defaults to `true` — only the latest config revision was listed, while the traversal path resolved non-latest ones.
- **DynamoDB global tables** shared a platform id with their us-east-1 replica, merging two real assets into one on a default `mql scan aws`.
- Init husks that produced unset (not null) fields now return not-found errors: `initAwsEc2Launchtemplate`; `initAwsEc2Keypair` keeps its deliberate deleted-key empty state but gets a unique key and null (not `""`) unknowns. `mqlAwsEc2Instance.vpc()`'s null check compared against `StateIsNull` where `RawToTValue` stamps `StateIsNull|StateIsSet`, so it was dead code and terminated instances triggered an account-wide VPC scan ending in a misleading error.

---

## Behavior changes

Two fixes change answers customers may have been reading. Both are unambiguous bugs — the `.lr` docs already described the correct behavior — and both `.lr` comments are updated:

- `aws.s3.bucket.public` — buckets that are genuinely public but reported `false` will now report `true`; unreadable buckets report `null` instead of `false`.
- `aws.ec2.eip.attached` — unassociated EIPs now report `false` instead of `true`.

`aws.iam.{user,role,instanceProfile}.tags` moved from a stored field to a computed accessor. The query surface is unchanged (`user.tags` works either way) and no `.lr.versions` entries change; queries that select tags now cost one `List*Tags` call per principal, and queries that don't cost nothing. This adds `iam:ListUserTags`, `iam:ListRoleTags` and `iam:ListInstanceProfileTags` to `aws.permissions.json`.

## Rebase note

Rebased onto `bbf26c9dd`. Two upstream commits overlapped:

- **#9433** independently fixed the SNS topic init (method → free function) and did it more thoroughly — asset-identifier handling and a comma-ok on the ARN. That fix is dropped from this branch in favour of upstream's.
- **#9434** added `aws:SourceOwner` to `isSourceScopingKey`. Merged with the widened key set and the new operator gate here, so both survive; `TestHasSourceScopingConditionOperators` covers `aws:SourceOwner` alongside the rest.

## Testing

`go build ./...` and `go test ./resources/...` pass; `make providers/build/aws` regenerates cleanly. Tests live in the file matching the source under test — `aws_s3_test.go`, `aws_elb_test.go`, `aws_test.go`, `aws_foundation_helpers_test.go`, `aws_iam_policy_statement_test.go`, `awspolicy/s3bucketpolicy_test.go`, and a new `aws_iam_test.go`.

Coverage added:

| Fix | Test |
|---|---|
| `s3.bucket.public` semantics | `TestS3BucketIsPublic` — 12 cases, incl. the static-site shape that regressed |
| policy / ACL public signals | `TestS3PolicyGrantsPublicAccess`, `TestS3GrantsArePublic` |
| single-object `Statement` | `TestS3BucketPolicySingleObjectStatement` (+ array still works) |
| condition-operator gate | `TestIsRestrictingConditionOperator`, `TestHasSourceScopingConditionOperators` |
| `Allow` + `NotPrincipal` | `TestPolicyStatementHasPublicPrincipalNotPrincipal` |
| operator gate end-to-end | `TestStatementsAllowPublicNegatedCondition` |
| ELB classic dispatch | `TestIsV1LoadBalancerArn` |
| Macie predicate | `TestIsMacieNotEnabledError` |
| **`__id` collisions** | `TestIamPolicyCacheKeysAreDistinct`, `TestIamLoginProfileCacheKeysAreDistinct` |

The `__id` tests drive `CreateResource` for real (map-backed `Resources`) and assert two instances get distinct keys *and* that the second call doesn't return the first object. That shape matters: the existing SageMaker tests assert the `id()` formula after manually setting the Internal cache field, which is why they passed while production ids were all empty. Verified by reverting the `mqlAwsIamPolicy.id()` fix — the test fails with `__id:""` and "Expected and actual point to the same object".

Not live-verified against real infrastructure — worth a `provider-verification` pass on the S3, WAF and SageMaker paths before release.

## Not included

Deliberately left for follow-ups, since each needs a schema change or a design decision:

- **WAF `REGIONAL` scope queries only one region** while every other AWS list resource fans out over `conn.Regions()`. Fixing it needs a `region` field on `aws.waf.acl`/`rulegroup`/`ipset`/`regexPatternSet` and region threading through the detail fetches.
- **Discovery swallows errors for ~35 of 48 targets.** `plugin.GetOrCompute` never returns nil, so every `if X == nil { return assetList, nil }` guard in `discovery.go` is dead code and a failed target returns `([], nil)` with no log at all.
- **~60 plain-`bool` double-check locks** across the provider (the project convention is `atomic.Bool`). Only the identity-center one is fixed here, because it also had a store-ordering bug.
- **Partition correctness**: 36 hardcoded `arn:aws:` templates and `getAssetIdentifier`'s `arn:aws:` prefix gate break GovCloud and China.
