### PR TITLE
✨ feat(network): add dns.authoritativeRecords for TTLs that don't move

### DIFF
--- a/providers/network/resources/dns.go
+++ b/providers/network/resources/dns.go
@@ -100,6 +100,32 @@ func (d *mqlDns) params(fqdn string) (any, error) {
 	return convert.JsonToDict(records)
 }
 
+// authoritativeParams resolves the same records as params, but against the
+// nameservers authoritative for the zone instead of a caching resolver.
+//
+// The answers are identical except for the TTL, which is the point: a caching
+// resolver reports the time left on its cached entry, so a record configured
+// with a TTL of 300 answers 300, then 208, then 144 as that entry ages. Any
+// check asserting on a TTL has to read it from here, or it flaps purely on when
+// the scan happened to run.
+func (d *mqlDns) authoritativeParams(fqdn string) (any, error) {
+	if fqdn == "" {
+		return nil, nil
+	}
+
+	dnsShaker, err := dnsshake.New(fqdn)
+	if err != nil {
+		return nil, err
+	}
+
+	records, err := dnsShaker.QueryAuthoritative()
+	if err != nil {
+		return nil, err
+	}
+
+	return convert.JsonToDict(records)
+}
+
 // dictTTL reads a DNS record's TTL out of a record map produced by
 // convert.JsonToDict (json.Marshal then Unmarshal of a dnsshake.DnsRecord).
 // The map key is therefore the json tag "ttl" (not the Go field name "TTL"),
