### PR TITLE
🐛 os: strip trailing comments from squid.conf directives

### DIFF
--- a/providers/os/resources/squid/inline_comments_test.go
+++ b/providers/os/resources/squid/inline_comments_test.go
@@ -1,0 +1,137 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package squid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The stock squid.conf that ships on Debian and RHEL annotates almost every
+// line with a trailing comment. Before trailing comments were stripped at the
+// token layer, those comment words became ACL values and access-rule ACL
+// names.
+func TestParse_StockConfigTrailingComments(t *testing.T) {
+	cfg := Parse(`acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
+http_access allow localnet	# allow internal users
+http_access deny all		# and nothing else
+`)
+
+	require.Len(t, cfg.ACLs, 2)
+
+	safePorts := findACL(t, cfg, "Safe_ports")
+	assert.Equal(t, "port", safePorts.Type)
+	assert.Equal(t, []string{"80", "21"}, safePorts.Values)
+
+	localnet := findACL(t, cfg, "localnet")
+	assert.Equal(t, "src", localnet.Type)
+	assert.Equal(t, []string{"10.0.0.0/8"}, localnet.Values)
+
+	require.Len(t, cfg.AccessRules, 2)
+	assert.Equal(t, "allow", cfg.AccessRules[0].Action)
+	assert.Equal(t, []string{"localnet"}, cfg.AccessRules[0].ACLs)
+	assert.Equal(t, "deny", cfg.AccessRules[1].Action)
+	assert.Equal(t, []string{"all"}, cfg.AccessRules[1].ACLs)
+}
+
+// A commented-out option must not be read as an active one. `ssl-bump` in a
+// trailing comment previously set TLS=true on a plaintext port — a comment
+// turning a security flag on.
+func TestParse_CommentedOptionDoesNotSetFlag(t *testing.T) {
+	cfg := Parse(`http_port 3128   # TODO enable ssl-bump
+http_port 3129 ssl-bump
+`)
+
+	require.Len(t, cfg.HTTPPorts, 2)
+	assert.EqualValues(t, 3128, cfg.HTTPPorts[0].Port)
+	assert.False(t, cfg.HTTPPorts[0].TLS, "a commented-out ssl-bump must not enable TLS")
+
+	assert.EqualValues(t, 3129, cfg.HTTPPorts[1].Port)
+	assert.True(t, cfg.HTTPPorts[1].TLS, "a real ssl-bump option must still enable TLS")
+}
+
+// Squid only treats `#` as a comment marker at a token boundary, so a `#`
+// inside a value is data. A password or URL fragment must survive intact.
+func TestTokenize_HashInsideTokenIsData(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "hash inside a value",
+			line: `cache_peer parent.example.com parent 3128 0 login=user:p@ss#word`,
+			want: []string{"cache_peer", "parent.example.com", "parent", "3128", "0", "login=user:p@ss#word"},
+		},
+		{
+			name: "trailing comment after whitespace",
+			line: `acl x port 80 # http`,
+			want: []string{"acl", "x", "port", "80"},
+		},
+		{
+			name: "tab before the comment",
+			line: "acl x port 80\t# http",
+			want: []string{"acl", "x", "port", "80"},
+		},
+		{
+			name: "quoted hash is not a comment",
+			line: `acl x note key "#literal"`,
+			want: []string{"acl", "x", "note", "key", "#literal"},
+		},
+		{
+			name: "comment immediately after the directive",
+			line: `acl #everything after this is gone`,
+			want: []string{"acl"},
+		},
+		{
+			name: "no comment at all",
+			line: `http_port 3128 ssl-bump`,
+			want: []string{"http_port", "3128", "ssl-bump"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tokenize(tc.line))
+		})
+	}
+}
+
+// Squid strips trailing comments after joining continuations, so a comment on
+// the tail of a continued directive must not swallow the tail's tokens.
+func TestParse_TrailingCommentOnContinuedLine(t *testing.T) {
+	cfg := Parse(`acl Safe_ports port \
+	80 443   # http and https
+`)
+
+	require.Len(t, cfg.ACLs, 1)
+	assert.Equal(t, []string{"80", "443"}, cfg.ACLs[0].Values)
+}
+
+// A line that is entirely a comment, and one that becomes empty once its
+// trailing comment is stripped, must both yield no directive.
+func TestParse_CommentOnlyLines(t *testing.T) {
+	cfg := Parse(`# this whole line is a comment
+   # so is this one, after indentation
+http_port 3128
+`)
+
+	require.Len(t, cfg.HTTPPorts, 1)
+	assert.EqualValues(t, 3128, cfg.HTTPPorts[0].Port)
+}
+
+func findACL(t *testing.T, cfg *Config, name string) ACL {
+	t.Helper()
+	for _, a := range cfg.ACLs {
+		if a.Name == name {
+			return a
+		}
+	}
+	t.Fatalf("acl %q not found in %+v", name, cfg.ACLs)
+	return ACL{}
+}

