### PR TITLE
🐛 k8s: stop classifying internal cloud load balancers as internet-exposed

### DIFF
--- a/providers/k8s/resources/network_posture.go
+++ b/providers/k8s/resources/network_posture.go
@@ -542,6 +542,12 @@ func serviceNetworkExposureArgs(svc *corev1.Service, publicNodeAddresses []strin
 		if len(addresses) == 0 {
 			exposureReason = "loadBalancerPending"
 			confidence = "low"
+		} else if internetExposed && hasInternalLoadBalancerAnnotation(svc.Annotations) {
+			// The declared scheme wins over the published address. An internal AWS
+			// NLB's DNS name looks exactly like an internet-facing one, so without
+			// this the address classification reports it as internet-reachable.
+			internetExposed = false
+			exposureReason = "internalLoadBalancerScheme"
 		} else if internetExposed && len(svc.Spec.LoadBalancerSourceRanges) > 0 && !contains(sourceRangeClassifications, "publicSourceRange") {
 			internetExposed = false
 			exposureReason = "restrictedLoadBalancerSourceRange"
@@ -610,10 +616,30 @@ func ingressNetworkExposureArgs(ing *networkingv1.Ingress) []map[string]*llx.Raw
 	specHostnames := ingressSpecHostnames(ing)
 	addresses := ingressExposureAddresses(ing)
 	classifications := classifyAddresses(addresses)
-	internetExposed := contains(classifications, "internet") || contains(classifications, "hostname")
+
+	// Reachability follows the address the controller actually published, not the
+	// rule hostnames. A rule host only matches the Host header of a request that
+	// already reached the load balancer, so an internal load balancer fronting
+	// public-looking names stays reachable only inside the VPC. The rule hostnames
+	// are consulted solely while no address has been published, where they are the
+	// one available signal of what the Ingress intends to serve.
+	reachabilityAddresses := statusAddresses
+	if len(reachabilityAddresses) == 0 {
+		reachabilityAddresses = specHostnames
+	}
+	reachability := classifyAddresses(reachabilityAddresses)
+	internetExposed := contains(reachability, "internet") || contains(reachability, "hostname")
+
 	exposureReason := "ingressNoPublishedAddress"
 	confidence := "low"
-	if internetExposed && len(statusAddresses) > 0 {
+	if hasInternalLoadBalancerAnnotation(ing.Annotations) {
+		// A declared scheme is authoritative and is reported as the reason in its own
+		// right: the controller provisions the load balancer from it, so it settles
+		// reachability whatever the published address or rule hostnames suggest.
+		internetExposed = false
+		exposureReason = "internalLoadBalancerScheme"
+		confidence = "high"
+	} else if internetExposed && len(statusAddresses) > 0 {
 		exposureReason = "publicIngressAddress"
 		confidence = "high"
 	} else if internetExposed && len(specHostnames) > 0 {
@@ -3268,7 +3294,61 @@ func isInternalHostname(hostname string) bool {
 		strings.HasSuffix(hostname, ".cluster.local") ||
 		strings.HasSuffix(hostname, ".local") ||
 		strings.HasSuffix(hostname, ".internal") ||
-		strings.Contains(hostname, ".svc.")
+		strings.Contains(hostname, ".svc.") ||
+		isInternalCloudLoadBalancerHostname(hostname)
+}
+
+// isInternalCloudLoadBalancerHostname reports whether a cloud load balancer's DNS
+// name identifies it as internal (reachable only inside the VPC) rather than
+// internet-facing.
+//
+// A Service or Ingress usually publishes its load balancer as a hostname, not an
+// IP, and an unrecognized hostname is otherwise classified as internet-reachable.
+// That is the safe default for an arbitrary name, but it misreads AWS load
+// balancer DNS: an internal Application or Classic Load Balancer is always named
+// internal-<name>-<id>.<region>.elb.amazonaws.com, and AWS never applies that
+// prefix to an internet-facing one, so treating the prefix as internal removes a
+// large class of false positives without risking a false negative.
+//
+// Network Load Balancers carry no equivalent marker in their DNS name, so an
+// internal NLB is not detectable here; those are classified from the load
+// balancer scheme annotation instead (see hasInternalLoadBalancerAnnotation).
+func isInternalCloudLoadBalancerHostname(hostname string) bool {
+	return strings.HasPrefix(hostname, "internal-") &&
+		strings.HasSuffix(hostname, ".amazonaws.com") &&
+		strings.Contains(hostname, ".elb.")
+}
+
+// internalLoadBalancerAnnotations maps the cloud controller annotations that
+// explicitly request an internal load balancer to the value that means internal.
+// The AWS NLB case is the reason this exists: unlike an ALB, an internal NLB's DNS
+// name is indistinguishable from an internet-facing one, so the declared scheme is
+// the only signal available.
+var internalLoadBalancerAnnotations = map[string]string{
+	// AWS Load Balancer Controller, Ingress (ALB) and Service (NLB)
+	"alb.ingress.kubernetes.io/scheme":                      "internal",
+	"service.beta.kubernetes.io/aws-load-balancer-scheme":   "internal",
+	"service.beta.kubernetes.io/aws-load-balancer-internal": "true",
+	// Azure cloud provider
+	"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
+	// GKE, current and legacy annotation
+	"networking.gke.io/load-balancer-type": "internal",
+	"cloud.google.com/load-balancer-type":  "internal",
+}
+
+// hasInternalLoadBalancerAnnotation reports whether the object explicitly requests
+// an internal load balancer through a cloud controller annotation. A declared
+// scheme is authoritative: the controller provisions the load balancer from it, so
+// it outranks any inference drawn from the published address.
+func hasInternalLoadBalancerAnnotation(annotations map[string]string) bool {
+	for key, internalValue := range internalLoadBalancerAnnotations {
+		if value, ok := annotations[key]; ok {
+			if strings.EqualFold(strings.TrimSpace(value), internalValue) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func filterNetworkObjectsByNamespace(runtime *plugin.Runtime, namespace string, list func(k8s *mqlK8s) *plugin.TValue[[]any]) ([]any, error) {

--- a/providers/k8s/resources/network_posture_test.go
+++ b/providers/k8s/resources/network_posture_test.go
@@ -1901,3 +1901,181 @@ func coverageArgsWithPolicyRef(t *testing.T, args []map[string]*llx.RawData, wan
 	require.Failf(t, "coverage policyRef not found", "wanted policyRef %q", want)
 	return nil
 }
+
+func TestClassifyAddressInternalCloudLoadBalancerHostname(t *testing.T) {
+	// AWS names an internal ALB/CLB with an internal- prefix and never applies it
+	// to an internet-facing one, so the prefix is a safe negative signal.
+	assert.Equal(t, "internalHostname",
+		classifyAddress("internal-bba-prod-ptp-2120307359.eu-central-1.elb.amazonaws.com"))
+	// An internet-facing load balancer of the same shape stays internet-reachable.
+	assert.Equal(t, "hostname",
+		classifyAddress("bba-prod-ptp-2120307359.eu-central-1.elb.amazonaws.com"))
+	// NLB DNS layout puts the region after .elb.; the prefix rule still applies.
+	assert.Equal(t, "internalHostname",
+		classifyAddress("internal-sftpgo-sftp-e4600cc5.elb.eu-central-1.amazonaws.com"))
+	// The prefix alone must not be enough outside AWS load balancer domains.
+	assert.Equal(t, "hostname", classifyAddress("internal-tools.example.com"))
+}
+
+func TestServiceNetworkExposureArgsInternalSchemeAnnotation(t *testing.T) {
+	// An internal NLB's DNS name is indistinguishable from an internet-facing one,
+	// so only the declared scheme reveals that it is VPC-only.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "sftpgo-sftp",
+			Namespace:   "sftpgo",
+			Annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 22, Protocol: corev1.ProtocolTCP}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{
+					Hostname: "sftpgo-sftp-e4600cc5a973d130.elb.eu-central-1.amazonaws.com",
+				}},
+			},
+		},
+	}
+
+	args := serviceNetworkExposureArgs(svc, nil)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, false, args[0]["internetExposed"].Value)
+	assert.Equal(t, "internalLoadBalancerScheme", args[0]["exposureReason"].Value)
+}
+
+func TestServiceNetworkExposureArgsInternetFacingSchemeStaysExposed(t *testing.T) {
+	// Guard against the annotation check over-reaching: an explicitly
+	// internet-facing scheme must remain flagged.
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "sftpgo-sftp",
+			Namespace:   "sftpgo",
+			Annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{{Port: 22, Protocol: corev1.ProtocolTCP}},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{
+					Hostname: "sftpgo-sftp-e4600cc5a973d130.elb.eu-central-1.amazonaws.com",
+				}},
+			},
+		},
+	}
+
+	args := serviceNetworkExposureArgs(svc, nil)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, true, args[0]["internetExposed"].Value)
+	assert.Equal(t, "publicLoadBalancerAddress", args[0]["exposureReason"].Value)
+}
+
+func TestIngressNetworkExposureArgsInternalSchemeAnnotation(t *testing.T) {
+	// The published address is an internal ALB and the rule host is an ordinary
+	// public-looking name; the declared scheme must keep this off the exposed list.
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "bba-prod-ptp",
+			Namespace:   "bba-prod-ptp",
+			Annotations: map[string]string{"alb.ingress.kubernetes.io/scheme": "internal"},
+		},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{Host: "plan.example.com"}},
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{
+					Hostname: "internal-bba-prod-ptp-2120307359.eu-central-1.elb.amazonaws.com",
+				}},
+			},
+		},
+	}
+
+	args := ingressNetworkExposureArgs(ing)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, false, args[0]["internetExposed"].Value)
+	assert.Equal(t, "internalLoadBalancerScheme", args[0]["exposureReason"].Value)
+}
+
+func TestIngressNetworkExposureArgsUnannotatedInternalAlbNotExposed(t *testing.T) {
+	// The AWS Load Balancer Controller defaults to an internal scheme, so an
+	// unannotated Ingress on an internal- ALB must be classified from its address.
+	// The rule host is a public-looking name on purpose: an Ingress essentially
+	// always defines one, and it must not override the published internal address.
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "atp-prod-ptp", Namespace: "atp-prod-ptp"},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{Host: "plan.atp.example.com"}},
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{
+					Hostname: "internal-atp-prod-ptp-1954117370.eu-central-1.elb.amazonaws.com",
+				}},
+			},
+		},
+	}
+
+	args := ingressNetworkExposureArgs(ing)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, false, args[0]["internetExposed"].Value)
+	assert.Equal(t, "privateIngressAddress", args[0]["exposureReason"].Value)
+	// The reported address set still unions both, so the evidence stays complete.
+	assert.Equal(t, []any{
+		"internal-atp-prod-ptp-1954117370.eu-central-1.elb.amazonaws.com",
+		"plan.atp.example.com",
+	}, args[0]["addresses"].Value)
+}
+
+func TestIngressNetworkExposureArgsPublicAlbWithRuleHostStaysExposed(t *testing.T) {
+	// Mirror of the test above: a genuinely internet-facing ALB must remain flagged
+	// once reachability is read from the published address instead of the rule host.
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "nbe-prod-public", Namespace: "nbe-prod-ptp"},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{Host: "plan.nbe.example.com"}},
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{
+					Hostname: "nbe-prod-public-795082853.eu-central-1.elb.amazonaws.com",
+				}},
+			},
+		},
+	}
+
+	args := ingressNetworkExposureArgs(ing)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, true, args[0]["internetExposed"].Value)
+	assert.Equal(t, "publicIngressAddress", args[0]["exposureReason"].Value)
+}
+
+func TestIngressNetworkExposureArgsPrivateIpWithPublicRuleHost(t *testing.T) {
+	// Not AWS-specific: an Ingress published on a private IP is internal, however
+	// public its rule hostnames look.
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Name: "onprem", Namespace: "prod"},
+		Spec: networkingv1.IngressSpec{
+			Rules: []networkingv1.IngressRule{{Host: "app.example.com"}},
+		},
+		Status: networkingv1.IngressStatus{
+			LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+				Ingress: []networkingv1.IngressLoadBalancerIngress{{IP: "10.0.0.5"}},
+			},
+		},
+	}
+
+	args := ingressNetworkExposureArgs(ing)
+	require.Len(t, args, 1)
+
+	assert.Equal(t, false, args[0]["internetExposed"].Value)
+	assert.Equal(t, "privateIngressAddress", args[0]["exposureReason"].Value)
+}