@@ -115,6 +141,17 @@ func dictTTL(m map[string]any) (int64, bool) {
 }
 
 func (d *mqlDns) records(params any) ([]any, error) {
+	return d.recordsFromParams(params)
+}
+
+// authoritativeRecords parses the same shape as records, from answers the
+// authoritative nameservers gave rather than a caching resolver. The records
+// are the same; their TTLs are the configured values.
+func (d *mqlDns) authoritativeRecords(authoritativeParams any) ([]any, error) {
+	return d.recordsFromParams(authoritativeParams)
+}
+
+func (d *mqlDns) recordsFromParams(params any) ([]any, error) {
 	// NOTE: mql does not cache the results of GetRecords since it has an input argument
 	// Iterations over map keys are not deterministic and therefore we need to sort the keys
 

--- a/providers/network/resources/dnsshake/dnsshake.go
+++ b/providers/network/resources/dnsshake/dnsshake.go
@@ -197,6 +197,131 @@ func (d *DnsClient) Query(dnsTypes ...string) (map[string]DnsRecord, error) {
 }
 
 func (d *DnsClient) queryDnsType(fqdn string, t string) (map[string]DnsRecord, error) {
+	return d.queryDnsTypeAt(d.config.Servers[0], true, fqdn, t)
+}
+
+// QueryAuthoritative resolves the requested types against the nameservers that
+// are authoritative for the zone, rather than through a caching resolver.
+//
+// Use it when the answer's TTL matters. A caching resolver returns the time
+// remaining on its cached entry, so a record configured with a TTL of 300
+// answers 300, then 208, then 144 as the entry ages. Only the authoritative
+// server reports the configured value, which is the one worth asserting on.
+//
+// Returns an error when the zone's nameservers cannot be determined, rather
+// than silently falling back to the caching resolver: a caller that asked for
+// authoritative data should not be handed cached data instead.
+func (d *DnsClient) QueryAuthoritative(dnsTypes ...string) (map[string]DnsRecord, error) {
+	servers, err := d.authoritativeNameservers()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(dnsTypes) == 0 {
+		for k := range stringToType {
+			dnsTypes = append(dnsTypes, k)
+		}
+	}
+
+	var workers sync.WaitGroup
+	var errs multierr.Errors
+
+	res := map[string]DnsRecord{}
+	for i := range dnsTypes {
+		dnsType := dnsTypes[i]
+
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+
+			// Try each nameserver in turn: an individual one may refuse, be
+			// unreachable, or lag behind its peers, and any authoritative server
+			// for the zone is an equally valid source for the record.
+			var lastErr error
+			for _, server := range servers {
+				records, err := d.queryDnsTypeAt(server, false, d.fqdn, dnsType)
+				if err != nil {
+					lastErr = err
+					continue
+				}
+
+				d.sync.Lock()
+				for k := range records {
+					res[k] = records[k]
+				}
+				d.sync.Unlock()
+				return
+			}
+
+			if lastErr != nil {
+				d.sync.Lock()
+				errs.Add(lastErr)
+				d.sync.Unlock()
+			}
+		}()
+	}
+
+	workers.Wait()
+	return res, errs.Deduplicate()
+}
+
+// authoritativeNameservers finds the addresses of the nameservers serving the
+// zone that contains the client's fqdn.
+//
+// The NS records live at the zone apex, not at every name within it, so this
+// walks up the labels until a delegation is found: a query for
+// "www.example.com" finds nothing at that name and succeeds at "example.com".
+// The walk stops before the root so a name that resolves nowhere fails rather
+// than returning the root servers, which would answer referrals instead of the
+// records the caller wants.
+func (d *DnsClient) authoritativeNameservers() ([]string, error) {
+	name := dns.Fqdn(d.fqdn)
+	if name == "." {
+		return nil, errors.New("cannot determine authoritative nameservers without a domain name")
+	}
+
+	for labels := dns.SplitDomainName(name); len(labels) > 0; labels = labels[1:] {
+		zone := strings.Join(labels, ".")
+
+		records, err := d.queryDnsTypeAt(d.config.Servers[0], true, zone, "NS")
+		if err != nil {
+			return nil, err
+		}
+
+		ns, ok := records["NS"]
+		if !ok || ns.RCode != dns.RcodeToString[dns.RcodeSuccess] || len(ns.RData) == 0 {
+			continue
+		}
+
+		addrs := []string{}
+		for _, host := range ns.RData {
+			// Nameservers are named, so each one needs resolving to an address
+			// before it can be queried. Skip any that do not resolve; as long as
+			// one does, the zone is reachable.
+			ips, err := net.LookupHost(strings.TrimSuffix(host, "."))
+			if err != nil {
+				continue
+			}
+			addrs = append(addrs, ips...)
+		}
+
+		if len(addrs) > 0 {
+			return addrs, nil
+		}
+	}
+
+	return nil, errors.New("no authoritative nameserver found for " + d.fqdn)
+}
+
+// queryDnsTypeAt performs the lookup against a named server.
+//
+// recursion decides who resolves the name: true asks a caching resolver to do
+// the work, false requires the server to answer from its own zone data. The
+// distinction matters for TTLs. A caching resolver reports the time remaining
+// on its cached entry, counting down toward zero, so the same query returns a
+// different TTL depending on when it is asked. An authoritative server reports
+// the value configured in the zone.
+func (d *DnsClient) queryDnsTypeAt(server string, recursion bool, fqdn string, t string) (map[string]DnsRecord, error) {
 	dnsType, ok := stringToType[t]
 	if !ok {
 		return nil, errors.New("unknown dns type")
@@ -209,9 +334,9 @@ func (d *DnsClient) queryDnsType(fqdn string, t string) (map[string]DnsRecord, e
 	m := &dns.Msg{}
 	m.SetEdns0(4096, false)
 	m.SetQuestion(dns.Fqdn(fqdn), dnsType)
-	m.RecursionDesired = true
+	m.RecursionDesired = recursion
 
-	r, _, err := c.Exchange(m, net.JoinHostPort(d.config.Servers[0], d.config.Port))
+	r, _, err := c.Exchange(m, net.JoinHostPort(server, d.config.Port))
 	if err != nil {
 		res[dnsTypText] = DnsRecord{
 			Type:  dnsTypText,

--- a/providers/network/resources/dnsshake/dnsshake_test.go
+++ b/providers/network/resources/dnsshake/dnsshake_test.go
@@ -18,3 +18,56 @@ func TestDnsShake(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, len(records) > 0)
 }
+
+func TestAuthoritativeNameserversRejectsRoot(t *testing.T) {
+	// Guards the walk's stopping condition. Falling through to the root would
+	// return the root servers, which answer referrals rather than the records
+	// the caller asked for, so an unresolvable name has to fail instead.
+	for _, fqdn := range []string{"", "."} {
+		c, err := New(fqdn)
+		require.NoError(t, err)
+
+		_, err = c.authoritativeNameservers()
+		assert.Error(t, err, "fqdn %q should not resolve to the root servers", fqdn)
+	}
+}
+
+func TestAuthoritativeNameserversWalksUpToTheZone(t *testing.T) {
+	// NS records live at the zone apex, not at every name inside it, so a
+	// subdomain has to walk up before it finds a delegation. Both of these are
+	// served by the same zone and must therefore find the same nameservers.
+	apex, err := New("mondoo.com")
+	require.NoError(t, err)
+	apexServers, err := apex.authoritativeNameservers()
+	require.NoError(t, err)
+	require.NotEmpty(t, apexServers)
+
+	sub, err := New("www.mondoo.com")
+	require.NoError(t, err)
+	subServers, err := sub.authoritativeNameservers()
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, apexServers, subServers,
+		"a subdomain should resolve to its zone's nameservers")
+}
+
+func TestQueryAuthoritativeReportsConfiguredTTL(t *testing.T) {
+	// The reason this path exists: a caching resolver reports the time left on
+	// its cached entry, so the same query answers a different TTL depending on
+	// when it runs. The authoritative answer is the configured value and does
+	// not move between consecutive reads.
+	c, err := New("mondoo.com")
+	require.NoError(t, err)
+
+	first, err := c.QueryAuthoritative("A")
+	require.NoError(t, err)
+	require.Contains(t, first, "A")
+
+	second, err := c.QueryAuthoritative("A")
+	require.NoError(t, err)
+	require.Contains(t, second, "A")
+
+	assert.Equal(t, first["A"].TTL, second["A"].TTL,
+		"authoritative TTL should not vary between reads")
+	assert.Positive(t, first["A"].TTL)
+}

--- a/providers/network/resources/network.lr
+++ b/providers/network/resources/network.lr
@@ -552,8 +552,31 @@ dns @defaults("fqdn") {
   // `rData` payload, and `rCode` response status. The `records`, `mx`,
   // `dkim`, `spf`, `dmarc`, and `dnssec` fields parse this into records.
   params(fqdn) dict
+  // DNS query results from the zone's authoritative nameservers
+  //
+  // Same shape as `params`, resolved against the nameservers authoritative
+  // for the zone rather than through a caching resolver. The records match;
+  // the TTLs are the values configured in the zone.
+  authoritativeParams(fqdn) dict
   // Successful DNS records
   records(params) []dns.record
+  // Successful DNS records as published in the zone
+  //
+  // Same records as `records`, carrying the TTL configured in the zone rather
+  // than the time remaining on a resolver's cached copy. Use this whenever a
+  // TTL is being asserted on: a caching resolver counts its cached TTL down
+  // toward zero, so a record configured at 300 answers 300, then 208, then
+  // 144 as the entry ages, and a threshold check on that flaps depending on
+  // when the scan ran.
+  //
+  // Unlike `records`, this does not follow CNAMEs, because the zone's own
+  // nameservers answer only for what the zone contains. A name published as a
+  // CNAME therefore appears here as a CNAME and not as the address it
+  // eventually resolves to: `records` for a CNAME'd name returns A and CNAME,
+  // while this returns CNAME alone. Filtering to `type == "A"` on such a name
+  // yields an empty list, so guard against that rather than letting an
+  // `all()` pass vacuously.
+  authoritativeRecords(authoritativeParams) []dns.record
   // Successful DNS MX records
   mx(params) []dns.mxRecord
   // DKIM TXT records

--- a/providers/network/resources/network.lr.go
+++ b/providers/network/resources/network.lr.go
@@ -699,8 +699,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"dns.params": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetParams()).ToDataRes(types.Dict)
 	},
+	"dns.authoritativeParams": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetAuthoritativeParams()).ToDataRes(types.Dict)
+	},
 	"dns.records": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetRecords()).ToDataRes(types.Array(types.Resource("dns.record")))
