### PR TITLE
🐛 azure: let the inventory name the sign-in method

### DIFF
--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -48,13 +48,18 @@ var DefaultCredentialMethods = []CredentialMethod{
 	CredentialMethodWorkloadIdentity,
 }
 
-// credentialMethodDescriptions renders each method the way we talk about it in
-// user-facing sign-in guidance.
-var credentialMethodDescriptions = map[CredentialMethod]string{
-	CredentialMethodCLI:              "your local Azure CLI session",
-	CredentialMethodEnv:              "Azure environment variables",
-	CredentialMethodManagedIdentity:  "a managed identity",
-	CredentialMethodWorkloadIdentity: "workload identity federation",
+// credentialMethodNames renders a method selection as a plain list; an empty
+// selection renders the full default chain. These are the names auth-method
+// accepts, so a message built from them doubles as a usage hint.
+func credentialMethodNames(methods []CredentialMethod) string {
+	if len(methods) == 0 {
+		methods = DefaultCredentialMethods
+	}
+	names := make([]string, 0, len(methods))
+	for _, m := range methods {
+		names = append(names, string(m))
+	}
+	return strings.Join(names, ", ")
 }
 
 // ParseCredentialMethods reads a comma-separated method list, e.g.
@@ -77,23 +82,15 @@ func ParseCredentialMethods(s string) ([]CredentialMethod, error) {
 		}
 
 		method := CredentialMethod(name)
-		if _, ok := credentialMethodDescriptions[method]; !ok {
+		if !slices.Contains(DefaultCredentialMethods, method) {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				strings.TrimSpace(part), strings.Join(credentialMethodNames(), ", "))
+				strings.TrimSpace(part), credentialMethodNames(nil))
 		}
 		if !slices.Contains(methods, method) {
 			methods = append(methods, method)
 		}
 	}
 	return methods, nil
-}
-
-func credentialMethodNames() []string {
-	names := make([]string, 0, len(DefaultCredentialMethods))
-	for _, m := range DefaultCredentialMethods {
-		names = append(names, string(m))
-	}
-	return names
 }
 
 // AllowsMethod reports whether m is permitted by the selection. An empty
@@ -214,7 +211,7 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		resolver, ok := resolvers[method]
 		if !ok {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				method, strings.Join(credentialMethodNames(), ", "))
+				method, credentialMethodNames(nil))
 		}
 		opts = append(opts, resolver)
 	}
@@ -306,7 +303,8 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 	}
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		log.Info().Msg("no Azure credentials were provided; trying to sign in with " + describeMethods(chainOpts.Methods))
+		log.Info().Str("methods", credentialMethodNames(chainOpts.Methods)).
+			Msg("no Azure credentials were provided, trying the configured sign-in methods")
 		azCred, err = GetDefaultChainedToken(&chainOpts)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating CLI credentials")
@@ -332,33 +330,6 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 		}
 	}
 	return &guidedCredential{inner: azCred, usedDefaultChain: usedDefaultChain, methods: chainOpts.Methods}, nil
-}
-
-// describeMethods renders a method selection as an English list, so sign-in
-// guidance names what we actually tried rather than the full chain. An empty
-// selection describes the default chain.
-func describeMethods(methods []CredentialMethod) string {
-	if len(methods) == 0 {
-		methods = DefaultCredentialMethods
-	}
-
-	parts := make([]string, 0, len(methods))
-	for _, m := range methods {
-		desc, ok := credentialMethodDescriptions[m]
-		if !ok {
-			desc = string(m)
-		}
-		parts = append(parts, desc)
-	}
-
-	switch len(parts) {
-	case 1:
-		return parts[0]
-	case 2:
-		return parts[0] + " or " + parts[1]
-	default:
-		return strings.Join(parts[:len(parts)-1], ", ") + ", or " + parts[len(parts)-1]
-	}
 }
 
 // guidedCredential decorates an azcore.TokenCredential so that a failed sign-in
@@ -391,8 +362,8 @@ func enrichTokenError(err error, usedDefaultChain bool, methods []CredentialMeth
 		return errors.Wrap(err, "Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret")
 	}
 