### PR DESCRIPTION
## Problem

`networkExposures` treated any unrecognized hostname as internet-reachable. That is a sound default for an arbitrary name, but a Service or Ingress publishes its load balancer as a *hostname*, and an AWS **internal** load balancer's DNS name looks entirely ordinary. Every internal load balancer was therefore reported as internet-exposed.

Measured on one customer estate (~30k assets, 67 AWS accounts, 69 EKS clusters): **608 of 608 ingresses** were reported internet-exposed, **359** of them on load balancers whose authoritative `aws-elb-loadbalancer` `Scheme` is `internal`.

## Two independent causes

**1. Address classification did not know cloud load balancer DNS.** AWS names an internal Application or Classic Load Balancer `internal-<name>-<id>.<region>.elb.amazonaws.com` and never applies that prefix to an internet-facing one, so the prefix is a reliable negative signal. `isInternalHostname` now recognizes it. A Network Load Balancer carries no equivalent marker in its DNS name, which is why the declared scheme is honored as well.

**2. Ingress reachability was derived from the union of the published address and the spec rule hostnames.** A rule host only matches the `Host` header of a request that *already reached* the load balancer, so public-looking rule names made an internal Ingress look internet-facing regardless of where it was actually published. Reachability now follows the published address, falling back to rule hostnames only while no address exists — which preserves the pre-existing `publicIngressHostname` intent signal.

