### PR TITLE
🧹 gcp: don't discover Pub/Sub snapshots by default

### DIFF
--- a/providers/gcp/resources/discovery.go
+++ b/providers/gcp/resources/discovery.go
@@ -74,9 +74,20 @@ const (
 	DiscoverDatastreamProfiles               = "datastream-connectionprofiles"
 )
 
-// All includes every discovery target: Auto covers all of them for GCP.
-var All = slices.Clone(Auto)
+// AdditionalResources holds the discovery targets that are not part of the
+// default (auto) set. They remain selectable by name and are covered by "all".
+//
+// Pub/Sub snapshots expire after at most seven days, so discovering them by
+// default churns the asset inventory with short-lived assets.
+var AdditionalResources = []string{
+	DiscoverPubSubSnapshots,
+}
 
+// All includes every discovery target: the default set plus the additional
+// resources that are not discovered by default.
+var All = append(slices.Clone(Auto), AdditionalResources...)
+
+// Auto is the default discovery set, used when no explicit targets are given.
 var Auto = []string{
 	DiscoveryOrganization,
 	DiscoveryFolders,
@@ -99,7 +110,6 @@ var Auto = []string{
 	DiscoverSecretManager,
 	DiscoverPubSubTopics,
 	DiscoverPubSubSubscriptions,
-	DiscoverPubSubSnapshots,
 	DiscoverCloudRunServices,
 	DiscoverCloudRunJobs,
 	DiscoverCloudFunctions,

--- a/providers/gcp/resources/discovery_test.go
+++ b/providers/gcp/resources/discovery_test.go
@@ -89,7 +89,6 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverSecretManager,
 		DiscoverPubSubTopics,
 		DiscoverPubSubSubscriptions,
-		DiscoverPubSubSnapshots,
 		DiscoverCloudRunServices,
 		DiscoverCloudRunJobs,
 		DiscoverCloudFunctions,
@@ -112,6 +111,25 @@ func TestAutoResolvedResources(t *testing.T) {
 		DiscoverDatastreamProfiles,
 	}
 	require.ElementsMatch(t, expected, Auto)
+}
+
+// Additional resources must stay out of the default set but remain reachable,
+// both through "all" and by naming them explicitly.
+func TestAdditionalResourcesAreNotDiscoveredByDefault(t *testing.T) {
+	for _, target := range AdditionalResources {
+		require.NotContains(t, Auto, target, "%s must not be in the auto set", target)
+		require.Contains(t, All, target, "%s must still be in the all set", target)
+
+		auto := getDiscoveryTargets(&inventoryv1.Config{
+			Discover: &inventoryv1.Discovery{Targets: []string{DiscoveryAuto}},
+		})
+		require.NotContains(t, auto, target)
+
+		explicit := getDiscoveryTargets(&inventoryv1.Config{
+			Discover: &inventoryv1.Discovery{Targets: []string{target}},
+		})
+		require.Contains(t, explicit, target)
+	}
 }
 
 func TestGetDiscoveryTargets(t *testing.T) {


### PR DESCRIPTION
## What

`gcp-pubsub-snapshot` assets are no longer discovered by default.

Pub/Sub snapshots expire after at most seven days, so discovering them on every scan churns the asset inventory with short-lived assets that disappear again before they are worth tracking.

## How

`All` was literally `slices.Clone(Auto)` for GCP, so the two sets could not diverge. This splits them:

- `pubsub-snapshots` is removed from `Auto` (the `--discover auto` default).
- A new `AdditionalResources` list holds targets that are deliberately excluded from the default set, and `All` is now `Auto + AdditionalResources`.

Snapshots stay fully reachable:

| Invocation | Discovers snapshots |
|---|---|
| default / `--discover auto` | no |
| `--discover all` | yes |
| `--discover pubsub-snapshots` | yes |

The provider's advertised discovery options in `config/config.go` are unchanged, so `pubsub-snapshots` remains a valid `--discover` value and `dist/gcp.json` does not change.

## Tests

- `TestAutoResolvedResources` updated to expect the smaller default set.
- `TestAllResolvedResources` unchanged — `all` still covers every target.
- New `TestAdditionalResourcesAreNotDiscoveredByDefault` asserts, for every entry in `AdditionalResources`, that it is absent from `Auto` / the resolved `auto` targets and present in `All` and when named explicitly.

`go build ./...` and `go test ./resources/` pass in `providers/gcp`.
