### PR TITLE
🐛 os: one unreadable dist-info no longer empties python.packages

### DIFF
--- a/providers/os/resources/python.go
+++ b/providers/os/resources/python.go
@@ -277,8 +277,14 @@ func collectPythonPackages(runtime *plugin.Runtime, fs afero.Fs, path string) ([
 			pythonPackageDir := filepath.Join(path, packagePayload)
 			packageDirFiles, err := afs.ReadDir(pythonPackageDir)
 			if err != nil {
-				log.Warn().Err(err).Str("dir", pythonPackageDir).Msg("error while walking through files in directory")
-				return nil, err
+				// Skip this package and keep the rest of the directory.
+				// Container images routinely list entries that cannot be read:
+				// a dist-info removed in a later layer still appears in the
+				// merged listing but fails to open. Aborting here discarded
+				// every other package in the same site-packages, so one stale
+				// entry cost an image its entire Python inventory.
+				log.Debug().Err(err).Str("dir", pythonPackageDir).Msg("skipping unreadable python package directory")
+				continue
 			}
 
 			foundMeta := false

--- a/providers/os/resources/python_unreadable_entry_internal_test.go
+++ b/providers/os/resources/python_unreadable_entry_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ghostDirFs lists ghost as a directory but fails to open it, reproducing what a
+// container image's layered filesystem does with a dist-info deleted in a later
+// layer: the entry survives in the merged listing, opening it does not.
+type ghostDirFs struct {
+	afero.Fs
+	ghost string
+}
+
+func (f *ghostDirFs) Open(name string) (afero.File, error) {
+	if name == f.ghost {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+	}
+	return f.Fs.Open(name)
+}
+
+// A single unreadable entry must not abort the whole site-packages directory.
+//
+// Regression test for a real container scan: site-packages listed a stale
+// autocommand-2.2.2.dist-info, reading it failed, collection returned that error
+// for the entire directory, and the image reported zero Python packages --
+// litellm among them, even though litellm-1.80.15.dist-info sat right there and
+// was perfectly readable.
+//
+// The readable sibling here deliberately carries no METADATA, so nothing has to
+// be turned into a resource and the test needs no plugin runtime. Reaching it at
+// all is the point: before the fix the ghost aborted the loop and this returned
+// an error.
+func TestCollectPythonPackages_UnreadableEntryDoesNotAbortDirectory(t *testing.T) {
+	const siteDir = "/usr/lib/python3.13/site-packages"
+
+	base := afero.NewMemMapFs()
+	// "autocommand" sorts before "litellm", matching the real failure where the
+	// bad entry is reached first and kills everything after it
+	require.NoError(t, base.MkdirAll(siteDir+"/autocommand-2.2.2.dist-info", 0o755))
+	require.NoError(t, base.MkdirAll(siteDir+"/litellm-1.80.15.dist-info", 0o755))
+
+	fs := &ghostDirFs{Fs: base, ghost: siteDir + "/autocommand-2.2.2.dist-info"}
+
+	// precondition: both are listed, and the ghost genuinely fails to open
+	entries, err := afero.ReadDir(fs, siteDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "both entries must appear in the listing")
+	_, err = afero.ReadDir(fs, siteDir+"/autocommand-2.2.2.dist-info")
+	require.Error(t, err, "the ghost entry must fail to open")
+
+	_, err = collectPythonPackages(nil, fs, siteDir)
+	assert.NoError(t, err,
+		"one unreadable entry must be skipped, not fail the entire site-packages directory")
+}


### PR DESCRIPTION
## What

A container scan reported **zero** Python packages for an image that plainly had them. One stale directory entry was responsible:

```
! error while walking through files in directory
  error="file does not exist"
  dir=/usr/lib/python3.13/site-packages/autocommand-2.2.2.dist-info
```

`collectPythonPackages` returned that error for the entire directory, so every other package in the same `site-packages` was discarded with it — including the application's own, which sat right beside it and was perfectly readable.

## Why it happens routinely

`autocommand-2.2.2.dist-info` does **not** exist in the image — I checked. A `dist-info` removed in a later layer still shows up in a container filesystem's merged listing but fails to open. So the entry is real to `ReadDir` and missing to everything else. That makes this the normal case for container images, not an exotic one.

## Verified against the image from the original report

| | before | after |
|---|---|---|
| `python.packages.length` | **0** | **182** |
| the app's own package | absent | `pkg:pypi/litellm@1.80.15` |
| walk error | present | gone |

End-to-end through the platform, a full scan now stores **174 pypi packages** alongside the 48 apk ones, and produces **6 PyPI advisory findings** (`pypdf`, `pyasn1`) that were previously invisible.

## Not the same bug as #9452

Worth being explicit, since they look alike. #9452 fixed `collectPythonPackagesInPaths`, so a bad *glob match* stops killing the **other** directories. This is one level down: inside a single `site-packages`, one bad **entry** still discarded everything in that directory. The earlier fix does not help here — the whole directory still aborted.

## Test

`TestCollectPythonPackages_UnreadableEntryDoesNotAbortDirectory` uses a small `afero.Fs` wrapper that lists an entry but fails to open it, reproducing the layered-filesystem behaviour. The bad entry sorts before the good one, matching the real failure where it is reached first.

Confirmed it fails on unfixed code (`Received unexpected error`) and passes with the fix. The readable sibling deliberately carries no `METADATA`, so nothing needs to become a resource and the test needs no plugin runtime — reaching it at all is the assertion.