### PR TITLE
🐛 azure: scope the root asset to an explicitly named subscription

### DIFF
--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -73,9 +73,25 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 			Password:       string(certificateSecret),
 		})
 	}
+	filterOpts := parseFlagsToFiltersOpts(flags)
+
+	// A caller who named exactly one subscription is scoping the whole run to it,
+	// so the root asset has to carry it as well.
+	//
+	// Only discovery ever set subscription-id (getSubConfig, per discovered
+	// subscription). The root asset therefore connected with no subscription at
+	// all, and every azure.subscription.* query against it failed with the SDK's
+	// "parameter subscriptionID cannot be empty" -- one guaranteed broken asset on
+	// every scan, whose empty PlatformId ("...:/subscriptions/") is also not
+	// unique. Naming several subscriptions stays a discovery-only filter: there is
+	// no single subscription to scope the root asset to.
+	if id, ok := singleSubscriptionFilter(filterOpts); ok {
+		opts[connection.OptionSubscriptionID] = id
+	}
+
 	config := &inventory.Config{
 		Type:        "azure",
-		Discover:    parseDiscover(flags, parseFlagsToFiltersOpts(flags)),
+		Discover:    parseDiscover(flags, filterOpts),
 		Credentials: creds,
 		Options:     opts,
 	}
@@ -93,6 +109,26 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	}
 
 	return &plugin.ParseCLIRes{Asset: &asset}, nil
+}
+
+// singleSubscriptionFilter returns the subscription id when the caller scoped the
+// run to exactly one, so the root asset can be scoped to it too. A list of
+// subscriptions has no single answer and stays a discovery-only filter.
+func singleSubscriptionFilter(filterOpts map[string]string) (string, bool) {
+	raw, ok := filterOpts["subscriptions"]
+	if !ok {
+		return "", false
+	}
+	var ids []string
+	for _, part := range strings.Split(raw, ",") {
+		if id := strings.TrimSpace(part); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) != 1 {
+		return "", false
+	}
+	return ids[0], true
 }
 
 func parseDiscover(flags map[string]*llx.Primitive, filterOpts map[string]string) *inventory.Discovery {

--- a/providers/azure/provider/subscription_scope_test.go
+++ b/providers/azure/provider/subscription_scope_test.go
@@ -1,0 +1,98 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+func TestSingleSubscriptionFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters map[string]string
+		want    string
+		wantOk  bool
+	}{
+		{"no filter", map[string]string{}, "", false},
+		{"one subscription", map[string]string{"subscriptions": "sub-a"}, "sub-a", true},
+		{"one subscription padded", map[string]string{"subscriptions": " sub-a "}, "sub-a", true},
+		// several named subscriptions have no single answer; this stays a
+		// discovery-only filter
+		{"two subscriptions", map[string]string{"subscriptions": "sub-a,sub-b"}, "", false},
+		{"trailing comma", map[string]string{"subscriptions": "sub-a,"}, "sub-a", true},
+		{"empty value", map[string]string{"subscriptions": ""}, "", false},
+		{"only commas", map[string]string{"subscriptions": ",,"}, "", false},
+		{"unrelated filter", map[string]string{"subscriptions-exclude": "sub-a"}, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := singleSubscriptionFilter(tt.filters)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseCLIScopesRootAssetToNamedSubscription is the regression test for the
+// phantom asset.
+//
+// subscription-id was only ever set by discovery (getSubConfig, once per
+// discovered subscription). The root asset therefore connected with no
+// subscription, so every azure.subscription.* query against it failed with the
+// SDK's "parameter subscriptionID cannot be empty" -- one guaranteed broken asset
+// on every scan, even when the caller had named the subscription explicitly. Its
+// PlatformId also degenerated to ".../subscriptions/" with no id, which is not
+// unique across runs.
+func TestParseCLIScopesRootAssetToNamedSubscription(t *testing.T) {
+	s := &Service{}
+
+	t.Run("named subscription scopes the root asset", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "azure",
+			Flags: map[string]*llx.Primitive{
+				"subscription": llx.StringPrimitive("sub-a"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res.Asset)
+		require.Len(t, res.Asset.Connections, 1)
+
+		conf := res.Asset.Connections[0]
+		assert.Equal(t, "sub-a", conf.Options[connection.OptionSubscriptionID],
+			"the root asset must carry the subscription the caller named")
+		// still a discovery filter, so discovery keeps narrowing to it
+		assert.Equal(t, "sub-a", conf.Discover.Filter["subscriptions"])
+	})
+
+	t.Run("several subscriptions leave the root asset unscoped", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "azure",
+			Flags: map[string]*llx.Primitive{
+				"subscriptions": llx.StringPrimitive("sub-a,sub-b"),
+			},
+		})
+		require.NoError(t, err)
+		conf := res.Asset.Connections[0]
+		assert.Empty(t, conf.Options[connection.OptionSubscriptionID],
+			"there is no single subscription to scope the root asset to")
+		assert.Equal(t, "sub-a,sub-b", conf.Discover.Filter["subscriptions"])
+	})
+
+	t.Run("no subscription flag", func(t *testing.T) {
+		res, err := s.ParseCLI(&plugin.ParseCLIReq{
+			Connector: "azure",
+			Flags:     map[string]*llx.Primitive{},
+		})
+		require.NoError(t, err)
+		conf := res.Asset.Connections[0]
+		assert.Empty(t, conf.Options[connection.OptionSubscriptionID])
+	})
+}


