### PR TITLE
🐛 recording: route multi-asset recording requests by connected asset

### DIFF
--- a/llx/runtime.go
+++ b/llx/runtime.go
@@ -34,6 +34,11 @@ type AssetRecordingLookup struct {
 type AddDataReq struct {
 	// the id of the connection that was used to fetch the data
 	ConnectionID uint32
+	// optionally identifies the asset this data belongs to. Preferred over
+	// ConnectionID when it carries an Mrn or platform ids, because connection
+	// ids in a recording that was loaded from disk are not guaranteed to be
+	// unique across its assets.
+	Lookup AssetRecordingLookup
 	// the resource type name
 	Resource string
 	// the id of the resource as returned by the connection

--- a/providers-sdk/v1/recording/recording.go
+++ b/providers-sdk/v1/recording/recording.go
@@ -403,7 +403,15 @@ func (r *recording) resyncAsset(recordingAsset *Asset) {
 }
 
 func (r *recording) AddData(req llx.AddDataReq) {
-	asset, ok := r.resolveAsset(llx.AssetRecordingLookup{ConnectionId: req.ConnectionID})
+	// The connection id is only the last resort: resolveAsset prefers the mrn
+	// and platform ids the caller may have supplied, which identify the asset
+	// unambiguously even when a loaded recording reuses one connection id across
+	// several of its assets.
+	lookup := req.Lookup
+	if lookup.ConnectionId == 0 {
+		lookup.ConnectionId = req.ConnectionID
+	}
+	asset, ok := r.resolveAsset(lookup)
 	if !ok {
 		return
 	}

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -287,7 +287,7 @@ func (s *recordingProvider) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, e
 	// connection's asset (see GetData). Fall back to the selected asset for
 	// programmatic callers that don't set a connection.
 	connID := req.GetConnection()
-	lookup := llx.AssetRecordingLookup{}
+	var lookup llx.AssetRecordingLookup
 	if connID != 0 {
 		lookup = s.lookupFor(connID)
 	} else {

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -5,6 +5,7 @@ package providers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	"go.mondoo.com/mql/v13"
@@ -75,8 +76,39 @@ func NewRecordingProvider(opts ...RecordingProviderOpt) *recordingProvider {
 }
 
 type recordingProvider struct {
+	// mu guards selectedAsset and connections: one static provider instance
+	// serves every asset of a multi-asset recording, and those assets are
+	// connected and scanned concurrently.
+	mu            sync.Mutex
 	selectedAsset *inventory.Asset
-	recording     llx.Recording
+	// the asset each connection was established for, so requests can be routed
+	// to that asset's section of the recording
+	connections map[uint32]*inventory.Asset
+	recording   llx.Recording
+}
+
+// asset returns the asset selected by the most recent connect. It only serves
+// callers that don't set a connection on their requests; anything that does is
+// routed by connection instead.
+func (s *recordingProvider) asset() *inventory.Asset {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.selectedAsset
+}
+
+func (s *recordingProvider) selectAsset(asset *inventory.Asset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.selectedAsset = asset
+}
+
+func (s *recordingProvider) addConnection(connID uint32, asset *inventory.Asset) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.connections == nil {
+		s.connections = map[uint32]*inventory.Asset{}
+	}
+	s.connections[connID] = asset
 }
 
 func (s *recordingProvider) Heartbeat(req *plugin.HeartbeatReq) (*plugin.HeartbeatRes, error) {
@@ -130,6 +162,23 @@ func (s *recordingProvider) Connect(req *plugin.ConnectReq, callback plugin.Prov
 		Inventory: inv,
 	}
 
+	// A concrete asset was connected (as opposed to the discovery pass, which
+	// returns the inventory above): remember which asset this connection serves
+	// and report the connection id back to the runtime, which then sends it on
+	// every GetData/StoreData request. One provider instance serves every asset
+	// of a multi-asset recording, so routing by connection is what keeps assets
+	// from reading and writing each other's data. Without an id, requests fall
+	// back to the shared selectedAsset (see GetData).
+	if asset := req.GetAsset(); asset.GetPlatform() != nil && len(asset.GetConnections()) > 0 &&
+		(asset.GetMrn() != "" || len(asset.GetPlatformIds()) > 0) {
+		conf := asset.Connections[0]
+		if conf.Id == 0 {
+			conf.Id = Coordinator.NextConnectionId()
+		}
+		s.addConnection(conf.Id, asset)
+		res.Id = conf.Id
+	}
+
 	return res, nil
 }
 
@@ -139,7 +188,7 @@ func (s *recordingProvider) detect(asset *inventory.Asset) (*inventory.Inventory
 			if asset.GetMrn() == "" && len(asset.GetPlatformIds()) == 0 {
 				return nil, errors.New("missing mrn or platform ids for asset selection")
 			}
-			s.selectedAsset = asset
+			s.selectAsset(asset)
 		}
 		return nil, nil
 	}
@@ -150,13 +199,16 @@ func (s *recordingProvider) detect(asset *inventory.Asset) (*inventory.Inventory
 		if len(a.Connections) == 0 {
 			continue
 		}
-		id := a.Connections[0].Id
+		// Assign a fresh connection id per asset. The id carried by the recording
+		// file is not guaranteed to be unique across its assets — every asset of
+		// a synthesized recording may share id 1 — and connections are what
+		// requests are routed by, so two assets sharing an id would collapse onto
+		// one of them.
 		a.Connections = []*inventory.Config{
 			{
 				Type:           "recording",
 				DelayDiscovery: true,
-				// preserve conn id so it can consistently be looked up from the recording
-				Id: id,
+				Id:             Coordinator.NextConnectionId(),
 			},
 		}
 		assets = append(assets, a)
@@ -178,6 +230,29 @@ func (s *recordingProvider) Shutdown(req *plugin.ShutdownReq) (*plugin.ShutdownR
 	return nil, nil
 }
 
+// lookupFor identifies the recording section a request belongs to. The mrn and
+// platform ids of the connection's asset take precedence over the connection id
+// itself: a recording loaded from disk may reuse one connection id across
+// several of its assets, in which case the recording's connection index only
+// resolves to whichever asset claimed the id last.
+func (s *recordingProvider) lookupFor(connID uint32) llx.AssetRecordingLookup {
+	s.mu.Lock()
+	asset, ok := s.connections[connID]
+	s.mu.Unlock()
+	if !ok {
+		return llx.AssetRecordingLookup{ConnectionId: connID}
+	}
+	return assetLookup(asset, connID)
+}
+
+func assetLookup(asset *inventory.Asset, connID uint32) llx.AssetRecordingLookup {
+	return llx.AssetRecordingLookup{
+		ConnectionId: connID,
+		Mrn:          asset.GetMrn(),
+		PlatformIds:  asset.GetPlatformIds(),
+	}
+}
+
 func (s *recordingProvider) GetData(req *plugin.DataReq) (*plugin.DataRes, error) {
 	resource := req.GetResource()
 	id := req.GetResourceId()
@@ -188,14 +263,9 @@ func (s *recordingProvider) GetData(req *plugin.DataReq) (*plugin.DataRes, error
 		// that connection's asset: one static provider instance serves all
 		// assets of a multi-asset recording, so routing by the shared
 		// selectedAsset would cross-read between assets.
-		lookup.ConnectionId = connID
-	} else if s.selectedAsset != nil {
-		if s.selectedAsset.GetMrn() != "" {
-			lookup.Mrn = s.selectedAsset.GetMrn()
-		}
-		if len(s.selectedAsset.GetPlatformIds()) > 0 {
-			lookup.PlatformIds = s.selectedAsset.GetPlatformIds()
-		}
+		lookup = s.lookupFor(connID)
+	} else if asset := s.asset(); asset != nil {
+		lookup = assetLookup(asset, 0)
 	}
 	data, ok := s.recording.GetData(lookup, resource, id, field)
 	if !ok {
@@ -217,19 +287,25 @@ func (s *recordingProvider) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, e
 	// connection's asset (see GetData). Fall back to the selected asset for
 	// programmatic callers that don't set a connection.
 	connID := req.GetConnection()
-	if connID == 0 {
-		if s.selectedAsset == nil {
+	lookup := llx.AssetRecordingLookup{}
+	if connID != 0 {
+		lookup = s.lookupFor(connID)
+	} else {
+		asset := s.asset()
+		if asset == nil {
 			return nil, errors.New("no asset selected, cannot store data")
 		}
-		if len(s.selectedAsset.Connections) == 0 {
+		if len(asset.Connections) == 0 {
 			return nil, errors.New("selected asset has no connections, cannot store data")
 		}
-		connID = s.selectedAsset.Connections[0].Id
+		connID = asset.Connections[0].Id
+		lookup = assetLookup(asset, connID)
 	}
 	for _, info := range req.Resources {
 		for field, result := range info.Fields {
 			s.recording.AddData(llx.AddDataReq{
 				ConnectionID:      connID,
+				Lookup:            lookup,
 				Resource:          info.Name,
 				ResourceID:        info.Id,
 				Field:             field,

--- a/providers/recording.go
+++ b/providers/recording.go
@@ -183,7 +183,13 @@ func (s *recordingProvider) GetData(req *plugin.DataReq) (*plugin.DataRes, error
 	id := req.GetResourceId()
 	field := req.GetField()
 	lookup := llx.AssetRecordingLookup{}
-	if s.selectedAsset != nil {
+	if connID := req.GetConnection(); connID != 0 {
+		// The runtime sets the connection on every request. Scope the lookup to
+		// that connection's asset: one static provider instance serves all
+		// assets of a multi-asset recording, so routing by the shared
+		// selectedAsset would cross-read between assets.
+		lookup.ConnectionId = connID
+	} else if s.selectedAsset != nil {
 		if s.selectedAsset.GetMrn() != "" {
 			lookup.Mrn = s.selectedAsset.GetMrn()
 		}
@@ -207,14 +213,19 @@ func (s *recordingProvider) GetData(req *plugin.DataReq) (*plugin.DataRes, error
 }
 
 func (s *recordingProvider) StoreData(req *plugin.StoreReq) (*plugin.StoreRes, error) {
-	if s.selectedAsset == nil {
-		return nil, errors.New("no asset selected, cannot store data")
+	// The runtime sets the connection on every request; store under that
+	// connection's asset (see GetData). Fall back to the selected asset for
+	// programmatic callers that don't set a connection.
+	connID := req.GetConnection()
+	if connID == 0 {
+		if s.selectedAsset == nil {
+			return nil, errors.New("no asset selected, cannot store data")
+		}
+		if len(s.selectedAsset.Connections) == 0 {
+			return nil, errors.New("selected asset has no connections, cannot store data")
+		}
+		connID = s.selectedAsset.Connections[0].Id
 	}
-	if len(s.selectedAsset.Connections) == 0 {
-		return nil, errors.New("selected asset has no connections, cannot store data")
-	}
-
-	connID := s.selectedAsset.Connections[0].Id
 	for _, info := range req.Resources {
 		for field, result := range info.Fields {
 			s.recording.AddData(llx.AddDataReq{

--- a/providers/recording_test.go
+++ b/providers/recording_test.go
@@ -174,3 +174,182 @@ func TestRecordingProviderStoreWithoutAsset(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no asset selected")
 }
+
+// TestRecordingProviderConnectAssignsUniqueConnectionIds covers the input shape
+// of https://github.com/mondoohq/mql/issues/9461: a recording file may give
+// every one of its assets the same connection id (1), and the recording indexes
+// its sections by connection id, so duplicated ids collapse several assets onto
+// a single section. Discovery therefore has to hand out a unique id per asset,
+// and Connect has to report it back to the runtime, which sends it on every
+// GetData/StoreData request.
+func TestRecordingProviderConnectAssignsUniqueConnectionIds(t *testing.T) {
+	asset1 := &inventory.Asset{
+		Name:        "asset1",
+		Mrn:         "asset1-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset1"},
+		Platform:    &inventory.Platform{Name: "debian"},
+		Connections: []*inventory.Config{{Type: "recording", Id: 1}},
+	}
+	asset2 := &inventory.Asset{
+		Name:        "asset2",
+		Mrn:         "asset2-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset2"},
+		Platform:    &inventory.Platform{Name: "debian"},
+		Connections: []*inventory.Config{{Type: "recording", Id: 1}},
+	}
+
+	rec := recording.NewWithAsset(asset1)
+	rec.EnsureAsset(asset1, "recording", 1, asset1.Connections[0])
+	rec.EnsureAsset(asset2, "recording", 1, asset2.Connections[0])
+
+	p := NewRecordingProvider(WithRecording(rec))
+
+	// Discovery pass: an asset without a platform makes the provider enumerate
+	// the recording's assets.
+	discovery, err := p.Connect(&plugin.ConnectReq{Asset: &inventory.Asset{
+		Connections: []*inventory.Config{{Type: "recording"}},
+	}}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, discovery.Inventory)
+	require.Zero(t, discovery.Id, "the discovery pass connects no asset")
+
+	discovered := discovery.Inventory.Spec.Assets
+	require.Len(t, discovered, 2)
+	require.Len(t, discovered[0].Connections, 1)
+	require.Len(t, discovered[1].Connections, 1)
+	assert.True(t, discovered[0].Connections[0].DelayDiscovery)
+	assert.True(t, discovered[1].Connections[0].DelayDiscovery)
+	assert.NotZero(t, discovered[0].Connections[0].Id)
+	assert.NotEqual(t, discovered[0].Connections[0].Id, discovered[1].Connections[0].Id,
+		"each discovered asset needs its own connection id, even though the recording gave them both id 1")
+
+	// Connecting a discovered asset keeps the id it was discovered with...
+	discovered[0].Connections[0].DelayDiscovery = false
+	res1, err := p.Connect(&plugin.ConnectReq{Asset: discovered[0]}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, discovered[0].Connections[0].Id, res1.Id)
+
+	// ...and an asset that arrives without one gets a fresh id.
+	asset2Conn := &inventory.Asset{
+		Mrn:         asset2.Mrn,
+		PlatformIds: asset2.PlatformIds,
+		Platform:    asset2.Platform,
+		Connections: []*inventory.Config{{Type: "recording"}},
+	}
+	res2, err := p.Connect(&plugin.ConnectReq{Asset: asset2Conn}, nil)
+	require.NoError(t, err)
+	assert.NotZero(t, res2.Id)
+	assert.Equal(t, asset2Conn.Connections[0].Id, res2.Id)
+	require.NotEqual(t, res1.Id, res2.Id)
+
+	// Each connection now resolves to its own asset's section. Storing the same
+	// computed clone id on both — a `where` rewrap clone is keyed by the query
+	// checksum, so its id is identical across assets — must not mix their data,
+	// even though selectedAsset points at the asset that connected last.
+	_, err = p.StoreData(storeUsersList(res1.Id, "asset1-list"))
+	require.NoError(t, err)
+	_, err = p.StoreData(storeUsersList(res2.Id, "asset2-list"))
+	require.NoError(t, err)
+
+	data, err := p.GetData(getUsersList(res1.Id))
+	require.NoError(t, err)
+	assert.Equal(t, "asset1-list", primitiveString(data.Data))
+
+	data, err = p.GetData(getUsersList(res2.Id))
+	require.NoError(t, err)
+	assert.Equal(t, "asset2-list", primitiveString(data.Data))
+}
+
+// TestRecordingProviderConnectWithoutPlatformIdsReportsNoConnection: an asset
+// that cannot be resolved in the recording (no mrn, no platform ids) must not
+// get a connection id, so its requests keep falling back to selectedAsset
+// instead of being routed to a section it was never bound to.
+func TestRecordingProviderConnectWithoutPlatformIdsReportsNoConnection(t *testing.T) {
+	p := NewRecordingProvider(WithRecording(newMultiAssetTestRecording(t)))
+
+	res, err := p.Connect(&plugin.ConnectReq{Asset: &inventory.Asset{
+		Name:     "asset-no-ids",
+		Platform: &inventory.Platform{Name: "debian"},
+		// DelayDiscovery keeps detect() from rejecting the asset outright.
+		Connections: []*inventory.Config{{Type: "recording", DelayDiscovery: true}},
+	}}, nil)
+	require.NoError(t, err)
+	assert.Zero(t, res.Id, "an asset with no mrn or platform ids cannot be bound to a recording section")
+}
+
+// TestRecordingProviderRoutesByAssetIdentity pins down what a request is routed
+// by. A recording loaded from disk may reuse one connection id across several of
+// its assets, and the recording indexes a section under EVERY connection id that
+// section carries — so the asset indexed last owns a shared id. Routing by the
+// id alone would then still serve one asset's data to another, no matter how
+// carefully the ids are handed out; the provider routes by the connected asset's
+// identity instead.
+func TestRecordingProviderRoutesByAssetIdentity(t *testing.T) {
+	asset1 := &inventory.Asset{
+		Name:        "asset1",
+		Mrn:         "asset1-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset1"},
+		Platform:    &inventory.Platform{Name: "debian"},
+	}
+	asset2 := &inventory.Asset{
+		Name:        "asset2",
+		Mrn:         "asset2-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset2"},
+		Platform:    &inventory.Platform{Name: "debian"},
+	}
+
+	// Both assets carry connection id 1, as every asset of a synthesized
+	// recording does.
+	rec := recording.NewWithAsset(asset1)
+	rec.EnsureAsset(asset1, "recording", 1, &inventory.Config{Type: "recording", Id: 1})
+	rec.EnsureAsset(asset2, "recording", 1, &inventory.Config{Type: "recording", Id: 1})
+
+	// asset2 claimed the shared id last, so the recording resolves it to asset2.
+	rec.AddData(llx.AddDataReq{
+		ConnectionID:      1,
+		Resource:          "users",
+		ResourceID:        "probe",
+		Field:             "list",
+		Data:              llx.StringData("routed-by-connection-id"),
+		RequestResourceId: "probe",
+	})
+	_, ok := rec.GetData(llx.AssetRecordingLookup{Mrn: "asset2-mrn"}, "users", "probe", "list")
+	require.True(t, ok, "the shared connection id is expected to resolve to asset2")
+
+	connectAsset := func(asset *inventory.Asset, connID uint32) *inventory.Asset {
+		return &inventory.Asset{
+			Name:        asset.Name,
+			Mrn:         asset.Mrn,
+			PlatformIds: asset.PlatformIds,
+			Platform:    asset.Platform,
+			Connections: []*inventory.Config{{Type: "recording", Id: connID}},
+		}
+	}
+
+	p := NewRecordingProvider(WithRecording(rec))
+	res1, err := p.Connect(&plugin.ConnectReq{Asset: connectAsset(asset1, 1)}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), res1.Id, "a preassigned connection id is kept")
+	res2, err := p.Connect(&plugin.ConnectReq{Asset: connectAsset(asset2, 2)}, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), res2.Id)
+
+	_, err = p.StoreData(storeUsersList(res1.Id, "asset1-list"))
+	require.NoError(t, err)
+	_, err = p.StoreData(storeUsersList(res2.Id, "asset2-list"))
+	require.NoError(t, err)
+
+	// Connection 1 must reach asset1 even though asset2 owns id 1 in the
+	// recording's connection index.
+	data, err := p.GetData(getUsersList(res1.Id))
+	require.NoError(t, err)
+	assert.Equal(t, "asset1-list", primitiveString(data.Data))
+
+	data, err = p.GetData(getUsersList(res2.Id))
+	require.NoError(t, err)
+	assert.Equal(t, "asset2-list", primitiveString(data.Data))
+
+	stored, ok := rec.GetData(llx.AssetRecordingLookup{Mrn: "asset1-mrn"}, "users", "qrid-derived-clone-id", "list")
+	require.True(t, ok, "asset1's data must be stored in asset1's own section")
+	assert.Equal(t, "asset1-list", stored.Value)
+}

--- a/providers/recording_test.go
+++ b/providers/recording_test.go
@@ -1,0 +1,176 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/recording"
+)
+
+// newMultiAssetTestRecording builds a recording with two assets, each reachable
+// by its own connection id (1 and 2), mirroring how a multi-asset recording
+// file is indexed when loaded from disk.
+func newMultiAssetTestRecording(t *testing.T) llx.Recording {
+	t.Helper()
+
+	asset1 := &inventory.Asset{
+		Name:        "asset1",
+		Mrn:         "asset1-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset1"},
+		Platform:    &inventory.Platform{Name: "debian"},
+	}
+	asset2 := &inventory.Asset{
+		Name:        "asset2",
+		Mrn:         "asset2-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset2"},
+		Platform:    &inventory.Platform{Name: "debian"},
+	}
+
+	rec := recording.NewWithAsset(asset1)
+	rec.EnsureAsset(asset1, "recording", 1, &inventory.Config{Type: "recording", Id: 1})
+	rec.EnsureAsset(asset2, "recording", 2, &inventory.Config{Type: "recording", Id: 2})
+	return rec
+}
+
+func storeUsersList(connID uint32, value string) *plugin.StoreReq {
+	return &plugin.StoreReq{
+		Connection: connID,
+		Resources: []*plugin.ResourceData{{
+			Name: "users",
+			Id:   "qrid-derived-clone-id",
+			Fields: map[string]*llx.Result{
+				"list": {Data: llx.StringPrimitive(value)},
+			},
+		}},
+	}
+}
+
+// primitiveString extracts a string from a primitive that round-tripped
+// through the recording (string values come back as raw bytes).
+func primitiveString(p *llx.Primitive) string {
+	return string(p.Value)
+}
+
+func getUsersList(connID uint32) *plugin.DataReq {
+	return &plugin.DataReq{
+		Connection: connID,
+		Resource:   "users",
+		ResourceId: "qrid-derived-clone-id",
+		Field:      "list",
+	}
+}
+
+// TestRecordingProviderConnScopedRouting reproduces
+// https://github.com/mondoohq/mql/issues/9461: a single static recording
+// provider serves all assets of a multi-asset recording. When queries store
+// computed data (e.g. `where` rewrap clones, whose resource id is derived from
+// the query checksum and is therefore identical across assets), the provider
+// must route GetData/StoreData by the request's connection. Routing by the
+// shared selectedAsset instead makes one asset's data land in (or get read
+// from) another asset's recording section.
+func TestRecordingProviderConnScopedRouting(t *testing.T) {
+	rec := newMultiAssetTestRecording(t)
+
+	// Simulate the shared singleton after the scan framework connected asset2
+	// last: selectedAsset points at asset2 while both assets are being scanned.
+	asset2 := &inventory.Asset{
+		Mrn:         "asset2-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset2"},
+		Platform:    &inventory.Platform{Name: "debian"},
+		Connections: []*inventory.Config{{Type: "recording", Id: 2}},
+	}
+	p := NewRecordingProvider(WithRecording(rec), WithAsset(asset2))
+
+	// Both assets store a computed clone under the same (checksum-derived)
+	// resource id, each tagged with its own connection.
+	_, err := p.StoreData(storeUsersList(1, "asset1-list"))
+	require.NoError(t, err)
+	_, err = p.StoreData(storeUsersList(2, "asset2-list"))
+	require.NoError(t, err)
+
+	// Each connection must read back its own asset's data.
+	res, err := p.GetData(getUsersList(1))
+	require.NoError(t, err)
+	assert.Equal(t, "asset1-list", primitiveString(res.Data))
+
+	res, err = p.GetData(getUsersList(2))
+	require.NoError(t, err)
+	assert.Equal(t, "asset2-list", primitiveString(res.Data))
+
+	// A lookup for data that was never stored under a connection must not be
+	// served from another asset's section.
+	_, err = p.GetData(&plugin.DataReq{
+		Connection: 2,
+		Resource:   "users",
+		ResourceId: "only-stored-on-conn-1",
+		Field:      "list",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "doesn't exist")
+
+	_, err = p.StoreData(&plugin.StoreReq{
+		Connection: 1,
+		Resources: []*plugin.ResourceData{{
+			Name:   "users",
+			Id:     "only-stored-on-conn-1",
+			Fields: map[string]*llx.Result{"list": {Data: llx.StringPrimitive("x")}},
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = p.GetData(&plugin.DataReq{
+		Connection: 2,
+		Resource:   "users",
+		ResourceId: "only-stored-on-conn-1",
+		Field:      "list",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "doesn't exist")
+}
+
+// TestRecordingProviderSelectedAssetFallback ensures the legacy programmatic
+// flow (no connection set on requests) still resolves via the selected asset.
+func TestRecordingProviderSelectedAssetFallback(t *testing.T) {
+	rec := newMultiAssetTestRecording(t)
+
+	asset1 := &inventory.Asset{
+		Mrn:         "asset1-mrn",
+		PlatformIds: []string{"//platformid.api.mondoo.app/hostname/asset1"},
+		Platform:    &inventory.Platform{Name: "debian"},
+		Connections: []*inventory.Config{{Type: "recording", Id: 1}},
+	}
+	p := NewRecordingProvider(WithRecording(rec), WithAsset(asset1))
+
+	_, err := p.StoreData(storeUsersList(0, "legacy-value"))
+	require.NoError(t, err)
+
+	res, err := p.GetData(getUsersList(0))
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-value", primitiveString(res.Data))
+
+	// The data must have landed in the selected asset's section (conn id 1),
+	// and must not be visible from the other asset's connection.
+	res, err = p.GetData(getUsersList(1))
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-value", primitiveString(res.Data))
+
+	_, err = p.GetData(getUsersList(2))
+	require.Error(t, err)
+}
+
+// TestRecordingProviderStoreWithoutAsset keeps the existing error behavior for
+// StoreData when neither a connection nor a selected asset is available.
+func TestRecordingProviderStoreWithoutAsset(t *testing.T) {
+	p := NewRecordingProvider(WithRecording(newMultiAssetTestRecording(t)))
+
+	_, err := p.StoreData(storeUsersList(0, "x"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no asset selected")
+}


### PR DESCRIPTION
Fixes #9461

## Problem

One static `recordingProvider` instance serves **every** asset of a multi-asset recording. `GetData` and `StoreData` resolved the recording section through the shared mutable `selectedAsset` (last connect wins), so with 2+ assets, computed data whose resource id is derived from the query checksum — `where`/`all` rewrap clones written via `Runtime.CloneResource`/`watchAndUpdate`, identical across assets — was stored under one asset and looked up in another's section. Scanning a multi-asset recording with a `where`/`all` lambda over a populated collection scored `error` (`resource users (id: <qrid>, field: list) doesn't exist`) on every such asset but one, deterministically.

## What the first commit got wrong

Keying both handlers on `req.GetConnection()` looked sufficient — the runtime sends `provider.Connection.Id` on every request — but `recordingProvider.Connect` never set `ConnectRes.Id`, and the provider is a builtin, so no plugin service assigns one. `req.Connection` was therefore **always 0** and every request took the `selectedAsset` fallback: a patched and an unpatched `cnspec` produced byte-identical verdicts on the issue's repro. The change was inert.

Two further problems only show up end to end:

1. **Connection ids in a recording file are not unique across its assets.** A synthesized recording gives every asset id `1`, and `detect()` propagated that id verbatim, so all assets connected as "1".
2. **Unique ids are still not enough.** `resyncAsset` indexes a section under *every* connection id that section carries, so a stale duplicate id in another asset's section steals the index entry back after ours is bound. A unit test reproduces this deterministically: connection 1 reads back asset2's data.

## Fix

- `providers/recording.go`
  - `Connect` records which asset a connection was established for (`connections map[uint32]*inventory.Asset`, guarded by a mutex — assets are connected and scanned concurrently) and returns that id as `ConnectRes.Id`, so the runtime sends it on every request. An asset that cannot be identified in the recording (no mrn, no platform ids) gets no id, preserving the legacy `selectedAsset` behavior instead of misrouting silently.
  - `detect()` hands out a fresh `Coordinator.NextConnectionId()` per discovered asset rather than reusing the file's ids.
  - `GetData`/`StoreData` resolve the section by the **connected asset's mrn and platform ids**, with the connection id only as a fallback, so a colliding or stolen index entry cannot cross-route. `selectedAsset` still serves requests that carry no connection.
- `llx/runtime.go`: `AddDataReq` gained an optional `Lookup AssetRecordingLookup`, so stores can be keyed by asset identity the way reads already were.
- `providers-sdk/v1/recording/recording.go`: `AddData` honors that lookup and falls back to `ConnectionID` when it carries no connection id. `resolveAsset` already prefers mrn > platform ids > connection id, so behavior is unchanged for every existing caller.

## Verification

End to end, through a `cnspec` built against this branch, `cnspec scan recording --recording-path <rec> -f <bundle> --incognito` with `users.where(enabled == true).all(uid >= 0 && gid >= 0)`:

| scenario | before | after |
| --- | --- | --- |
| the issue's repro: 2 identical, fully populated assets | `asset1: error`, `asset2: pass` | both `pass` |
| 3 assets, all sharing connection id 1 in the file | `asset1: error`, `asset2: error`, `asset3: pass` | all `pass` |
| 2 assets whose data must score differently (`uid=1` vs `uid=-1`) | `asset1: error`, `asset2: fail` | `asset1: pass`, `asset2: fail` |

The third row is the one that rules out the failure mode where both assets are quietly served from one section: the verdicts differ, so each asset reads its own data.

`providers/recording_test.go` covers the routing contract:

- `TestRecordingProviderConnScopedRouting` — each connection reads back its own data; a lookup for an id stored only on another connection errors.
- `TestRecordingProviderConnectAssignsUniqueConnectionIds` — a recording whose assets all carry id 1 yields distinct per-asset ids; a preassigned id is kept, a missing one is assigned; both connections then read their own data.
- `TestRecordingProviderRoutesByAssetIdentity` — with the shared id owned by *another* asset in the recording's index, the connection still reaches its own asset's section.
- `TestRecordingProviderSelectedAssetFallback`, `TestRecordingProviderConnectWithoutPlatformIdsReportsNoConnection`, `TestRecordingProviderStoreWithoutAsset` — the no-connection flow and its existing error behavior are unchanged.

`go build ./...`, `go test -race ./providers/`, `go test ./providers-sdk/v1/... ./llx/...` green; `gofmt`/`go vet` clean.

## Note on the issue's "additional smell"

`Runtime.Close()` → `Recording().Save()` persisting phantom computed resources over the user's recording file: `recordingProvider.Connect` loads via `recording.LoadRecordingFile`, which leaves `Path` empty, and the runtime's own recording is `Null` in this flow, so nothing writes the file back. No file-corruption path in these flows.