-	msg := "Azure sign-in failed. No credentials were provided, so we tried to sign in using " +
-		describeMethods(methods) + ", and none of them worked. "
+	msg := "Azure sign-in failed. No credentials were provided, so we tried these sign-in methods: " +
+		credentialMethodNames(methods) + ". None of them worked. "
 	if AllowsMethod(methods, CredentialMethodCLI) {
 		msg += "Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials "
 	} else {

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,6 +18,109 @@ import (
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
+
+// CredentialMethod names one source in the default sign-in chain. A caller who
+// already knows how its environment hands out credentials can name the source
+// instead of paying for the whole chain: probing a source that cannot work
+// costs real time (the managed identity probe alone retries for up to 15
+// seconds before giving up) and it is paid again for every asset in a scan.
+type CredentialMethod string
+
+const (
+	// CredentialMethodCLI signs in with the local Azure CLI session (`az login`).
+	CredentialMethodCLI CredentialMethod = "cli"
+	// CredentialMethodEnv signs in with the AZURE_* environment variables.
+	CredentialMethodEnv CredentialMethod = "env"
+	// CredentialMethodManagedIdentity signs in with the managed identity
+	// assigned to the Azure host we are running on.
+	CredentialMethodManagedIdentity CredentialMethod = "managed-identity"
+	// CredentialMethodWorkloadIdentity exchanges an OIDC token for an Entra
+	// access token via a federated identity credential.
+	CredentialMethodWorkloadIdentity CredentialMethod = "workload-identity"
+)
+
+// DefaultCredentialMethods is the chain we try when the caller does not name
+// any method, in order.
+var DefaultCredentialMethods = []CredentialMethod{
+	CredentialMethodCLI,
+	CredentialMethodEnv,
+	CredentialMethodManagedIdentity,
+	CredentialMethodWorkloadIdentity,
+}
+
+// credentialMethodDescriptions renders each method the way we talk about it in
+// user-facing sign-in guidance.
+var credentialMethodDescriptions = map[CredentialMethod]string{
+	CredentialMethodCLI:              "your local Azure CLI session",
+	CredentialMethodEnv:              "Azure environment variables",
+	CredentialMethodManagedIdentity:  "a managed identity",
+	CredentialMethodWorkloadIdentity: "workload identity federation",
+}
+
+// ParseCredentialMethods reads a comma-separated method list, e.g.
+// "workload-identity" or "workload-identity,managed-identity". An empty value
+// (as well as the explicit "default" and "auto") returns nil, meaning try every
+// method. Values are normalized, so "Workload_Identity" is accepted.
+//
+// An unrecognized value is an error rather than a silent fallback to the full
+// chain: the whole point of naming a method is to avoid the slow probing, so a
+// typo that quietly reinstates it would be invisible in exactly the deployment
+// that asked not to have it.
+func ParseCredentialMethods(s string) ([]CredentialMethod, error) {
+	var methods []CredentialMethod
+	for part := range strings.SplitSeq(s, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		name = strings.ReplaceAll(name, "_", "-")
+		switch name {
+		case "", "default", "auto":
+			continue
+		}
+
+		method := CredentialMethod(name)
+		if _, ok := credentialMethodDescriptions[method]; !ok {
+			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
+				strings.TrimSpace(part), strings.Join(credentialMethodNames(), ", "))
+		}
+		if !slices.Contains(methods, method) {
+			methods = append(methods, method)
+		}
+	}
+	return methods, nil
+}
+
+func credentialMethodNames() []string {
+	names := make([]string, 0, len(DefaultCredentialMethods))
+	for _, m := range DefaultCredentialMethods {
+		names = append(names, string(m))
+	}
+	return names
+}
+
+// AllowsMethod reports whether m is permitted by the selection. An empty
+// selection permits everything.
+func AllowsMethod(methods []CredentialMethod, m CredentialMethod) bool {
+	return len(methods) == 0 || slices.Contains(methods, m)
+}
+
+// ChainedTokenOptions configures the sign-in chain we fall back to when no
+// explicit credential (client secret or certificate) is available.
+type ChainedTokenOptions struct {
+	azidentity.DefaultAzureCredentialOptions
+
+	// ClientID of the service principal to sign in as. Workload identity needs
+	// it and errors out without one; empty falls back to AZURE_CLIENT_ID. The
+	// tenant comes from the embedded DefaultAzureCredentialOptions.TenantID.
+	ClientID string
+
+	// FederatedTokenFile is the path to the OIDC token that workload identity
+	// federation exchanges for an access token. Empty falls back to
+	// AZURE_FEDERATED_TOKEN_FILE.
+	FederatedTokenFile string
+
+	// Methods restricts the chain to these sources, tried in the given order.
+	// Empty means DefaultCredentialMethods.
+	Methods []CredentialMethod
+}
 
 type TokenResolverFn (func() (azcore.TokenCredential, error))
 
@@ -56,30 +160,63 @@ func WithWorkloadIdentityCredentials(opts *azidentity.WorkloadIdentityCredential
 	}
 }
 
