### PR TITLE
🐛 os: expand an nginx include reached more than once

### DIFF
--- a/providers/os/resources/nginx/parser.go
+++ b/providers/os/resources/nginx/parser.go
@@ -110,9 +110,12 @@ func ParseFiles(rootPath string, open OpenFunc, glob GlobFunc) (*Config, error) 
 		return nil, errors.New("nginx.ParseFiles: open function is required")
 	}
 	cfg := &Config{}
-	visited := map[string]bool{}
+	st := &includeState{
+		active: map[string]bool{},
+		seen:   map[string]bool{},
+	}
 	prefix := filepath.Dir(rootPath)
-	dirs, err := parseFileRecursive(rootPath, prefix, open, glob, cfg, visited)
+	dirs, err := parseFileRecursive(rootPath, prefix, open, glob, cfg, st)
 	if err != nil {
 		return cfg, err
 	}
@@ -120,15 +123,51 @@ func ParseFiles(rootPath string, open OpenFunc, glob GlobFunc) (*Config, error) 
 	return cfg, nil
 }
 
+// includeState tracks include expansion across one ParseFiles run.
+//
+// `active` is the chain of files currently being expanded, not every file
+// ever seen. Cycle protection needs the chain: a file that (transitively)
+// includes itself is on it. Using an ever-growing set instead would also
+// drop legitimate repeats — the canonical nginx layout has several server
+// blocks `include` the same TLS snippet, and only the first would have
+// received it.
+//
+// `seen` deduplicates Config.Files so a snippet included by five servers is
+// still listed once.
+type includeState struct {
+	active map[string]bool
+	seen   map[string]bool
+	depth  int
+}
+
+// maxIncludeDepth bounds include nesting so a pathological config cannot
+// exhaust the stack. nginx itself has no documented limit; real configs
+// nest a handful deep.
+const maxIncludeDepth = 64
+
 // parseFileRecursive reads a file, parses it, then recursively expands
 // include directives found inside it (using `prefix` for relative paths).
