### PR TITLE
🌟 os: expose the nginx stream block

### DIFF
--- a/providers/os/resources/nginx.go
+++ b/providers/os/resources/nginx.go
@@ -265,8 +265,11 @@ func (s *mqlNginxConf) parse(file *mqlFile) error {
 		errMap := plugin.TValue[map[string]any]{Error: err, State: plugin.StateIsSet | plugin.StateIsNull}
 		s.Params = errMap
 		s.HttpParams = errMap
+		s.StreamParams = errMap
 		s.Servers = errSlice
 		s.Upstreams = errSlice
+		s.StreamServers = errSlice
+		s.StreamUpstreams = errSlice
 		s.ListenAddresses = errSlice
 		s.Files = errSlice
 		return err
@@ -274,14 +277,19 @@ func (s *mqlNginxConf) parse(file *mqlFile) error {
 
 	mainParams := map[string]any{}
 	httpParams := map[string]any{}
+	streamParams := map[string]any{}
 	var servers []nginxServer
 	var upstreams []nginxUpstream
+	var streamServers []nginxServer
+	var streamUpstreams []nginxUpstream
 	var allListenAddrs []string
 
 	for _, d := range cfg.Directives {
 		switch d.Name {
 		case "http":
 			walkHTTPBlock(d.Block, httpParams, &servers, &upstreams, &allListenAddrs)
+		case "stream":
+			walkStreamBlock(d.Block, streamParams, &streamServers, &streamUpstreams)
 		case "events":
 			for _, ed := range d.Block {
 				if !ed.IsBlock() {
@@ -306,6 +314,7 @@ func (s *mqlNginxConf) parse(file *mqlFile) error {
 
 	s.Params = plugin.TValue[map[string]any]{Data: mergedParams, State: plugin.StateIsSet}
 	s.HttpParams = plugin.TValue[map[string]any]{Data: httpParams, State: plugin.StateIsSet}
+	s.StreamParams = plugin.TValue[map[string]any]{Data: streamParams, State: plugin.StateIsSet}
 
 	serverResources, err := nginxServers2Resources(servers, s.MqlRuntime, s.__id)
 	if err != nil {
@@ -318,6 +327,24 @@ func (s *mqlNginxConf) parse(file *mqlFile) error {
 		return err
 	}
 	s.Upstreams = plugin.TValue[[]any]{Data: upstreamResources, State: plugin.StateIsSet}
+
+	// Stream resources take a distinct owner ID: server IDs are built from a
+	// positional index and upstream IDs from the pool name, both of which
+	// restart inside stream{} and would otherwise collide with their http{}
+	// counterparts in the resource cache.
+	streamOwnerID := s.__id + "/stream"
+
+	streamServerResources, err := nginxServers2Resources(streamServers, s.MqlRuntime, streamOwnerID)
+	if err != nil {
+		return err
+	}
+	s.StreamServers = plugin.TValue[[]any]{Data: streamServerResources, State: plugin.StateIsSet}
+
+	streamUpstreamResources, err := nginxUpstreams2Resources(streamUpstreams, s.MqlRuntime, streamOwnerID)
+	if err != nil {
+		return err
+	}
+	s.StreamUpstreams = plugin.TValue[[]any]{Data: streamUpstreamResources, State: plugin.StateIsSet}
 
 	// Deduplicate listen addresses in first-seen order.
 	seen := map[string]bool{}
@@ -365,6 +392,18 @@ func (s *mqlNginxConf) servers(file *mqlFile) ([]any, error) {
 }
 
 func (s *mqlNginxConf) upstreams(file *mqlFile) ([]any, error) {
+	return nil, s.parse(file)
+}
+
+func (s *mqlNginxConf) streamParams(file *mqlFile) (map[string]any, error) {
+	return nil, s.parse(file)
+}
+
+func (s *mqlNginxConf) streamServers(file *mqlFile) ([]any, error) {
+	return nil, s.parse(file)
+}
+
+func (s *mqlNginxConf) streamUpstreams(file *mqlFile) ([]any, error) {
 	return nil, s.parse(file)
 }
 
@@ -429,6 +468,7 @@ type nginxListen struct {
 	Port          int64  // numeric port; 0 if the directive used a unix:/path target
 	SSL           bool   // `ssl` flag present
 	HTTP2         bool   // `http2` flag present
+	UDP           bool   // `udp` flag present (stream listeners only)
 	DefaultServer bool   // `default_server` flag present
 	ProxyProtocol bool   // `proxy_protocol` flag present
 }
@@ -490,6 +530,16 @@ func walkHTTPBlock(directives []nginx.Directive, httpParams map[string]any, serv
 			}
 		}
 	}
+}
+
+// walkStreamBlock processes the stream{} block's directives. A stream server
+// proxies TCP or UDP rather than HTTP, but the block's grammar is identical to
+// http{} — flat directives, server{}, and upstream{} — so the same walker
+// handles both. Stream listeners are deliberately kept out of listenAddresses,
+// which reports the http server blocks.
+func walkStreamBlock(directives []nginx.Directive, streamParams map[string]any, servers *[]nginxServer, upstreams *[]nginxUpstream) {
+	var listenAddrs []string
+	walkHTTPBlock(directives, streamParams, servers, upstreams, &listenAddrs)
 }
 
 // parseNginxServerBlock extracts structured data from a server{} block.
@@ -603,6 +653,8 @@ func parseNginxListen(args []string) nginxListen {
 			l.SSL = true
 		case "http2":
 			l.HTTP2 = true
+		case "udp":
+			l.UDP = true
 		case "default_server", "default":
 			l.DefaultServer = true
 		case "proxy_protocol":
@@ -817,6 +869,7 @@ func nginxServers2Resources(servers []nginxServer, runtime *plugin.Runtime, owne
 				"port":          l.Port,
 				"ssl":           l.SSL,
 				"http2":         l.HTTP2,
+				"udp":           l.UDP,
 				"defaultServer": l.DefaultServer,
 				"proxyProtocol": l.ProxyProtocol,
 			}

--- a/providers/os/resources/nginx_test.go
+++ b/providers/os/resources/nginx_test.go
@@ -151,6 +151,69 @@ func TestWalkHTTPBlock(t *testing.T) {
 	assert.Equal(t, "443 ssl", listenAddrs[1])
 }
 
+func TestWalkStreamBlock(t *testing.T) {
+	// Parse real config text rather than hand-built directives so the test
+	// also covers the tokenizer dropping the trailing comment.
+	directives, err := nginx.Parse(`
+stream {
+    log_format basic '$remote_addr $protocol';
+    upstream postgres {
+        least_conn;
+        server 10.0.0.1:5432 weight=2;
+        server 10.0.0.2:5432 backup;
+    }
+    server {
+        listen 5432 ssl;
+        ssl_protocols TLSv1.2 TLSv1.3; # Dropping SSLv3 (POODLE), TLS 1.0, 1.1
+        ssl_certificate /etc/ssl/db.pem;
+        proxy_pass postgres;
+    }
+    server {
+        listen 53 udp;
+        proxy_pass dns_backend;
+    }
+}
+`)
+	require.NoError(t, err)
+	require.Len(t, directives, 1)
+	require.Equal(t, "stream", directives[0].Name)
+
+	streamParams := map[string]any{}
+	var servers []nginxServer
+	var upstreams []nginxUpstream
+	walkStreamBlock(directives[0].Block, streamParams, &servers, &upstreams)
+
+	assert.Equal(t, "basic $remote_addr $protocol", streamParams["log_format"])
+
+	require.Len(t, upstreams, 1)
+	assert.Equal(t, "postgres", upstreams[0].Name)
+	assert.Equal(t, "least_conn", upstreams[0].LoadBalancingMethod)
+	require.Len(t, upstreams[0].ServerDetails, 2)
+	assert.Equal(t, int64(2), upstreams[0].ServerDetails[0].Weight)
+	assert.True(t, upstreams[0].ServerDetails[1].Backup)
+
+	require.Len(t, servers, 2)
+
+	// The TLS listener: the trailing comment must not reach the value.
+	assert.True(t, servers[0].SSL)
+	assert.Equal(t, "TLSv1.2 TLSv1.3", servers[0].SSLProtocols)
+	assert.Equal(t, "/etc/ssl/db.pem", servers[0].SSLCertificate)
+	assert.Equal(t, "postgres", servers[0].Params["proxy_pass"])
+	require.Len(t, servers[0].Listens, 1)
+	assert.Equal(t, int64(5432), servers[0].Listens[0].Port)
+	assert.False(t, servers[0].Listens[0].UDP)
+
+	// The UDP listener.
+	require.Len(t, servers[1].Listens, 1)
+	assert.Equal(t, int64(53), servers[1].Listens[0].Port)
+	assert.True(t, servers[1].Listens[0].UDP)
+	assert.False(t, servers[1].SSL)
+
+	// Directives that only exist in an http server block stay unset.
+	assert.Empty(t, servers[1].ServerName)
+	assert.Empty(t, servers[1].Locations)
+}
+
 func TestSetNginxParam(t *testing.T) {
 	t.Run("simple param overwrites", func(t *testing.T) {
 		m := map[string]any{}
@@ -407,6 +470,10 @@ func TestParseNginxListen(t *testing.T) {
 		}},
 		{"unix socket", []string{"unix:/var/run/nginx.sock"}, nginxListen{
 			Raw: "unix:/var/run/nginx.sock", Address: "unix:/var/run/nginx.sock",
+		}},
+		{"stream udp", []string{"53", "udp"}, nginxListen{Raw: "53 udp", Port: 53, UDP: true}},
+		{"stream udp on an address", []string{"127.0.0.1:53", "udp", "reuseport"}, nginxListen{
+			Raw: "127.0.0.1:53 udp reuseport", Address: "127.0.0.1", Port: 53, UDP: true,
 		}},
 	}
 	for _, tc := range cases {

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -1574,8 +1574,10 @@ nginx {
 // Parsed Nginx configuration covering flat directives, per-server
 // blocks, upstream backend pools, and listen addresses, merged across
 // the main config and every include fragment. Surfaces TLS settings and
-// response headers per server block for hardening audits. Pass
-// `init(path: "...")` to point at a non-default config file.
+// response headers per server block for hardening audits. TCP and UDP
+// proxying declared in the stream block is covered by streamParams,
+// streamServers, and streamUpstreams. Pass `init(path: "...")` to point
+// at a non-default config file.
 nginx.conf {
   init(path? string)
   // Primary configuration file
@@ -1590,7 +1592,7 @@ nginx.conf {
   workerProcesses(params) string
   // Error log path
   errorLog(params) string
-  // Listen addresses/ports across all server blocks
+  // Listen addresses/ports across the http server blocks
   listenAddresses(file) []string
   // HTTP-level directives (inside http block, outside server blocks)
   httpParams(file) map[string]string
@@ -1598,6 +1600,20 @@ nginx.conf {
   servers(file) []nginx.conf.server
   // Upstream blocks
   upstreams(file) []nginx.conf.upstream
+  // Stream-level directives (inside stream block, outside server blocks)
+  streamParams(file) map[string]string
+  // Server blocks inside the stream block
+  //
+  // TCP and UDP proxy listeners. Each carries its own listen address and
+  // TLS settings, so protocol and cipher checks reach mail, database, and
+  // other non-HTTP traffic that Nginx terminates.
+  streamServers(file) []nginx.conf.server
+  // Upstream blocks inside the stream block
+  //
+  // Backend pools for TCP and UDP proxying, with the load-balancing
+  // method and the per-backend weight, failure threshold, and backup or
+  // down state of each member.
+  streamUpstreams(file) []nginx.conf.upstream
 }
 
 // Nginx server block
@@ -1606,7 +1622,7 @@ private nginx.conf.server @defaults("serverName ssl") {
   serverName string
   // Listen directives (comma-separated if multiple)
   listen string
-  // Listen directives broken out per declaration (port, ssl, http2, defaultServer, proxyProtocol, address, raw)
+  // Listen directives broken out per declaration (port, ssl, http2, udp, defaultServer, proxyProtocol, address, raw)
   listens []dict
   // Document root
   root string

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -3693,6 +3693,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"nginx.conf.upstreams": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNginxConf).GetUpstreams()).ToDataRes(types.Array(types.Resource("nginx.conf.upstream")))
 	},
+	"nginx.conf.streamParams": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNginxConf).GetStreamParams()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"nginx.conf.streamServers": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNginxConf).GetStreamServers()).ToDataRes(types.Array(types.Resource("nginx.conf.server")))
+	},
+	"nginx.conf.streamUpstreams": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlNginxConf).GetStreamUpstreams()).ToDataRes(types.Array(types.Resource("nginx.conf.upstream")))
+	},
 	"nginx.conf.server.serverName": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlNginxConfServer).GetServerName()).ToDataRes(types.String)
 	},
