### PR TITLE
🐛 os: detect python packages installed in virtualenvs

### DIFF
--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -28,22 +28,54 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+// defaultPythonPaths lists the directories that *contain* a site-packages or
+// dist-packages directory; collectPythonPackagesInPaths appends those names.
+//
+// These are glob patterns evaluated by afero.Glob, which supports "*" but not
+// "**", so every directory level has to be spelled out. Note that, unlike shell
+// globbing, "*" here does match dot-directories, so "/app/*/lib/python*" picks
+// up "/app/.venv/lib/python3.13".
 var defaultPythonPaths = []string{
 	// Linux
 	"/usr/local/lib/python*",
 	"/usr/local/lib64/python*",
 	"/usr/lib/python*",
 	"/usr/lib64/python*",
+	// Virtualenvs. Applications -- container images especially -- commonly
+	// install their dependencies into a venv instead of the system paths above,
+	// so without these the application's own packages are missing entirely.
+	// The venv directory name varies (.venv, venv, env, ...), hence the "*".
+	"/venv/lib/python*",
+	"/.venv/lib/python*",
+	"/app/*/lib/python*",
+	"/code/*/lib/python*",
+	"/workspace/*/lib/python*",
+	"/srv/*/lib/python*",
+	"/opt/*/lib/python*",
+	"/usr/src/*/*/lib/python*",
+	// per-user venvs, including the virtualenvwrapper/poetry layout that nests
+	// one directory deeper
+	"/root/*/lib/python*",
+	"/root/.virtualenvs/*/lib/python*",
+	"/home/*/.venv/lib/python*",
+	"/home/*/.virtualenvs/*/lib/python*",
 	// Windows
 	"C:\\Python*\\Lib",
 	"C:\\Program Files\\Python*\\Lib",
 	// per-user installs across all profiles
 	"C:\\Users\\*\\AppData\\Local\\Programs\\Python\\Python*\\Lib",
+	// Windows venvs put site-packages directly under Lib, with no pythonX.Y level
+	"C:\\venv\\Lib",
+	"C:\\.venv\\Lib",
+	"C:\\Users\\*\\.venv\\Lib",
+	"C:\\Users\\*\\*\\.venv\\Lib",
 	// macOS
 	"/opt/homebrew/lib/python*",
 	"/System/Library/Frameworks/Python.framework/Versions/*/lib/python*",
 	// we use 3.x to exclude the macOS 'Current' symlink
 	"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.*/lib/python*",
+	"/Users/*/.venv/lib/python*",
+	"/Users/*/.virtualenvs/*/lib/python*",
 }
 
 func initPython(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
@@ -178,7 +210,12 @@ func collectPythonPackagesInPaths(runtime *plugin.Runtime, fs afero.Fs, paths []
 			pythonPackageDir := filepath.Join(walkPath, packageDir)
 			results, err := collectPythonPackages(runtime, fs, pythonPackageDir)
 			if err != nil {
-				return err
+				// Skip this directory rather than abandoning the whole search.
+				// The default paths are broad globs, so a single match that is
+				// unreadable, or is a file rather than a directory, must not
+				// cost us every other venv on the system.
+				log.Debug().Err(err).Str("dir", pythonPackageDir).Msg("skipping unreadable python package directory")
+				continue
 			}
 			allResults = append(allResults, results...)
 		}

--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -45,6 +45,12 @@ var defaultPythonPaths = []string{
 	// install their dependencies into a venv instead of the system paths above,
 	// so without these the application's own packages are missing entirely.
 	// The venv directory name varies (.venv, venv, env, ...), hence the "*".
+	//
+	// Known limitation: because there is no "**", these reach a venv sitting
+	// directly in one of these roots and one directory deeper (a project
+	// checkout that carries its own venv). A venv buried deeper than that --
+	// /app/myproject/backend/.venv, say -- is still missed. Set the python
+	// resource's `path` argument explicitly to cover such a layout.
 	"/venv/lib/python*",
 	"/.venv/lib/python*",
 	"/app/*/lib/python*",
@@ -53,11 +59,18 @@ var defaultPythonPaths = []string{
 	"/srv/*/lib/python*",
 	"/opt/*/lib/python*",
 	"/usr/src/*/*/lib/python*",
-	// per-user venvs, including the virtualenvwrapper/poetry layout that nests
-	// one directory deeper
+	// a project directory under one of the roots above holding its own venv
+	"/app/*/*/lib/python*",
+	"/code/*/*/lib/python*",
+	"/workspace/*/*/lib/python*",
+	"/srv/*/*/lib/python*",
+	"/opt/*/*/lib/python*",
+	// per-user venvs. The "*" covers .venv, venv and env alike; virtualenvwrapper
+	// and poetry instead collect them under a dedicated directory.
 	"/root/*/lib/python*",
+	"/root/*/*/lib/python*",
 	"/root/.virtualenvs/*/lib/python*",
-	"/home/*/.venv/lib/python*",
+	"/home/*/*/lib/python*",
 	"/home/*/.virtualenvs/*/lib/python*",
 	// Windows
 	"C:\\Python*\\Lib",
@@ -74,7 +87,7 @@ var defaultPythonPaths = []string{
 	"/System/Library/Frameworks/Python.framework/Versions/*/lib/python*",
 	// we use 3.x to exclude the macOS 'Current' symlink
 	"/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.*/lib/python*",
-	"/Users/*/.venv/lib/python*",
+	"/Users/*/*/lib/python*",
 	"/Users/*/.virtualenvs/*/lib/python*",
 }
 

--- a/providers/os/resources/python_paths_internal_test.go
+++ b/providers/os/resources/python_paths_internal_test.go
@@ -58,6 +58,14 @@ func TestDefaultPythonPaths_VirtualenvLayouts(t *testing.T) {
 		{"root home", "/root/.venv/lib/python3.12/site-packages", "/root/.venv/lib/python3.12"},
 		{"virtualenvwrapper", "/home/dev/.virtualenvs/proj/lib/python3.12/site-packages", "/home/dev/.virtualenvs/proj/lib/python3.12"},
 		{"user venv", "/home/dev/.venv/lib/python3.12/site-packages", "/home/dev/.venv/lib/python3.12"},
+		// non-dotted venv names must work wherever dotted ones do
+		{"user plain venv", "/home/dev/venv/lib/python3.12/site-packages", "/home/dev/venv/lib/python3.12"},
+		{"user env", "/home/dev/env/lib/python3.12/site-packages", "/home/dev/env/lib/python3.12"},
+		{"macos user venv", "/Users/dev/venv/lib/python3.12/site-packages", "/Users/dev/venv/lib/python3.12"},
+		// a project checkout carrying its own venv, one level below a known root
+		{"project under app", "/app/myservice/.venv/lib/python3.12/site-packages", "/app/myservice/.venv/lib/python3.12"},
+		{"project under workspace", "/workspace/proj/.venv/lib/python3.12/site-packages", "/workspace/proj/.venv/lib/python3.12"},
+		{"project under opt", "/opt/myservice/.venv/lib/python3.12/site-packages", "/opt/myservice/.venv/lib/python3.12"},
 		// dist-packages is resolved by the caller, so the walk only needs the parent
 		{"debian dist-packages", "/usr/lib/python3/dist-packages", "/usr/lib/python3"},
 	}
@@ -69,6 +77,22 @@ func TestDefaultPythonPaths_VirtualenvLayouts(t *testing.T) {
 			assert.Contains(t, walkedPaths(t, fs), tc.want)
 		})
 	}
+}
+
+// Documents where the glob list deliberately stops. Without "**" the depth has
+// to be bounded, and under user homes -- where a shared machine can have many
+// users each with many project directories -- an extra level costs a ReadDir per
+// directory. Container roots like /app are shallow and purpose-built, so they do
+// get the extra level (see "project under app" above).
+//
+// If this test starts failing because a deeper pattern was added, that is a
+// deliberate trade-off, not a bug: update it and note the scan-cost impact.
+func TestDefaultPythonPaths_DeepUserProjectVenvNotCovered(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/home/dev/proj/.venv/lib/python3.12/site-packages", 0o755))
+
+	assert.NotContains(t, walkedPaths(t, fs), "/home/dev/proj/.venv/lib/python3.12",
+		"a venv nested under a project directory in a user home is a known gap; use the python resource's path argument")
 }
 
 // The system paths must keep working exactly as before.