+// BuildChainedToken assembles the credentials that could be constructed into a
+// single chain. A resolver whose constructor fails is left out, because most of
+// them fail simply because that way of signing in is not configured here. When
+// *every* resolver fails we surface the collected errors instead: with an
+// explicit method selection that is the caller being told why the source they
+// asked for is unusable, which the SDK's bare "at least one credential
+// required" hides.
 func BuildChainedToken(opts ...TokenResolverFn) (*azidentity.ChainedTokenCredential, error) {
 	chain := []azcore.TokenCredential{}
+	errs := []error{}
 	for _, fn := range opts {
 		cred, err := fn()
-		if err == nil {
-			chain = append(chain, cred)
+		if err != nil {
+			errs = append(errs, err)
+			continue
 		}
+		chain = append(chain, cred)
+	}
+	if len(chain) == 0 && len(errs) > 0 {
+		return nil, errors.Wrap(errors.Join(errs...), "no Azure credential source could be configured")
 	}
 	return azidentity.NewChainedTokenCredential(chain, nil)
 }
 
-func GetDefaultChainedToken(options *azidentity.DefaultAzureCredentialOptions) (*azidentity.ChainedTokenCredential, error) {
+func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTokenCredential, error) {
 	if options == nil {
-		options = &azidentity.DefaultAzureCredentialOptions{}
+		options = &ChainedTokenOptions{}
 	}
-	opts := []TokenResolverFn{
-		WithCliCredentials(&azidentity.AzureCLICredentialOptions{AdditionallyAllowedTenants: []string{"*"}}),
-		WithEnvCredentials(&azidentity.EnvironmentCredentialOptions{ClientOptions: options.ClientOptions}),
-		WithRetryableManagedIdentityCredentials(5*time.Second, 3, &azidentity.ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions}),
-		WithWorkloadIdentityCredentials(&azidentity.WorkloadIdentityCredentialOptions{
+
+	resolvers := map[CredentialMethod]TokenResolverFn{
+		CredentialMethodCLI: WithCliCredentials(&azidentity.AzureCLICredentialOptions{AdditionallyAllowedTenants: []string{"*"}}),
+		CredentialMethodEnv: WithEnvCredentials(&azidentity.EnvironmentCredentialOptions{ClientOptions: options.ClientOptions}),
+		CredentialMethodManagedIdentity: WithRetryableManagedIdentityCredentials(5*time.Second, 3,
+			&azidentity.ManagedIdentityCredentialOptions{ClientOptions: options.ClientOptions}),
+		CredentialMethodWorkloadIdentity: WithWorkloadIdentityCredentials(&azidentity.WorkloadIdentityCredentialOptions{
 			ClientOptions:            options.ClientOptions,
 			DisableInstanceDiscovery: options.DisableInstanceDiscovery,
 			TenantID:                 options.TenantID,
+			ClientID:                 options.ClientID,
+			TokenFilePath:            options.FederatedTokenFile,
 		}),
+	}
+
+	methods := options.Methods
+	if len(methods) == 0 {
+		methods = DefaultCredentialMethods
+	}
+
+	// iterate the selection, not the map, so the chain keeps the caller's order
+	opts := make([]TokenResolverFn, 0, len(methods))
+	for _, method := range methods {
+		resolver, ok := resolvers[method]
+		if !ok {
+			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
+				method, strings.Join(credentialMethodNames(), ", "))
+		}
+		opts = append(opts, resolver)
 	}
 	return BuildChainedToken(opts...)
 }
@@ -149,14 +286,28 @@ func GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile string) (az
 	})
 }
 
-func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId string) (azcore.TokenCredential, error) {
+// GetTokenFromCredential builds a credential from an explicit client secret or
+// certificate. When there is none, it falls back to the sign-in chain described
+// by options (nil means the full default chain). tenantId and clientId are the
+// authoritative values for the connection and override anything options carries.
+func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId string, options *ChainedTokenOptions) (azcore.TokenCredential, error) {
 	var azCred azcore.TokenCredential
 	var err error
 	usedDefaultChain := credential == nil
+	chainOpts := ChainedTokenOptions{}
+	if options != nil {
+		chainOpts = *options
+	}
+	if tenantId != "" {
+		chainOpts.TenantID = tenantId
+	}
+	if clientId != "" {
+		chainOpts.ClientID = clientId
+	}
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		log.Info().Msg("no Azure credentials were provided; trying to sign in with your local Azure CLI session, Azure environment variables, or a managed identity")
-		azCred, err = GetDefaultChainedToken(&azidentity.DefaultAzureCredentialOptions{})
+		log.Info().Msg("no Azure credentials were provided; trying to sign in with " + describeMethods(chainOpts.Methods))
+		azCred, err = GetDefaultChainedToken(&chainOpts)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating CLI credentials")
 		}
@@ -180,7 +331,34 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 			return nil, errors.New("invalid secret configuration for microsoft transport: " + credential.Type.String())
 		}
 	}