### PR DESCRIPTION
## The bug

`subscription-id` was only ever set by **discovery**, once per discovered subscription (`getSubConfig`). `ParseCLI` never set it, so the **root asset always connected with no subscription at all** — `--subscription` only ever became a discovery *filter*.

Every `azure.subscription.*` query against that asset failed:

```
$ mql run azure --subscription <id> --discover subscriptions \
    -c "azure.subscription { subscriptionId name }"

rpc error: code = Unknown desc = parameter subscriptionID cannot be empty
azure.subscription: no data available                <- root asset
azure.subscription: { subscriptionId: "<id>", ... }  <- discovered asset
```

One guaranteed failed asset on **every** Azure scan — even when the caller had named the subscription explicitly. Related symptoms from the same cause:

- deeper resources failed from the SDK client constructor: `parameter client.subscriptionID cannot be empty`
- `azure.subscription.policy` built a malformed request against `/subscriptions/providers/Microsoft.Authorization/policyAssignments?api-version=...` → `400 Bad Request`
- `AzureConnection.PlatformId()` degenerated to `//platformid.api.mondoo.app/runtime/azure/subscriptions/` with no id, which is not unique across runs

## The fix

When the caller scopes the run to exactly one subscription, the root asset now carries it too. Naming several stays a discovery-only filter — there is no single subscription to scope the root asset to.

## Verification

Live, against a real tenant with the provider built from this branch:

```
# before
rpc error: parameter subscriptionID cannot be empty
azure.subscription: no data available
azure.subscription: { subscriptionId: "e9ee…" }

# after
azure.subscription: { name: "…", subscriptionId: "e9ee…" }
azure.subscription: { name: "…", subscriptionId: "e9ee…" }
```

`azure.subscription.computeService.vms` — which previously failed on the root asset — now returns the VM on both assets.

Tests: `TestSingleSubscriptionFilter` (parsing, including padding, trailing commas, empty and multi-valued input) and `TestParseCLIScopesRootAssetToNamedSubscription` (the root asset carries a single named subscription; several named subscriptions leave it unscoped; no flag leaves it unscoped). Full `providers/azure` suite is green.

## Deliberately not addressed

With **no** subscription named on a multi-subscription tenant the root asset stays unscoped, because there is no unambiguous choice. Making the individual resources degrade to null rather than erroring is the follow-up — it needs a change at each `conn.SubId()` call site, not one in `ParseCLI`.