+	},
+	"dns.authoritativeRecords": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDns).GetAuthoritativeRecords()).ToDataRes(types.Array(types.Resource("dns.record")))
 	},
 	"dns.mx": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDns).GetMx()).ToDataRes(types.Array(types.Resource("dns.mxRecord")))
@@ -1552,8 +1558,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlDns).Params, ok = plugin.RawToTValue[any](v.Value, v.Error)
 		return
 	},
+	"dns.authoritativeParams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).AuthoritativeParams, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
 	"dns.records": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDns).Records, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"dns.authoritativeRecords": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDns).AuthoritativeRecords, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"dns.mx": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3861,16 +3875,18 @@ type mqlDns struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlDnsInternal it will be used here
-	Fqdn           plugin.TValue[string]
-	Params         plugin.TValue[any]
-	Records        plugin.TValue[[]any]
-	Mx             plugin.TValue[[]any]
-	Dkim           plugin.TValue[[]any]
-	Dnssec         plugin.TValue[*mqlDnsDnssecConfig]
-	Spf            plugin.TValue[[]any]
-	Dmarc          plugin.TValue[*mqlDnsDmarcRecord]
-	Reverse        plugin.TValue[[]any]
-	ReverseRecords plugin.TValue[[]any]
+	Fqdn                 plugin.TValue[string]
+	Params               plugin.TValue[any]
+	AuthoritativeParams  plugin.TValue[any]
+	Records              plugin.TValue[[]any]
+	AuthoritativeRecords plugin.TValue[[]any]
+	Mx                   plugin.TValue[[]any]
+	Dkim                 plugin.TValue[[]any]
+	Dnssec               plugin.TValue[*mqlDnsDnssecConfig]
+	Spf                  plugin.TValue[[]any]
+	Dmarc                plugin.TValue[*mqlDnsDmarcRecord]
+	Reverse              plugin.TValue[[]any]
+	ReverseRecords       plugin.TValue[[]any]
 }
 
 // createDns creates a new instance of this resource
@@ -3925,6 +3941,17 @@ func (c *mqlDns) GetParams() *plugin.TValue[any] {
 	})
 }
 
