### PR TITLE
🐛 gcp: resolve the serviceEnabled gate on every construction path

### DIFF
--- a/providers/gcp/resources/asset.go
+++ b/providers/gcp/resources/asset.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	"cloud.google.com/go/asset/apiv1/assetpb"
@@ -23,6 +24,8 @@ import (
 
 type mqlGcpProjectAssetServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) assetInventory() (*mqlGcpProjectAssetService, error) {
@@ -85,7 +88,11 @@ func (g *mqlGcpProjectAssetServiceIamPolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -157,7 +164,11 @@ func (g *mqlGcpProjectAssetService) resources() ([]any, error) {
 }
 
 func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -230,4 +241,33 @@ func (g *mqlGcpProjectAssetService) iamPolicies() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectAssetService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudasset)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/batch.go
+++ b/providers/gcp/resources/batch.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	batch "cloud.google.com/go/batch/apiv1"
 	"cloud.google.com/go/batch/apiv1/batchpb"
@@ -22,6 +23,8 @@ import (
 
 type mqlGcpProjectBatchServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) batch() (*mqlGcpProjectBatchService, error) {
@@ -83,7 +86,11 @@ func (g *mqlGcpProjectBatchServiceJobTaskGroup) id() (string, error) {
 }
 
 func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -179,4 +186,33 @@ func (g *mqlGcpProjectBatchService) jobs() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectBatchService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_batch)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/bigquery_connection.go
+++ b/providers/gcp/resources/bigquery_connection.go
@@ -49,7 +49,11 @@ func (g *mqlGcpProjectBigqueryService) bigqueryLocations() ([]string, error) {
 }
 
 func (g *mqlGcpProjectBigqueryService) connections() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {

--- a/providers/gcp/resources/bigquery_reservation.go
+++ b/providers/gcp/resources/bigquery_reservation.go
@@ -17,7 +17,11 @@ import (
 )
 
 func (g *mqlGcpProjectBigqueryService) reservations() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {

--- a/providers/gcp/resources/certificatemanager.go
+++ b/providers/gcp/resources/certificatemanager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	certificatemanager "cloud.google.com/go/certificatemanager/apiv1"
 	"cloud.google.com/go/certificatemanager/apiv1/certificatemanagerpb"
@@ -48,6 +49,8 @@ func (g *mqlGcpProject) certificateManager() (*mqlGcpProjectCertificateManagerSe
 
 type mqlGcpProjectCertificateManagerServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 type mqlGcpProjectCertificateManagerServiceCertificateInternal struct {
@@ -79,7 +82,11 @@ func (g *mqlGcpProjectCertificateManagerService) id() (string, error) {
 }
 
 func (g *mqlGcpProjectCertificateManagerService) certificates() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -188,7 +195,11 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificate) daysUntilExpiry() (i
 }
 
 func (g *mqlGcpProjectCertificateManagerService) certificateMaps() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -324,7 +335,11 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateMapEntry) id() (string
 }
 
 func (g *mqlGcpProjectCertificateManagerService) dnsAuthorizations() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -397,7 +412,11 @@ func (g *mqlGcpProjectCertificateManagerServiceDnsAuthorization) id() (string, e
 }
 
 func (g *mqlGcpProjectCertificateManagerService) certificateIssuanceConfigs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -471,7 +490,11 @@ func (g *mqlGcpProjectCertificateManagerServiceCertificateIssuanceConfig) id() (
 }
 
 func (g *mqlGcpProjectCertificateManagerService) trustConfigs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -854,4 +877,33 @@ func initGcpProjectCertificateManagerServiceCertificateIssuanceConfig(runtime *p
 		return nil, nil, err
 	}
 	return args, res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectCertificateManagerService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_certificatemanager)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/cloudrun.go
+++ b/providers/gcp/resources/cloudrun.go
@@ -52,6 +52,8 @@ func initGcpProjectCloudRunService(runtime *plugin.Runtime, args map[string]*llx
 
 type mqlGcpProjectCloudRunServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) cloudRun() (*mqlGcpProjectCloudRunService, error) {
@@ -283,7 +285,11 @@ func (g *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) id() (str
 }
 
 func (g *mqlGcpProjectCloudRunService) regions() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -318,7 +324,11 @@ func (g *mqlGcpProjectCloudRunService) regions() ([]any, error) {
 }
 
 func (g *mqlGcpProjectCloudRunService) operations() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -391,7 +401,11 @@ func (g *mqlGcpProjectCloudRunService) operations() ([]any, error) {
 }
 
 func (g *mqlGcpProjectCloudRunService) services() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -758,7 +772,11 @@ func (g *mqlGcpProjectCloudRunServiceJobExecutionTemplateTaskTemplate) serviceAc
 }
 
 func (g *mqlGcpProjectCloudRunService) jobs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1123,4 +1141,33 @@ func mqlVolumes(volumes []*runpb.Volume) []any {
 		})
 	}
 	return mqlVolumes
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectCloudRunService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_cloudrun)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/dlp.go
+++ b/providers/gcp/resources/dlp.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
@@ -23,6 +24,8 @@ import (
 
 type mqlGcpProjectDlpServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) dlp() (*mqlGcpProjectDlpService, error) {
@@ -84,7 +87,11 @@ func (g *mqlGcpProjectDlpServiceInspectTemplate) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) inspectTemplates() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -155,7 +162,11 @@ func (g *mqlGcpProjectDlpServiceDeidentifyTemplate) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) deidentifyTemplates() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -226,7 +237,11 @@ func (g *mqlGcpProjectDlpServiceJobTrigger) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) jobTriggers() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -318,7 +333,11 @@ func (g *mqlGcpProjectDlpServiceStoredInfoType) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) storedInfoTypes() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -444,7 +463,11 @@ func (g *mqlGcpProjectDlpServiceDlpJob) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) dlpJobs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -531,7 +554,11 @@ func (g *mqlGcpProjectDlpServiceDiscoveryConfig) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) discoveryConfigs() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -624,7 +651,11 @@ func (g *mqlGcpProjectDlpServiceConnection) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) connections() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -699,7 +730,11 @@ func (g *mqlGcpProjectDlpServiceProjectDataProfile) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) projectDataProfiles() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -770,7 +805,11 @@ func (g *mqlGcpProjectDlpServiceTableDataProfile) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) tableDataProfiles() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -900,7 +939,11 @@ func (g *mqlGcpProjectDlpServiceColumnDataProfile) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) columnDataProfiles() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -1008,7 +1051,11 @@ func (g *mqlGcpProjectDlpServiceFileStoreDataProfile) id() (string, error) {
 }
 
 func (g *mqlGcpProjectDlpService) fileStoreDataProfiles() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -1242,4 +1289,33 @@ func (g *mqlGcpProjectBigqueryServiceTable) dlpDataProfile() (*mqlGcpProjectDlpS
 
 	g.DlpDataProfile.State = plugin.StateIsSet | plugin.StateIsNull
 	return nil, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectDlpService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_dlp)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/eventarc.go