@@ -13859,6 +13868,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"nginx.conf.upstreams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlNginxConf).Upstreams, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"nginx.conf.streamParams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNginxConf).StreamParams, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"nginx.conf.streamServers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNginxConf).StreamServers, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"nginx.conf.streamUpstreams": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlNginxConf).StreamUpstreams, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"nginx.conf.server.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -33196,6 +33217,9 @@ type mqlNginxConf struct {
 	HttpParams      plugin.TValue[map[string]any]
 	Servers         plugin.TValue[[]any]
 	Upstreams       plugin.TValue[[]any]
+	StreamParams    plugin.TValue[map[string]any]
+	StreamServers   plugin.TValue[[]any]
+	StreamUpstreams plugin.TValue[[]any]
 }
 
 // createNginxConf creates a new instance of this resource
@@ -33377,6 +33401,59 @@ func (c *mqlNginxConf) GetUpstreams() *plugin.TValue[[]any] {
 		}
 
 		return c.upstreams(vargFile.Data)
+	})
+}
+
+func (c *mqlNginxConf) GetStreamParams() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.StreamParams, func() (map[string]any, error) {
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.streamParams(vargFile.Data)
+	})
+}
+
+func (c *mqlNginxConf) GetStreamServers() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.StreamServers, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nginx.conf", c.__id, "streamServers")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.streamServers(vargFile.Data)
+	})
+}
+
+func (c *mqlNginxConf) GetStreamUpstreams() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.StreamUpstreams, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("nginx.conf", c.__id, "streamUpstreams")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		vargFile := c.GetFile()
+		if vargFile.Error != nil {
+			return nil, vargFile.Error
+		}
+
+		return c.streamUpstreams(vargFile.Data)
 	})
 }
 

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -1853,6 +1853,9 @@ nginx.conf.server.sslProtocols 13.16.10
 nginx.conf.server.sslSessionTickets 13.16.10
 nginx.conf.server.sslSessionTimeout 13.16.10
 nginx.conf.servers 13.14.1
