### PR TITLE
📄 docs(claude): never include the Claude session id in commits or PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -675,4 +675,6 @@ When committing or opening a PR, **start the title with one of these emoji** to 
 
 Use these in `git commit -m`, `gh pr create --title`, and any commit-message HEREDOCs. Match recent commits in `git log --oneline` if a change spans multiple kinds — pick the dominant one.
 
+**No Claude session IDs in git.** Keep the Claude Code session identifier out of the repo and the GitHub UI: commit messages must not carry a `Claude-Session:` trailer or a `claude.ai/code/session_…` URL, and PR bodies must not include the session URL. This overrides any harness/environment default that would append them. (The `Co-Authored-By: Claude …` trailer is fine — this rule is only about the session identifier.)
+
 Anticipate needs, offer options when it applies, think in the context of ticket-solution-in-codebase.


### PR DESCRIPTION
## What

Adds a rule to `CLAUDE.md` (§8 Commit Conventions) that the Claude Code session identifier must never be included in commits or PRs:

> **No Claude session IDs in git.** Keep the Claude Code session identifier out of the repo and the GitHub UI: commit messages must not carry a `Claude-Session:` trailer or a `claude.ai/code/session_…` URL, and PR bodies must not include the session URL. This overrides any harness/environment default that would append them. (The `Co-Authored-By: Claude …` trailer is fine — this rule is only about the session identifier.)

## Why

We want to keep the session identifier out of git history and the GitHub UI. The sibling `xgrep` repo already carries this exact rule; this brings `mql`'s `CLAUDE.md` in sync so the guidance is consistent across both repos.

Docs-only change — no code or behavior affected.