### PR TITLE
🐛 ms365: let the inventory name the sign-in method

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -77,6 +77,12 @@ Notes:
 					Default: "",
 					Desc:    "Passphrase for the authentication certificate file",
 				},
+				{
+					Long:    "auth-method",
+					Type:    plugin.FlagType_String,
+					Default: "",
+					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, managed-identity, workload-identity (default: try all)",
+				},
 			},
 		},
 	},

--- a/providers/ms365/connection/auth_method_test.go
+++ b/providers/ms365/connection/auth_method_test.go
@@ -1,0 +1,28 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// TestNewMs365Connection_InvalidAuthMethod asserts that an unusable auth-method
+// is reported before anything reaches the network. NewMs365Connection signs in
+// and then probes the Graph API to validate the connection, so the parse has to
+// come first for the failure to be about the option rather than about
+// connectivity — and so this test can run offline.
+func TestNewMs365Connection_InvalidAuthMethod(t *testing.T) {
+	_, err := NewMs365Connection(0, &inventory.Asset{}, &inventory.Config{
+		Options: map[string]string{
+			OptionTenantID:   "tid",
+			OptionClientID:   "cid",
+			OptionAuthMethod: "service-principal",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service-principal")
+}

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -26,6 +26,10 @@ const (
 	OptionClientID      = "client-id"
 	OptionOrganization  = "organization"
 	OptionSharepointUrl = "sharepoint-url"
+	// OptionAuthMethod names the sign-in method(s) to use when no client secret
+	// or certificate is supplied, as a comma-separated list of
+	// azauth.CredentialMethod values. Unset means try all of them.
+	OptionAuthMethod = "auth-method"
 )
 
 type Ms365Connection struct {
@@ -76,7 +80,17 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 	if len(tenantId) == 0 {
 		return nil, errors.New("ms365 provider requires a tenant-id")
 	}
-	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId, nil)
+
+	// Without a client secret or certificate we fall back to the sign-in chain,
+	// which probes every method in turn; the managed identity probe alone burns
+	// ~15s before giving up. A keyless connection that knows how it
+	// authenticates can name the method and skip straight to it.
+	methods, err := azauth.ParseCredentialMethods(conf.Options[OptionAuthMethod])
+	if err != nil {
+		return nil, err
+	}
+	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId,
+		&azauth.ChainedTokenOptions{Methods: methods})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}

--- a/providers/ms365/provider/provider.go
+++ b/providers/ms365/provider/provider.go
@@ -39,6 +39,7 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	certificateSecret := flags["certificate-secret"]
 	organization := flags["organization"]
 	sharepointUrl := flags["sharepoint-url"]
+	authMethod := flags["auth-method"]
 
 	opts := map[string]string{}
 	creds := []*vault.Credential{}
@@ -47,6 +48,9 @@ func (s *Service) ParseCLI(req *plugin.ParseCLIReq) (*plugin.ParseCLIRes, error)
 	opts[connection.OptionClientID] = string(clientId.Value)
 	opts[connection.OptionOrganization] = string(organization.Value)
 	opts[connection.OptionSharepointUrl] = string(sharepointUrl.Value)
+	if authMethod != nil && len(authMethod.Value) > 0 {
+		opts[connection.OptionAuthMethod] = string(authMethod.Value)
+	}
 
 	if len(clientSecret.Value) > 0 {
 		creds = append(creds, &vault.Credential{


### PR DESCRIPTION
Follow-up to #9468, which added this for the azure provider. Same bug, same fix, ms365 side.

## Problem

An ms365 connection with no client secret or certificate falls back to the default sign-in chain and probes every method in turn. The managed identity probe alone burns ~15s before giving up. A keyless (workload identity federation) integration carries no credential *by design*, so it pays that on every connection it opens — the root asset and the discovered tenant asset both — and logs a sign-in failure each time:

```
ERROR → no Azure credentials were provided; trying to sign in with your local Azure CLI session, Azure environment variables, or a managed identity
ERROR x failed to get managed identity token (max retries reached) num_attempts=3
```

Less severe than azure, where every discovered asset gets its own connection, but the same wasted probe and the same misleading errors.

## Fix

ms365 connections read the same `auth-method` option (and `--auth-method` flag) the azure provider takes, using the `azauth` API #9468 already landed — `ParseCredentialMethods` plus `ChainedTokenOptions`. Unset keeps the full chain, so nothing changes for callers that don't opt in.

No `FederatedTokenFile` plumbing here, unlike azure: ms365 has no flag for a token file, and `azidentity` falls back to `AZURE_FEDERATED_TOKEN_FILE` on its own.

## Test plan

- [x] `go build ./...` and `go test ./...` clean for `providers/ms365`
- [x] `gofmt` clean; `go vet` clean apart from two pre-existing findings in `resources/users.go` that this branch doesn't touch
- [x] New offline test: an invalid `auth-method` is rejected *before* `NewMs365Connection` reaches the Graph API, so the failure is about the option rather than about connectivity

## Note

The server-side counterpart (setting `auth-method: workload-identity` on keyless ms365 integrations, alongside the azure one) is in mondoohq/server#17900.

🤖 Generated with [Claude Code](https://claude.com/claude-code)