-	return &guidedCredential{inner: azCred, usedDefaultChain: usedDefaultChain}, nil
+	return &guidedCredential{inner: azCred, usedDefaultChain: usedDefaultChain, methods: chainOpts.Methods}, nil
+}
+
+// describeMethods renders a method selection as an English list, so sign-in
+// guidance names what we actually tried rather than the full chain. An empty
+// selection describes the default chain.
+func describeMethods(methods []CredentialMethod) string {
+	if len(methods) == 0 {
+		methods = DefaultCredentialMethods
+	}
+
+	parts := make([]string, 0, len(methods))
+	for _, m := range methods {
+		desc, ok := credentialMethodDescriptions[m]
+		if !ok {
+			desc = string(m)
+		}
+		parts = append(parts, desc)
+	}
+
+	switch len(parts) {
+	case 1:
+		return parts[0]
+	case 2:
+		return parts[0] + " or " + parts[1]
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + ", or " + parts[len(parts)-1]
+	}
 }
 
 // guidedCredential decorates an azcore.TokenCredential so that a failed sign-in
@@ -192,12 +370,15 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 type guidedCredential struct {
 	inner            azcore.TokenCredential
 	usedDefaultChain bool
+	// methods records which sign-in sources the chain was restricted to, so the
+	// guidance names what we actually tried. Empty means the full chain.
+	methods []CredentialMethod
 }
 
 func (c *guidedCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	tk, err := c.inner.GetToken(ctx, opts)
 	if err != nil {
-		return azcore.AccessToken{}, enrichTokenError(err, c.usedDefaultChain)
+		return azcore.AccessToken{}, enrichTokenError(err, c.usedDefaultChain, c.methods)
 	}
 	return tk, nil
 }
@@ -205,13 +386,19 @@ func (c *guidedCredential) GetToken(ctx context.Context, opts policy.TokenReques
 // enrichTokenError wraps a sign-in failure with guidance tailored to how the
 // credential was configured. The original error is always preserved so no
 // diagnostic detail is lost.
-func enrichTokenError(err error, usedDefaultChain bool) error {
+func enrichTokenError(err error, usedDefaultChain bool, methods []CredentialMethod) error {
 	if !usedDefaultChain {
 		return errors.Wrap(err, "Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret")
 	}
 
-	msg := "Azure sign-in failed. No credentials were provided, so we tried to sign in using your local Azure CLI session, Azure environment variables, and a managed identity, and none of them worked. " +
-		"Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials directly with --tenant-id and --client-id plus a certificate or client secret"
+	msg := "Azure sign-in failed. No credentials were provided, so we tried to sign in using " +
+		describeMethods(methods) + ", and none of them worked. "
+	if AllowsMethod(methods, CredentialMethodCLI) {
+		msg += "Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials "
+	} else {
+		msg += "Provide credentials "
+	}
+	msg += "directly with --tenant-id and --client-id plus a certificate or client secret"
 
 	// azidentity's Azure CLI credential reports output that isn't a token (for
 	// example a message asking you to sign in again) as a JSON decode error.

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -111,13 +111,10 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 	})
 }
 