+++ b/providers/gcp/resources/eventarc.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	eventarc "cloud.google.com/go/eventarc/apiv1"
 	"cloud.google.com/go/eventarc/apiv1/eventarcpb"
@@ -22,6 +23,8 @@ import (
 
 type mqlGcpProjectEventarcServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) eventarc() (*mqlGcpProjectEventarcService, error) {
@@ -119,7 +122,11 @@ func (g *mqlGcpProjectEventarcServiceTriggerEventFilter) id() (string, error) {
 }
 
 func (g *mqlGcpProjectEventarcService) triggers() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -234,7 +241,11 @@ func (g *mqlGcpProjectEventarcServiceChannel) kmsKey() (*mqlGcpProjectKmsService
 }
 
 func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -291,4 +302,33 @@ func (g *mqlGcpProjectEventarcService) channels() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectEventarcService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_eventarc)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/gke.go
+++ b/providers/gcp/resources/gke.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mondoo.com/mql/v13/llx"
@@ -24,6 +25,8 @@ import (
 
 type mqlGcpProjectGkeServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProjectGkeService) id() (string, error) {
@@ -315,7 +318,11 @@ func (g *mqlGcpProjectGkeServiceCluster) networkPolicy() (*mqlGcpProjectGkeServi
 
 func (g *mqlGcpProjectGkeService) clusters() ([]any, error) {
 	// when the service is not enabled, we return nil
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1565,4 +1572,33 @@ func (g *mqlGcpProjectGkeServiceClusterNodepoolConfig) hasFullCloudPlatformScope
 // config reports both as false (the secure default).
 func gkeRbacInsecureBindings(cfg *containerpb.RBACBindingConfig) (systemUnauthenticated, systemAuthenticated bool) {
 	return cfg.GetEnableInsecureBindingSystemUnauthenticated(), cfg.GetEnableInsecureBindingSystemAuthenticated()
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectGkeService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_gke)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/gke_backup.go
+++ b/providers/gcp/resources/gke_backup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	gkebackup "cloud.google.com/go/gkebackup/apiv1"
 	"cloud.google.com/go/gkebackup/apiv1/gkebackuppb"
@@ -22,6 +23,8 @@ import (
 
 type mqlGcpProjectGkeBackupServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) gkeBackup() (*mqlGcpProjectGkeBackupService, error) {
@@ -83,7 +86,11 @@ func (g *mqlGcpProjectGkeBackupServiceBackupPlan) id() (string, error) {
 }
 
 func (g *mqlGcpProjectGkeBackupService) backupPlans() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -173,7 +180,11 @@ func (g *mqlGcpProjectGkeBackupServiceRestorePlan) id() (string, error) {
 }
 
 func (g *mqlGcpProjectGkeBackupService) restorePlans() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -257,4 +268,33 @@ func (g *mqlGcpProjectGkeBackupServiceRestorePlan) backupPlan() (*mqlGcpProjectG
 		return nil, err
 	}
 	return res.(*mqlGcpProjectGkeBackupServiceBackupPlan), nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectGkeBackupService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_gkebackup)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/iam.go
+++ b/providers/gcp/resources/iam.go
@@ -42,6 +42,8 @@ func (g *mqlGcpProjectIamService) id() (string, error) {
 
 type mqlGcpProjectIamServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 type mqlGcpProjectIamServiceServiceAccountInternal struct {
@@ -257,7 +259,11 @@ func initGcpProjectIamServiceServiceAccount(runtime *plugin.Runtime, args map[st
 }
 
 func (g *mqlGcpProjectIamService) serviceAccounts() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -731,7 +737,11 @@ func (g *mqlGcpProjectIamServiceDenyPolicy) id() (string, error) {
 }
 
 func (g *mqlGcpProjectIamService) denyPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -883,4 +893,33 @@ func (g *mqlGcpProjectIamServiceServiceAccount) canBeImpersonated() (bool, error
 		}
 	}
 	return false, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectIamService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_iam)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/iam_workload_identity.go
+++ b/providers/gcp/resources/iam_workload_identity.go
@@ -29,7 +29,11 @@ func wifPoolHostsProviders(mode string) bool {
 }
 
 func (g *mqlGcpProjectIamService) workloadIdentityPools() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 

--- a/providers/gcp/resources/identityplatform.go
+++ b/providers/gcp/resources/identityplatform.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -21,6 +22,8 @@ import (
 
 type mqlGcpProjectIdentityPlatformServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) identityPlatform() (*mqlGcpProjectIdentityPlatformService, error) {
@@ -83,7 +86,11 @@ func (g *mqlGcpProjectIdentityPlatformService) identityPlatformClient() (*identi
 }
 
 func (g *mqlGcpProjectIdentityPlatformService) config() (*mqlGcpProjectIdentityPlatformServiceConfig, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		g.Config.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
@@ -244,7 +251,11 @@ func (g *mqlGcpProjectIdentityPlatformServiceTenant) id() (string, error) {
 }
 
 func (g *mqlGcpProjectIdentityPlatformService) tenants() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -323,4 +334,33 @@ func newMqlIdentityPlatformTenant(runtime *plugin.Runtime, t *identitytoolkit.Go
 	}
 
 	return CreateResource(runtime, "gcp.project.identityPlatformService.tenant", args)
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectIdentityPlatformService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_identityplatform)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/ids.go
+++ b/providers/gcp/resources/ids.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	ids "cloud.google.com/go/ids/apiv1"
 	"cloud.google.com/go/ids/apiv1/idspb"
@@ -22,6 +23,8 @@ import (
 
 type mqlGcpProjectIdsServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) ids() (*mqlGcpProjectIdsService, error) {
@@ -79,7 +82,11 @@ func (g *mqlGcpProjectIdsServiceEndpoint) id() (string, error) {
 }
 
 func (g *mqlGcpProjectIdsService) endpoints() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -158,4 +165,33 @@ func (g *mqlGcpProjectIdsServiceEndpoint) network() (*mqlGcpProjectComputeServic
 		g.Network.State = plugin.StateIsNull | plugin.StateIsSet
 	}
 	return network, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectIdsService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_ids)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/kms.go
+++ b/providers/gcp/resources/kms.go
@@ -116,6 +116,8 @@ func initGcpProjectKmsServiceKeyring(runtime *plugin.Runtime, args map[string]*l
 
 type mqlGcpProjectKmsServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) kms() (*mqlGcpProjectKmsService, error) {
@@ -292,7 +294,11 @@ func (g *mqlGcpProjectKmsServiceKeyringCryptokeyVersionAttestationCertificatecha
 }
 
 func (g *mqlGcpProjectKmsService) locations() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -333,7 +339,11 @@ func (g *mqlGcpProjectKmsService) locations() ([]any, error) {
 }
 
 func (g *mqlGcpProjectKmsService) keyrings() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -730,7 +740,11 @@ func (g *mqlGcpProjectKmsServiceRetiredResource) id() (string, error) {
 }
 
 func (g *mqlGcpProjectKmsService) retiredResources() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -796,7 +810,11 @@ func (g *mqlGcpProjectKmsServiceEkmConnection) id() (string, error) {
 }
 
 func (g *mqlGcpProjectKmsService) ekmConnections() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -945,4 +963,33 @@ func (g *mqlGcpProjectKmsServiceKeyring) importJobs() ([]any, error) {
 		res = append(res, mqlIj)
 	}
 	return res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectKmsService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_kms)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/logging.go
+++ b/providers/gcp/resources/logging.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -30,6 +31,8 @@ func (g *mqlGcpProjectLoggingservice) id() (string, error) {
 
 type mqlGcpProjectLoggingserviceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) logging() (*mqlGcpProjectLoggingservice, error) {
@@ -85,7 +88,11 @@ func initGcpProjectLoggingservice(runtime *plugin.Runtime, args map[string]*llx.
 }
 
 func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -180,7 +187,11 @@ func (g *mqlGcpProjectLoggingservice) buckets() ([]any, error) {
 }
 
 func (g *mqlGcpProjectLoggingservice) metrics() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -299,7 +310,11 @@ func parseAlertPolicyConditionFilterMetricName(condition map[string]any) string 
 }
 
 func (g *mqlGcpProjectLoggingservice) sinks() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -361,7 +376,11 @@ func (g *mqlGcpProjectLoggingservice) sinks() ([]any, error) {
 }
 
 func (g *mqlGcpProjectLoggingservice) cmekKmsKeyName() (string, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return "", err
+	}
+	if !enabled {
 		return "", nil
 	}
 
@@ -638,7 +657,11 @@ func (g *mqlGcpProjectLoggingserviceBucketIndexConfig) id() (string, error) {
 }
 
 func (g *mqlGcpProjectLoggingservice) exclusions() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -881,4 +904,33 @@ func (g *mqlGcpFolderLoggingService) sinks() ([]any, error) {
 	conn := g.MqlRuntime.Connection.(*connection.GcpConnection)
 	return scopedSinks(g.MqlRuntime, conn, g.FolderName.Data,
 		"gcp.folder.loggingService.sink", "folderName")
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectLoggingservice) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_logging)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/modelarmor.go
+++ b/providers/gcp/resources/modelarmor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	modelarmor "cloud.google.com/go/modelarmor/apiv1"
 	"cloud.google.com/go/modelarmor/apiv1/modelarmorpb"
@@ -24,6 +25,8 @@ import (
 
 type mqlGcpProjectModelArmorServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) modelArmor() (*mqlGcpProjectModelArmorService, error) {
@@ -73,7 +76,11 @@ func (g *mqlGcpProjectModelArmorService) id() (string, error) {
 }
 
 func (g *mqlGcpProjectModelArmorService) templates() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -210,7 +217,11 @@ func (g *mqlGcpProjectModelArmorServiceFloorSetting) id() (string, error) {
 }
 
 func (g *mqlGcpProjectModelArmorService) floorSetting() (*mqlGcpProjectModelArmorServiceFloorSetting, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		g.FloorSetting.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
@@ -271,4 +282,33 @@ func (g *mqlGcpProjectModelArmorService) floorSetting() (*mqlGcpProjectModelArmo
 		return nil, err
 	}
 	return res.(*mqlGcpProjectModelArmorServiceFloorSetting), nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectModelArmorService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_modelarmor)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/networksecurity.go
+++ b/providers/gcp/resources/networksecurity.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
@@ -20,6 +21,8 @@ import (
 
 type mqlGcpProjectNetworkSecurityServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) networkSecurity() (*mqlGcpProjectNetworkSecurityService, error) {
@@ -121,7 +124,11 @@ func (g *mqlGcpProjectNetworkSecurityService) networkSecurityHTTPClient() (*conn
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) authorizationPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -172,7 +179,11 @@ func (g *mqlGcpProjectNetworkSecurityService) authorizationPolicies() ([]any, er
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) serverTlsPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -233,7 +244,11 @@ func (g *mqlGcpProjectNetworkSecurityService) serverTlsPolicies() ([]any, error)
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -289,7 +304,11 @@ func (g *mqlGcpProjectNetworkSecurityService) clientTlsPolicies() ([]any, error)
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) tlsInspectionPolicies() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -343,7 +362,11 @@ func (g *mqlGcpProjectNetworkSecurityService) tlsInspectionPolicies() ([]any, er
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) addressGroups() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -400,7 +423,11 @@ func (g *mqlGcpProjectNetworkSecurityService) addressGroups() ([]any, error) {
 }
 
 func (g *mqlGcpProjectNetworkSecurityService) urlLists() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	conn, parent, err := g.networkSecurityHTTPClient()
@@ -571,4 +598,33 @@ func (g *mqlGcpOrganization) networkSecurityProfileGroups() ([]any, error) {
 		return nil, err
 	}
 	return res, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectNetworkSecurityService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_networksecurity)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/osconfig.go
+++ b/providers/gcp/resources/osconfig.go
@@ -25,6 +25,8 @@ import (
 
 type mqlGcpProjectOsConfigServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) osConfig() (*mqlGcpProjectOsConfigService, error) {
@@ -99,7 +101,11 @@ func parseSecondsDuration(d string) int64 {
 }
 
 func (g *mqlGcpProjectOsConfigService) patchDeployments() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -176,7 +182,11 @@ func (g *mqlGcpProjectOsConfigService) patchDeployments() ([]any, error) {
 }
 
 func (g *mqlGcpProjectOsConfigService) osPolicyAssignments() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 	if g.ProjectId.Error != nil {
@@ -557,4 +567,33 @@ func newMqlVulnerabilityReportVulnerability(runtime *plugin.Runtime, reportName 
 		"references":                llx.ArrayData(references, types.Dict),
 		"updateTime":                llx.TimeDataPtr(parseTime(v.UpdateTime)),
 	})
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectOsConfigService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_osconfig)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/pubsub.go
+++ b/providers/gcp/resources/pubsub.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
@@ -54,6 +55,8 @@ func initGcpProjectPubsubService(runtime *plugin.Runtime, args map[string]*llx.R
 
 type mqlGcpProjectPubsubServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) pubsub() (*mqlGcpProjectPubsubService, error) {
@@ -311,7 +314,11 @@ func initGcpProjectPubsubServiceSnapshot(runtime *plugin.Runtime, args map[strin
 }
 
 func (g *mqlGcpProjectPubsubService) topics() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -459,7 +466,11 @@ func (g *mqlGcpProjectPubsubServiceTopic) config() (*mqlGcpProjectPubsubServiceT
 }
 
 func (g *mqlGcpProjectPubsubService) subscriptions() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -676,7 +687,11 @@ func (g *mqlGcpProjectPubsubServiceSubscription) config() (*mqlGcpProjectPubsubS
 }
 
 func (g *mqlGcpProjectPubsubService) snapshots() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1245,4 +1260,33 @@ func (g *mqlGcpProjectPubsubServiceTopicConfig) kmsKey() (*mqlGcpProjectKmsServi
 		return nil, err
 	}
 	return res.(*mqlGcpProjectKmsServiceKeyringCryptokey), nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectPubsubService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_pubsub)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/redis.go
+++ b/providers/gcp/resources/redis.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	redis "cloud.google.com/go/redis/apiv1"
@@ -26,6 +27,8 @@ import (
 
 type mqlGcpProjectRedisServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 type mqlGcpProjectRedisServiceInstanceInternal struct {
@@ -203,7 +206,11 @@ func (g *mqlGcpProjectRedisServiceInstance) id() (string, error) {
 // Docs https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations/list#authorization-scopes
 func (g *mqlGcpProjectRedisService) instances() ([]any, error) {
 	// when the service is not enabled, we return nil
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -565,7 +572,11 @@ func initGcpProjectRedisServiceCluster(runtime *plugin.Runtime, args map[string]
 
 func (g *mqlGcpProjectRedisService) clusters() ([]any, error) {
 	// when the service is not enabled, we return nil
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1298,4 +1309,33 @@ func clusterConvertConnectionDetails(runtime *plugin.Runtime, projectId, cluster
 		list = append(list, r)
 	}
 	return
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectRedisService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_redis)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/secretmanager.go
+++ b/providers/gcp/resources/secretmanager.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -53,6 +54,8 @@ func initGcpProjectSecretmanagerService(runtime *plugin.Runtime, args map[string
 
 type mqlGcpProjectSecretmanagerServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) secretmanager() (*mqlGcpProjectSecretmanagerService, error) {
@@ -84,7 +87,11 @@ func (g *mqlGcpProject) secretmanager() (*mqlGcpProjectSecretmanagerService, err
 
 func (g *mqlGcpProjectSecretmanagerService) secrets() ([]any, error) {
 	// when the service is not enabled, we return nil
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -559,4 +566,33 @@ func durationToString(d *durationpb.Duration) string {
 		return ""
 	}
 	return fmt.Sprintf("%ds", d.Seconds)
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectSecretmanagerService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_secretmanager)
+	})
+	return g.serviceEnabled, g.serviceErr
 }

--- a/providers/gcp/resources/service_gate_test.go
+++ b/providers/gcp/resources/service_gate_test.go
@@ -1,0 +1,103 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoBareServiceEnabledGate pins the service-enabled contract.
+//
+// `serviceEnabled` is populated only by the gcp.project.<service>() accessor.
+// The same resource is reachable without it -- addressed by its own type name
+// (gcp.project.cloudRunService.services), through an alias (gcp.storage), or
+// built by a resource init with CreateResource. On those paths the Go zero value
+// is `false`, so a bare
+//
+//	if !g.serviceEnabled { return nil, nil }
+//
+// reports an authoritative "there is nothing here" for a service that is in fact
+// enabled and populated. An empty list is the most dangerous wrong answer for a
+// posture check: it passes vacuously instead of failing or erroring.
+//
+// Verified against a live project: gcp.project.cloudRunService.services returned
+// [] while gcp.project.cloudRun.services returned the real service.
+//
+// Every gate must therefore resolve the flag first, via the isEnabled() helper
+// (bigquery.go, storage.go, ...) or the serviceChecked companion flag (dns.go).
+func TestNoBareServiceEnabledGate(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			ifs, ok := n.(*ast.IfStmt)
+			if !ok {
+				return true
+			}
+			// match exactly `!<recv>.serviceEnabled`, with no other operand
+			unary, ok := ifs.Cond.(*ast.UnaryExpr)
+			if !ok || unary.Op != token.NOT {
+				return true
+			}
+			sel, ok := unary.X.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "serviceEnabled" {
+				return true
+			}
+			t.Errorf("%s: gates on serviceEnabled without resolving it first; "+
+				"an unresolved flag is false and reports an empty collection for an "+
+				"enabled service. Call isEnabled() (see bigquery.go) instead",
+				fset.Position(ifs.Pos()))
+			return true
+		})
+	}
+}
+
+// TestEveryServiceEnabledFlagHasAResolver checks the other direction: a resource
+// that carries the flag must also carry the machinery to resolve it, so a new
+// service cannot reintroduce the zero-value bug by omission.
+func TestEveryServiceEnabledFlagHasAResolver(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob package sources: %v", err)
+	}
+
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		src := string(raw)
+		if !strings.Contains(src, "serviceEnabled bool") {
+			continue
+		}
+		// either the lazy resolver or the explicit "was it checked" companion
+		if strings.Contains(src, "serviceOnce") || strings.Contains(src, "serviceChecked") {
+			continue
+		}
+		t.Errorf("%s: declares serviceEnabled but has neither serviceOnce "+
+			"(the isEnabled() resolver) nor serviceChecked; the flag defaults to "+
+			"false and would report empty collections for an enabled service", path)
+	}
+}

--- a/providers/gcp/resources/sql.go
+++ b/providers/gcp/resources/sql.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -262,6 +263,8 @@ func (g *mqlGcpProjectSqlService) id() (string, error) {
 
 type mqlGcpProjectSqlServiceInternal struct {
 	serviceEnabled bool
+	serviceOnce    sync.Once
+	serviceErr     error
 }
 
 func (g *mqlGcpProject) sql() (*mqlGcpProjectSqlService, error) {
@@ -292,7 +295,11 @@ func (g *mqlGcpProject) sql() (*mqlGcpProjectSqlService, error) {
 }
 
 func (g *mqlGcpProjectSqlService) instances() ([]any, error) {
-	if !g.serviceEnabled {
+	enabled, err := g.isEnabled()
+	if err != nil {
+		return nil, err
+	}
+	if !enabled {
 		return nil, nil
 	}
 
@@ -1477,4 +1484,33 @@ func (g *mqlGcpProjectSqlServiceInstance) localRootEnabled() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// isEnabled resolves the service-enabled gate lazily.
+//
+// serviceEnabled is only set by the gcp.project.<service>() accessor, but this
+// resource is reachable without going through it: it can be addressed by its own
+// type name and resource inits build it with CreateResource. On those paths the
+// Go zero value `false` made every collection return an empty list with no error
+// -- an authoritative "there is nothing here" that makes an audit pass
+// vacuously. Resolving it here makes every construction path agree.
+func (g *mqlGcpProjectSqlService) isEnabled() (bool, error) {
+	g.serviceOnce.Do(func() {
+		if g.serviceEnabled {
+			return // already set by the parent accessor
+		}
+		if g.ProjectId.Error != nil {
+			g.serviceErr = g.ProjectId.Error
+			return
+		}
+		proj, err := CreateResource(g.MqlRuntime, "gcp.project", map[string]*llx.RawData{
+			"id": llx.StringData(g.ProjectId.Data),
+		})
+		if err != nil {
+			g.serviceErr = err
+			return
+		}
+		g.serviceEnabled, g.serviceErr = proj.(*mqlGcpProject).isServiceEnabled(service_sqladmin)
+	})
+	return g.serviceEnabled, g.serviceErr
 }


### PR DESCRIPTION
## The bug

`serviceEnabled` is populated **only** by the `gcp.project.<service>()` accessor. The same service resource is reachable without going through it:

- addressed by its own type name — `gcp.project.cloudRunService.services`
- through an alias — `gcp.storage`, `gcp.bigquery`
- built by a resource `init` with `CreateResource`

On those paths the flag is the Go zero value `false`, so every gated collection returned an **empty list with no error** — an authoritative "there is nothing here" for a service that is in fact enabled and populated.

An empty list is the most dangerous wrong answer for a posture check: it passes vacuously instead of failing or erroring.

## Live evidence

Against a real project with exactly one Cloud Run service in `us-central1` (existence confirmed independently via the `run.googleapis.com` REST API):

```
gcp.project.cloudRunService.services  ->  []             # regions [] -> 0 workers
gcp.project.cloudRun.services         ->  the service    # regions.length 43
```

Same runtime, same project, two addressing paths, different answers. `regions()` opens with the bare gate, and `services()`/`jobs()` fall back to `regions()` when the list is empty — so both yielded nothing.

## The fix

The lazy `isEnabled()` helper added in #9436 is the right shape, but it was applied to `bigquery.go` and `storage.go` only. This extends it to the remaining **20 service resources** and rewrites all **62 gates** across 23 files.

Also fixes three gates that were missed even in the already-patched services:

- `bigquery_connection.go` → `connections()`
- `bigquery_reservation.go` → `reservations()`
- `iam_workload_identity.go` → `workloadIdentityPools()`

`dns.go` already guards with a `serviceChecked` companion flag and is left alone.

Each gate becomes:

```go
enabled, err := g.isEnabled()
if err != nil {
    return nil, err
}
if !enabled {
    return nil, nil
}
```

## Tests

Two AST tests in `service_gate_test.go` lock the contract:

- **`TestNoBareServiceEnabledGate`** — no `if` may read `serviceEnabled` without resolving it first.
- **`TestEveryServiceEnabledFlagHasAResolver`** — any resource declaring the flag must carry a resolver (`serviceOnce` or `serviceChecked`), so a new service cannot reintroduce the bug by omission.

Both were confirmed to **fail** when a single gate is reverted to the old shape, and pass on this branch. Full `providers/gcp` suite is green.