+nginx.conf.streamParams 13.38.1
+nginx.conf.streamServers 13.38.1
+nginx.conf.streamUpstreams 13.38.1
 nginx.conf.upstream 13.14.1
 nginx.conf.upstream.keepalive 13.16.10
 nginx.conf.upstream.loadBalancingMethod 13.16.10


### PR DESCRIPTION
## Problem

`nginx.conf` walked only the `http{}` and `events{}` blocks. Every other top-level block directive fell into a `default` branch that handles simple directives only, so a `stream{}` block was skipped entirely — its TCP and UDP listeners, their TLS settings, and their backend pools were invisible to MQL even though the parser had already read them.

That matters for TLS audits. An `ssl_protocols` directive on a stream listener terminating Postgres, SMTP, or DNS was unreachable from the resource, so a policy could only inspect it by re-reading raw config lines — which drags any trailing comment along with the value. That is exactly the failure mode behind mondoo-community/workspace-telekom#211, where the stock `# Dropping SSLv3 (POODLE)` comment failed a correctly hardened server.

## Changes

Three new fields on `nginx.conf`:

| Field | Contents |
|---|---|
| `streamParams` | stream-level directives (outside server blocks) |
| `streamServers` | TCP/UDP listeners, each with its own TLS settings |
| `streamUpstreams` | TCP/UDP backend pools |

