### PR TITLE
🎉 os-13.38.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.37.0",
+	Version: "13.38.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.38.0)
- 🐛 os: one unreadable dist-info no longer empties python.packages (#9457)
- 🐛 os: detect python packages installed in virtualenvs (#9452)
- 🐛 os: group.members skips members that do not resolve to a user (#9449)
- 🐛 os: strip trailing comments from squid.conf directives (#9438)
- 🐛 os: expand an nginx include reached more than once (#9439)
- feat(languages): add deno.lock, vcpkg, and opam package extractors (#9429)
- fix(languages): strip quotes from CocoaPods pod names (#9428)
- feat(languages): tag conan build_requires as dev scope (#9427)
- feat(languages): tag composer dev/prod dependency scope (#9425)
- feat(languages): requirements.txt SBOM extractor (#9424)
- sbom: dependency graph + dev/prod scope + stable bom_ref (#9036)