### PR TITLE
🎉 os-13.39.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.38.0",
+	Version: "13.39.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.39.0)
- 🌟 os: expose the nginx stream block (#9475)
- ✨ os: collect the Microsoft 365 Apps update channel as a purl qualifier (#9466)
- ✨ os: detect WizOS (Alpine-derivative) and wire apk packages (#9396)