```
> nginx.conf.streamServers { listen sslProtocols params["proxy_pass"] }
nginx.conf.streamServers: [
  0: { listen: "5432 ssl"  sslProtocols: "TLSv1.2 TLSv1.3"  params[proxy_pass]: "postgres" }
  1: { listen: "53 udp"    sslProtocols: ""                 params[proxy_pass]: "dns" }
]
```

The grammar inside `stream{}` is identical to `http{}` (flat directives, `server{}`, `upstream{}`), so the same walker builds both and the existing `nginx.conf.server` / `nginx.conf.upstream` types are reused.

**Cache-key note.** Stream resources take a distinct owner ID (`<conf>/stream`). Server `__id`s are built from a positional index and upstream `__id`s from the pool name, both of which restart inside `stream{}`; without the namespace an http and a stream server both listening on `80` with no `server_name`, or two pools both named `backend`, would land on the same cache key and return each other's data.

Also parses the `udp` flag on `listen` directives, surfaced as `udp` in the `listens` dict. It is what distinguishes a UDP stream listener from a TCP one and had no representation before.

**Deliberately unchanged:** `listenAddresses` and `params` still report the http side only. Both are used by shipped checks (e.g. `cis-nginx--2.4.1` does `listenAddresses ... containsOnly(["443"])`), and folding stream listeners in would silently change customer results.

## Testing

`TestWalkStreamBlock` parses real config text (so it also covers the tokenizer dropping a trailing comment) and asserts the stream params, the upstream load-balancing method and per-backend weight/backup flags, the TLS listener's `ssl_protocols`, and the UDP listener's flag. `TestParseNginxListen` gains `udp` cases. Full `./providers/os/resources/...` suite passes.

Live-verified against a Debian 13 host with a config declaring both blocks, an http and a stream upstream both named `backend`, and an http and a stream server both listening on `80`:

- each side reports its own data, no cache collision
- `streamServers[0].sslProtocols` reads back as `TLSv1.2 TLSv1.3` from a line carrying `# Dropping SSLv3 (POODLE), TLS 1.0, 1.1`
- `listens[].udp` is `true` for `listen 53 udp` and `false` for `listen 80`
- `listenAddresses`, `servers`, and `upstreams` are unchanged
- a host with no `stream` block reports `streamParams: {}` and empty lists, not an error

## Follow-up

With this in place, TLS checks in `cnspec-enterprise-policies` can cover stream listeners via `nginx.conf.streamServers.map(sslProtocols)` — noted as a coverage gap in mondoohq/cnspec-enterprise-policies#3052.
