### PR TITLE
🐛 nutanix: accept the API token from a bearer credential

### DIFF
--- a/providers/nutanix/connection/connection.go
+++ b/providers/nutanix/connection/connection.go
@@ -85,11 +85,20 @@ func NewNutanixConnection(id uint32, asset *inventory.Asset, conf *inventory.Con
 
 	var password string
 	for _, cred := range conf.Credentials {
-		if cred.Type == vault.CredentialType_password {
+		switch cred.Type {
+		case vault.CredentialType_password:
 			if cred.User != "" {
 				user = cred.User
 			}
 			password = string(cred.Secret)
+		case vault.CredentialType_bearer:
+			if apiKey == "" {
+				if len(cred.Secret) > 0 {
+					apiKey = string(cred.Secret)
+				} else {
+					apiKey = cred.Password
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

The Nutanix connection read the API token only from `conf.Options["api-key"]` (`connection.go`), i.e. a plaintext CLI flag / inventory option. Credentials were consumed only for `CredentialType_password` (basic auth). As a result, an API token stored in a vault and referenced by `secret_id` in an inventory file never reached the SDK clients — only username/password could be sourced from a vault.

## Change

Read a `CredentialType_bearer` credential as a fallback to the `--api-key` flag. A CLI `--api-key` (which lands in `conf.Options`) still wins; a vault-resolved bearer credential is used otherwise. The token is read from `Secret` (vault `secret:` field) or `Password` (vault `password:` field / CLI), since `PreProcess` does not normalize bearer credentials the way it does for `password`.

```go
case vault.CredentialType_bearer:
    if apiKey == "" {
        if len(cred.Secret) > 0 {
            apiKey = string(cred.Secret)
        } else {
            apiKey = cred.Password
        }
    }
```

This mirrors the `bearer` shape already used by the fortios provider (which sets `{Type: bearer, Password: token}` and reads `cred.Password`), and additionally supports the vault `secret:` field.

## Example inventory now supported

```yaml
apiVersion: v1
kind: Inventory
metadata:
  name: nutanix-prism-central
spec:
  assets:
    - id: prism-central-prod
      connections:
        - type: nutanix
          host: pc.example.com
          credentials:
            - secret_id: nutanix-api-token
  vault:
    name: nutanix-vault
    type: encrypted-file
    options:
      path: ~/.mondoo/nutanix-vault
      password: "CHANGE_ME"
```

The vault secret `nutanix-api-token` is stored as a bearer credential.

## Notes

- No version bump: connection-only change, no `.lr` schema change, so no `.lr.versions` entries. The release flow handles `config.go` versioning.
- `gofmt` clean; `go build ./connection/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)