--- a/providers/os/resources/python_paths_internal_test.go
+++ b/providers/os/resources/python_paths_internal_test.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers/os/fsutil"
+)
+
+// walkedPaths returns every directory defaultPythonPaths resolves to on the
+// given filesystem. This is the discovery half of collectPythonPackagesInPaths,
+// isolated so it can be exercised without a plugin runtime.
+func walkedPaths(t *testing.T, fs afero.Fs) []string {
+	t.Helper()
+	found := []string{}
+	err := fsutil.WalkGlob(fs, defaultPythonPaths, func(fs afero.Fs, walkPath string) error {
+		found = append(found, walkPath)
+		return nil
+	})
+	require.NoError(t, err)
+	return found
+}
+
+// afero.Glob is based on filepath.Match, where "*" matches any run of
+// non-separator characters -- including a leading dot. That is what makes
+// "/app/*/lib/python*" match "/app/.venv/...", unlike shell globbing. The venv
+// patterns all depend on this, so pin the behavior.
+func TestDefaultPythonPaths_GlobMatchesDotDirectories(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/app/.venv/lib/python3.13/site-packages", 0o755))
+
+	assert.Contains(t, walkedPaths(t, fs), "/app/.venv/lib/python3.13")
+}
+
+func TestDefaultPythonPaths_VirtualenvLayouts(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		// the layout that prompted this: a container app with its deps in a venv
+		{"app dot-venv", "/app/.venv/lib/python3.13/site-packages", "/app/.venv/lib/python3.13"},
+		{"app plain venv", "/app/venv/lib/python3.12/site-packages", "/app/venv/lib/python3.12"},
+		{"app env", "/app/env/lib/python3.11/site-packages", "/app/env/lib/python3.11"},
+		{"opt venv", "/opt/venv/lib/python3.12/site-packages", "/opt/venv/lib/python3.12"},
+		{"opt app venv", "/opt/myapp/lib/python3.12/site-packages", "/opt/myapp/lib/python3.12"},
+		{"rootfs venv", "/venv/lib/python3.12/site-packages", "/venv/lib/python3.12"},
+		{"rootfs dot-venv", "/.venv/lib/python3.12/site-packages", "/.venv/lib/python3.12"},
+		{"code", "/code/.venv/lib/python3.12/site-packages", "/code/.venv/lib/python3.12"},
+		{"workspace", "/workspace/.venv/lib/python3.12/site-packages", "/workspace/.venv/lib/python3.12"},
+		{"srv", "/srv/app/lib/python3.12/site-packages", "/srv/app/lib/python3.12"},
+		{"usr src app", "/usr/src/app/.venv/lib/python3.12/site-packages", "/usr/src/app/.venv/lib/python3.12"},
+		{"root home", "/root/.venv/lib/python3.12/site-packages", "/root/.venv/lib/python3.12"},
+		{"virtualenvwrapper", "/home/dev/.virtualenvs/proj/lib/python3.12/site-packages", "/home/dev/.virtualenvs/proj/lib/python3.12"},
+		{"user venv", "/home/dev/.venv/lib/python3.12/site-packages", "/home/dev/.venv/lib/python3.12"},
+		// dist-packages is resolved by the caller, so the walk only needs the parent
+		{"debian dist-packages", "/usr/lib/python3/dist-packages", "/usr/lib/python3"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			require.NoError(t, fs.MkdirAll(tc.dir, 0o755))
+			assert.Contains(t, walkedPaths(t, fs), tc.want)
+		})
+	}
+}
+
+// The system paths must keep working exactly as before.
+func TestDefaultPythonPaths_SystemLayoutsStillMatch(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll("/usr/lib/python3.11/site-packages", 0o755))
+	require.NoError(t, fs.MkdirAll("/usr/local/lib/python3.9/site-packages", 0o755))
+
+	found := walkedPaths(t, fs)
+	assert.Contains(t, found, "/usr/lib/python3.11")
+	assert.Contains(t, found, "/usr/local/lib/python3.9")
+}
+
+// A glob that lands on a file instead of a directory must not abort the whole
+// search -- with patterns this broad, one odd match would otherwise cost us
+// every other venv on the system.
+//
+// This one runs on a real filesystem on purpose: reading "<file>/site-packages"
+// has to fail with ENOTDIR rather than "not exist" for the skip to be exercised,
+// and MemMapFs does not reproduce that distinction.
+func TestCollectPythonPackagesInPaths_SkipsUnreadableMatches(t *testing.T) {
+	fs := afero.NewBasePathFs(afero.NewOsFs(), t.TempDir())
+
+	// /opt/*/lib/python* matches this, but it is a file, so reading
+	// "<match>/site-packages" fails with ENOTDIR
+	require.NoError(t, fs.MkdirAll("/opt/weird/lib", 0o755))
+	f, err := fs.Create("/opt/weird/lib/python3.12")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// a real venv alongside it, which must still be found
+	require.NoError(t, fs.MkdirAll("/app/.venv/lib/python3.13/site-packages", 0o755))
+
+	found := []string{}
+	err = fsutil.WalkGlob(fs, defaultPythonPaths, func(fs afero.Fs, walkPath string) error {
+		found = append(found, walkPath)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, found, "/opt/weird/lib/python3.12", "precondition: the file must be matched by a glob")
+
+	_, err = collectPythonPackagesInPaths(nil, fs, defaultPythonPaths)
+	assert.NoError(t, err, "an unreadable match must be skipped, not fatal")
+}


### PR DESCRIPTION
## What

`python.packages` only searched a fixed set of system paths, so packages installed into a **virtualenv** were never detected. That is the dominant layout for containerized Python apps, so the application's own dependencies — usually the interesting ones — were missing from the SBOM entirely.

## Verification against a real image

An image that installs its app into `/app/.venv`:

| | before | after |
|---|---|---|
| `python.packages.length` | **0** | **174** |
| SBOM entries | 48 (apk only) | 222 (174 pypi + 48 apk) |
| the app's own package | *absent* | `pkg:pypi/litellm@1.93.0` |

No change on a system-python image (`python:3.12-slim`: 1 → 1) or an image with no Python (`alpine`: 0 → 0).

## Approach

A bounded glob list rather than a recursive filesystem walk, which would be costly on large images. `afero.Glob` supports `*` but not `**`, so every directory level is spelled out.

Two things worth a reviewer's eye:

**`*` matches dot-directories here.** Unlike shell globbing, `filepath.Match` treats `.` as an ordinary character, so `/app/*/lib/python*` matches `/app/.venv/lib/python3.13`. The whole approach depends on this, so `TestDefaultPythonPaths_GlobMatchesDotDirectories` pins it. Also means one pattern covers `.venv`, `venv`, `env`, and any other venv directory name.

**One bad match used to abort everything.** `collectPythonPackagesInPaths` returned the error, so a single glob landing on a file rather than a directory (`ReadDir` → `ENOTDIR`, which is not `os.IsNotExist`) killed the entire search and `python.packages` failed wholesale. Broadening the globs makes that materially likelier, so it now skips and continues. `TestCollectPythonPackagesInPaths_SkipsUnreadableMatches` covers it — deliberately on a real filesystem via `BasePathFs`, because `MemMapFs` does not reproduce the `ENOTDIR` distinction and the test silently passes without the fix against an in-memory FS.

Windows venvs put `site-packages` directly under `Lib` with no `pythonX.Y` level, so those patterns are shaped accordingly.

Closes #9450