### PR TITLE
🐛 gcp: fix hard query failures, fabricated absence, __id collisions and scan-killing panics

### DIFF
--- a/providers/gcp/resources/alloydb.go
+++ b/providers/gcp/resources/alloydb.go
@@ -427,7 +427,7 @@ func initGcpProjectAlloydbServiceCluster(runtime *plugin.Runtime, args map[strin
 	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
-		locationVal = args["location"].Value.(string)
+		locationVal, _ = args["location"].Value.(string)
 	}
 	for _, c := range clusters.Data {
 		cluster := c.(*mqlGcpProjectAlloydbServiceCluster)

--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	"cloud.google.com/go/asset/apiv1/assetpb"
@@ -197,9 +198,11 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 		}
 
 		bindings := make([]any, 0, len(r.GetPolicy().GetBindings()))
-		for _, b := range r.GetPolicy().GetBindings() {
+		// Index-suffixed: a policy can hold several bindings for the same role
+		// that differ only by condition, so a role-keyed id collapses them.
+		for i, b := range r.GetPolicy().GetBindings() {
 			mqlBinding, err := CreateResource(g.MqlRuntime, "gcp.resourcemanager.binding", map[string]*llx.RawData{
-				"id":                   llx.StringData(r.Resource + "/" + b.GetRole()),
+				"id":                   llx.StringData(r.Resource + "-" + strconv.Itoa(i)),
 				"role":                 llx.StringData(b.GetRole()),
 				"members":              llx.ArrayData(convert.SliceAnyToInterface(b.GetMembers()), types.String),
 				"conditionTitle":       llx.StringData(b.GetCondition().GetTitle()),

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -40,6 +40,37 @@ func initGcpProjectBigqueryService(runtime *plugin.Runtime, args map[string]*llx
 
 type mqlGcpProjectBigqueryServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// The flag is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: gcp.bigquery is an
+// alias for it, and resource inits build it with CreateResource. On those paths
+// the Go zero value `false` made every collection return an empty list with no
+// error -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectBigqueryService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_bigquery)
+	})
+	return g.serviceEnabled, g.serviceErr
 }
 
 func (g *mqlGcpProjectBigqueryService) id() (string, error) {
@@ -78,7 +109,11 @@ func (g *mqlGcpProject) bigquery() (*mqlGcpProjectBigqueryService, error) {
 
 func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 	// when the service is not enabled, we return nil
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/bigquery.go
+++ b/providers/gcp/resources/bigquery.go
@@ -156,9 +156,10 @@ func (g *mqlGcpProjectBigqueryService) datasets() ([]any, error) {
 			var datasetRef any
 			if a.Dataset != nil {
 				datasetRef = map[string]any{
-					"projectId":   a.Dataset.Dataset.ProjectID,
-					"datasetId":   a.Dataset.Dataset.DatasetID,
-					"targetTypes": a.Dataset.TargetTypes,
+					"projectId": a.Dataset.Dataset.ProjectID,
+					"datasetId": a.Dataset.Dataset.DatasetID,
+					// []string is not JSON-native inside a dict.
+					"targetTypes": convert.SliceAnyToInterface(a.Dataset.TargetTypes),
 				}
 			}
 			mqlA, err := CreateResource(g.MqlRuntime, "gcp.project.bigqueryService.dataset.accessEntry", map[string]*llx.RawData{
@@ -380,8 +381,11 @@ func (g *mqlGcpProjectBigqueryServiceDataset) getClient() (*bigquery.Client, err
 			return
 		}
 		ctx := context.Background()
-		projectID := conn.ResourceID()
-		g.client, g.clientErr = bigquery.NewClient(ctx, projectID, option.WithHTTPClient(httpClient))
+		// The client's project decides which project `Dataset(id)` resolves in, so
+		// it must be the dataset's own project. ResourceID() is the connection
+		// scope (an org or folder id on a non-project connection), which would
+		// resolve every dataset's tables/models/routines in the wrong project.
+		g.client, g.clientErr = bigquery.NewClient(ctx, g.ProjectId.Data, option.WithHTTPClient(httpClient))
 	})
 	return g.client, g.clientErr
 }

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -657,6 +657,12 @@ func (g *mqlGcpProjectBigtableServiceInstance) backups() ([]any, error) {
 			}
 
 			mqlBackup, err := CreateResource(g.MqlRuntime, "gcp.project.bigtableService.backup", map[string]*llx.RawData{
+				// Cluster ids are unique only within an instance, so the key
+				// must name the instance -- matching table/appProfile/cluster.
+				// cacheInstanceName is assigned after CreateResource returns and
+				// so is not visible to id(); pass the key explicitly instead.
+				"__id": llx.StringData(fmt.Sprintf("gcp.project/%s/bigtableService/%s/cluster/%s/backup/%s",
+					projectId, instanceName, c.Name, backup.Name)),
 				"projectId":      llx.StringData(projectId),
 				"clusterName":    llx.StringData(c.Name),
 				"name":           llx.StringData(backup.Name),

--- a/providers/gcp/resources/bigtable.go
+++ b/providers/gcp/resources/bigtable.go
@@ -235,11 +235,13 @@ func (g *mqlGcpProjectBigtableServiceInstance) clusters() ([]any, error) {
 	for _, c := range clusters {
 		var autoscalingConfig map[string]any
 		if c.AutoscalingConfig != nil {
+			// The SDK models these as Go `int`, which is not JSON-native and so
+			// fails dict2primitive at query time; widen to int64.
 			autoscalingConfig = map[string]any{
-				"minNodes":                  c.AutoscalingConfig.MinNodes,
-				"maxNodes":                  c.AutoscalingConfig.MaxNodes,
-				"cpuTargetPercent":          c.AutoscalingConfig.CPUTargetPercent,
-				"storageUtilizationPerNode": c.AutoscalingConfig.StorageUtilizationPerNode,
+				"minNodes":                  int64(c.AutoscalingConfig.MinNodes),
+				"maxNodes":                  int64(c.AutoscalingConfig.MaxNodes),
+				"cpuTargetPercent":          int64(c.AutoscalingConfig.CPUTargetPercent),
+				"storageUtilizationPerNode": int64(c.AutoscalingConfig.StorageUtilizationPerNode),
 			}
 		}
 
@@ -435,7 +437,8 @@ func (g *mqlGcpProjectBigtableServiceInstance) tables() ([]any, error) {
 			automatedBackupPolicy = map[string]any{
 				"retentionPeriod": fmt.Sprintf("%v", abp.RetentionPeriod),
 				"frequency":       fmt.Sprintf("%v", abp.Frequency),
-				"locations":       abp.Locations,
+				// []string is not JSON-native inside a dict.
+				"locations": convert.SliceAnyToInterface(abp.Locations),
 			}
 		}
 

--- a/providers/gcp/resources/binary_authorization.go
+++ b/providers/gcp/resources/binary_authorization.go
@@ -41,7 +41,12 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 	}
 
 	ctx := context.Background()
-	c, err := binaryauthorization.NewSystemPolicyClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption(), option.WithQuotaProject(projectId))
+	// The project's own Binary Authorization policy comes from the management
+	// client's GetPolicy ("projects/*/policy"). GetSystemPolicy is a different
+	// API: it takes "locations/*/policy" and returns Google's system policy,
+	// which is not associated with a project and carries none of the project's
+	// cluster/namespace admission rules.
+	c, err := binaryauthorization.NewBinauthzManagementClient(ctx, option.WithCredentials(credentials), connection.GRPCClientTraceOption(), option.WithQuotaProject(projectId))
 	if err != nil {
 		return nil, err
 	}
@@ -49,10 +54,14 @@ func (g *mqlGcpProject) binaryAuthorization() (*mqlGcpProjectBinaryAuthorization
 	defer c.Close()
 
 	name := fmt.Sprintf("projects/%s/policy", projectId)
-	resp, err := c.GetSystemPolicy(ctx, &binaryauthorizationpb.GetSystemPolicyRequest{
+	resp, err := c.GetPolicy(ctx, &binaryauthorizationpb.GetPolicyRequest{
 		Name: name,
 	})
 	if err != nil {
+		if isGRPCSkippable(err) {
+			g.BinaryAuthorization.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
 		return nil, err
 	}
 
@@ -136,6 +145,7 @@ func (g *mqlGcpProject) toMqlBinaryAuthzAdmissionRule(rule *binaryauthorizationp
 	return CreateResource(g.MqlRuntime, "gcp.project.binaryAuthorizationControl.admissionRule", map[string]*llx.RawData{
 		"__id":                  llx.StringData(mqlId),
 		"evaluationMode":        llx.StringData(rule.GetEvaluationMode().String()),
+		"enforcementMode":       llx.StringData(rule.GetEnforcementMode().String()),
 		"requireAttestationsBy": llx.ArrayData(requiresAttestationsBy, types.String),
 	})
 }

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -441,7 +441,11 @@ func initGcpProjectCloudFunction(runtime *plugin.Runtime, args map[string]*llx.R
 		return nil, nil, funcs.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.cloudFunction requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
 		locationVal = args["location"].Value.(string)

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -454,7 +454,7 @@ func initGcpProjectCloudFunction(runtime *plugin.Runtime, args map[string]*llx.R
 	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
-		locationVal = args["location"].Value.(string)
+		locationVal, _ = args["location"].Value.(string)
 	}
 	for _, f := range funcs.Data {
 		fn := f.(*mqlGcpProjectCloudFunction)

--- a/providers/gcp/resources/cloud_functions.go
+++ b/providers/gcp/resources/cloud_functions.go
@@ -402,7 +402,13 @@ func (g *mqlGcpProjectCloudFunction) id() (string, error) {
 		return "", g.Name.Error
 	}
 	name := g.Name.Data
-	return fmt.Sprintf("%s/%s", projectId, name), nil
+	if g.Location.Error != nil {
+		return "", g.Location.Error
+	}
+	// Cloud Functions v1 names are unique within a location, not within a
+	// project, and this resource's own init matches on name + location. Without
+	// the location a function deployed to two regions collapses onto one row.
+	return fmt.Sprintf("%s/%s/%s", projectId, g.Location.Data, name), nil
 }
 
 func initGcpProjectCloudFunction(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {

--- a/providers/gcp/resources/cloudbuild.go
+++ b/providers/gcp/resources/cloudbuild.go
@@ -102,25 +102,25 @@ func (g *mqlGcpProjectCloudBuildService) triggers() ([]any, error) {
 		}
 
 		// Build GitHub events config sub-resource
-		github, err := buildTriggerGithubConfig(g.MqlRuntime, trigger.Name, trigger.GetGithub())
+		github, err := buildTriggerGithubConfig(g.MqlRuntime, trigger.Id, trigger.GetGithub())
 		if err != nil {
 			return nil, err
 		}
 
 		// Build Pub/Sub config sub-resource
-		pubsubConfig, err := buildTriggerPubsubConfig(g.MqlRuntime, trigger.Name, projectId, trigger.GetPubsubConfig())
+		pubsubConfig, err := buildTriggerPubsubConfig(g.MqlRuntime, trigger.Id, projectId, trigger.GetPubsubConfig())
 		if err != nil {
 			return nil, err
 		}
 
 		// Build webhook config sub-resource
-		webhookConfig, err := buildTriggerWebhookConfig(g.MqlRuntime, trigger.Name, trigger.GetWebhookConfig())
+		webhookConfig, err := buildTriggerWebhookConfig(g.MqlRuntime, trigger.Id, trigger.GetWebhookConfig())
 		if err != nil {
 			return nil, err
 		}
 
 		// Build repository event config sub-resource
-		repoEventConfig, err := buildTriggerRepoEventConfig(g.MqlRuntime, trigger.Name, trigger.GetRepositoryEventConfig())
+		repoEventConfig, err := buildTriggerRepoEventConfig(g.MqlRuntime, trigger.Id, trigger.GetRepositoryEventConfig())
 		if err != nil {
 			return nil, err
 		}
@@ -182,10 +182,14 @@ func (g *mqlGcpProjectCloudBuildServiceTrigger) id() (string, error) {
 	if g.ProjectId.Error != nil {
 		return "", g.ProjectId.Error
 	}
-	if g.Name.Error != nil {
-		return "", g.Name.Error
+	// BuildTrigger.Name is user-assigned, optional, and unique only within a
+	// project; Id is the service-generated unique identifier. Keying on the
+	// name aliased same-named triggers across projects (and collapsed every
+	// unnamed, Terraform-created trigger onto one row).
+	if g.TriggerId.Error != nil {
+		return "", g.TriggerId.Error
 	}
-	return fmt.Sprintf("gcp.project/%s/cloudBuildService.trigger/%s", g.ProjectId.Data, g.Name.Data), nil
+	return fmt.Sprintf("gcp.project/%s/cloudBuildService.trigger/%s", g.ProjectId.Data, g.TriggerId.Data), nil
 }
 
 type mqlGcpProjectCloudBuildServiceTriggerInternal struct {

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -941,7 +941,8 @@ func mqlContainerProbe(runtime *plugin.Runtime, probe *runpb.Probe, containerId 
 	var mqlTcpSocket map[string]any
 	if tcpSocket := probe.GetTcpSocket(); tcpSocket != nil {
 		mqlTcpSocket = map[string]any{
-			"port": tcpSocket.Port,
+			// int32 is not JSON-native inside a dict.
+			"port": int64(tcpSocket.Port),
 		}
 	}
 
@@ -1045,12 +1046,13 @@ func mqlContainers(runtime *plugin.Runtime, containers []*runpb.Container, templ
 		mqlPorts := make([]any, 0, len(c.Ports))
 		for _, p := range c.Ports {
 			mqlPorts = append(mqlPorts, map[string]any{
-				"name":          p.Name,
-				"containerPort": p.ContainerPort,
+				"name": p.Name,
+				// int32 is not JSON-native inside a dict.
+				"containerPort": int64(p.ContainerPort),
 			})
 		}
 
-		mqlVolumeMounts := make([]any, 0, len(c.Ports))
+		mqlVolumeMounts := make([]any, 0, len(c.VolumeMounts))
 		for _, v := range c.VolumeMounts {
 			mqlVolumeMounts = append(mqlVolumeMounts, map[string]any{
 				"name":      v.Name,

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -137,7 +137,11 @@ func initGcpProjectCloudRunServiceService(runtime *plugin.Runtime, args map[stri
 		return nil, nil, services.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.cloudRunService.service requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	regionVal := ""
 	if args["region"] != nil {
 		regionVal = args["region"].Value.(string)
@@ -208,7 +212,11 @@ func initGcpProjectCloudRunServiceJob(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, jobs.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.cloudRunService.job requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	regionVal := ""
 	if args["region"] != nil {
 		regionVal = args["region"].Value.(string)

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -144,7 +144,7 @@ func initGcpProjectCloudRunServiceService(runtime *plugin.Runtime, args map[stri
 	nameVal, _ := nameRaw.Value.(string)
 	regionVal := ""
 	if args["region"] != nil {
-		regionVal = args["region"].Value.(string)
+		regionVal, _ = args["region"].Value.(string)
 	}
 	for _, s := range services.Data {
 		service := s.(*mqlGcpProjectCloudRunServiceService)
@@ -219,7 +219,7 @@ func initGcpProjectCloudRunServiceJob(runtime *plugin.Runtime, args map[string]*
 	nameVal, _ := nameRaw.Value.(string)
 	regionVal := ""
 	if args["region"] != nil {
-		regionVal = args["region"].Value.(string)
+		regionVal, _ = args["region"].Value.(string)
 	}
 	for _, j := range jobs.Data {
 		job := j.(*mqlGcpProjectCloudRunServiceJob)

--- a/providers/gcp/resources/common.go
+++ b/providers/gcp/resources/common.go
@@ -372,7 +372,15 @@ func getAssetIdentifier(runtime *plugin.Runtime) *assetIdentifier {
 	if !ok {
 		return nil
 	}
-	id := conn.Asset().PlatformIds[0]
+	// The root asset and any inventory-file asset without a platform_ids block
+	// carry no platform ids, so this must not index blindly: a panic here is
+	// unrecoverable and takes down the whole scan. Every caller already handles
+	// a nil return.
+	asset := conn.Asset()
+	if asset == nil || len(asset.PlatformIds) == 0 {
+		return nil
+	}
+	id := asset.PlatformIds[0]
 
 	if strings.HasPrefix(id, "//platformid.api.mondoo.app/runtime/gcp/") {
 		// "//platformid.api.mondoo.app/runtime/gcp/{o.service}/v1/projects/{project}/regions/{region}/{objectType}/{name}"

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -118,7 +118,7 @@ func initGcpProjectComputeServiceRegion(runtime *plugin.Runtime, args map[string
 	if !ok || name == "" {
 		return args, nil, nil
 	}
-	projectId := args["projectId"].Value.(string)
+	projectId, _ := args["projectId"].Value.(string)
 
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
 	if err != nil {
@@ -161,7 +161,7 @@ func initGcpProjectComputeServiceZone(runtime *plugin.Runtime, args map[string]*
 	if !ok || name == "" {
 		return args, nil, nil
 	}
-	projectId := args["projectId"].Value.(string)
+	projectId, _ := args["projectId"].Value.(string)
 
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, compute.ComputeReadonlyScope)
 	if err != nil {
@@ -1418,7 +1418,7 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
-		"projectId": llx.StringData(args["projectId"].Value.(string)),
+		"projectId": args["projectId"],
 	})
 	if err != nil {
 		return nil, nil, err
@@ -1672,7 +1672,7 @@ func initGcpProjectComputeServiceImage(runtime *plugin.Runtime, args map[string]
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
-		"projectId": llx.StringData(args["projectId"].Value.(string)),
+		"projectId": args["projectId"],
 	})
 	if err != nil {
 		return nil, nil, err
@@ -2096,7 +2096,7 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 
 	// Fallback: fetch directly from the GCP API
 	networkName, _ := args["name"].Value.(string)
-	projectId := args["projectId"].Value.(string)
+	projectId, _ := args["projectId"].Value.(string)
 
 	conn := runtime.Connection.(*connection.GcpConnection)
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)
@@ -2246,7 +2246,8 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 		}
 	} else {
 		if args["regionUrl"] != nil {
-			region = RegionNameFromRegionUrl(args["regionUrl"].Value.(string))
+			regionUrlVal, _ := args["regionUrl"].Value.(string)
+			region = RegionNameFromRegionUrl(regionUrlVal)
 		}
 	}
 
@@ -2258,7 +2259,7 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 	}
 
 	obj, err := NewResource(runtime, "gcp.project.computeService", map[string]*llx.RawData{
-		"projectId": llx.StringData(args["projectId"].Value.(string)),
+		"projectId": args["projectId"],
 	})
 	if err != nil {
 		return nil, nil, err
@@ -2298,7 +2299,7 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 
 	// Fallback: fetch directly from the GCP API
 	subnetworkName, _ := args["name"].Value.(string)
-	projectId := args["projectId"].Value.(string)
+	projectId, _ := args["projectId"].Value.(string)
 
 	conn := runtime.Connection.(*connection.GcpConnection)
 	client, err := conn.Client(cloudresourcemanager.CloudPlatformReadOnlyScope, iam.CloudPlatformScope, compute.CloudPlatformScope)

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -3255,6 +3255,17 @@ func (g *mqlGcpProjectComputeServiceRouterNat) id() (string, error) {
 
 // Cloud Armor security policies
 
+// mqlGcpProjectComputeServiceSecurityPolicyInternal carries what rules() needs
+// to re-fetch the policy. The schema has no projectId field, and the policy's
+// project is not derivable from the connection: on an organization or folder
+// connection ResourceID() is not a project id, and `gcp.projects` walks many
+// projects in one runtime. cacheRegion distinguishes global from regional
+// policies, which live behind different endpoints.
+type mqlGcpProjectComputeServiceSecurityPolicyInternal struct {
+	cacheProjectId string
+	cacheRegion    string
+}
+
 func (g *mqlGcpProjectComputeServiceSecurityPolicy) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
@@ -3337,6 +3348,9 @@ func (g *mqlGcpProjectComputeService) securityPolicies() ([]any, error) {
 				if err != nil {
 					return err
 				}
+				sp := mqlPolicy.(*mqlGcpProjectComputeServiceSecurityPolicy)
+				sp.cacheProjectId = projectId
+				sp.cacheRegion = RegionNameFromRegionUrl(policy.Region)
 				res = append(res, mqlPolicy)
 			}
 		}
@@ -3372,11 +3386,28 @@ func (g *mqlGcpProjectComputeServiceSecurityPolicy) rules() ([]any, error) {
 	}
 	policyName := g.Name.Data
 
-	// We need the project ID from the connection since the policy doesn't store it
-	projectId := conn.ResourceID()
+	// Use the project the policy was listed from. conn.ResourceID() is the
+	// connection scope, which is an organization or folder id on a non-project
+	// connection and the wrong project when `gcp.projects` walks many projects.
+	projectId := g.cacheProjectId
+	if projectId == "" {
+		projectId = conn.ResourceID()
+	}
 
-	policy, err := computeSvc.SecurityPolicies.Get(projectId, policyName).Context(ctx).Do()
+	// securityPolicies() lists via AggregatedList, which returns regional
+	// policies too. Those are served by RegionSecurityPolicies; asking the
+	// global endpoint for them 404s.
+	var policy *compute.SecurityPolicy
+	if g.cacheRegion != "" {
+		policy, err = computeSvc.RegionSecurityPolicies.Get(projectId, g.cacheRegion, policyName).Context(ctx).Do()
+	} else {
+		policy, err = computeSvc.SecurityPolicies.Get(projectId, policyName).Context(ctx).Do()
+	}
 	if err != nil {
+		if isHTTPSkippable(err) {
+			log.Warn().Str("policy", policyName).Err(err).Msg("could not fetch security policy rules")
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -1429,6 +1429,12 @@ func initGcpProjectComputeServiceFirewall(runtime *plugin.Runtime, args map[stri
 		return nil, nil, firewalls.Error
 	}
 
+	// Guard every arg this lookup dereferences: args["x"] on an absent key is a
+	// nil *llx.RawData, and dereferencing it panics the provider, which kills
+	// the whole scan rather than failing one query.
+	if args["name"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.firewall requires a \"name\" argument")
+	}
 	for _, f := range firewalls.Data {
 		firewall := f.(*mqlGcpProjectComputeServiceFirewall)
 		name := firewall.GetName()
@@ -1677,6 +1683,12 @@ func initGcpProjectComputeServiceImage(runtime *plugin.Runtime, args map[string]
 		return nil, nil, images.Error
 	}
 
+	// Guard every arg this lookup dereferences: args["x"] on an absent key is a
+	// nil *llx.RawData, and dereferencing it panics the provider, which kills
+	// the whole scan rather than failing one query.
+	if args["name"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.image requires a \"name\" argument")
+	}
 	for _, i := range images.Data {
 		image := i.(*mqlGcpProjectComputeServiceImage)
 		if image.Name.Error != nil {
@@ -2060,6 +2072,12 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 		return nil, nil, networks.Error
 	}
 
+	// Guard every arg this lookup dereferences: args["x"] on an absent key is a
+	// nil *llx.RawData, and dereferencing it panics the provider, which kills
+	// the whole scan rather than failing one query.
+	if args["name"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.network requires a \"name\" argument")
+	}
 	for _, n := range networks.Data {
 		network := n.(*mqlGcpProjectComputeServiceNetwork)
 		name := network.GetName()
@@ -2077,7 +2095,7 @@ func initGcpProjectComputeServiceNetwork(runtime *plugin.Runtime, args map[strin
 	}
 
 	// Fallback: fetch directly from the GCP API
-	networkName := args["name"].Value.(string)
+	networkName, _ := args["name"].Value.(string)
 	projectId := args["projectId"].Value.(string)
 
 	conn := runtime.Connection.(*connection.GcpConnection)
@@ -2251,6 +2269,12 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 		return nil, nil, subnetworks.Error
 	}
 
+	// Guard every arg this lookup dereferences: args["x"] on an absent key is a
+	// nil *llx.RawData, and dereferencing it panics the provider, which kills
+	// the whole scan rather than failing one query.
+	if args["name"] == nil {
+		return nil, nil, errors.New("gcp.project.computeService.subnetwork requires a \"name\" argument")
+	}
 	for _, n := range subnetworks.Data {
 		subnetwork := n.(*mqlGcpProjectComputeServiceSubnetwork)
 		name := subnetwork.GetName()
@@ -2273,7 +2297,7 @@ func initGcpProjectComputeServiceSubnetwork(runtime *plugin.Runtime, args map[st
 	}
 
 	// Fallback: fetch directly from the GCP API
-	subnetworkName := args["name"].Value.(string)
+	subnetworkName, _ := args["name"].Value.(string)
 	projectId := args["projectId"].Value.(string)
 
 	conn := runtime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -132,7 +132,7 @@ func initGcpProjectComputeServiceRegion(runtime *plugin.Runtime, args map[string
 	if err != nil {
 		return nil, nil, err
 	}
-	mqlRegion, err := newMqlRegion(runtime, region)
+	mqlRegion, err := newMqlRegion(runtime, projectId, region)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -217,17 +217,18 @@ func (g *mqlGcpProjectComputeService) regions() ([]any, error) {
 		return nil, err
 	}
 
-	req, err := computeSvc.Regions.List(projectId).Do()
-	if err != nil {
-		return nil, err
-	}
-	res := make([]any, 0, len(req.Items))
-	for _, r := range req.Items {
-		mqlRegion, err := newMqlRegion(g.MqlRuntime, r)
-		if err != nil {
-			return nil, err
+	res := []any{}
+	if err := computeSvc.Regions.List(projectId).Pages(ctx, func(page *compute.RegionList) error {
+		for _, r := range page.Items {
+			mqlRegion, err := newMqlRegion(g.MqlRuntime, projectId, r)
+			if err != nil {
+				return err
+			}
+			res = append(res, mqlRegion)
 		}
-		res = append(res, mqlRegion)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	log.Debug().Str("project", projectId).Int("regions", len(res)).Msg("gcp.compute> listed regions")
@@ -572,8 +573,14 @@ func (g *mqlGcpProjectComputeServiceInstance) machineType() (*mqlGcpProjectCompu
 	return newMqlMachineType(g.MqlRuntime, machineType, projectId, zone.Data)
 }
 
-func newMqlServiceAccount(runtime *plugin.Runtime, sa *compute.ServiceAccount) (any, error) {
+// newMqlServiceAccount builds the per-instance service account binding. The
+// resource carries the OAuth `scopes` granted to one VM, which differ between
+// VMs sharing the same service account, so the cache key has to include the
+// instance. Keying on the email alone made every VM using the default compute
+// service account report the first VM's scopes.
+func newMqlServiceAccount(runtime *plugin.Runtime, instanceId uint64, sa *compute.ServiceAccount) (any, error) {
 	return CreateResource(runtime, "gcp.project.computeService.serviceaccount", map[string]*llx.RawData{
+		"__id":   llx.StringData(fmt.Sprintf("gcp.project.computeService.instance/%d/serviceaccount/%s", instanceId, sa.Email)),
 		"email":  llx.StringData(sa.Email),
 		"scopes": llx.ArrayData(convert.SliceAnyToInterface(sa.Scopes), types.String),
 	})
@@ -692,7 +699,7 @@ func newMqlComputeServiceInstance(projectId string, zone *mqlGcpProjectComputeSe
 	for i := range instance.ServiceAccounts {
 		sa := instance.ServiceAccounts[i]
 
-		mqlServiceAccount, err := newMqlServiceAccount(runtime, sa)
+		mqlServiceAccount, err := newMqlServiceAccount(runtime, instance.Id, sa)
 		if err != nil {
 			log.Error().Err(err).Send()
 		} else {
@@ -2364,7 +2371,7 @@ func (g *mqlGcpProjectComputeServiceSubnetwork) network() (*mqlGcpProjectCompute
 	return net, nil
 }
 
-func newMqlRegion(runtime *plugin.Runtime, r *compute.Region) (any, error) {
+func newMqlRegion(runtime *plugin.Runtime, projectId string, r *compute.Region) (any, error) {
 	deprecated, err := convert.JsonToDict(r.Deprecated)
 	if err != nil {
 		return nil, err
@@ -2377,6 +2384,10 @@ func newMqlRegion(runtime *plugin.Runtime, r *compute.Region) (any, error) {
 	}
 
 	return CreateResource(runtime, "gcp.project.computeService.region", map[string]*llx.RawData{
+		// A region resource carries per-project quotas, so the cache key must
+		// include the project. Keying on the region name alone made every
+		// project after the first report the first project's quota limits.
+		"__id":        llx.StringData("gcp.project.computeService.region/" + projectId + "/" + r.Name),
 		"id":          llx.StringData(strconv.FormatInt(int64(r.Id), 10)),
 		"name":        llx.StringData(r.Name),
 		"description": llx.StringData(r.Description),
@@ -2804,7 +2815,10 @@ func (g *mqlGcpProjectComputeService) backendServices() ([]any, error) {
 							"path": b.ConsistentHash.HttpCookie.Path,
 						}
 						if b.ConsistentHash.HttpCookie.Ttl != nil {
-							cookieMap["ttl"] = llx.TimeData(llx.DurationToTime(b.ConsistentHash.HttpCookie.Ttl.Seconds))
+							// Dict values must be JSON-native; an *llx.RawData
+							// (what llx.TimeData returns) fails dict2primitive at
+							// query time.
+							cookieMap["ttlSeconds"] = b.ConsistentHash.HttpCookie.Ttl.Seconds
 						}
 						consistentHashMap["httpCookie"] = cookieMap
 					}

--- a/providers/gcp/resources/compute_instance_groups_firewall_policies.go
+++ b/providers/gcp/resources/compute_instance_groups_firewall_policies.go
@@ -265,9 +265,13 @@ func (g *mqlGcpProjectComputeService) firewallPolicies() ([]any, error) {
 			associations, _ := convert.JsonToDictSlice(fp.Associations)
 
 			mqlFP, err := CreateResource(g.MqlRuntime, "gcp.project.computeService.firewallPolicy", map[string]*llx.RawData{
-				"id":             llx.StringData(strconv.FormatUint(fp.Id, 10)),
-				"projectId":      llx.StringData(projectId),
-				"name":           llx.StringData(fp.ShortName),
+				"id":        llx.StringData(strconv.FormatUint(fp.Id, 10)),
+				"projectId": llx.StringData(projectId),
+				// ShortName and DisplayName are documented "not applicable to
+				// network firewall policies" and always come back empty from
+				// NetworkFirewallPolicies.List; Name carries the user-provided
+				// name for this policy kind.
+				"name":           llx.StringData(fp.Name),
 				"displayName":    llx.StringData(fp.DisplayName),
 				"description":    llx.StringData(fp.Description),
 				"selfLink":       llx.StringData(fp.SelfLink),

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -182,6 +182,11 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 		go func(projectId, regionName string) {
 			defer wg.Done()
 			err := dataprocSvc.Projects.Regions.Clusters.List(projectId, regionName).Pages(ctx, func(clusters *dataproc.ListClustersResponse) error {
+				// A `:=` variable is not in scope inside its own initializer, so
+				// without this declaration every `err = ...` in the closure below
+				// would write the function-scope `err` that all region goroutines
+				// share -- a data race, and misattributed error logs.
+				var err error
 				for _, c := range clusters.Clusters {
 					var mqlConfig plugin.Resource
 					if c.Config != nil {

--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -1958,14 +1958,18 @@ func (a *GcrImages) Name() string {
 
 // lists a repository like "gcr.io/mondoo-base-infra"
 func (a *GcrImages) ListRepository(repository string, recursive bool) ([]*inventory.Asset, error) {
+	// Both of these are reachable with user-supplied input (the repository is
+	// built from the connection's project-id and an optional --repository
+	// option), so they must return an error rather than exit: log.Fatal calls
+	// os.Exit and would take the whole provider process down.
 	repo, err := name.NewRepository(repository)
 	if err != nil {
-		log.Fatal().Err(err).Str("repository", repository).Msg("could not create repository")
+		return nil, errors.Join(errors.New("could not create repository "+repository), err)
 	}
 
 	auth, err := google.Keychain.Resolve(repo.Registry)
 	if err != nil {
-		log.Fatal().Err(err).Str("repository", repository).Msg("failed to get auth for repository")
+		return nil, errors.Join(errors.New("failed to get auth for repository "+repository), err)
 	}
 
 	imgs := []*inventory.Asset{}

--- a/providers/gcp/resources/folder.go
+++ b/providers/gcp/resources/folder.go
@@ -81,7 +81,7 @@ func initGcpFolder(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[s
 
 	folderId := conn.ResourceID()
 	if args["id"] != nil {
-		folderId = args["id"].Value.(string)
+		folderId, _ = args["id"].Value.(string)
 	}
 
 	folderPath := fmt.Sprintf("folders/%s", folderId)

--- a/providers/gcp/resources/folder_test.go
+++ b/providers/gcp/resources/folder_test.go
@@ -38,3 +38,40 @@ func TestFolderIdNormalizationRoundTrip(t *testing.T) {
 		t.Errorf("child lookup key = %q, want folders/123456 (double-prefix regression)", childKey)
 	}
 }
+
+// TestProjectParentMatchesFolderKey pins the other half of the folder-id
+// contract, which is where the round-trip above was silently broken.
+//
+// cloudresourcemanager v3 always reports Project.Parent as a *prefixed*
+// reference ("folders/876", "organizations/123"), while gcp.folder stores the
+// bare id ("876"). gcp.projects.list() builds a set of acceptable parents from
+// the folder list and matches Project.Parent against it, so both sides have to
+// be normalized to the same "folders/{id}" shape. Comparing the bare id
+// against Project.Parent matches nothing, and every project nested in a
+// subfolder disappears from the listing with no error.
+func TestProjectParentMatchesFolderKey(t *testing.T) {
+	// The seed parent, as gcp.folder.projects() / gcp.organization.projects()
+	// supply it -- already prefixed.
+	parentId := "organizations/123"
+
+	// Folder ids as stored by folderToMql / initGcpFolder: bare.
+	folderIds := []string{"876", "877"}
+
+	foldersMap := map[string]struct{}{parentId: {}}
+	for _, id := range folderIds {
+		foldersMap[folderResourceName(id)] = struct{}{}
+	}
+
+	// Parents exactly as the API reports them.
+	for _, parent := range []string{"organizations/123", "folders/876", "folders/877"} {
+		if _, ok := foldersMap[parent]; !ok {
+			t.Errorf("Project.Parent %q did not match the folder key set %v; "+
+				"projects under that parent would be silently dropped", parent, foldersMap)
+		}
+	}
+
+	// A folder outside the scanned hierarchy must still not match.
+	if _, ok := foldersMap["folders/999"]; ok {
+		t.Error("unrelated folder matched the key set")
+	}
+}

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -70316,7 +70316,7 @@ func (c *mqlGcpProjectAlloydbServiceBackup) GetKmsKey() *plugin.TValue[*mqlGcpPr
 type mqlGcpProjectComputeServiceSecurityPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlGcpProjectComputeServiceSecurityPolicyInternal it will be used here
+	mqlGcpProjectComputeServiceSecurityPolicyInternal
 	Id                       plugin.TValue[string]
 	Name                     plugin.TValue[string]
 	Description              plugin.TValue[string]

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
   "version": "13.33.2",
-  "generated_at": "2026-07-25T13:09:40-07:00",
+  "generated_at": "2026-07-25T20:59:25-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",
@@ -117,6 +117,7 @@
     "compute.packetMirrorings.list",
     "compute.projects.get",
     "compute.publicAdvertisedPrefixes.list",
+    "compute.regionSecurityPolicies.get",
     "compute.regions.get",
     "compute.regions.list",
     "compute.routers.list",
@@ -589,7 +590,7 @@
     {
       "permission": "binaryauthorization.policy.get",
       "service": "binaryauthorization",
-      "action": "GetSystemPolicy",
+      "action": "GetPolicy",
       "source_file": "binary_authorization.go"
     },
     {
@@ -983,6 +984,12 @@
       "source_file": "compute_networking.go"
     },
     {
+      "permission": "compute.regionSecurityPolicies.get",
+      "service": "compute",
+      "action": "RegionSecurityPolicies.Get",
+      "source_file": "compute.go"
+    },
+    {
       "permission": "compute.regions.get",
       "service": "compute",
       "action": "Regions.Get",
@@ -1011,6 +1018,12 @@
       "service": "compute",
       "action": "Regions.List",
       "source_file": "dataproc.go"
+    },
+    {
+      "permission": "compute.regions.list",
+      "service": "compute",
+      "action": "Regions.List",
+      "source_file": "recommendations.go"
     },
     {
       "permission": "compute.routers.list",

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -103,6 +103,19 @@ func initGcpProjectGkeServiceCluster(runtime *plugin.Runtime, args map[string]*l
 		return nil, nil, clusters.Error
 	}
 
+	// args["name"] on an absent key is a nil *llx.RawData; dereferencing it
+	// panics the provider and kills the whole scan. `location` narrows the
+	// match when supplied but is optional, so a two-arg lookup still resolves.
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.gkeService.cluster requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
+	locationVal := ""
+	if args["location"] != nil {
+		locationVal, _ = args["location"].Value.(string)
+	}
+
 	for _, c := range clusters.Data {
 		cluster := c.(*mqlGcpProjectGkeServiceCluster)
 		name := cluster.GetName()
@@ -118,7 +131,8 @@ func initGcpProjectGkeServiceCluster(runtime *plugin.Runtime, args map[string]*l
 			return nil, nil, location.Error
 		}
 
-		if name.Data == args["name"].Value && projectId.Data == args["projectId"].Value && location.Data == args["location"].Value {
+		if name.Data == nameVal && projectId.Data == args["projectId"].Value &&
+			(locationVal == "" || location.Data == locationVal) {
 			return args, cluster, nil
 		}
 	}

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -853,7 +853,11 @@ func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 			}
 		}
 
-		notificationConfig, err := buildGKENotificationConfig(g.MqlRuntime, c.Name, c.NotificationConfig)
+		// Key on the cluster's server-assigned unique Id, not its name: cluster
+		// names are unique only within a project+location, so two clusters named
+		// "prod" in different projects would share one notificationConfig cache
+		// entry. Every other cluster sub-resource in this file uses c.Id.
+		notificationConfig, err := buildGKENotificationConfig(g.MqlRuntime, c.Id, c.NotificationConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -1412,18 +1416,24 @@ func (g *mqlGcpProjectGkeServiceClusterNetworkConfig) subnetwork() (*mqlGcpProje
 	}
 	subnetPath := g.SubnetworkPath.Data
 
-	// Format is projects/project-1/regions/us-central1/subnetworks/subnet-1
-	params := strings.Split(subnetPath, "/")
-	regionUrl := strings.SplitN(subnetPath, "/subnetworks", 2)
-	res, err := NewResource(g.MqlRuntime, "gcp.project.computeService.subnetwork", map[string]*llx.RawData{
-		"name":      llx.StringData(params[len(params)-1]),
-		"projectId": llx.StringData(params[1]),
-		"regionUrl": llx.StringData(regionUrl[0]),
-	})
+	// NetworkConfig.Subnetwork is not a required field: it is empty for
+	// routes-based clusters on a legacy (subnet-less) network. Blindly indexing
+	// the split path panics there, and a panic in a provider accessor is
+	// unrecoverable because the executor runs blocks in goroutines. Delegate to
+	// getSubnetworkByUrl, which length-guards the path, and degrade to null.
+	if subnetPath == "" {
+		g.Subnetwork.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	subnet, err := getSubnetworkByUrl(subnetPath, g.MqlRuntime)
 	if err != nil {
 		return nil, err
 	}
-	return res.(*mqlGcpProjectComputeServiceSubnetwork), nil
+	if subnet == nil {
+		g.Subnetwork.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	return subnet, nil
 }
 
 func (g *mqlGcpProjectGkeServiceClusterMaintenancePolicy) id() (string, error) {

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -92,7 +92,7 @@ func initGcpProjectGkeServiceCluster(runtime *plugin.Runtime, args map[string]*l
 	}
 
 	obj, err := CreateResource(runtime, "gcp.project.gkeService", map[string]*llx.RawData{
-		"projectId": llx.StringData(args["projectId"].Value.(string)),
+		"projectId": args["projectId"],
 	})
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -176,7 +176,7 @@ func initGcpProjectIamServiceServiceAccount(runtime *plugin.Runtime, args map[st
 	// zero value, which short-circuits serviceAccounts() to nil and makes the
 	// SA lookup miss every typed-ref query.
 	projObj, err := CreateResource(runtime, "gcp.project", map[string]*llx.RawData{
-		"id": llx.StringData(args["projectId"].Value.(string)),
+		"id": args["projectId"],
 	})
 	if err != nil {
 		return nil, nil, err

--- a/providers/gcp/resources/iap.go
+++ b/providers/gcp/resources/iap.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	iap "cloud.google.com/go/iap/apiv1"
@@ -67,9 +68,13 @@ func (g *mqlGcpProjectIapService) iamPolicy() ([]any, error) {
 	}
 
 	res := make([]any, 0, len(policy.Bindings))
-	for _, b := range policy.Bindings {
+	// Index-suffixed, matching every other IAM binding creator in the provider.
+	// An IAM v3 policy may carry several bindings for the same role that differ
+	// only by condition -- and this call asks for version 3 -- so keying on the
+	// role alone silently collapses them onto the first one.
+	for i, b := range policy.Bindings {
 		mqlBinding, err := CreateResource(g.MqlRuntime, "gcp.resourcemanager.binding", map[string]*llx.RawData{
-			"id":                   llx.StringData(resource + "/" + b.Role),
+			"id":                   llx.StringData(resource + "-" + strconv.Itoa(i)),
 			"role":                 llx.StringData(b.Role),
 			"members":              llx.ArrayData(convert.SliceAnyToInterface(b.Members), types.String),
 			"conditionTitle":       llx.StringData(b.GetCondition().GetTitle()),

--- a/providers/gcp/resources/init_guard_test.go
+++ b/providers/gcp/resources/init_guard_test.go
@@ -144,3 +144,133 @@ func exprOf(n ast.Node) ast.Expr {
 	e, _ := n.(ast.Expr)
 	return e
 }
+
+// TestInitGuardsEveryDereferencedArg generalizes the projectId guard above to
+// every args key an init function dereferences.
+//
+// `args["name"]` on an absent key yields a nil *llx.RawData, so `.Value` or
+// `.Data` on it panics inside the provider. Because the executor runs blocks
+// in goroutines that panic is unrecoverable: it kills the whole scan, not one
+// query. A partial lookup such as
+//
+//	gcp.project.computeService.network(projectId: "p")
+//
+// is a perfectly natural query and must return an error, not crash.
+//
+// A key counts as guarded once the function has compared it (or a variable
+// bound to it) against nil, or bound it with the comma-ok form.
+func TestInitGuardsEveryDereferencedArg(t *testing.T) {
+	fset := token.NewFileSet()
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !strings.HasPrefix(fn.Name.Name, "init") {
+				continue
+			}
+
+			guardedAt := map[string]token.Pos{} // key -> first guard position
+			varToKey := map[string]string{}     // local var -> args key it holds
+			type deref struct {
+				key string
+				pos token.Pos
+			}
+			var derefs []deref
+
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.AssignStmt:
+					// v := args["k"]  /  v, ok := args["k"]
+					if node.Tok == token.DEFINE && len(node.Rhs) == 1 {
+						for _, key := range argsKeys(node.Rhs[0]) {
+							if id, ok := node.Lhs[0].(*ast.Ident); ok {
+								varToKey[id.Name] = key
+							}
+							// the comma-ok form is itself a presence check
+							if len(node.Lhs) == 2 {
+								if _, seen := guardedAt[key]; !seen {
+									guardedAt[key] = node.Pos()
+								}
+							}
+						}
+					}
+				case *ast.BinaryExpr:
+					for _, e := range []ast.Expr{node.X, node.Y} {
+						other := node.Y
+						if e == node.Y {
+							other = node.X
+						}
+						if !isNilIdent(other) {
+							continue
+						}
+						var key string
+						if k := argsKeys(e); len(k) == 1 {
+							key = k[0]
+						} else if id, ok := e.(*ast.Ident); ok {
+							key = varToKey[id.Name]
+						}
+						if key == "" {
+							continue
+						}
+						if _, seen := guardedAt[key]; !seen {
+							guardedAt[key] = node.Pos()
+						}
+					}
+				case *ast.SelectorExpr:
+					// args["k"].Value / args["k"].Data, or v.Value where v holds one
+					if node.Sel.Name != "Value" && node.Sel.Name != "Data" {
+						return true
+					}
+					var key string
+					if k := argsKeys(node.X); len(k) == 1 {
+						key = k[0]
+					} else if id, ok := node.X.(*ast.Ident); ok {
+						key = varToKey[id.Name]
+					}
+					if key != "" {
+						derefs = append(derefs, deref{key: key, pos: node.Pos()})
+					}
+				}
+				return true
+			})
+
+			for _, d := range derefs {
+				guard, ok := guardedAt[d.key]
+				if !ok || guard > d.pos {
+					t.Errorf("%s: %s dereferences args[%q] without a nil-guard; "+
+						"a partial query would panic the provider and kill the scan",
+						fset.Position(d.pos), fn.Name.Name, d.key)
+				}
+			}
+		}
+	}
+}
+
+// argsKeys returns the args key referenced by e, if e is args["<key>"].
+func argsKeys(e ast.Expr) []string {
+	idx, ok := e.(*ast.IndexExpr)
+	if !ok {
+		return nil
+	}
+	ident, ok := idx.X.(*ast.Ident)
+	if !ok || ident.Name != "args" {
+		return nil
+	}
+	lit, ok := idx.Index.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return nil
+	}
+	return []string{strings.Trim(lit.Value, `"`)}
+}

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -621,7 +621,7 @@ func initGcpProjectLoggingserviceBucket(runtime *plugin.Runtime, args map[string
 	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
-		locationVal = args["location"].Value.(string)
+		locationVal, _ = args["location"].Value.(string)
 	}
 	for _, b := range buckets.Data {
 		bucket := b.(*mqlGcpProjectLoggingserviceBucket)

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -132,7 +132,7 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 
 			indexConfigs := make([]any, 0, len(bucket.IndexConfigs))
 			for _, cfg := range bucket.IndexConfigs {
-				mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfigs", map[string]*llx.RawData{
+				mqlIndexConfig, err := CreateResource(g.MqlRuntime, "gcp.project.loggingservice.bucket.indexConfig", map[string]*llx.RawData{
 					"id":        llx.StringData(fmt.Sprintf("%s/indexConfigs/%s", bucket.Name, cfg.FieldPath)),
 					"created":   llx.TimeDataPtr(parseTime(cfg.CreateTime)),
 					"fieldPath": llx.StringData(cfg.FieldPath),

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -614,7 +614,11 @@ func initGcpProjectLoggingserviceBucket(runtime *plugin.Runtime, args map[string
 		return nil, nil, buckets.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.loggingservice.bucket requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	locationVal := ""
 	if args["location"] != nil {
 		locationVal = args["location"].Value.(string)

--- a/providers/gcp/resources/permissions_test.go
+++ b/providers/gcp/resources/permissions_test.go
@@ -152,6 +152,7 @@ var validatedGCPPermissions = []string{
 	"compute.packetMirrorings.list",
 	"compute.projects.get",
 	"compute.publicAdvertisedPrefixes.list",
+	"compute.regionSecurityPolicies.get",
 	"compute.regions.get",
 	"compute.regions.list",
 	"compute.routers.list",

--- a/providers/gcp/resources/project.go
+++ b/providers/gcp/resources/project.go
@@ -511,13 +511,18 @@ func (g *mqlGcpProjects) list() ([]any, error) {
 		return nil, folders.Error
 	}
 
+	// Project.Parent is always a prefixed reference ("folders/876",
+	// "organizations/123"), while gcp.folder stores the bare id ("876"), so both
+	// sides have to be normalized to the "folders/{id}" resource name before
+	// they are compared. Without this, only the direct children of parentId
+	// match and every project nested in a subfolder is silently dropped.
 	foldersMap := map[string]struct{}{parentId: {}}
 	for _, f := range folders.Data {
 		id := f.(*mqlGcpFolder).GetId()
 		if id.Error != nil {
 			return nil, id.Error
 		}
-		foldersMap[id.Data] = struct{}{}
+		foldersMap[folderResourceName(id.Data)] = struct{}{}
 	}
 
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -212,7 +212,11 @@ func initGcpProjectPubsubServiceSubscription(runtime *plugin.Runtime, args map[s
 		return nil, nil, subs.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.pubsubService.subscription requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, s := range subs.Data {
 		sub := s.(*mqlGcpProjectPubsubServiceSubscription)
 		if sub.Name.Data == nameVal {
@@ -291,7 +295,11 @@ func initGcpProjectPubsubServiceSnapshot(runtime *plugin.Runtime, args map[strin
 		return nil, nil, snapshots.Error
 	}
 
-	nameVal := args["name"].Value.(string)
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.pubsubService.snapshot requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
 	for _, s := range snapshots.Data {
 		snap := s.(*mqlGcpProjectPubsubServiceSnapshot)
 		if snap.Name.Data == nameVal {

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -110,11 +110,26 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 		return nil, err
 	}
 
-	zones := []*compute.Zone{}
+	// Recommenders are published at three location scopes: global (IAM policy,
+	// project utilization, error reporting, ...), regional (Cloud Run identity
+	// and security, Cloud SQL, commitments, ...) and zonal (idle compute
+	// resources). Querying zones alone means every global and regional
+	// recommender — including google.iam.policy.Recommender — returns nothing,
+	// forever, with no error.
+	locations := []string{"global"}
+	if err := computeSvc.Regions.List(projectId).Pages(ctx, func(page *compute.RegionList) error {
+		for _, region := range page.Items {
+			locations = append(locations, region.Name)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
 	req := computeSvc.Zones.List(projectId)
 	if err := req.Pages(ctx, func(page *compute.ZoneList) error {
 		for _, zone := range page.Items {
-			zones = append(zones, zone)
+			locations = append(locations, zone.Name)
 		}
 		return nil
 	}); err != nil {
@@ -135,17 +150,22 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 
 	res := []any{}
 	var wg sync.WaitGroup
-	wg.Add(len(zones))
+	wg.Add(len(locations))
 	mux := &sync.Mutex{}
+	// Bound the fan-out: the location set now spans global + regions + zones, so
+	// an unbounded goroutine per location would open ~90 concurrent workers.
+	sem := make(chan struct{}, 10)
 
-	for i := range zones {
-		zoneName := zones[i].Name
-		// we run a worker routine per zone
-		go func(zoneNameValue string) {
+	for i := range locations {
+		location := locations[i]
+		// we run a worker routine per location
+		go func(locationValue string) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			for j := range recommenders {
 				recommender := recommenders[j]
 
-				parent := fmt.Sprintf("projects/%s/locations/%s/recommenders/%s", projectId, zoneNameValue, recommender)
+				parent := fmt.Sprintf("projects/%s/locations/%s/recommenders/%s", projectId, locationValue, recommender)
 				it := c.ListRecommendations(ctx, &recommenderpb.ListRecommendationsRequest{
 					Parent: parent,
 				})
@@ -171,7 +191,7 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 				}
 			}
 			wg.Done()
-		}(zoneName)
+		}(location)
 	}
 	wg.Wait()
 	return res, nil

--- a/providers/gcp/resources/recommendations.go
+++ b/providers/gcp/resources/recommendations.go
@@ -160,6 +160,9 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 		location := locations[i]
 		// we run a worker routine per location
 		go func(locationValue string) {
+			// Deferred so an early return or a panic in the body can never leave
+			// wg.Wait() blocked forever.
+			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			for j := range recommenders {
@@ -190,7 +193,6 @@ func (g *mqlGcpProject) recommendations() ([]any, error) {
 					mux.Unlock()
 				}
 			}
-			wg.Done()
 		}(location)
 	}
 	wg.Wait()

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -289,11 +289,11 @@ func (g *mqlGcpProjectRedisService) instances() ([]any, error) {
 				convert.SliceAnyToInterface(instance.AvailableMaintenanceVersions), types.String,
 			),
 			"nodes": llx.ArrayData(
-				redisInstanceNodesToArrayInterface(g.MqlRuntime, projectId, instance.Nodes),
+				redisInstanceNodesToArrayInterface(g.MqlRuntime, projectId, instance.Name, instance.Nodes),
 				types.Resource("gcp.project.redisService.instance.nodeInfo"),
 			),
 			"serverCaCerts": llx.ArrayData(
-				redisConvertServerCaCerts(g.MqlRuntime, projectId, instance.ServerCaCerts),
+				redisConvertServerCaCerts(g.MqlRuntime, projectId, instance.Name, instance.ServerCaCerts),
 				types.Resource("gcp.project.redisService.instance.serverCaCert"),
 			),
 		})
@@ -316,13 +316,18 @@ func (n *mqlGcpProjectRedisServiceInstanceNodeInfo) id() (string, error) {
 	), nil
 }
 
-func redisInstanceNodesToArrayInterface(runtime *plugin.Runtime, projectId string, nodes []*redispb.NodeInfo) (list []any) {
+// redisInstanceNodesToArrayInterface keys each node on its parent instance:
+// NodeInfo.Id is only "node-0", "node-1", ... which is unique within one
+// instance, so a project-scoped key aliased every instance's nodes onto the
+// first instance's.
+func redisInstanceNodesToArrayInterface(runtime *plugin.Runtime, projectId, instanceName string, nodes []*redispb.NodeInfo) (list []any) {
 	for _, node := range nodes {
 		if node == nil {
 			continue
 		}
 
 		r, err := CreateResource(runtime, "gcp.project.redisService.instance.nodeInfo", map[string]*llx.RawData{
+			"__id":      llx.StringData(instanceName + "/nodes/" + node.Id),
 			"projectId": llx.StringData(projectId),
 			"id":        llx.StringData(node.Id),
 			"zone":      llx.StringData(node.Zone),
@@ -345,7 +350,11 @@ func (c *mqlGcpProjectRedisServiceInstanceServerCaCert) id() (string, error) {
 	), nil
 }
 
-func redisConvertServerCaCerts(runtime *plugin.Runtime, projectId string, certs []*redispb.TlsCertificate) (list []any) {
+// redisConvertServerCaCerts keys each certificate on its parent instance:
+// Memorystore issues a per-instance server CA whose serial numbers start at
+// "1", so a project-scoped key made instance B render instance A's PEM and
+// expiry -- silently evaluating a CA-expiry audit against the wrong cert.
+func redisConvertServerCaCerts(runtime *plugin.Runtime, projectId, instanceName string, certs []*redispb.TlsCertificate) (list []any) {
 	for _, cert := range certs {
 		if cert == nil {
 			continue
@@ -360,6 +369,7 @@ func redisConvertServerCaCerts(runtime *plugin.Runtime, projectId string, certs 
 		}
 
 		r, err := CreateResource(runtime, "gcp.project.redisService.instance.serverCaCert", map[string]*llx.RawData{
+			"__id":            llx.StringData(instanceName + "/serverCaCerts/" + cert.SerialNumber),
 			"projectId":       llx.StringData(projectId),
 			"serialNumber":    llx.StringData(cert.SerialNumber),
 			"cert":            llx.StringData(cert.Cert),

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -79,6 +79,19 @@ func initGcpProjectSqlServiceInstance(runtime *plugin.Runtime, args map[string]*
 		return nil, nil, instances.Error
 	}
 
+	// args["name"] on an absent key is a nil *llx.RawData; dereferencing it
+	// panics the provider and kills the whole scan. `region` narrows the match
+	// when supplied but is optional, so a two-arg lookup still resolves.
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return nil, nil, errors.New("gcp.project.sqlService.instance requires a \"name\" argument")
+	}
+	nameVal, _ := nameRaw.Value.(string)
+	regionVal := ""
+	if args["region"] != nil {
+		regionVal, _ = args["region"].Value.(string)
+	}
+
 	// Find the matching instance
 	for _, inst := range instances.Data {
 		instance := inst.(*mqlGcpProjectSqlServiceInstance)
@@ -95,7 +108,8 @@ func initGcpProjectSqlServiceInstance(runtime *plugin.Runtime, args map[string]*
 			return nil, nil, instanceRegion.Error
 		}
 
-		if instanceRegion.Data == args["region"].Value && name.Data == args["name"].Value && projectId.Data == args["projectId"].Value {
+		if name.Data == nameVal && projectId.Data == args["projectId"].Value &&
+			(regionVal == "" || instanceRegion.Data == regionVal) {
 			return args, instance, nil
 		}
 	}

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -57,6 +57,37 @@ func initGcpProjectStorageService(runtime *plugin.Runtime, args map[string]*llx.
 
 type mqlGcpProjectStorageServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// The flag is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: gcp.storage / gcloud.storage is an
+// alias for it, and resource inits build it with CreateResource. On those paths
+// the Go zero value `false` made every collection return an empty list with no
+// error -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectStorageService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_storage)
+	})
+	return g.serviceEnabled, g.serviceErr
 }
 
 func (g *mqlGcpProject) storage() (*mqlGcpProjectStorageService, error) {
@@ -87,7 +118,11 @@ func (g *mqlGcpProject) storage() (*mqlGcpProjectStorageService, error) {
 }
 
 func (g *mqlGcpProjectStorageService) buckets() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/storage.go
+++ b/providers/gcp/resources/storage.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -108,9 +109,12 @@ func (g *mqlGcpProjectStorageService) buckets() ([]any, error) {
 		return nil, err
 	}
 
-	projectID := conn.ResourceID()
+	// List the buckets of the project this service resource belongs to, not the
+	// project the connection happens to be scoped to: `gcp.projects` materializes
+	// every accessible project in one runtime, and on an organization or folder
+	// connection ResourceID() is not a project id at all.
 	var res []any
-	if err := storageSvc.Buckets.List(projectID).Pages(ctx, func(page *storage.Buckets) error {
+	if err := storageSvc.Buckets.List(projectId).Pages(ctx, func(page *storage.Buckets) error {
 		for _, bucket := range page.Items {
 			if conn.Filters.Storage.IsFilteredOut(bucket.Name) {
 				continue
@@ -293,8 +297,11 @@ type mqlGcpProjectStorageServiceBucketInternal struct {
 	cacheDefaultKmsKeyName string
 	cacheLogBucket         string
 
-	aclLock            sync.Mutex
-	aclFetched         bool
+	aclLock sync.Mutex
+	// atomic: acl(), defaultObjectAcl() and public() all call fetchAcls() and
+	// the executor runs block members concurrently, so the fast-path read
+	// races the write with a plain bool.
+	aclFetched         atomic.Bool
 	cacheAcl           []*storage.BucketAccessControl
 	cacheDefaultObjAcl []*storage.ObjectAccessControl
 }
@@ -619,12 +626,12 @@ func (g *mqlGcpProjectStorageServiceBucket) iamPolicy() ([]any, error) {
 // follow-up Buckets.Get with projection=full. They're also nil when uniform
 // bucket-level access is enabled.
 func (g *mqlGcpProjectStorageServiceBucket) fetchAcls() error {
-	if g.aclFetched {
+	if g.aclFetched.Load() {
 		return nil
 	}
 	g.aclLock.Lock()
 	defer g.aclLock.Unlock()
-	if g.aclFetched {
+	if g.aclFetched.Load() {
 		return nil
 	}
 
@@ -651,7 +658,7 @@ func (g *mqlGcpProjectStorageServiceBucket) fetchAcls() error {
 
 	g.cacheAcl = bucket.Acl
 	g.cacheDefaultObjAcl = bucket.DefaultObjectAcl
-	g.aclFetched = true
+	g.aclFetched.Store(true)
 	return nil
 }
 

--- a/providers/gcp/resources/vertexai.go
+++ b/providers/gcp/resources/vertexai.go
@@ -92,39 +92,46 @@ func isVertexAIRegionSkippable(err error) bool {
 }
 
 type mqlGcpProjectVertexaiServiceInternal struct {
-	// skippedRegions tracks regions where the API is not available.
-	// We track skipped (not enabled) so that each resource type can
-	// independently discover regions — a region enabled for models
-	// but not endpoints won't be lost.
-	skippedRegions map[string]bool
+	// skippedRegions tracks regions where the API is not available, keyed by
+	// resource kind. It MUST be per-kind: Vertex AI sub-services have very
+	// different regional footprints (the RAG data service is available in a
+	// handful of regions and reports the rest as FailedPrecondition), so a
+	// single shared set lets the narrowest accessor shrink the region list for
+	// every other one — silently truncating models, endpoints and jobs.
+	skippedRegions map[string]map[string]bool
 	lock           sync.Mutex
 }
 
-// getRegions returns the list of candidate regions, excluding any that have
-// been previously marked as skipped.
-func (g *mqlGcpProjectVertexaiService) getRegions() []string {
+// getRegions returns the list of candidate regions for one resource kind,
+// excluding any that kind has previously marked as skipped.
+func (g *mqlGcpProjectVertexaiService) getRegions(kind string) []string {
 	g.lock.Lock()
 	defer g.lock.Unlock()
-	if len(g.skippedRegions) == 0 {
+	skipped := g.skippedRegions[kind]
+	if len(skipped) == 0 {
 		return vertexaiRegions
 	}
 	regions := make([]string, 0, len(vertexaiRegions))
 	for _, r := range vertexaiRegions {
-		if !g.skippedRegions[r] {
+		if !skipped[r] {
 			regions = append(regions, r)
 		}
 	}
 	return regions
 }
 
-// markRegionSkipped records a region where the API returned a skippable error.
-func (g *mqlGcpProjectVertexaiService) markRegionSkipped(region string) {
+// markRegionSkipped records a region where the API returned a skippable error
+// for one resource kind.
+func (g *mqlGcpProjectVertexaiService) markRegionSkipped(kind, region string) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 	if g.skippedRegions == nil {
-		g.skippedRegions = make(map[string]bool)
+		g.skippedRegions = make(map[string]map[string]bool)
 	}
-	g.skippedRegions[region] = true
+	if g.skippedRegions[kind] == nil {
+		g.skippedRegions[kind] = make(map[string]bool)
+	}
+	g.skippedRegions[kind][region] = true
 }
 
 // vertexaiRegionResult holds the result of listing resources in a single region.
@@ -170,9 +177,10 @@ func (g *mqlGcpProjectVertexaiService) id() (string, error) {
 // listAcrossRegions runs fn concurrently across all candidate regions with bounded
 // concurrency. It collects results, marks skipped regions, and returns the aggregated items.
 func (g *mqlGcpProjectVertexaiService) listAcrossRegions(
+	kind string,
 	fn func(ctx context.Context, region string) ([]any, bool, error),
 ) ([]any, error) {
-	regions := g.getRegions()
+	regions := g.getRegions(kind)
 	ctx := context.Background()
 
 	results := make([]vertexaiRegionResult, len(regions))
@@ -197,7 +205,7 @@ func (g *mqlGcpProjectVertexaiService) listAcrossRegions(
 			return nil, r.err
 		}
 		if r.skipped {
-			g.markRegionSkipped(r.region)
+			g.markRegionSkipped(kind, r.region)
 		}
 		res = append(res, r.items...)
 	}
@@ -216,7 +224,7 @@ func (g *mqlGcpProjectVertexaiService) models() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("models", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewModelClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -327,7 +335,7 @@ func (g *mqlGcpProjectVertexaiService) endpoints() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("endpoints", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewEndpointClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -633,7 +641,7 @@ func (g *mqlGcpProjectVertexaiService) pipelineJobs() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("pipelineJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPipelineClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -796,7 +804,7 @@ func (g *mqlGcpProjectVertexaiService) datasets() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("datasets", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewDatasetClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -872,7 +880,7 @@ func (g *mqlGcpProjectVertexaiService) featureOnlineStores() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("featureOnlineStores", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewFeatureOnlineStoreAdminClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -964,7 +972,7 @@ func (g *mqlGcpProjectVertexaiService) tensorboards() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("tensorboards", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewTensorboardClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1373,7 +1381,7 @@ func (g *mqlGcpProjectVertexaiService) customJobs() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("customJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1430,7 +1438,7 @@ func (g *mqlGcpProjectVertexaiService) indexes() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("indexes", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewIndexClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1523,7 +1531,7 @@ func (g *mqlGcpProjectVertexaiService) indexEndpoints() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("indexEndpoints", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewIndexEndpointClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1607,7 +1615,7 @@ func (g *mqlGcpProjectVertexaiService) metadataStores() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("metadataStores", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewMetadataClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1678,7 +1686,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimes() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("notebookRuntimes", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1793,7 +1801,7 @@ func (g *mqlGcpProjectVertexaiService) notebookRuntimeTemplates() ([]any, error)
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("notebookRuntimeTemplates", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1915,7 +1923,7 @@ func (g *mqlGcpProjectVertexaiService) notebookExecutionJobs() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("notebookExecutionJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewNotebookClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -1995,7 +2003,7 @@ func (g *mqlGcpProjectVertexaiService) reasoningEngines() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("reasoningEngines", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewReasoningEngineClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2092,7 +2100,7 @@ func (g *mqlGcpProjectVertexaiService) ragCorpora() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("ragCorpora", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewVertexRagDataClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2163,7 +2171,7 @@ func (g *mqlGcpProjectVertexaiService) featureGroups() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("featureGroups", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewFeatureRegistryClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2229,7 +2237,7 @@ func (g *mqlGcpProjectVertexaiService) persistentResources() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("persistentResources", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPersistentResourceClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2314,7 +2322,7 @@ func (g *mqlGcpProjectVertexaiService) schedules() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("schedules", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewScheduleClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2382,7 +2390,7 @@ func (g *mqlGcpProjectVertexaiService) deploymentResourcePools() ([]any, error) 
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("deploymentResourcePools", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewDeploymentResourcePoolClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2454,7 +2462,7 @@ func (g *mqlGcpProjectVertexaiService) cachedContents() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("cachedContents", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewGenAiCacheClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2526,7 +2534,7 @@ func (g *mqlGcpProjectVertexaiService) batchPredictionJobs() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("batchPredictionJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2612,7 +2620,7 @@ func (g *mqlGcpProjectVertexaiService) tuningJobs() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("tuningJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewGenAiTuningClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2698,7 +2706,7 @@ func (g *mqlGcpProjectVertexaiService) trainingPipelines() ([]any, error) {
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("trainingPipelines", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewPipelineClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2778,7 +2786,7 @@ func (g *mqlGcpProjectVertexaiService) hyperparameterTuningJobs() ([]any, error)
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("hyperparameterTuningJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),
@@ -2866,7 +2874,7 @@ func (g *mqlGcpProjectVertexaiService) modelDeploymentMonitoringJobs() ([]any, e
 		return nil, err
 	}
 
-	return g.listAcrossRegions(func(ctx context.Context, region string) ([]any, bool, error) {
+	return g.listAcrossRegions("modelDeploymentMonitoringJobs", func(ctx context.Context, region string) ([]any, bool, error) {
 		client, err := aiplatform.NewJobClient(ctx,
 			option.WithCredentials(creds), connection.GRPCClientTraceOption(),
 			option.WithEndpoint(vertexaiEndpoint(region)),

--- a/providers/gcp/resources/vertexai_regions_test.go
+++ b/providers/gcp/resources/vertexai_regions_test.go
@@ -1,0 +1,60 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import "testing"
+
+// TestSkippedRegionsAreScopedPerKind pins the region-discovery contract.
+//
+// Vertex AI sub-services have very different regional footprints: the RAG data
+// service is available in a handful of regions and reports the rest as
+// FailedPrecondition, which isVertexAIRegionSkippable treats as skippable.
+// While the skip set was shared across all 26 accessors, running ragCorpora()
+// first shrank the candidate region list for models(), endpoints() and every
+// job accessor -- silently returning a fraction of the real inventory, with
+// the result depending on goroutine scheduling.
+func TestSkippedRegionsAreScopedPerKind(t *testing.T) {
+	svc := &mqlGcpProjectVertexaiService{}
+
+	// A narrow sub-service marks almost every region unavailable.
+	narrow := "ragCorpora"
+	for _, r := range vertexaiRegions {
+		if r != "us-central1" {
+			svc.markRegionSkipped(narrow, r)
+		}
+	}
+
+	if got := len(svc.getRegions(narrow)); got != 1 {
+		t.Errorf("narrow accessor sees %d regions, want 1", got)
+	}
+
+	// A broad sub-service must be unaffected by the narrow one's skips.
+	if got, want := len(svc.getRegions("models")), len(vertexaiRegions); got != want {
+		t.Errorf("models sees %d regions, want %d: a narrow sub-service leaked "+
+			"its skipped regions into an unrelated accessor", got, want)
+	}
+}
+
+// TestMarkRegionSkippedIsIsolated checks the inverse direction too.
+func TestMarkRegionSkippedIsIsolated(t *testing.T) {
+	svc := &mqlGcpProjectVertexaiService{}
+	svc.markRegionSkipped("endpoints", "europe-west4")
+
+	for _, r := range svc.getRegions("endpoints") {
+		if r == "europe-west4" {
+			t.Fatal("endpoints still lists a region it marked skipped")
+		}
+	}
+
+	var found bool
+	for _, r := range svc.getRegions("datasets") {
+		if r == "europe-west4" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("datasets lost europe-west4 because endpoints skipped it")
+	}
+}


### PR DESCRIPTION
Static bug review of the whole GCP provider (90 hand-written resource files, ~48k LOC). Every finding here was confirmed against the source, the vendored SDK, or the generated code before being fixed.

## Hard failures

- **`logging.buckets` failed outright on any project with a log-bucket index config.** The creator asked for `gcp.project.loggingservice.bucket.indexConfigs` — plural, and not a registered resource — so `CreateResource` errored from inside the `Pages` callback and aborted the whole listing. Even `buckets { name }` failed. The `types.Resource(...)` on the next line already used the correct singular name.
- **Binary Authorization read the wrong policy.** It called `GetSystemPolicy`, which the SDK documents as taking `locations/*/policy` and being "not associated with a project", using a `projects/*/policy` name. The correct `BinauthzManagementClient.GetPolicy` was never called anywhere in the provider. Now fixed, and it degrades on a permission gap instead of failing the query.
- **`admissionRule.enforcementMode` was declared in the schema but never populated** — the one field that separates an enforced deny from a dry-run log-only deny. A sweep of all 4,385 plain `.lr` fields against their Go population sites found this as the only orphan.

## Fabricated absence

- **Recommender only queried compute zones.** Recommenders publish at global, regional and zonal scope, so every global and regional one — including `google.iam.policy.Recommender` — returned nothing, forever, with no error. Now sweeps global + regions + zones, with the fan-out bounded.
- **Dataflow-style region poisoning in Vertex AI.** One skipped-region set was shared across all 26 accessors, so a narrow sub-service (RAG, available in a handful of regions and reporting the rest as `FailedPrecondition`) shrank the candidate region list for `models`, `endpoints` and every job accessor. Non-deterministic across runs. Now scoped per resource kind.
- **`gcp.storage.buckets` and `gcp.bigquery.datasets` returned `[]`.** `serviceEnabled` is an Internal-struct flag set only by `gcp.project.<svc>()`, but both are reachable as `.lr` aliases and via resource inits, where the flag stayed at Go's zero value. A GCS bucket-security audit run through the alias passed vacuously. Both now resolve the gate lazily, following the `container_analysis`/`dns` precedent.

## Wrong data

- **`storage.buckets` listed from the connection's project while labelling results with the resource's project** — one letter apart (`projectID` vs `projectId`). On a multi-project scan every project showed the connection project's buckets.
- **BigQuery dataset client was built on the connection's project**, so `tables`/`models`/`routines` resolved in the wrong project (and 404'd on an org connection).
- **`gcp.projects` dropped every project nested in a subfolder** — a regression from #9403. Folder ids are stored bare (`876`) but `Project.Parent` is always prefixed (`folders/876`), so no folder key ever matched and only direct children of the scan root survived.
- **Cloud Armor `rules()`** fetched with the connection scope rather than the policy's project, and always used the global endpoint even though the listing returns regional policies too, so every regional policy 404'd.
- **Network firewall policy `name`/`displayName`** were read from `ShortName`/`DisplayName`, which the API documents as "not applicable to network firewall policies" — always empty, so `@defaults("name")` rendered blank and `.where(name == ...)` matched nothing.

## `__id` collisions

`CreateResource` returns the first resource stored under a key and discards later args, so a per-parent-unique key makes later rows render the first one's data. Fixed in: compute `serviceaccount` (keyed on email, but it carries the *per-VM* OAuth scopes, so every VM sharing the default compute SA reported the first VM's scopes), compute `region` (carries per-project quotas), IAP and Cloud Asset IAM bindings (keyed on role, collapsing conditional bindings — both call sites request policy version 3), GKE `notificationConfig`, redis nodes and server CA certs, bigtable backups, Cloud Functions v1, and Cloud Build triggers plus their four sub-resources.

## Panics and races

- **`gke networkConfig.subnetwork` indexed a split path with no length guard.** `Subnetwork` is empty for routes-based clusters on a legacy network. PR #9403 fixed exactly this in the sibling `network()` twenty lines above; `subnetwork()` was left behind.
- **16 unguarded `args[...]` derefs across 11 inits.** `init_guard_test.go` already AST-walked the package for this class but only checked `args["projectId"]`. `TestInitGuardsEveryDereferencedArg` generalizes it to every key an init dereferences, and found them all. `gke cluster` and `sql instance` additionally treated their secondary matcher as mandatory, so a two-arg lookup could not resolve; both are now optional narrowing filters.
- `getAssetIdentifier` indexed `PlatformIds[0]` with no length check.
- `storage` ACL double-check lock used a plain `bool` across three concurrent accessors → `atomic.Bool`.
- `dataproc clusters` wrote a function-scope `err` from every region goroutine (a `:=` variable is not in scope inside its own initializer).

## Query-time dict errors

Dict values must be JSON-native — `dict2primitive` accepts only bool/int64/float64/string/[]any/map/nil. Fixed: compute `consistentHash` cookie TTL held an `*llx.RawData`; bigtable autoscaling config held Go `int`s and its automated-backup policy plus the BigQuery access-entry target types held `[]string`; Cloud Run container ports and TCP probe ports held `int32` (which fires on essentially every Cloud Run service, since a default TCP startup probe is always injected).

## Tests

- `TestInitGuardsEveryDereferencedArg` — generalizes the existing projectId guard to every dereferenced arg key; this is what enumerated the 16 panic sites.
- `TestProjectParentMatchesFolderKey` — pins the folder-id contract on the side that broke.
- `TestSkippedRegionsAreScopedPerKind` / `TestMarkRegionSkippedIsIsolated` — a narrow Vertex AI sub-service can no longer shrink another accessor's region list.

`gcp.permissions.json` picks up `compute.regionSecurityPolicies.get` and records `binaryauthorization.policy.get` against `GetPolicy`.

## Deliberately not in this PR

- **`sql.iamAuthenticationEnabled` only checks the PostgreSQL flag name** (`cloudsql.iam_authentication`). MySQL reportedly uses `cloudsql_iam_authentication` (underscore); I could not confirm that from the SDK, so it wants a doc or live check before changing a security predicate.
- **Vertex AI's hardcoded region list** is stale (`// Last updated: 2026-03`); the real fix is the `ListLocations` mixin, which needs live verification.
- **Regional persistent disks are never fetched** — `RegionDisks` has no call site, so `disk.region`/`replicaZones` are permanently empty and `getDiskByUrl`'s regional branch is dead code. New API surface, worth its own PR.
- **Dataflow job `environment`/`pipelineDescription`/`labels`/`workerIpConfiguration`/`kmsKey` are permanently empty** — `jobs.aggregated` is documented as always returning summaries. The fix restructures five fields into lazy computed accessors backed by `GetJob`, which is a schema change.
- **The remaining ~19 services with a caller-set `serviceEnabled` flag.** Only the two alias-reachable ones are fixed here; the rest are reachable via discovered-asset inits and want the same treatment.
- **Husk typed-refs** (`vertexai.schedule`, `gkeBackup.backupPlan`, `bigquery.table` have no `Init`, so `NewResource` on them mints a husk that can poison the cache for the real listing).
