### PR TITLE
🎉 aws-13.51.0

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.50.3",
+	Version:         "13.51.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.51.0)
- 🐛 aws: fix cache-key collisions, hard failures, and wrong security verdicts (#9435)
- 🐛 Treat aws:SourceOwner as a principal-scoping condition (#9434)
- ✨ Discover SNS topics and SQS queues as assets (#9433)
- ✨ Update cloud deps and expose the new fields and resources they bring (#9432)