A declared internal scheme is now authoritative for both Service and Ingress, reported as `exposureReason: internalLoadBalancerScheme`. Annotations honored:

| Controller | Annotation |
|---|---|
| AWS LB Controller (ALB) | `alb.ingress.kubernetes.io/scheme: internal` |
| AWS LB Controller (NLB) | `service.beta.kubernetes.io/aws-load-balancer-scheme: internal` |
| AWS legacy | `service.beta.kubernetes.io/aws-load-balancer-internal: "true"` |
| Azure | `service.beta.kubernetes.io/azure-load-balancer-internal: "true"` |
| GKE | `networking.gke.io/load-balancer-type: internal` |
| GKE legacy | `cloud.google.com/load-balancer-type: internal` |

## Validation

Against the same estate, using the authoritative `aws-elb-loadbalancer` `Scheme` field as ground truth:

| | before | after |
|---|---|---|
| ingresses flagged internet-exposed | 608 / 608 | **205** |
| false positives | 359 | **0** |
| false negatives | 0 | **0** |

Zero FP and zero FN across the 596 ingresses whose load balancer is present in the dataset. The 205-vs-193 gap is ingresses declared `internet-facing` whose ELB is absent from the data (deleted or cross-account), correctly flagged from their declaration.

Genuinely internet-facing ALBs and NLBs, NodePort-on-public-node services, and `hostPort` pods all remain flagged.

## Tests

Six new cases in `network_posture_test.go`, plus a strengthened existing one. Full `providers/k8s/resources` suite passes.

- internal ALB/CLB and NLB hostname classification, including that the `internal-` prefix alone is not enough outside AWS LB domains
- internal scheme annotation on Service and on Ingress
- explicit `internet-facing` scheme stays exposed (guards the annotation check against over-reach)
- unannotated internal ALB **with a public-looking rule host** is not exposed — the case the first iteration of this fix missed
- genuinely public ALB with the same rule host stays exposed
- private-IP Ingress with a public rule host is not exposed (not AWS-specific)

## Note for reviewers

Two Kubernetes checks were recently added to the `internet-exposed` risk factor in `server` (mondoohq/server#17890): `k8s-service-public` and `k8s-ingress-public` consume `networkExposures.internetExposed` directly. **They depend on this fix** — without it they flag internal load balancers. Worth landing this first.

Separately, and out of scope here: `aws.ec2.instance.exposure.internetReachable` is `hasPublicIp && inPublicSubnet && sgAllows && naclAllows` and does **not** consider load balancers at all, even though `internetFacingLoadBalancers` is computed right beside it. An instance-type target group behind an internet-facing LB is therefore not flagged anywhere. Probably worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