--- a/providers/os/resources/squid/parser.go
+++ b/providers/os/resources/squid/parser.go
@@ -544,9 +544,10 @@ func parseAccessLog(args []string) AccessLog {
 // ----------------------------------------------------------------------
 
 // splitAndClean returns the logical directive lines for content: it
-// strips comments, joins backslash-continuations, and drops blank
-// lines. Inline comments (mid-line `#`) are not stripped because Squid
-// uses `#` only as a full-line comment marker.
+// strips full-line comments, joins backslash-continuations, and drops
+// blank lines. Trailing comments are handled one layer down, in
+// tokenize, because Squid strips them at the token layer — after
+// continuations have been joined.
 func splitAndClean(content string) []string {
 	raw := strings.Split(content, "\n")
 	var lines []string
@@ -629,6 +630,18 @@ func tokenize(line string) []string {
 			flush()
 		case '"', '\'':
 			inQuote = c
+		case '#':
+			// An unquoted `#` at a token boundary starts a trailing
+			// comment: the rest of the line is discarded. This mirrors
+			// ConfigParser::TokenParse in src/ConfigParser.cc, which
+			// skips leading whitespace and bails on `#`.
+			//
+			// A `#` *inside* a token is data, not a comment marker, so
+			// values such as a password containing `#` survive intact.
+			if buf.Len() == 0 {
+				return tokens
+			}
+			buf.WriteByte(c)
 		default:
 			buf.WriteByte(c)
 		}


### PR DESCRIPTION
## Problem

The squid tokenizer kept everything after a mid-line `#`. The reasoning was stated in a comment on `splitAndClean`:

> Inline comments (mid-line `#`) are not stripped because Squid uses `#` only as a full-line comment marker.

That isn't right. Squid strips full-line comments in `cache_cf.cc`, and trailing comments one layer down in `ConfigParser::TokenParse` (`src/ConfigParser.cc`), which skips leading whitespace and bails when the next token starts with `#`:

```c
nextToken += strspn(nextToken, w_space);
if (*nextToken == '#')
    return nullptr;
```

The stock `squid.conf` shipped by Debian and RHEL annotates nearly every line, so on `main` the comment words became data:

```
acl Safe_ports port 80          # http
  -> values ["80" "#" "http"]
acl localnet src 10.0.0.0/8     # RFC1918 possible internal network
  -> values ["10.0.0.0/8" "#" "RFC1918" "possible" "internal" "network"]
http_access allow localnet      # allow internal users
  -> acls ["localnet" "#" "allow" "internal" "users"]
```

Every audit over `squid.conf.acls[].values` or `accessRules[].acls` compared against that.

Worse, `parseListen` walks the trailing tokens of a port line looking for options, so a **commented-out** option was applied:

```
http_port 3128   # TODO enable ssl-bump   ->   tls: true
```

A comment turning a security flag on, for a port that is in fact plaintext.

## Fix

Drop the rest of the line in `tokenize` when an unquoted `#` appears **at a token boundary**. A `#` inside a token is data, not a comment marker, so a password or URL fragment containing `#` survives intact — matching Squid.

Doing it in `tokenize` rather than in `splitAndClean` matches Squid's own ordering: continuations are joined first, so a comment on the tail of a continued directive can't swallow the tail's tokens. It also fixes every consumer at once, since `Raw`, `Params` and all the typed fields are built from tokens.

## Tests

`inline_comments_test.go` adds 5 tests (10 cases). Verified they fail on the unfixed tokenizer and pass with the fix:

- the stock Debian/RHEL `squid.conf` shape — ACL values and access-rule ACLs come back clean
- **the security case:** a commented-out `ssl-bump` no longer sets `tls: true`, while a real `ssl-bump` still does
- `tokenize` table: `#` inside a value is data; trailing comment after a space and after a tab; a quoted `#` is not a comment; a comment right after the directive; a line with no comment at all
- a trailing comment on a continued (`\`) directive doesn't eat the tail
- comment-only lines, indented or not, yield no directive

All 15 pre-existing squid tests still pass, as does `providers/os/resources`.

## Found by

A static review pass over the `os` provider parsers.
