### PR TITLE
🐛 os: group.members skips members that do not resolve to a user

### DIFF
--- a/providers/os/resources/group.go
+++ b/providers/os/resources/group.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
@@ -90,13 +91,29 @@ func (x *mqlGroup) members() ([]any, error) {
 		return nil, err
 	}
 
-	res := make([]any, len(x.membersArr))
-	for i, name := range x.membersArr {
+	// Skip member names that do not resolve to a user instead of erroring the field.
+	// A name can be unresolvable for several reasons: it is a stale /etc/group entry for
+	// an account that was deleted, the member field had a trailing comma, or this
+	// connection simply cannot see the account — the users list falls back to parsing
+	// /etc/passwd whenever `getent passwd` is unavailable (image, snapshot and tar scans
+	// have no command execution) or does not enumerate directory accounts (SSSD leaves
+	// enumerate=FALSE by default). Erroring is strictly worse than degrading: it discards
+	// the entire member list, so a single stale entry fails every check that reads
+	// group.members on an otherwise compliant host. Resolve what we can, and log what we
+	// drop so a missing member is diagnosable. Same rationale as file.user/file.group on
+	// an unknown uid/gid.
+	res := make([]any, 0, len(x.membersArr))
+	for _, name := range x.membersArr {
 		user, ok := users.usersByName[name]
 		if !ok {
-			return nil, errors.New("cannot find user with name '" + name + "'")
+			// A trailing comma parses to an empty name and means nothing was there.
+			if name != "" {
+				log.Warn().Str("group", x.Name.Data).Str("member", name).
+					Msg("cannot resolve group member to a user, skipping it")
+			}
+			continue
 		}
-		res[i] = user
+		res = append(res, user)
 	}
 
 	return res, nil

--- a/providers/os/resources/group_members_internal_test.go
+++ b/providers/os/resources/group_members_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+// A group whose /etc/group entry names an account that does not resolve (a stale
+// entry left behind by a deleted user, or a trailing comma in the member field)
+// must still resolve group.members to the members it can resolve, rather than
+// erroring the whole field with "cannot find user with name 'x'". Erroring it
+// discards the entire member list, so every check reading group.members — such
+// as "ensure the root group is empty" — fails on an otherwise compliant host.
+func TestGroupMembers_UnresolvableMemberName(t *testing.T) {
+	fixturePath, err := filepath.Abs("testdata/group_dangling_member.toml")
+	require.NoError(t, err)
+
+	asset := &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "centos",
+			Family: []string{"linux", "unix"},
+		},
+	}
+	conn, err := mock.New(0, asset, mock.WithPath(fixturePath))
+	require.NoError(t, err)
+
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	raw, err := CreateResource(runtime, "groups", nil)
+	require.NoError(t, err)
+	groups := raw.(*mqlGroups)
+
+	list := groups.GetList()
+	require.NoError(t, list.Error)
+
+	// /etc/group lists "ldapadmin,alice" for root; ldapadmin has no passwd entry.
+	// root itself is a member via its primary gid.
+	root, ok := groups.groupsByName["root"]
+	require.True(t, ok, "root group must be present")
+
+	members := root.GetMembers()
+	require.NoError(t, members.Error, "group.members must not error on an unresolvable member name")
+
+	names := make([]string, 0, len(members.Data))
+	for i, m := range members.Data {
+		user, ok := m.(*mqlUser)
+		// A fix that keeps the pre-sized slice and skips leaves nil holes behind; report
+		// that as a failure rather than panicking the package's test binary.
+		require.True(t, ok, "member %d must be a user, got %#v", i, m)
+		names = append(names, user.Name.Data)
+	}
+
+	// The unresolvable name is dropped, but every resolvable member is kept — a fix
+	// that bailed out on the first miss would leave the list short or empty.
+	assert.ElementsMatch(t, []string{"root", "alice"}, names)
+}

--- a/providers/os/resources/testdata/group_dangling_member.toml
+++ b/providers/os/resources/testdata/group_dangling_member.toml
@@ -1,0 +1,11 @@
+[commands."getent passwd"]
+stdout = """root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+alice:x:1001:1001::/home/alice:/bin/bash
+"""
+
+[files."/etc/group"]
+path = "/etc/group"
+content = """root:x:0:ldapadmin,alice
+daemon:x:1:
+"""


### PR DESCRIPTION
## Summary

`group.members` returned a hard error the moment a name in `/etc/group` had no matching entry in the resolved users list:

```
cannot find user with name 'ldapadmin'
```

That errors the whole field, so the **entire member list is lost** and every check reading `group.members` fails on an otherwise compliant host.

A customer hit this on `mondoo-linux-security-root-group-is-empty` (impact 100)

```
[failed] groups.all() actual: [ 0: group { gid: 0 name: "root" members: null } ]
```

This PR resolves the members it can and skips the rest, logging each dropped name.

## Why an unresolvable member is not an error

It is a normal data condition:

- a stale `/etc/group` entry for an account that was deleted;
- a trailing comma in the member field (parses to an empty name);
- the connection genuinely cannot see the account — `UnixUserManager.List()` falls back to parsing `/etc/passwd` whenever `getent passwd` is unavailable (`filesystem`, block-device/snapshot, `tar` and container-registry connections return `ErrRunCommandNotImplemented`) or does not enumerate directory accounts (SSSD leaves `enumerate=FALSE` by default, and it is unsupported for `id_provider = ad`/`ipa`).

Erroring is strictly worse than degrading: a single stale entry takes out every group-member check. Same rationale as #8524, which made `file.user`/`file.group` degrade on an unknown owner uid/gid.

Because the last bullet means a member we drop *could* be a real directory account, the skip is logged rather than silent, so a short member list stays diagnosable:

```
! cannot resolve group member to a user, skipping it group=root member=ldapadmin
```

## Verification

Reproduced with mock rootfs fixtures scanned via `cnspec run filesystem <dir>`, using the deployed check MQL `groups.where(name == "root").all(members.all(uid < 1000))`:

| `/etc/group` root line | `/etc/passwd` | before | after |
|---|---|---|---|
| `root:x:0:` (Debian/RHEL default) | root only | pass | pass |
| `root:x:0:root` | root only | pass | pass |
| `root:x:0:root,alice` | root + alice(1001) | **fail** (true positive) | **fail** (true positive kept) |
| `root:x:0:ldapadmin` | root only | **fail, `members: null`** | **pass** + warning logged |

- New regression test `TestGroupMembers_UnresolvableMemberName` fails without the fix with the exact customer error, and passes with it.
- `go test ./providers/os/resources/...` fully green (102 packages, 0 failures); `gofmt`/`go vet` clean.
- The stray `llx: encountered a primitive with no type information` log this triggered is also gone — it was a downstream symptom of the errored field, not a separate defect.

## Blast radius

The same defect broke every check reading `group.members`, all verified fixed against a fixture with dangling members in `shadow`/`wheel`/`sudo`:

- `mondoo-linux-security-shadow-group-is-empty` — `groups.where(name == "shadow").all(members.length == 0)` (also in 19+ CIS distro policies)
- su-restriction checks — `groups.where(name.in(suRestrictedPam)).all(members == empty)` (10+ policies)
- `cis-nginx--2.2.1` — `groups.where(name == /wheel|sudo/).all(members.none(name == nginxUser))`
- `cos--ensure-shadow-group-is-empty`

Note a defensive `members == empty` guard does **not** help, because the field is an *error*, not an empty list.

## Related

- Fixes #6355
- Follows the pattern from #8524
- Root cause introduced in #3614