+func (c *mqlDns) GetAuthoritativeParams() *plugin.TValue[any] {
+	return plugin.GetOrCompute[any](&c.AuthoritativeParams, func() (any, error) {
+		vargFqdn := c.GetFqdn()
+		if vargFqdn.Error != nil {
+			return nil, vargFqdn.Error
+		}
+
+		return c.authoritativeParams(vargFqdn.Data)
+	})
+}
+
 func (c *mqlDns) GetRecords() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Records, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -3943,6 +3970,27 @@ func (c *mqlDns) GetRecords() *plugin.TValue[[]any] {
 		}
 
 		return c.records(vargParams.Data)
+	})
+}
+
+func (c *mqlDns) GetAuthoritativeRecords() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.AuthoritativeRecords, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("dns", c.__id, "authoritativeRecords")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargAuthoritativeParams := c.GetAuthoritativeParams()
+		if vargAuthoritativeParams.Error != nil {
+			return nil, vargAuthoritativeParams.Error
+		}
+
+		return c.authoritativeRecords(vargAuthoritativeParams.Data)
 	})
 }
 

--- a/providers/network/resources/network.lr.versions
+++ b/providers/network/resources/network.lr.versions
@@ -36,6 +36,8 @@ certificates 9.0.0
 certificates.list 9.0.0
 certificates.pem 9.0.0
 dns 9.0.1
+dns.authoritativeParams 13.2.9
+dns.authoritativeRecords 13.2.9
 dns.dkim 9.0.1
 dns.dkimRecord 9.0.1
 dns.dkimRecord.dnsTxt 9.0.1


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #9445** — targets `fix/network-dns-query-amplification`, not `main`, since both touch `dns.go` and `network.lr`. Review/merge #9445 first; this retargets automatically.

Adds a way to read DNS records as the zone publishes them, rather than as a caching resolver currently holds them. **Additive — no existing field changes.**

## The problem

Every TTL that reaches MQL today comes from a caching resolver, which reports the time *remaining* on its cached entry rather than the value configured in the zone. That number counts down. Against `mondoo.com`, whose A record is configured at 300:

```
dns.records.where(type == "A").first.ttl              ->  170, 300, 278, 300
dns.authoritativeRecords.where(type == "A").first.ttl ->  300, 300, 300, 300
```

So any check asserting on a TTL passes or fails depending on when the scan happened to run. That's how this was found: cnspec's `mondoo-dns-security-reasonable-ttls` asserts `ttl >= 60` and flaps for the last 60 seconds of every 300-second cache cycle **on a correctly configured domain**.

## The change

Two new fields mirroring the existing pair — `authoritativeParams` performs the queries, `authoritativeRecords` parses them. `records` and `authoritativeRecords` now share `recordsFromParams`, so the two can't drift.

In dnsshake, `queryDnsType` is refactored to `queryDnsTypeAt(server, recursion, ...)`, and `QueryAuthoritative` resolves the zone's own nameservers and asks them directly with recursion disabled.

Three details that took some care:

- **Nameserver discovery walks up the labels.** NS records live at the zone apex, not at every name within it — a query for `www.example.com` finds nothing and succeeds at `example.com`.
- **The walk stops before the root.** Otherwise an unresolvable name would return the root servers, which answer referrals rather than the records the caller wants. There's a test for that guard.
- **Each type is tried against every nameserver in turn.** An individual server may refuse or be unreachable, and any authoritative server for the zone is an equally valid source.

`QueryAuthoritative` returns an error when the nameservers can't be determined, rather than falling back to the caching resolver — a caller that asked for authoritative data shouldn't silently receive cached data.

## One semantic difference worth knowing

Authoritative answers **do not follow CNAMEs**, because a zone's nameservers answer only for what the zone contains. `www.mondoo.com` is published as a CNAME:

```
dns.records              -> A, CNAME, RRSIG   (resolver followed the CNAME)
dns.authoritativeRecords -> CNAME, RRSIG      (what the zone actually holds)
```

Filtering that to `type == "A"` yields an empty list, which an `all()` would pass **vacuously**. The field docs call this out explicitly, since that's precisely how a check ends up unable to fail.

## Verification

- `go test ./providers/network/...` passes, including new tests for the label walk, the root-rejection guard, and TTL stability across reads.
- Authoritative TTLs confirmed stable and equal to the configured value: `mondoo.com` 300, `example.com` 300, `github.com` 60.
- An IP-scanned asset returns no records rather than erroring.

No version bump: provider versions are bumped by the release commits, not by features.

## Downstream

Unblocks the `reasonable-ttls` fix in cnspec, which can move from `dns.records` to `dns.authoritativeRecords` and stop flapping. That content change needs the CNAME caveat above handled — a CNAME'd name has no authoritative A record, so the check must not treat an empty list as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