-func TestDescribeMethods(t *testing.T) {
-	assert.Equal(t, "workload identity federation", describeMethods([]CredentialMethod{CredentialMethodWorkloadIdentity}))
-	assert.Equal(t, "a managed identity or workload identity federation",
-		describeMethods([]CredentialMethod{CredentialMethodManagedIdentity, CredentialMethodWorkloadIdentity}))
-	assert.Equal(t,
-		"your local Azure CLI session, Azure environment variables, a managed identity, or workload identity federation",
-		describeMethods(nil))
+func TestCredentialMethodNames(t *testing.T) {
+	assert.Equal(t, "workload-identity", credentialMethodNames([]CredentialMethod{CredentialMethodWorkloadIdentity}))
+	// an empty selection stands for the whole chain
+	assert.Equal(t, "cli, env, managed-identity, workload-identity", credentialMethodNames(nil))
 }
 
 func TestGuidedCredential_EnrichesErrors(t *testing.T) {
@@ -152,10 +149,10 @@ func TestGuidedCredential_EnrichesErrors(t *testing.T) {
 		}
 		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "workload identity federation")
+		assert.Contains(t, err.Error(), "workload-identity")
 		// no CLI in the chain, so no point telling anyone to run az login
 		assert.NotContains(t, err.Error(), "az login")
-		assert.NotContains(t, err.Error(), "managed identity")
+		assert.NotContains(t, err.Error(), "managed-identity")
 	})
 
 	t.Run("explicit credentials failure", func(t *testing.T) {

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,94 @@ func (f *fakeCredential) GetToken(ctx context.Context, opts policy.TokenRequestO
 		return azcore.AccessToken{}, f.err
 	}
 	return azcore.AccessToken{Token: "token"}, nil
+}
+
+func TestParseCredentialMethods(t *testing.T) {
+	t.Run("empty means every method", func(t *testing.T) {
+		methods, err := ParseCredentialMethods("")
+		require.NoError(t, err)
+		assert.Nil(t, methods)
+		assert.True(t, AllowsMethod(methods, CredentialMethodManagedIdentity))
+	})
+
+	t.Run("default and auto also mean every method", func(t *testing.T) {
+		for _, in := range []string{"default", "auto", " , "} {
+			methods, err := ParseCredentialMethods(in)
+			require.NoError(t, err, in)
+			assert.Nil(t, methods, in)
+		}
+	})
+
+	t.Run("single method", func(t *testing.T) {
+		methods, err := ParseCredentialMethods("workload-identity")
+		require.NoError(t, err)
+		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity}, methods)
+		assert.False(t, AllowsMethod(methods, CredentialMethodManagedIdentity))
+	})
+
+	t.Run("list keeps the caller's order", func(t *testing.T) {
+		methods, err := ParseCredentialMethods("workload-identity,cli")
+		require.NoError(t, err)
+		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity, CredentialMethodCLI}, methods)
+	})
+
+	t.Run("normalizes case, spacing, underscores, and duplicates", func(t *testing.T) {
+		methods, err := ParseCredentialMethods(" Workload_Identity , workload-identity ")
+		require.NoError(t, err)
+		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity}, methods)
+	})
+
+	t.Run("unknown method is an error, not a silent full chain", func(t *testing.T) {
+		_, err := ParseCredentialMethods("managed_identiy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "managed_identiy")
+		assert.Contains(t, err.Error(), "workload-identity")
+	})
+}
+
+func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
+	t.Run("workload identity uses the configured client id", func(t *testing.T) {
+		// NewWorkloadIdentityCredential errors without a client id, so a
+		// credential coming back at all proves ClientID was passed through
+		// rather than left to AZURE_CLIENT_ID.
+		cred, err := GetDefaultChainedToken(&ChainedTokenOptions{
+			DefaultAzureCredentialOptions: azidentity.DefaultAzureCredentialOptions{
+				TenantID: "aba673d8-12f8-4315-90c1-848f09d747f1",
+			},
+			ClientID:           "f424bc0b-7f95-4270-8ffc-694a52e60b9f",
+			FederatedTokenFile: "/var/run/secrets/azure/tokens/azure-identity-token",
+			Methods:            []CredentialMethod{CredentialMethodWorkloadIdentity},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cred)
+	})
+
+	t.Run("an unbuildable sole method surfaces why", func(t *testing.T) {
+		// nothing to build the credential from, so the chain comes back empty
+		// and we report the constructor error instead of the SDK's bare
+		// "at least one credential required"
+		_, err := GetDefaultChainedToken(&ChainedTokenOptions{
+			Methods: []CredentialMethod{CredentialMethodWorkloadIdentity},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no Azure credential source could be configured")
+		assert.Contains(t, err.Error(), "specified")
+	})
+
+	t.Run("unknown method is rejected", func(t *testing.T) {
+		_, err := GetDefaultChainedToken(&ChainedTokenOptions{Methods: []CredentialMethod{"nope"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nope")
+	})
+}
+
+func TestDescribeMethods(t *testing.T) {
+	assert.Equal(t, "workload identity federation", describeMethods([]CredentialMethod{CredentialMethodWorkloadIdentity}))
+	assert.Equal(t, "a managed identity or workload identity federation",
+		describeMethods([]CredentialMethod{CredentialMethodManagedIdentity, CredentialMethodWorkloadIdentity}))
+	assert.Equal(t,
+		"your local Azure CLI session, Azure environment variables, a managed identity, or workload identity federation",
+		describeMethods(nil))
 }
 
 func TestGuidedCredential_EnrichesErrors(t *testing.T) {
@@ -53,6 +142,20 @@ func TestGuidedCredential_EnrichesErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), "No credentials were provided")
 		assert.NotContains(t, err.Error(), "Azure CLI returned something other than")
 		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("restricted chain only names what was tried", func(t *testing.T) {
+		cred := &guidedCredential{
+			inner:            &fakeCredential{err: errors.New("boom")},
+			usedDefaultChain: true,
+			methods:          []CredentialMethod{CredentialMethodWorkloadIdentity},
+		}
+		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "workload identity federation")
+		// no CLI in the chain, so no point telling anyone to run az login
+		assert.NotContains(t, err.Error(), "az login")
+		assert.NotContains(t, err.Error(), "managed identity")
 	})
 
 	t.Run("explicit credentials failure", func(t *testing.T) {

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -67,10 +67,12 @@ func TestParseCredentialMethods(t *testing.T) {
 		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity}, methods)
 	})
 
+	// a real Azure auth concept that is simply not one of ours, which is the
+	// likelier mistake than a misspelling
 	t.Run("unknown method is an error, not a silent full chain", func(t *testing.T) {
-		_, err := ParseCredentialMethods("managed_identiy")
+		_, err := ParseCredentialMethods("service-principal")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "managed_identiy")
+		assert.Contains(t, err.Error(), "service-principal")
 		assert.Contains(t, err.Error(), "workload-identity")
 	})
 }

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -118,6 +118,12 @@ Examples run in the Azure CLI:
 					Desc:    "Path to a file containing an OIDC token to exchange via Azure workload identity federation",
 				},
 				{
+					Long:    "auth-method",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, managed-identity, workload-identity (default: try all)",
+				},
+				{
 					Long:    "filters",
 					Type:    plugin.FlagType_KeyValue,
 					Default: "",

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -89,8 +89,13 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 	if err != nil {
 		return nil, err
 	}
+	// an empty token file leaves azidentity to fall back to
+	// AZURE_FEDERATED_TOKEN_FILE, so only the option needs forwarding here
 	token, err := azauth.GetTokenFromCredential(cred, conf.Options["tenant-id"], conf.Options["client-id"],
-		&azauth.ChainedTokenOptions{Methods: methods})
+		&azauth.ChainedTokenOptions{
+			FederatedTokenFile: conf.Options["azure-federated-token-file"],
+			Methods:            methods,
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -85,7 +85,12 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 	if len(conf.Credentials) > 0 {
 		cred = conf.Credentials[0]
 	}
-	token, err := azauth.GetTokenFromCredential(cred, conf.Options["tenant-id"], conf.Options["client-id"])
+	methods, err := azauth.ParseCredentialMethods(conf.Options["auth-method"])
+	if err != nil {
+		return nil, err
+	}
+	token, err := azauth.GetTokenFromCredential(cred, conf.Options["tenant-id"], conf.Options["client-id"],
+		&azauth.ChainedTokenOptions{Methods: methods})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -26,6 +26,10 @@ const (
 	OptionSubscriptionID     = "subscription-id"
 	OptionPlatformOverride   = "platform-override"
 	OptionFederatedTokenFile = "azure-federated-token-file"
+	// OptionAuthMethod names the sign-in method(s) to use when no client secret
+	// or certificate is supplied, as a comma-separated list of
+	// azauth.CredentialMethod values. Unset means try all of them.
+	OptionAuthMethod = "auth-method"
 )
 
 type AzureConnection struct {
@@ -45,9 +49,20 @@ type AzureConnection struct {
 // option or env var) and no explicit vault credential is present, it returns a
 // WorkloadIdentityCredential for keyless auth. Otherwise it falls through to
 // the standard cert/secret/default-chain path.
+//
+// The default chain is the expensive branch: it probes every sign-in method in
+// turn, and the managed identity probe alone burns ~15s before giving up. That
+// cost is paid per asset, since every discovered asset gets its own connection.
+// A caller that knows how it authenticates can say so with OptionAuthMethod and
+// skip straight to the method that works.
 func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, error) {
 	tenantId := conf.Options[OptionTenantID]
 	clientId := conf.Options[OptionClientID]
+
+	methods, err := azauth.ParseCredentialMethods(conf.Options[OptionAuthMethod])
+	if err != nil {
+		return nil, err
+	}
 
 	var cred *vault.Credential
 	if len(conf.Credentials) != 0 {
@@ -59,10 +74,17 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 		federatedTokenFile = os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
 	}
 
-	if cred == nil && federatedTokenFile != "" {
+	// A token file with no method selection is unambiguously workload identity
+	// federation, so there is nothing to probe. Once a selection exists it
+	// decides instead: the file can be a leftover env var from the pod spec,
+	// and a selection that rules workload identity out has to be honored.
+	if cred == nil && federatedTokenFile != "" && len(methods) == 0 {
 		return azauth.GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile)
 	}
-	return azauth.GetTokenFromCredential(cred, tenantId, clientId)
+	return azauth.GetTokenFromCredential(cred, tenantId, clientId, &azauth.ChainedTokenOptions{
+		FederatedTokenFile: federatedTokenFile,
+		Methods:            methods,
+	})
 }
 
 func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -223,10 +223,10 @@ func TestSelectAzureCredential_AuthMethodBeatsTokenFile(t *testing.T) {
 
 func TestSelectAzureCredential_InvalidAuthMethod(t *testing.T) {
 	conf := &inventory.Config{
-		Options: map[string]string{"auth-method": "workload-identiy"},
+		Options: map[string]string{"auth-method": "service-principal"},
 	}
 
 	_, err := selectAzureCredential(conf)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "workload-identiy")
+	require.Contains(t, err.Error(), "service-principal")
 }

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -174,6 +174,30 @@ func TestSelectAzureCredential_AuthMethodWorkloadIdentity(t *testing.T) {
 	require.NotNil(t, cred)
 }
 
+// TestSelectAzureCredential_AuthMethodWorkloadIdentity_TokenFileFromOption is
+// the version of the test above that actually proves the plumbing. With
+// AZURE_FEDERATED_TOKEN_FILE unset, the only way to build the credential is for
+// the option to be forwarded as ChainedTokenOptions.FederatedTokenFile: drop
+// that and the chain comes back empty. The env-var version passes either way,
+// because azidentity reads that variable itself.
+func TestSelectAzureCredential_AuthMethodWorkloadIdentity_TokenFileFromOption(t *testing.T) {
+	unsetFederatedTokenFile(t)
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":                  "tid",
+			"client-id":                  "cid",
+			"azure-federated-token-file": "/tmp/x.jwt",
+			"auth-method":                "workload-identity",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
 // TestSelectAzureCredential_AuthMethodBeatsTokenFile asserts that an explicit
 // method selection wins over a federated token file. The file can be a leftover
 // env var from the pod spec, so it must not silently override what the

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -115,3 +115,94 @@ func TestSelectAzureCredential_DefaultChain(t *testing.T) {
 	_, isWIF := cred.(*azidentity.WorkloadIdentityCredential)
 	require.False(t, isWIF, "no vault cred + no token file must fall through to the default chain, not WorkloadIdentityCredential")
 }
+
+// unsetFederatedTokenFile clears AZURE_FEDERATED_TOKEN_FILE for the duration of
+// the test and restores whatever was there before.
+func unsetFederatedTokenFile(t *testing.T) {
+	t.Helper()
+	prev, ok := os.LookupEnv("AZURE_FEDERATED_TOKEN_FILE")
+	os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+	t.Cleanup(func() {
+		if ok {
+			os.Setenv("AZURE_FEDERATED_TOKEN_FILE", prev)
+		} else {
+			os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
+		}
+	})
+}
+
+// TestSelectAzureCredential_AuthMethodRestrictsChain asserts that naming an
+// auth method really does narrow the chain rather than just reordering it.
+// Nothing here can build a WorkloadIdentityCredential (no token file anywhere),
+// so a chain restricted to workload identity has to come back empty and error.
+// A chain that had quietly kept the CLI and managed identity probes would have
+// succeeded instead — and gone on to burn ~15s per asset probing them.
+func TestSelectAzureCredential_AuthMethodRestrictsChain(t *testing.T) {
+	unsetFederatedTokenFile(t)
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":   "tid",
+			"client-id":   "cid",
+			"auth-method": "workload-identity",
+		},
+		Credentials: nil,
+	}
+
+	_, err := selectAzureCredential(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no Azure credential source could be configured")
+}
+
+// TestSelectAzureCredential_AuthMethodWorkloadIdentity covers the deployment
+// this option exists for: the inventory names workload identity, the pod's
+// webhook supplies the token file, and no client secret is in play.
+func TestSelectAzureCredential_AuthMethodWorkloadIdentity(t *testing.T) {
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":   "aba673d8-12f8-4315-90c1-848f09d747f1",
+			"client-id":   "f424bc0b-7f95-4270-8ffc-694a52e60b9f",
+			"auth-method": "workload-identity",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
+// TestSelectAzureCredential_AuthMethodBeatsTokenFile asserts that an explicit
+// method selection wins over a federated token file. The file can be a leftover
+// env var from the pod spec, so it must not silently override what the
+// inventory asked for.
+func TestSelectAzureCredential_AuthMethodBeatsTokenFile(t *testing.T) {
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":   "tid",
+			"client-id":   "cid",
+			"auth-method": "cli",
+		},
+		Credentials: nil,
+	}
+
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	_, isWIF := cred.(*azidentity.WorkloadIdentityCredential)
+	require.False(t, isWIF, "an explicit auth-method must win over a federated token file")
+}
+
+func TestSelectAzureCredential_InvalidAuthMethod(t *testing.T) {
+	conf := &inventory.Config{
+		Options: map[string]string{"auth-method": "workload-identiy"},
+	}
+
+	_, err := selectAzureCredential(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "workload-identiy")
+}

--- a/providers/azure/provider/provider.go
+++ b/providers/azure/provider/provider.go
@@ -53,6 +53,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	certificatePath := flagBytes(flags, "certificate-path")
 	certificateSecret := flagBytes(flags, "certificate-secret")
 	federatedTokenFile := flagBytes(flags, "federated-token-file")
+	authMethod := flagBytes(flags, "auth-method")
 	opts := map[string]string{}
 	creds := []*vault.Credential{}
 
@@ -60,6 +61,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	opts["client-id"] = string(clientId)
 	if len(federatedTokenFile) > 0 {
 		opts[connection.OptionFederatedTokenFile] = string(federatedTokenFile)
+	}
+	if len(authMethod) > 0 {
+		opts[connection.OptionAuthMethod] = string(authMethod)
 	}
 	if len(clientSecret) > 0 {
 		creds = append(creds, &vault.Credential{

--- a/providers/k8s/connection/api/aks_auth.go
+++ b/providers/k8s/connection/api/aks_auth.go
@@ -44,8 +44,10 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 	log.Debug().Msg("attempting to get a bearer token using the kubelogin flow")
 
 	// the managed identity token credential is used for AKS authentication
-	chainedToken, err := azauth.GetDefaultChainedToken(&azidentity.DefaultAzureCredentialOptions{
-		ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
+	chainedToken, err := azauth.GetDefaultChainedToken(&azauth.ChainedTokenOptions{
+		DefaultAzureCredentialOptions: azidentity.DefaultAzureCredentialOptions{
+			ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
+		},
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to get chained token credential for Azure AKS authentication")

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -76,7 +76,7 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 	if len(tenantId) == 0 {
 		return nil, errors.New("ms365 provider requires a tenant-id")
 	}
-	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId)
+	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}


### PR DESCRIPTION
## Problem

An Azure connection with no client secret or certificate falls back to the default sign-in chain, which probes every method in turn. The managed identity probe alone retries for up to 15 seconds before giving up, and **every discovered asset gets its own connection** — so that cost is paid per asset. A scan of a subscription full of assets spends minutes probing credentials it was never going to get, and fills the log with one of these per asset:

```
ERROR → no Azure credentials were provided; trying to sign in with your local Azure CLI session, Azure environment variables, or a managed identity
ERROR x failed to get managed identity token (max retries reached) num_attempts=3
```

Timestamps from a live runner show ~19s burned per asset on a chain that had already definitively failed on the previous one.

## What this does

Connections can name the method(s) they authenticate with, via the `auth-method` option (or `--auth-method`), as a comma-separated list of `cli`, `env`, `managed-identity`, `workload-identity`:

```yaml
spec:
  assets:
  - connections:
    - type: azure
      options:
        client-id: <client-id>
        tenant-id: <tenant-id>
        auth-method: workload-identity
```

That builds a one-link chain — no `az` exec probe, no 3×5s managed identity retry.

- Unset (as well as the explicit `default` / `auto`) keeps the full chain, so nothing changes for callers that don't opt in.
- Values are normalized, so `Workload_Identity` is accepted.
- An unrecognized value is an **error**, not a silent fall-back to the full chain: a typo that quietly reinstated the probing would be invisible in exactly the deployment that asked to avoid it.
- An explicit `auth-method` beats a federated token file, since that file is often a leftover env var in the pod spec. With no `auth-method` set, the existing token-file short-circuit is untouched.

## Workload identity was unreachable anyway

`GetDefaultChainedToken` built its `WorkloadIdentityCredentialOptions` with a `TenantID` but no `ClientID`, and `GetTokenFromCredential` discarded the tenant and client it was handed (it passed an empty `DefaultAzureCredentialOptions{}`). So `NewWorkloadIdentityCredential` fell back to `AZURE_CLIENT_ID` and, absent that, failed to *construct* — at which point `BuildChainedToken` dropped it from the chain without a word. Both values now reach it, along with the federated token file.

## Supporting fixes

- `BuildChainedToken` swallowed every constructor error, so naming one method and getting nothing back surfaced only the SDK's bare `at least one credential required`. When the chain ends up empty it now reports why the named source is unusable.
- The sign-in guidance in `enrichTokenError` names the methods actually tried, and drops the `az login` advice when the CLI was never in the chain.

## API change

`azidentity.DefaultAzureCredentialOptions` has nowhere to put a `ClientID`, so `GetDefaultChainedToken` now takes an `azauth.ChainedTokenOptions` (which embeds it), and `GetTokenFromCredential` takes it as a trailing argument. All in-repo callers are updated.

Two call sites **outside** this repo will need a companion PR when they bump their pinned mql version:
- `server/apps/cnspec-runner/extendedscanner/extended_azure.go` — needs a trailing arg. Worth wiring to `auth-method` off `pCfg.Options` while there: it gates on `scan-vms: "true"` and calls `GetTokenFromCredential` with the same nil credential, so it is a second, independent source of the same log spam in the runner pod.
- `server/cnspec/cli/reporter/azure_service_bus_handler.go` — `&azidentity.DefaultAzureCredentialOptions{}` becomes `&azauth.ChainedTokenOptions{}`.

## Not addressed here

The credential is still rebuilt per asset with no process-level cache, so a scan does N token acquisitions instead of one. Naming the method collapses the per-asset cost from ~15s to near-zero, which makes this much less urgent, but it is still there.

## Test plan

- [x] `go test ./providers-sdk/v1/util/azauth/...` — new coverage for method parsing/normalization/rejection, chain restriction, `ClientID` plumb-through, and the guidance wording
- [x] `go test ./providers/azure/...` — new coverage for the `auth-method` option, its precedence over a token file, and invalid values
- [x] `go build ./...` clean for azure, ms365, k8s, os
- [x] `gofmt` / `go vet` clean
- [x] Provider CLI JSON regenerates with the new `--auth-method` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)