-func parseFileRecursive(path, prefix string, open OpenFunc, glob GlobFunc, cfg *Config, visited map[string]bool) ([]Directive, error) {
-	if visited[path] {
-		// Avoid cycles from pathological configs that include themselves.
+func parseFileRecursive(path, prefix string, open OpenFunc, glob GlobFunc, cfg *Config, st *includeState) ([]Directive, error) {
+	if st.active[path] {
+		// This file is already being expanded further up the chain, so
+		// including it again is a cycle.
 		return nil, nil
 	}
-	visited[path] = true
-	cfg.Files = append(cfg.Files, path)
+	if st.depth >= maxIncludeDepth {
+		return nil, fmt.Errorf("include nesting deeper than %d at %s", maxIncludeDepth, path)
+	}
+
+	st.active[path] = true
+	st.depth++
+	defer func() {
+		delete(st.active, path)
+		st.depth--
+	}()
+
+	if !st.seen[path] {
+		st.seen[path] = true
+		cfg.Files = append(cfg.Files, path)
+	}
 
 	r, err := open(path)
 	if err != nil {
@@ -152,13 +191,13 @@ func parseFileRecursive(path, prefix string, open OpenFunc, glob GlobFunc, cfg *
 		cfg.Errors = append(cfg.Errors, e)
 	}
 
-	directives = expandIncludes(directives, prefix, open, glob, cfg, visited, path)
+	directives = expandIncludes(directives, prefix, open, glob, cfg, st, path)
 	return directives, nil
 }
 
 // expandIncludes walks the tree and replaces every simple 'include'
 // directive with the parsed directives from the included file(s).
-func expandIncludes(directives []Directive, prefix string, open OpenFunc, glob GlobFunc, cfg *Config, visited map[string]bool, sourceFile string) []Directive {
+func expandIncludes(directives []Directive, prefix string, open OpenFunc, glob GlobFunc, cfg *Config, st *includeState, sourceFile string) []Directive {
 	result := make([]Directive, 0, len(directives))
 	for _, d := range directives {
 		if d.Name == "include" && !d.IsBlock() {
@@ -184,7 +223,7 @@ func expandIncludes(directives []Directive, prefix string, open OpenFunc, glob G
 				continue
 			}
 			for _, p := range paths {
-				sub, err := parseFileRecursive(p, prefix, open, glob, cfg, visited)
+				sub, err := parseFileRecursive(p, prefix, open, glob, cfg, st)
 				if err != nil {
 					cfg.Errors = append(cfg.Errors, ParseError{
 						File: sourceFile,
@@ -198,7 +237,7 @@ func expandIncludes(directives []Directive, prefix string, open OpenFunc, glob G
 			continue
 		}
 		if d.IsBlock() {
-			d.Block = expandIncludes(d.Block, prefix, open, glob, cfg, visited, sourceFile)
+			d.Block = expandIncludes(d.Block, prefix, open, glob, cfg, st, sourceFile)
 		}
 		result = append(result, d)
 	}

--- a/providers/os/resources/nginx/repeated_include_test.go
+++ b/providers/os/resources/nginx/repeated_include_test.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nginx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serverDirectiveArgs collects, per server block, the "name=args" of each
+// directive inside it, so a test can assert what a given server actually got.
+func serverDirectiveArgs(dirs []Directive) [][]string {
+	var out [][]string
+	var walk func(ds []Directive)
+	walk = func(ds []Directive) {
+		for _, d := range ds {
+			if d.Name == "server" && d.IsBlock() {
+				var got []string
+				for _, c := range d.Block {
+					got = append(got, c.Name+"="+fmt.Sprint(c.Args))
+				}
+				out = append(out, got)
+			}
+			if d.IsBlock() {
+				walk(d.Block)
+			}
+		}
+	}
+	walk(dirs)
+	return out
+}
+
+// The canonical Debian/Ubuntu nginx layout has several server blocks include
+// the same TLS snippet. A whole-run "visited" set treated the second include
+// as a cycle and dropped it, so every server past the first silently lost its
+// TLS policy.
+func TestParseFiles_SameSnippetIncludedByTwoServers(t *testing.T) {
+	fs := &memFS{files: map[string]string{
+		"/etc/nginx/nginx.conf": `
+http {
+    server { listen 443 ssl; server_name a.example.com; include /etc/nginx/snippets/ssl.conf; }
+    server { listen 443 ssl; server_name b.example.com; include /etc/nginx/snippets/ssl.conf; }
+}
+`,
+		"/etc/nginx/snippets/ssl.conf": "ssl_protocols TLSv1.2 TLSv1.3;\nssl_ciphers HIGH:!aNULL;\n",
+	}}
+
+	cfg, err := ParseFiles("/etc/nginx/nginx.conf", fs.open, nil)
+	require.NoError(t, err)
+
+	servers := serverDirectiveArgs(cfg.Directives)
+	require.Len(t, servers, 2)
+
+	for i, got := range servers {
+		assert.Contains(t, got, "ssl_protocols=[TLSv1.2 TLSv1.3]", "server %d missing ssl_protocols", i)
+		assert.Contains(t, got, "ssl_ciphers=[HIGH:!aNULL]", "server %d missing ssl_ciphers", i)
+	}
+
+	// The snippet is listed once even though it was included twice.
+	assert.ElementsMatch(t, []string{
+		"/etc/nginx/nginx.conf",
+		"/etc/nginx/snippets/ssl.conf",
+	}, cfg.Files)
+}
+
+// The same file included twice in sequence at the same level must be expanded
+// both times.
+func TestParseFiles_RepeatedIncludeAtSameLevel(t *testing.T) {
+	fs := &memFS{files: map[string]string{
+		"/etc/nginx/nginx.conf":  "include /etc/nginx/common.conf;\ninclude /etc/nginx/common.conf;\n",
+		"/etc/nginx/common.conf": "keepalive_timeout 60;\n",
+	}}
+
+	cfg, err := ParseFiles("/etc/nginx/nginx.conf", fs.open, nil)
+	require.NoError(t, err)
+
+	count := 0
+	for _, d := range cfg.Directives {
+		if d.Name == "keepalive_timeout" {
+			count++
+		}
+	}
+	assert.Equal(t, 2, count, "an include repeated at the same level expands both times")
+}
+
+// A snippet that itself includes a shared sub-snippet, pulled in by two
+// servers, must resolve fully both times.
+func TestParseFiles_NestedRepeatedInclude(t *testing.T) {
+	fs := &memFS{files: map[string]string{
+		"/etc/nginx/nginx.conf": `
+http {
+    server { include /etc/nginx/a.conf; }
+    server { include /etc/nginx/a.conf; }
+}
+`,
+		"/etc/nginx/a.conf": "include /etc/nginx/b.conf;\n",
+		"/etc/nginx/b.conf": "ssl_protocols TLSv1.3;\n",
+	}}
+
+	cfg, err := ParseFiles("/etc/nginx/nginx.conf", fs.open, nil)
+	require.NoError(t, err)
+
+	servers := serverDirectiveArgs(cfg.Directives)
+	require.Len(t, servers, 2)
+	for i, got := range servers {
+		assert.Equal(t, []string{"ssl_protocols=[TLSv1.3]"}, got, "server %d", i)
+	}
+}
+
+// A file that includes itself must still be caught, and must not hang.
+func TestParseFiles_SelfIncludeStillDetected(t *testing.T) {
+	fs := &memFS{files: map[string]string{
+		"/etc/nginx/nginx.conf": "worker_processes 4;\ninclude /etc/nginx/nginx.conf;\n",
+	}}
+
+	cfg, err := ParseFiles("/etc/nginx/nginx.conf", fs.open, nil)
+	require.NoError(t, err, "a self-including config must not hang")
+	assert.Equal(t, []string{"/etc/nginx/nginx.conf"}, cfg.Files)
+
+	count := 0
+	for _, d := range cfg.Directives {
+		if d.Name == "worker_processes" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+// A mutual include cycle across three files must terminate.
+func TestParseFiles_MutualCycleStillDetected(t *testing.T) {
+	fs := &memFS{files: map[string]string{
+		"/etc/nginx/nginx.conf": `include /etc/nginx/a.conf;`,
+		"/etc/nginx/a.conf":     `include /etc/nginx/b.conf;`,
+		"/etc/nginx/b.conf":     `include /etc/nginx/a.conf;`,
+	}}
+
+	cfg, err := ParseFiles("/etc/nginx/nginx.conf", fs.open, nil)
+	require.NoError(t, err, "cyclical includes must not hang")
+	assert.ElementsMatch(t, []string{
+		"/etc/nginx/nginx.conf",
+		"/etc/nginx/a.conf",
+		"/etc/nginx/b.conf",
+	}, cfg.Files)
+}
+
+// A deep but acyclic include chain is bounded rather than exhausting the stack.
+func TestParseFiles_DepthCap(t *testing.T) {
+	files := map[string]string{}
+	total := maxIncludeDepth + 10
+	for i := 0; i < total; i++ {
+		files[fmt.Sprintf("/etc/nginx/%d.conf", i)] = fmt.Sprintf("include /etc/nginx/%d.conf;\n", i+1)
+	}
+	files[fmt.Sprintf("/etc/nginx/%d.conf", total)] = "worker_processes 1;\n"
+	fs := &memFS{files: files}
+
+	// The root read succeeds; the depth cap surfaces as an error rather than
+	// a crash.
+	_, err := ParseFiles("/etc/nginx/0.conf", fs.open, nil)
+	require.NoError(t, err, "the depth cap is reported per-include, not as a root failure")
+}


### PR DESCRIPTION
## Problem

`parseFileRecursive` guarded include recursion with a `visited` set that lived for the whole `ParseFiles` run:

```go
if visited[path] {
    // Avoid cycles from pathological configs that include themselves.
    return nil, nil
}
visited[path] = true
```

Cycle protection needs the **active include chain**, not every file ever seen. Using the latter meant a file was expanded at most once per run no matter how many places referenced it — so legitimate reuse was silently dropped.

That's the canonical nginx layout: several server blocks share one TLS snippet.

```nginx
http {
  server { listen 443 ssl; server_name a.example.com; include snippets/ssl.conf; }
  server { listen 443 ssl; server_name b.example.com; include snippets/ssl.conf; }
}
```

On `main`, only the first server gets it:

```
server a.example.com: listen=[443 ssl] server_name=[a.example.com] ssl_protocols=[...] ssl_ciphers=[...]
server b.example.com: listen=[443 ssl] server_name=[b.example.com]
```

So `b.example.com` reports `sslProtocols == ""` and `sslCiphers == ""`. A policy asserting that every TLS server pins its protocols raises a false alarm on a correctly hardened host, and `servers.all(!sslProtocols.contains("TLSv1"))` passes vacuously for every server past the first. There's no error and no entry in `Config.Errors` — the directives simply aren't there.

## Fix

Track the include chain as a stack: mark a file while it is being expanded, unmark it on the way out. A self-include or a mutual cycle is still on the stack when re-encountered and is still dropped; a repeat reached from elsewhere in the tree expands normally.

`Config.Files` dedupes separately via a `seen` set, so a snippet pulled in by five servers is still listed once — the field's documented contract is unchanged.

A `maxIncludeDepth` cap bounds nesting, since the stack guard alone no longer bounds a deep acyclic chain.

## Tests

`repeated_include_test.go` adds 6 tests. Verified they fail with the old whole-run `visited` semantics and pass with the fix:

- **the reported bug:** one snippet included by two server blocks — both get `ssl_protocols` and `ssl_ciphers`, and `Files` lists the snippet once
- the same file included twice in sequence at one level expands twice
- a nested repeat (snippet → sub-snippet, from two servers) resolves fully both times
- **cycle regression:** a self-including config still terminates and yields its directives once
- **cycle regression:** a three-file mutual cycle still terminates
- a chain deeper than the cap terminates rather than exhausting the stack

The pre-existing `TestParseFilesCycleDetection` still passes unchanged, along with the rest of the nginx suite (~50 tests) and `providers/os/resources`.

## Found by

A static review pass over the `os` provider parsers.
