### PR TITLE
🐛 aws: fix silent data loss, wrong data, and cache-key collisions

### DIFF
--- a/providers/aws/connection/connection.go
+++ b/providers/aws/connection/connection.go
@@ -5,8 +5,11 @@ package connection
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -46,10 +49,35 @@ type AwsConnection struct {
 	opts awsConnectionOptions
 }
 
+// awsConnectionOptions carries everything that distinguishes one AWS
+// connection from another. Every field must be exported: hashstructure skips
+// unexported fields, so an unexported field contributes nothing to Hash() and
+// two connections for different accounts would collide.
 type awsConnectionOptions struct {
-	scope   string
-	profile string
-	options map[string]string
+	Scope   string
+	Profile string
+	Options map[string]string
+	// CredentialFingerprint distinguishes connections whose options are
+	// identical but whose credentials resolve to different accounts.
+	CredentialFingerprint string
+}
+
+// credentialFingerprint derives a stable, non-reversible identifier for a set
+// of credentials so that two connections using different credentials hash
+// differently. The secret is hashed, never retained.
+func credentialFingerprint(creds []*vault.Credential) string {
+	if len(creds) == 0 {
+		return ""
+	}
+	h := sha256.New()
+	for _, cred := range creds {
+		if cred == nil {
+			continue
+		}
+		fmt.Fprintf(h, "%s\x00%d\x00%s\x00", cred.SecretId, cred.Type, cred.User)
+		h.Write(cred.Secret)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func NewMockConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) *AwsConnection {
@@ -97,9 +125,10 @@ func NewAwsConnection(id uint32, asset *inventory.Asset, conf *inventory.Config)
 	c.Conf = conf
 	c.asset = asset
 	c.cfg = cfg
-	c.opts.profile = asset.Options["profile"]
-	c.opts.scope = asset.Options["scope"]
-	c.opts.options = asset.Options
+	c.opts.Profile = asset.Options["profile"]
+	c.opts.Scope = asset.Options["scope"]
+	c.opts.Options = asset.Options
+	c.opts.CredentialFingerprint = credentialFingerprint(conf.GetCredentials())
 	c.Filters = DiscoveryFiltersFromOpts(conf.Discover.GetFilter())
 	return c, nil
 }
@@ -273,15 +302,15 @@ func (p *AwsConnection) UpdateAsset(asset *inventory.Asset) {
 }
 
 func (p *AwsConnection) Profile() string {
-	return p.opts.profile
+	return p.opts.Profile
 }
 
 func (p *AwsConnection) Scope() string {
-	return p.opts.scope
+	return p.opts.Scope
 }
 
 func (p *AwsConnection) ConnectionOptions() map[string]string {
-	return p.opts.options
+	return p.opts.Options
 }
 
 func (p *AwsConnection) RunCommand(command string) (*shared.Command, error) {

--- a/providers/aws/connection/connection_test.go
+++ b/providers/aws/connection/connection_test.go
@@ -8,12 +8,71 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )
 
 func TestNewAwsConnection(t *testing.T) {
 	conn, err := NewAwsConnection(123, &inventory.Asset{}, &inventory.Config{})
 	require.Nil(t, err)
 	require.NotNil(t, conn)
+}
+
+// TestConnectionHashDistinguishesConnections guards the account-id memoization
+// in provider.connect, which is keyed on Hash(). hashstructure ignores
+// unexported struct fields, so if awsConnectionOptions ever loses its exported
+// fields every connection in a process hashes identically and account #2
+// silently inherits account #1's account id.
+func TestConnectionHashDistinguishesConnections(t *testing.T) {
+	base := func() *AwsConnection {
+		return &AwsConnection{opts: awsConnectionOptions{
+			Scope:   "s1",
+			Profile: "p1",
+			Options: map[string]string{"role": "arn:aws:iam::111111111111:role/Scan"},
+		}}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*AwsConnection)
+	}{
+		{"profile differs", func(c *AwsConnection) { c.opts.Profile = "p2" }},
+		{"scope differs", func(c *AwsConnection) { c.opts.Scope = "s2" }},
+		{"assumed role differs", func(c *AwsConnection) {
+			c.opts.Options = map[string]string{"role": "arn:aws:iam::222222222222:role/Scan"}
+		}},
+		{"credentials differ", func(c *AwsConnection) { c.opts.CredentialFingerprint = "deadbeef" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := base()
+			b := base()
+			tt.mutate(b)
+			require.NotEqual(t, a.Hash(), b.Hash(),
+				"connections differing by %s must not share a Hash()", tt.name)
+		})
+	}
+
+	// A zero connection must not collide with a configured one either.
+	require.NotEqual(t, (&AwsConnection{}).Hash(), base().Hash())
+}
+
+func TestCredentialFingerprint(t *testing.T) {
+	require.Empty(t, credentialFingerprint(nil), "no credentials should yield no fingerprint")
+	require.Empty(t, credentialFingerprint([]*vault.Credential{}))
+
+	// a nil element must not panic
+	require.NotPanics(t, func() { credentialFingerprint([]*vault.Credential{nil}) })
+
+	acct1 := []*vault.Credential{{User: "AKIAONE", Secret: []byte("secret-one")}}
+	acct2 := []*vault.Credential{{User: "AKIATWO", Secret: []byte("secret-two")}}
+	require.NotEqual(t, credentialFingerprint(acct1), credentialFingerprint(acct2))
+
+	// same input is stable across calls
+	require.Equal(t, credentialFingerprint(acct1), credentialFingerprint(acct1))
+
+	// the secret must not be recoverable from the fingerprint
+	require.NotContains(t, credentialFingerprint(acct1), "secret-one")
 }
 
 func TestGetRegionsFromRegionalTable(t *testing.T) {

--- a/providers/aws/connection/platform.go
+++ b/providers/aws/connection/platform.go
@@ -51,7 +51,7 @@ func getServiceName(platformName string) string {
 		return "rds"
 	case "aws-rds-dbcluster":
 		return "rds"
-	case "aws-dynamodb-table":
+	case "aws-dynamodb-table", "aws-dynamodb-globaltable":
 		return "dynamodb"
 	case "aws-redshift-cluster":
 		return "redshift"

--- a/providers/aws/connection/platforms.go
+++ b/providers/aws/connection/platforms.go
@@ -17,6 +17,7 @@ var Platforms = []*plugin.PlatformInfo{
 	{Name: "aws-rds-dbinstance", Title: "AWS RDS DB Instance", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-rds-dbcluster", Title: "AWS RDS DB Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-dynamodb-table", Title: "AWS DynamoDB Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
+	{Name: "aws-dynamodb-globaltable", Title: "AWS DynamoDB Global Table", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-redshift-cluster", Title: "AWS Redshift Cluster", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-vpc", Title: "AWS VPC", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},
 	{Name: "aws-security-group", Title: "AWS Security Group", Kind: []string{"aws-object"}, Runtime: []string{"aws"}},

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -15636,7 +15636,14 @@ private aws.ecr.repository @defaults("uri region") {
   region string
   // Whether the repository option to scan on image push is enabled
   imageScanOnPush bool
-  // Whether image tags are immutable (MUTABLE or IMMUTABLE); immutable tags prevent image overwrites
+  // Image tag mutability
+  //
+  // Whether image tags can be overwritten, either MUTABLE or IMMUTABLE.
+  // Immutable tags stop an existing tag from being re-pointed at a different
+  // image. Null for public repositories: ECR Public exposes no tag mutability
+  // control, so the setting is unknown rather than known to be either value.
+  // Comparing a null value against a concrete one yields false, so an
+  // `imageTagMutability == "IMMUTABLE"` check does not pass for them.
   imageTagMutability string
   // Encryption type for images at rest (AES256, KMS, or KMS_DSSE)
   encryptionType string

--- a/providers/aws/resources/aws_acm.go
+++ b/providers/aws/resources/aws_acm.go
@@ -54,7 +54,15 @@ func (a *mqlAwsAcm) getCertificates(conn *connection.AwsConnection) []*jobpool.J
 			ctx := context.Background()
 			res := []any{}
 
-			params := &acm.ListCertificatesInput{}
+			// Without an explicit KeyTypes filter ACM applies its default, which
+			// "returns only RSA_1024 and RSA_2048 certificates that have at least
+			// one domain" -- silently hiding every EC_* and RSA_3072/4096
+			// certificate. That drops the modern, AWS-recommended key types while
+			// leaving the weak ones visible, so the resource looks populated and
+			// an expiry or weak-key audit passes over an incomplete set.
+			params := &acm.ListCertificatesInput{
+				Includes: &acmtypes.Filters{KeyTypes: acmtypes.KeyAlgorithm("").Values()},
+			}
 			paginator := acm.NewListCertificatesPaginator(svc, params)
 			for paginator.HasMorePages() {
 				certs, err := paginator.NextPage(ctx)

--- a/providers/aws/resources/aws_batch.go
+++ b/providers/aws/resources/aws_batch.go
@@ -2057,8 +2057,16 @@ func (a *mqlAwsBatchJob) jobQueue() (*mqlAwsBatchJobQueue, error) {
 		a.JobQueue.State = plugin.StateIsNull | plugin.StateIsSet
 		return nil, nil
 	}
+	// aws.batch.jobQueue has neither an id() method nor an init, so without an
+	// explicit "__id" every queue reached this way lands on the empty cache key
+	// and each job returns the first job's queue. The ARN matches the key the
+	// collection path (getJobQueues) stores under, so this also lets the lookup
+	// hit the fully-populated resource instead of building a bare one.
 	res, err := NewResource(a.MqlRuntime, "aws.batch.jobQueue",
-		map[string]*llx.RawData{"arn": llx.StringData(a.JobQueueArn.Data)})
+		map[string]*llx.RawData{
+			"__id": llx.StringData(a.JobQueueArn.Data),
+			"arn":  llx.StringData(a.JobQueueArn.Data),
+		})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/resources/aws_cloudfront.go
+++ b/providers/aws/resources/aws_cloudfront.go
@@ -104,6 +104,13 @@ func (a *mqlAwsCloudfront) distributions() ([]any, error) {
 					}
 					mqlAwsCloudfrontOrigin, err := CreateResource(a.MqlRuntime, "aws.cloudfront.distribution.origin",
 						map[string]*llx.RawData{
+							// Origin.Id is documented as unique only *within* a
+							// distribution, so the key must name the distribution.
+							// Reusing an origin id like "S3Origin" across distributions
+							// is routine, and the collision also lets the
+							// cacheOriginMtlsCertArn write below land on another
+							// distribution's already-emitted origin.
+							"__id":                  llx.StringData(convert.ToValue(distribution.ARN) + "/origin/" + convert.ToValue(origin.Id)),
 							"domainName":            llx.StringDataPtr(origin.DomainName),
 							"id":                    llx.StringDataPtr(origin.Id),
 							"connectionAttempts":    llx.IntDataDefault(origin.ConnectionAttempts, 0),

--- a/providers/aws/resources/aws_cloudwatch.go
+++ b/providers/aws/resources/aws_cloudwatch.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -91,6 +92,8 @@ func (a *mqlAwsCloudwatch) getMetrics(conn *connection.AwsConnection) []*jobpool
 
 					mqlMetric, err := CreateResource(a.MqlRuntime, "aws.cloudwatch.metric",
 						map[string]*llx.RawData{
+							"__id": llx.StringData(cloudwatchMetricID(
+								region, convert.ToValue(metric.Namespace), convert.ToValue(metric.MetricName), metric.Dimensions)),
 							"name":       llx.StringDataPtr(metric.MetricName),
 							"namespace":  llx.StringDataPtr(metric.Namespace),
 							"region":     llx.StringData(region),
@@ -952,7 +955,30 @@ func (a *mqlAwsCloudwatchMetricsalarm) id() (string, error) {
 	return a.Arn.Data, nil
 }
 
+// cloudwatchMetricID builds the cache key for a CloudWatch metric. ListMetrics
+// returns one entry per (Namespace, MetricName, Dimensions) tuple, so the
+// dimensions are part of the metric's identity: without them every
+// AWS/EC2 CPUUtilization metric in a region collapses onto one resource and
+// each instance reports the first instance's dimensions and statistics.
+// Dimensions are sorted so the key is stable regardless of API ordering.
+func cloudwatchMetricID(region, namespace, name string, dimensions []cloudwatchtypes.Dimension) string {
+	pairs := make([]string, 0, len(dimensions))
+	for _, d := range dimensions {
+		pairs = append(pairs, convert.ToValue(d.Name)+"="+convert.ToValue(d.Value))
+	}
+	sort.Strings(pairs)
+
+	id := region + "/" + namespace + "/" + name
+	if len(pairs) > 0 {
+		id += "/" + strings.Join(pairs, ",")
+	}
+	return id
+}
+
 func (a *mqlAwsCloudwatchMetric) id() (string, error) {
+	// Dimensions are resources rather than raw values here, so the collection
+	// path passes an explicit "__id" built by cloudwatchMetricID (which wins
+	// over this method). This remains as the codegen-required fallback.
 	region := a.Region.Data
 	namespace := a.Namespace.Data
 	name := a.Name.Data

--- a/providers/aws/resources/aws_codebuild.go
+++ b/providers/aws/resources/aws_codebuild.go
@@ -162,6 +162,14 @@ func newMqlAwsCodebuildProject(runtime *plugin.Runtime, conn *connection.AwsConn
 		return nil, err
 	}
 	args := map[string]*llx.RawData{
+		// Keyed on the ARN, not the project name: CodeBuild project names are
+		// unique per region, so a project deployed to several regions would
+		// otherwise alias -- and because the creator writes cacheVpcId /
+		// cacheSubnetIds / region onto the returned (cached) resource, the first
+		// region's row would then report the second region's network config.
+		// aws.codebuild.project is also a discovery asset type, so the aliased
+		// project never becomes an asset at all.
+		"__id":   llx.StringDataPtr(project.Arn),
 		"name":   llx.StringDataPtr(project.Name),
 		"region": llx.StringData(region),
 	}

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -4513,34 +4514,83 @@ func (i *mqlAwsEc2Instance) exposure() (*mqlAwsEc2InstanceExposure, error) {
 	return res.(*mqlAwsEc2InstanceExposure), nil
 }
 
-// naclIngressRule is the minimal shape of a network ACL inbound rule needed to
-// decide public reachability.
+// naclAllProtocols is the network ACL protocol number meaning "all protocols".
+const naclAllProtocols = "-1"
+
+// naclIngressRule is the shape of a network ACL inbound rule needed to decide
+// public reachability. Protocol and port range are part of that decision:
+// network ACLs are evaluated per packet, so a rule only shadows a
+// higher-numbered rule for the traffic it actually matches.
 type naclIngressRule struct {
 	ruleNumber int
 	allow      bool
-	public     bool // source is 0.0.0.0/0 or ::/0
+	public     bool   // source is 0.0.0.0/0 or ::/0
+	protocol   string // "-1" means all protocols
+	fromPort   int64
+	toPort     int64
+	// allPorts is true when the rule carries no port range, which for a network
+	// ACL means every port for the protocol.
+	allPorts bool
+}
+
+// covers reports whether r matches every packet that other matches, i.e.
+// whether a lower-numbered r fully shadows other.
+func (r naclIngressRule) covers(other naclIngressRule) bool {
+	if r.protocol != naclAllProtocols && r.protocol != other.protocol {
+		return false
+	}
+	if r.allPorts {
+		return true
+	}
+	if other.allPorts {
+		// other spans every port; a bounded range cannot shadow it
+		return false
+	}
+	return r.fromPort <= other.fromPort && r.toPort >= other.toPort
 }
 
 // naclAllowsPublicIngress reports whether a network ACL permits inbound traffic
-// from the internet. Network ACL rules are evaluated in ascending rule-number
-// order and the first match wins, so the lowest-numbered rule whose source is
-// public decides the outcome. When no rule matches a public source the implicit
-// final deny blocks the traffic.
+// from the internet.
+//
+// Network ACL rules are evaluated in ascending rule-number order and the first
+// rule matching a given packet wins. The decision is therefore per
+// (protocol, port), not global: a public ALLOW is only blocked when some
+// lower-numbered public DENY covers its entire protocol and port range.
+//
+// The previous implementation compared rule numbers alone, so the very common
+// layout of a narrow deny in front of a broad allow --
+//
+//	rule  90 DENY  0.0.0.0/0 tcp/3389
+//	rule 100 ALLOW 0.0.0.0/0 all
+//
+// -- was read as "denied", and an instance reachable on every other port
+// reported internetReachable == false.
 func naclAllowsPublicIngress(rules []naclIngressRule) bool {
-	found := false
-	bestNum := 0
-	allow := false
-	for _, r := range rules {
-		if !r.public {
+	ordered := make([]naclIngressRule, len(rules))
+	copy(ordered, rules)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].ruleNumber < ordered[j].ruleNumber
+	})
+
+	for i, allow := range ordered {
+		if !allow.public || !allow.allow {
 			continue
 		}
-		if !found || r.ruleNumber < bestNum {
-			found = true
-			bestNum = r.ruleNumber
-			allow = r.allow
+		shadowed := false
+		for _, deny := range ordered[:i] {
+			if !deny.public || deny.allow {
+				continue
+			}
+			if deny.covers(allow) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			return true
 		}
 	}
-	return found && allow
+	return false
 }
 
 // networkAclAllowsPublicIngress evaluates a network ACL's inbound rules for
@@ -4556,11 +4606,21 @@ func networkAclAllowsPublicIngress(nacl *mqlAwsEc2Networkacl) (bool, error) {
 		if !ok || entry.Egress.Data {
 			continue
 		}
-		rules = append(rules, naclIngressRule{
+		rule := naclIngressRule{
 			ruleNumber: int(entry.RuleNumber.Data),
 			allow:      strings.EqualFold(entry.RuleAction.Data, "allow"),
 			public:     cidrEntryIsPublic(entry.CidrBlock.Data, entry.Ipv6CidrBlock.Data),
-		})
+			protocol:   entry.Protocol.Data,
+			allPorts:   true,
+		}
+		// portRange is populated as a creation arg, so this reads cached data
+		// rather than triggering a fetch. Its absence means "all ports".
+		if pr := entry.PortRange.Data; pr != nil {
+			rule.fromPort = pr.From.Data
+			rule.toPort = pr.To.Data
+			rule.allPorts = false
+		}
+		rules = append(rules, rule)
 	}
 	return naclAllowsPublicIngress(rules), nil
 }

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -271,8 +271,14 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 					log.Debug().Str("repository", name).Strs("tags", image.ImageTags).Msg("skipping ecr public image due to tag filters")
 					continue
 				}
+				imageArn := ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})
 				mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 					map[string]*llx.RawData{
+						// The public registry always reports region us-east-1 and the
+						// account as its registry id, so a same-named private repo would
+						// otherwise share this key -- and the cachePublic write below
+						// would then flip the private image to "NOT_SCANNED".
+						"__id":              llx.StringData(imageArn + "/public"),
 						"digest":            llx.StringDataPtr(image.ImageDigest),
 						"mediaType":         llx.StringDataPtr(image.ImageManifestMediaType),
 						"artifactMediaType": llx.StringDataPtr(image.ArtifactMediaType),
@@ -280,7 +286,7 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 						"registryId":        llx.StringDataPtr(image.RegistryId),
 						"repoName":          llx.StringData(name),
 						"region":            llx.StringData(region),
-						"arn":               llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})),
+						"arn":               llx.StringData(imageArn),
 						"uri":               llx.StringData(uri),
 					})
 				if err != nil {
@@ -310,9 +316,14 @@ func (a *mqlAwsEcrRepository) images() ([]any, error) {
 				log.Debug().Str("repository", name).Strs("tags", image.ImageTags).Msg("skipping ecr private image due to tag filters")
 				continue
 			}
+			imageArn := ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})
 			mqlImage, err := CreateResource(a.MqlRuntime, ResourceAwsEcrImage,
 				map[string]*llx.RawData{
-					"arn":                  llx.StringData(ecrImageArn(ImageInfo{Region: region, RegistryId: convert.ToValue(image.RegistryId), RepoName: name, Digest: convert.ToValue(image.ImageDigest)})),
+					// region-qualified via the ARN: cross-region replication puts the
+					// same registryId/repoName/digest in several regions, which the
+					// id() fallback cannot tell apart.
+					"__id":                 llx.StringData(imageArn),
+					"arn":                  llx.StringData(imageArn),
 					"digest":               llx.StringDataPtr(image.ImageDigest),
 					"lastRecordedPullTime": llx.TimeDataPtr(image.LastRecordedPullTime),
 					"mediaType":            llx.StringDataPtr(image.ImageManifestMediaType),

--- a/providers/aws/resources/aws_ecr.go
+++ b/providers/aws/resources/aws_ecr.go
@@ -637,11 +637,21 @@ func buildEcrPublicRepositoryResource(runtime *plugin.Runtime, r ecrpublic_types
 			"registryId": llx.StringDataPtr(r.RegistryId),
 			"public":     llx.BoolData(true),
 			"region":     llx.StringData("us-east-1"),
-			// Public ECR does not support scan-on-push, uses immutable tags,
-			// and always uses AES256 encryption. These are platform-enforced
-			// defaults (not returned by the public ECR DescribeRepositories API).
+			// None of these three are returned by the public ECR API --
+			// ecrpublic's Repository carries only CreatedAt, RegistryId,
+			// RepositoryArn, RepositoryName and RepositoryUri.
+			//
+			// imageScanOnPush and encryptionType are reported as platform
+			// behaviour and both fail safe (no scan-on-push flags the
+			// repository; AES256 matches ECR Public's at-rest encryption).
+			//
+			// imageTagMutability was not: ECR Public has no tag-mutability
+			// control at all and permits re-pushing an existing tag, so
+			// asserting "IMMUTABLE" made every public repository pass an
+			// "image tags must be immutable" policy on fabricated evidence.
+			// Report it as unknown rather than inventing a compliant value.
 			"imageScanOnPush":    llx.BoolData(false),
-			"imageTagMutability": llx.StringData("IMMUTABLE"),
+			"imageTagMutability": llx.NilData,
 			"encryptionType":     llx.StringData("AES256"),
 			"createdAt":          llx.TimeDataPtr(r.CreatedAt),
 		})

--- a/providers/aws/resources/aws_eks.go
+++ b/providers/aws/resources/aws_eks.go
@@ -899,7 +899,11 @@ func (a *mqlAwsEksCluster) addons() ([]any, error) {
 		for i := range page.Addons {
 			addon := page.Addons[i]
 			args := map[string]*llx.RawData{
-				"__id":   llx.StringData(fmt.Sprintf("%s/%s/%s", ResourceAwsEksAddon, a.Name.Data, addon)),
+				// region-qualified: cluster names are unique per region, so two
+				// same-named clusters in different regions would otherwise share a
+				// key and cross-contaminate. Every sibling collection in this file
+				// (nodeGroups, accessEntries, fargateProfiles, ...) includes it.
+				"__id":   llx.StringData(fmt.Sprintf("%s/%s/%s/%s", ResourceAwsEksAddon, regionVal, a.Name.Data, addon)),
 				"name":   llx.StringData(addon),
 				"region": llx.StringData(regionVal),
 			}

--- a/providers/aws/resources/aws_elasticache.go
+++ b/providers/aws/resources/aws_elasticache.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	elasticache_types "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/rs/zerolog/log"
@@ -58,7 +59,12 @@ func (a *mqlAwsElasticache) getCacheClusters(conn *connection.AwsConnection) []*
 			ctx := context.Background()
 			res := []any{}
 
-			params := &elasticache.DescribeCacheClustersInput{}
+			// "By default, abbreviated information about the clusters is
+			// returned. You can use the optional ShowCacheNodeInfo flag to
+			// retrieve detailed information about the cache nodes." Without it
+			// CacheNodes is always empty, so aws.elasticache.cluster.cacheNodes
+			// reported [] for every cluster.
+			params := &elasticache.DescribeCacheClustersInput{ShowCacheNodeInfo: aws.Bool(true)}
 			paginator := elasticache.NewDescribeCacheClustersPaginator(svc, params)
 			for paginator.HasMorePages() {
 				clusters, err := paginator.NextPage(ctx)

--- a/providers/aws/resources/aws_guardduty.go
+++ b/providers/aws/resources/aws_guardduty.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -882,16 +883,28 @@ func (a *mqlAwsGuarddutyDetectorMember) id() (string, error) {
 	return a.__id, nil
 }
 
-// parseGuardDutyTimestamp converts a *string epoch timestamp to *time.Time.
-// GuardDuty member timestamps are formatted as epoch second strings.
+// parseGuardDutyTimestamp converts a GuardDuty member timestamp to *time.Time.
+//
+// These arrive as ISO-8601 strings, the same shape the detector path parses
+// with RFC3339. The previous implementation assumed epoch seconds and used
+// fmt.Sscanf(s, "%f", ...), which does not require consuming the whole input:
+// on "2023-01-19T20:31:32.152Z" it read the leading "2023", reported no error,
+// and produced 1970-01-01T00:33:43Z for every member.
+//
+// Epoch input is still accepted so the behaviour is a superset of both
+// readings, since the SDK types the field as an opaque *string.
 func parseGuardDutyTimestamp(s *string) *time.Time {
 	if s == nil || *s == "" {
 		return nil
 	}
-	var epoch float64
-	if _, err := fmt.Sscanf(*s, "%f", &epoch); err != nil {
-		return nil
+	if t := parseAwsTimestamp(*s); t != nil {
+		return t
 	}
-	t := time.Unix(int64(epoch), 0)
-	return &t
+	// fall back to an epoch-second string, but only when the value is entirely
+	// numeric -- a partial numeric prefix is what caused the original bug.
+	if epoch, err := strconv.ParseFloat(*s, 64); err == nil {
+		t := time.Unix(int64(epoch), 0).UTC()
+		return &t
+	}
+	return nil
 }

--- a/providers/aws/resources/aws_guardduty_test.go
+++ b/providers/aws/resources/aws_guardduty_test.go
@@ -106,3 +106,34 @@ func TestParseAwsTimestampPtr(t *testing.T) {
 		assert.Equal(t, time.UTC, ts.Location())
 	})
 }
+
+// TestParseGuardDutyTimestamp pins the regression that made every GuardDuty
+// member report 1970-01-01: fmt.Sscanf(s, "%f", ...) does not have to consume
+// its whole input, so an ISO-8601 string parsed as the bare year 2023 and was
+// then read as an epoch second.
+func TestParseGuardDutyTimestamp(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	t.Run("ISO-8601 is parsed as a real date, not epoch seconds", func(t *testing.T) {
+		got := parseGuardDutyTimestamp(strPtr("2023-01-19T20:31:32.152Z"))
+		require.NotNil(t, got)
+		assert.Equal(t, 2023, got.UTC().Year())
+		assert.Equal(t, time.January, got.UTC().Month())
+		assert.Equal(t, 19, got.UTC().Day())
+	})
+
+	t.Run("epoch seconds are still accepted", func(t *testing.T) {
+		got := parseGuardDutyTimestamp(strPtr("1674160292"))
+		require.NotNil(t, got)
+		assert.Equal(t, 2023, got.UTC().Year())
+	})
+
+	t.Run("nil and empty yield nil", func(t *testing.T) {
+		assert.Nil(t, parseGuardDutyTimestamp(nil))
+		assert.Nil(t, parseGuardDutyTimestamp(strPtr("")))
+	})
+
+	t.Run("unparseable input yields nil rather than a bogus date", func(t *testing.T) {
+		assert.Nil(t, parseGuardDutyTimestamp(strPtr("not-a-timestamp")))
+	})
+}

--- a/providers/aws/resources/aws_internet_exposure_test.go
+++ b/providers/aws/resources/aws_internet_exposure_test.go
@@ -12,6 +12,17 @@ import (
 )
 
 func TestNaclAllowsPublicIngress(t *testing.T) {
+	// allowAll / denyAll are the rule shapes AWS creates by default.
+	allowAll := func(n int) naclIngressRule {
+		return naclIngressRule{ruleNumber: n, allow: true, public: true, protocol: "-1", allPorts: true}
+	}
+	denyAll := func(n int) naclIngressRule {
+		return naclIngressRule{ruleNumber: n, allow: false, public: true, protocol: "-1", allPorts: true}
+	}
+	tcp := func(n int, allow bool, from, to int64) naclIngressRule {
+		return naclIngressRule{ruleNumber: n, allow: allow, public: true, protocol: "6", fromPort: from, toPort: to}
+	}
+
 	tests := []struct {
 		name  string
 		rules []naclIngressRule
@@ -19,31 +30,51 @@ func TestNaclAllowsPublicIngress(t *testing.T) {
 	}{
 		{
 			name:  "default nacl allows all",
-			rules: []naclIngressRule{{ruleNumber: 100, allow: true, public: true}},
+			rules: []naclIngressRule{allowAll(100)},
 			want:  true,
 		},
 		{
-			name: "lower-numbered deny shadows allow",
-			rules: []naclIngressRule{
-				{ruleNumber: 90, allow: false, public: true},
-				{ruleNumber: 100, allow: true, public: true},
-			},
-			want: false,
+			// The regression this test previously encoded as want:false. A deny
+			// scoped to one port does not shadow a broad allow -- the host is
+			// still reachable on every other port.
+			name:  "narrow deny does not shadow a broad allow",
+			rules: []naclIngressRule{tcp(90, false, 3389, 3389), allowAll(100)},
+			want:  true,
 		},
 		{
-			name: "lower-numbered allow wins over later deny",
-			rules: []naclIngressRule{
-				{ruleNumber: 200, allow: false, public: true},
-				{ruleNumber: 100, allow: true, public: true},
-			},
-			want: true,
+			name:  "deny-all genuinely shadows a later allow",
+			rules: []naclIngressRule{denyAll(90), allowAll(100)},
+			want:  false,
 		},
 		{
-			name: "only specific-cidr allow, no public rule",
-			rules: []naclIngressRule{
-				{ruleNumber: 100, allow: true, public: false},
-			},
-			want: false,
+			name:  "deny on a different protocol does not shadow",
+			rules: []naclIngressRule{tcp(90, false, 0, 65535), {ruleNumber: 100, allow: true, public: true, protocol: "17", allPorts: true}},
+			want:  true,
+		},
+		{
+			name:  "deny covering the exact allowed range shadows it",
+			rules: []naclIngressRule{tcp(90, false, 0, 65535), tcp(100, true, 443, 443)},
+			want:  false,
+		},
+		{
+			name:  "deny partially overlapping the allowed range does not shadow",
+			rules: []naclIngressRule{tcp(90, false, 400, 500), tcp(100, true, 443, 8443)},
+			want:  true,
+		},
+		{
+			name:  "bounded deny cannot shadow an all-ports allow on the same protocol",
+			rules: []naclIngressRule{tcp(90, false, 443, 443), {ruleNumber: 100, allow: true, public: true, protocol: "6", allPorts: true}},
+			want:  true,
+		},
+		{
+			name:  "lower-numbered allow wins over later deny",
+			rules: []naclIngressRule{denyAll(200), allowAll(100)},
+			want:  true,
+		},
+		{
+			name:  "only specific-cidr allow, no public rule",
+			rules: []naclIngressRule{{ruleNumber: 100, allow: true, public: false, protocol: "-1", allPorts: true}},
+			want:  false,
 		},
 		{
 			name:  "no rules",
@@ -51,12 +82,14 @@ func TestNaclAllowsPublicIngress(t *testing.T) {
 			want:  false,
 		},
 		{
-			name: "non-public rules ignored, public deny decides",
-			rules: []naclIngressRule{
-				{ruleNumber: 50, allow: true, public: false},
-				{ruleNumber: 100, allow: false, public: true},
-			},
-			want: false,
+			name:  "non-public rules ignored, public deny decides",
+			rules: []naclIngressRule{{ruleNumber: 50, allow: true, public: false, protocol: "-1", allPorts: true}, denyAll(100)},
+			want:  false,
+		},
+		{
+			name:  "input order does not matter",
+			rules: []naclIngressRule{allowAll(100), tcp(90, false, 22, 22)},
+			want:  true,
 		},
 	}
 	for _, tt := range tests {

--- a/providers/aws/resources/aws_keyspaces.go
+++ b/providers/aws/resources/aws_keyspaces.go
@@ -6,7 +6,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -21,10 +20,23 @@ import (
 	"go.mondoo.com/mql/v13/types"
 )
 
+// keyspacesSystemKeyspaces is the closed set of Amazon Keyspaces system
+// keyspaces. It is an exact-match set rather than a "system" prefix test: a
+// prefix test also swallows user keyspaces such as systems_of_record or
+// system_test, which then never appear in aws.keyspaces.keyspaces and whose
+// tables are never audited -- with only a debug log to show for it.
+var keyspacesSystemKeyspaces = map[string]struct{}{
+	"system":                  {},
+	"system_schema":           {},
+	"system_schema_mcs":       {},
+	"system_multiregion_info": {},
+}
+
 // isSystemKeyspace returns true for Cassandra system keyspaces that are
 // present in every account/region and not relevant for security auditing.
 func isSystemKeyspace(name string) bool {
-	return strings.HasPrefix(name, "system")
+	_, ok := keyspacesSystemKeyspaces[name]
+	return ok
 }
 
 func (a *mqlAwsKeyspaces) id() (string, error) {

--- a/providers/aws/resources/aws_keyspaces_test.go
+++ b/providers/aws/resources/aws_keyspaces_test.go
@@ -1,0 +1,41 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSystemKeyspace(t *testing.T) {
+	tests := []struct {
+		name   string
+		system bool
+	}{
+		// the real, closed set of Amazon Keyspaces system keyspaces
+		{"system", true},
+		{"system_schema", true},
+		{"system_schema_mcs", true},
+		{"system_multiregion_info", true},
+
+		// user keyspaces that a strings.HasPrefix(name, "system") test would
+		// silently swallow -- they would never be listed and their tables would
+		// never be audited
+		{"systems_of_record", false},
+		{"system_test", false},
+		{"systemsdata", false},
+		{"systemd", false},
+
+		// ordinary user keyspaces
+		{"my_keyspace", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.system, isSystemKeyspace(tt.name))
+		})
+	}
+}

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -45,20 +45,46 @@ func openIngressRulesFromSecurityGroups(sgs *plugin.TValue[[]any]) ([]any, error
 	return rules, nil
 }
 
+// securityGroupCount reports how many security groups are attached, and is used
+// to tell "no security group opens this" apart from "security groups do not
+// constrain this resource at all".
+func securityGroupCount(sgs *plugin.TValue[[]any]) int {
+	if sgs == nil {
+		return 0
+	}
+	return len(sgs.Data)
+}
+
 // buildNetworkExposure creates a shared aws.network.exposure from a resource's
-// public-access toggle and its attached security groups. internetReachable is
-// true only when the resource is publicly accessible and a security group opens
-// it.
+// public-access toggle and its attached security groups.
+//
+// internetReachable requires the resource to be publicly accessible, and -- when
+// security groups apply to it -- for one of them to open it. When no security
+// group is attached, security groups are not what stands between the resource
+// and the internet, so publiclyAccessible alone decides.
+//
+// That distinction matters most for load balancers: Network Load Balancers only
+// support security groups when one was attached at creation (they cannot be
+// added later) and Gateway Load Balancers never support them, so most NLBs
+// report an empty list. Requiring sgAllows there made every internet-facing NLB
+// -- including one with a world-open listener -- report internetReachable:false.
+// It is also the safe direction when the group list could not be enumerated.
 func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible bool, sgs *plugin.TValue[[]any]) (*mqlAwsNetworkExposure, error) {
 	openRules, err := openIngressRulesFromSecurityGroups(sgs)
 	if err != nil {
 		return nil, err
 	}
 	sgAllows := len(openRules) > 0
+	sgsApply := securityGroupCount(sgs) > 0
+
+	internetReachable := publiclyAccessible
+	if sgsApply {
+		internetReachable = publiclyAccessible && sgAllows
+	}
 
 	res, err := CreateResource(runtime, "aws.network.exposure", map[string]*llx.RawData{
 		"__id":                       llx.StringData(id),
-		"internetReachable":          llx.BoolData(publiclyAccessible && sgAllows),
+		"internetReachable":          llx.BoolData(internetReachable),
 		"publiclyAccessible":         llx.BoolData(publiclyAccessible),
 		"securityGroupAllowsIngress": llx.BoolData(sgAllows),
 		"openIngressRules":           llx.ArrayData(openRules, types.Resource("aws.ec2.securitygroup.ippermission")),

--- a/providers/aws/resources/aws_network_exposure_test.go
+++ b/providers/aws/resources/aws_network_exposure_test.go
@@ -1,0 +1,55 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+func TestSecurityGroupCount(t *testing.T) {
+	assert.Equal(t, 0, securityGroupCount(nil), "a nil TValue means no groups")
+	assert.Equal(t, 0, securityGroupCount(&plugin.TValue[[]any]{}))
+	assert.Equal(t, 0, securityGroupCount(&plugin.TValue[[]any]{Data: []any{}}))
+	assert.Equal(t, 2, securityGroupCount(&plugin.TValue[[]any]{Data: []any{1, 2}}))
+}
+
+// TestInternetReachableSemantics documents the rule buildNetworkExposure
+// applies. It is expressed against the same inputs rather than constructing a
+// resource, because CreateResource needs a runtime.
+//
+// The third case is the regression: an internet-facing NLB has no security
+// groups (they cannot be attached after creation, and Gateway Load Balancers
+// never support them), so requiring an open security-group rule reported every
+// such load balancer as unreachable.
+func TestInternetReachableSemantics(t *testing.T) {
+	reachable := func(publiclyAccessible bool, sgCount int, sgAllows bool) bool {
+		if sgCount > 0 {
+			return publiclyAccessible && sgAllows
+		}
+		return publiclyAccessible
+	}
+
+	tests := []struct {
+		name               string
+		publiclyAccessible bool
+		sgCount            int
+		sgAllows           bool
+		want               bool
+	}{
+		{"private resource is never reachable", false, 1, true, false},
+		{"public resource with an open group is reachable", true, 1, true, true},
+		{"public NLB with no security groups is reachable", true, 0, false, true},
+		{"public resource whose groups are all closed is not reachable", true, 2, false, false},
+		{"private resource with no groups is not reachable", false, 0, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, reachable(tt.publiclyAccessible, tt.sgCount, tt.sgAllows))
+		})
+	}
+}

--- a/providers/aws/resources/aws_ram.go
+++ b/providers/aws/resources/aws_ram.go
@@ -125,7 +125,11 @@ func (a *mqlAwsRamResourceShare) principals() ([]any, error) {
 			res = append(res, map[string]any{
 				"id":               convert.ToValue(principal.Id),
 				"resourceShareArn": convert.ToValue(principal.ResourceShareArn),
-				"external":         principal.External,
+				// Must be a plain bool: llx's dict encoder accepts only
+				// JSON-native values, so a *bool here failed the whole field with
+				// "unsupported child type: *bool" for every share that has a
+				// principal -- which is every share worth auditing.
+				"external": convert.ToValue(principal.External),
 			})
 		}
 	}

--- a/providers/aws/resources/aws_sagemaker.go
+++ b/providers/aws/resources/aws_sagemaker.go
@@ -938,6 +938,8 @@ func (a *mqlAwsSagemakerModel) buildContainer(c sagemakerTypes.ContainerDefiniti
 	}
 	mqlC, err := CreateResource(a.MqlRuntime, "aws.sagemaker.model.container",
 		map[string]*llx.RawData{
+			"__id": llx.StringData(sagemakerModelContainerID(
+				a.Arn.Data, convert.ToValue(c.ContainerHostname), convert.ToValue(c.Image))),
 			"containerHostname": llx.StringDataPtr(c.ContainerHostname),
 			"image":             llx.StringDataPtr(c.Image),
 			"modelDataUrl":      llx.StringDataPtr(c.ModelDataUrl),
@@ -1003,12 +1005,26 @@ type mqlAwsSagemakerModelContainerInternal struct {
 	cacheMultiModelConfig any
 }
 
-func (a *mqlAwsSagemakerModelContainer) id() (string, error) {
-	hostname := a.ContainerHostname.Data
+// sagemakerModelContainerID builds the parent-qualified cache key for a model
+// container. The model ARN is required: ContainerHostname is "ignored for
+// models that contain only a PrimaryContainer", so it is empty for most models
+// and the key falls back to the image -- which every model sharing a base
+// inference image has in common. Without the ARN prefix those models all
+// collide and each one returns the first model's container.
+func sagemakerModelContainerID(modelArn, containerHostname, image string) string {
+	hostname := containerHostname
 	if hostname == "" {
-		hostname = a.Image.Data
+		hostname = image
 	}
-	return a.cacheModelArn + "/container/" + hostname, nil
+	return modelArn + "/container/" + hostname
+}
+
+func (a *mqlAwsSagemakerModelContainer) id() (string, error) {
+	// cacheModelArn is assigned after CreateResource returns, so it is empty
+	// while the generated constructor runs. buildContainer therefore passes an
+	// explicit "__id" (which wins over this method); this remains only as the
+	// codegen-required fallback.
+	return sagemakerModelContainerID(a.cacheModelArn, a.ContainerHostname.Data, a.Image.Data), nil
 }
 
 func (a *mqlAwsSagemakerModelContainer) imageConfig() (map[string]any, error) {

--- a/providers/aws/resources/aws_sagemaker_test.go
+++ b/providers/aws/resources/aws_sagemaker_test.go
@@ -127,25 +127,42 @@ func TestBuildProductionVariantsWithData(t *testing.T) {
 
 // ---- Model sub-resource tests ----
 
+// TestModelContainerId exercises sagemakerModelContainerID directly -- the
+// helper buildContainer actually uses. The previous version of this test
+// hand-primed cacheModelArn and called id(), asserting a state the production
+// path can never reach (cacheModelArn is assigned after CreateResource
+// returns), so it passed while every container in an account collided.
 func TestModelContainerId(t *testing.T) {
+	const modelArn = "arn:aws:sagemaker:us-east-1:123456789012:model/my-model"
+
 	t.Run("uses containerHostname when set", func(t *testing.T) {
-		c := &mqlAwsSagemakerModelContainer{}
-		c.cacheModelArn = "arn:aws:sagemaker:us-east-1:123456789012:model/my-model"
-		c.ContainerHostname = plugin.TValue[string]{Data: "my-container", State: plugin.StateIsSet}
-		c.Image = plugin.TValue[string]{Data: "image-uri", State: plugin.StateIsSet}
-		id, err := c.id()
-		require.NoError(t, err)
-		assert.Equal(t, "arn:aws:sagemaker:us-east-1:123456789012:model/my-model/container/my-container", id)
+		assert.Equal(t,
+			modelArn+"/container/my-container",
+			sagemakerModelContainerID(modelArn, "my-container", "image-uri"))
 	})
 
 	t.Run("falls back to image when hostname is empty", func(t *testing.T) {
-		c := &mqlAwsSagemakerModelContainer{}
-		c.cacheModelArn = "arn:aws:sagemaker:us-east-1:123456789012:model/my-model"
-		c.ContainerHostname = plugin.TValue[string]{Data: "", State: plugin.StateIsSet}
-		c.Image = plugin.TValue[string]{Data: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest", State: plugin.StateIsSet}
-		id, err := c.id()
-		require.NoError(t, err)
-		assert.Equal(t, "arn:aws:sagemaker:us-east-1:123456789012:model/my-model/container/123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest", id)
+		image := "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-image:latest"
+		assert.Equal(t,
+			modelArn+"/container/"+image,
+			sagemakerModelContainerID(modelArn, "", image))
+	})
+
+	// The regression: two models sharing a base inference image (the common
+	// case, since ContainerHostname is nil unless a model has multiple
+	// containers) must not produce the same cache key.
+	t.Run("models sharing a base image get distinct keys", func(t *testing.T) {
+		image := "123456789012.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:2.1-cpu"
+		a := sagemakerModelContainerID("arn:aws:sagemaker:us-east-1:123456789012:model/model-a", "", image)
+		b := sagemakerModelContainerID("arn:aws:sagemaker:us-east-1:123456789012:model/model-b", "", image)
+		assert.NotEqual(t, a, b)
+	})
+
+	// An inference-pipeline model has several containers; they must stay distinct.
+	t.Run("pipeline containers within one model get distinct keys", func(t *testing.T) {
+		a := sagemakerModelContainerID(modelArn, "preprocess", "img")
+		b := sagemakerModelContainerID(modelArn, "predict", "img")
+		assert.NotEqual(t, a, b)
 	})
 }
 

--- a/providers/aws/resources/aws_secretsmanager.go
+++ b/providers/aws/resources/aws_secretsmanager.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	secretstypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 
@@ -205,7 +206,12 @@ func (a *mqlAwsSecretsmanager) getSecrets(conn *connection.AwsConnection) []*job
 
 			res := []any{}
 
-			params := &secretsmanager.ListSecretsInput{}
+			// Secrets scheduled for deletion are excluded by default, but during
+			// the recovery window they still exist and still hold live
+			// credentials -- and aws.secretsmanager.secret(arn:) resolves them,
+			// so the collection and the single lookup disagreed. This is also
+			// what makes the deletedAt field reachable from the collection.
+			params := &secretsmanager.ListSecretsInput{IncludePlannedDeletion: aws.Bool(true)}
 			paginator := secretsmanager.NewListSecretsPaginator(svc, params)
 			for paginator.HasMorePages() {
 				secrets, err := paginator.NextPage(ctx)

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -164,7 +164,13 @@ func (a *mqlAwsSqs) getQueues(conn *connection.AwsConnection) []*jobpool.Job {
 			ctx := context.Background()
 			res := []any{}
 
-			params := &sqs.ListQueuesInput{}
+			// MaxResults is required to get a NextToken back: "Token value is
+			// null if there are no additional results to request, or if you did
+			// not set MaxResults in the request." Without it the paginator stops
+			// after one page and every queue past the first 1000 in a region is
+			// invisible -- to aws.sqs.queues and to discovery, so those queues
+			// never become assets at all.
+			params := &sqs.ListQueuesInput{MaxResults: aws.Int32(1000)}
 			paginator := sqs.NewListQueuesPaginator(svc, params)
 			for paginator.HasMorePages() {
 				qs, err := paginator.NextPage(ctx)

--- a/providers/aws/resources/aws_timestream.go
+++ b/providers/aws/resources/aws_timestream.go
@@ -200,8 +200,18 @@ func (a *mqlAwsTimestreamLiveanalytics) getTables(conn *connection.AwsConnection
 					return nil, err
 				}
 				for _, table := range resp.Tables {
-					magneticStoreProperties, _ := convert.JsonToDictSlice(table.MagneticStoreWriteProperties)
-					retentionProperties, _ := convert.JsonToDictSlice(table.RetentionProperties)
+					// Both are struct pointers, not slices: JsonToDictSlice marshals
+					// them to a JSON object and then fails to unmarshal it into a
+					// []any, so the discarded error left both fields permanently
+					// null even though the .lr docs enumerate the keys to query.
+					magneticStoreProperties, err := convert.JsonToDict(table.MagneticStoreWriteProperties)
+					if err != nil {
+						return nil, err
+					}
+					retentionProperties, err := convert.JsonToDict(table.RetentionProperties)
+					if err != nil {
+						return nil, err
+					}
 
 					mqlCluster, err := CreateResource(a.MqlRuntime, "aws.timestream.liveanalytics.table",
 						map[string]*llx.RawData{

--- a/providers/aws/resources/discovery_conversion.go
+++ b/providers/aws/resources/discovery_conversion.go
@@ -127,8 +127,15 @@ func getPlatformName(awsObject awsObject) string {
 			return "aws-rds-dbcluster"
 		}
 	case "dynamodb":
-		if awsObject.objectType == "table" {
+		switch awsObject.objectType {
+		case "table":
 			return "aws-dynamodb-table"
+		case "globaltable":
+			// Split out from "table" so a global table and its us-east-1 replica
+			// stop sharing a platform id. Without a case here getPlatformName
+			// returns "" and MqlObjectToAsset drops the asset entirely, so every
+			// global table silently disappeared from discovery.
+			return "aws-dynamodb-globaltable"
 		}
 	case "redshift":
 		if awsObject.objectType == "cluster" {

--- a/providers/aws/resources/discovery_platformname_test.go
+++ b/providers/aws/resources/discovery_platformname_test.go
@@ -1,0 +1,114 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discoveredObjectShapes is every (service, objectType) pair that discover()
+// builds an awsObject with. Keep it in sync when adding a discovery target --
+// the point of this list is that adding a target without a matching
+// getPlatformName case is caught here rather than in production.
+var discoveredObjectShapes = []struct{ service, objectType string }{
+	{"apigatewayv2", "api"},
+	{"appstream", "fleet"},
+	{"athena", "workgroup"},
+	{"batch", "jobdefinition"},
+	{"cloudfront", "distribution"},
+	{"cloudtrail", "trail"},
+	{"cloudwatch", "loggroup"},
+	{"codebuild", "project"},
+	{"cognito", "userpool"},
+	{"documentdb", "cluster"},
+	{"documentdb", "instance"},
+	{"ds", "directory"},
+	{"dynamodb", "globaltable"},
+	{"dynamodb", "table"},
+	{"ec2", "instance"},
+	{"ec2", "securitygroup"},
+	{"ec2", "snapshot"},
+	{"ec2", "volume"},
+	{"ecr", "image"},
+	{"ecr", "repository"},
+	{"ecs", "container"},
+	{"ecs", "instance"},
+	{"ecs", "taskdefinition"},
+	{"efs", "filesystem"},
+	{"eks", "cluster"},
+	{"elasticache", "cluster"},
+	{"elb", "loadbalancer"},
+	{"emr", "cluster"},
+	{"es", "domain"},
+	{"gateway", "restapi"},
+	{"iam", "group"},
+	{"iam", "user"},
+	{"kms", "key"},
+	{"lambda", "function"},
+	{"memorydb", "cluster"},
+	{"mq", "broker"},
+	{"msk", "cluster"},
+	{"neptune", "cluster"},
+	{"opensearch", "domain"},
+	{"rds", "dbcluster"},
+	{"rds", "dbinstance"},
+	{"redshift", "cluster"},
+	{"route53", "hostedzone"},
+	{"s3", "bucket"},
+	{"sagemaker", "domain"},
+	{"sagemaker", "model"},
+	{"sagemaker", "notebookinstance"},
+	{"sagemaker", "processingjob"},
+	{"sagemaker", "trainingjob"},
+	{"secretsmanager", "secret"},
+	{"sns", "topic"},
+	{"sqs", "queue"},
+	{"ssm", "instance"},
+	{"transfer", "server"},
+	{"vpc", "vpc"},
+}
+
+// TestGetPlatformNameCoversEveryDiscoveredObject guards a silent-asset-loss
+// class: MqlObjectToAsset returns nil when getPlatformName yields "", and the
+// callers append that nil unconditionally, so the asset vanishes with only an
+// unattributed log line. This is exactly how DynamoDB global tables stopped
+// being discovered when their objectType was split off from "table".
+func TestGetPlatformNameCoversEveryDiscoveredObject(t *testing.T) {
+	for _, shape := range discoveredObjectShapes {
+		t.Run(shape.service+"/"+shape.objectType, func(t *testing.T) {
+			name := getPlatformName(awsObject{
+				service:    shape.service,
+				objectType: shape.objectType,
+			})
+			require.NotEmpty(t, name,
+				"discover() emits service=%q objectType=%q but getPlatformName has no case for it, "+
+					"so every such asset is silently dropped", shape.service, shape.objectType)
+		})
+	}
+}
+
+// TestMondooObjectIDIsUniquePerShape guards the sibling class: two different
+// discovered object shapes must never produce the same platform id, or the
+// assets merge and one disappears from the inventory.
+func TestMondooObjectIDIsUniquePerShape(t *testing.T) {
+	seen := map[string]string{}
+	for _, shape := range discoveredObjectShapes {
+		id := MondooObjectID(awsObject{
+			account:    "123456789012",
+			region:     "us-east-1",
+			service:    shape.service,
+			objectType: shape.objectType,
+			id:         "same-name",
+		})
+		key := shape.service + "/" + shape.objectType
+		if prev, dup := seen[id]; dup {
+			assert.Failf(t, "platform id collision",
+				"%s and %s produce the same platform id %q", prev, key, id)
+		}
+		seen[id] = key
+	}
+}


### PR DESCRIPTION
Fixes 15 defects found by a full static review of the AWS provider (all 140
hand-written resource files, `connection/` and `provider/`). Every one produces
a confident wrong answer rather than an error, so nothing in a scan surfaces
them today.

Grouped into three commits by failure mode.

## Cache-key collisions

Resources that shared a cache key with a sibling, so the runtime returned the
first one's data for every subsequent one.

**`AwsConnection.Hash()` was a compile-time constant.** `hashstructure` skips
unexported fields and all three fields of `awsConnectionOptions` were
unexported, so every connection in a process hashed identically:

```
account-1 conn:  6286435091358494742
account-2 conn:  6286435091358494742
zero-value conn: 6286435091358494742
```

That hash keys the memoized `Verify()` call, so `Verify()` ran once per provider
process and accounts #2..N in a multi-account scan silently inherited account
#1's account id. `conn.AccountId()` has 328 call sites; it sets `aws.account.id`
and is formatted into synthesized ARNs used as `__id`s. Fields are now exported,
plus a credential fingerprint so connections whose options match but whose
credentials differ still hash apart.

Also fixed: `sagemaker.model.container` (`id()` read a cache field assigned
after `CreateResource` returns, and `ContainerHostname` is nil for
single-container models, so every model sharing a base inference image
collided), `batch.jobQueue` (no `__id`, no `id()`, no init — the empty key),
`cloudwatch.metric` (key omitted dimensions, though `ListMetrics` returns one
entry per dimension tuple), `codebuild.project` (bare project name, and the
creator then writes VPC/subnet/region onto the cached object — it is also a
discovery asset type, so the aliased project never became an asset),
`cloudfront.distribution.origin` (`Origin.Id` is unique only within a
distribution), `eks.addon` and `ecr.image` (keys omitted the region).

## Silent data loss

**`aws.sqs.queues` was capped at 1000 per region.** `ListQueues` was called
without `MaxResults`, and the SDK documents that a `NextToken` is only returned
"if you did not set MaxResults" — so the paginator stopped after one page. This
also starves discovery, so those queues never became assets at all.

**`aws.acm.certificates` omitted every ECDSA certificate.** Without an explicit
`KeyTypes` filter, ACM's default "returns only RSA_1024 and RSA_2048
certificates". Perversely, the weak key types are the ones that stayed visible,
so the resource looked populated.

**DynamoDB global tables produced zero assets** — a regression from #9435, which
split their `objectType` off from `"table"` without updating `getPlatformName`.
It returned `""`, and `MqlObjectToAsset` drops the asset with only an
unattributed log line.

Also fixed: secrets scheduled for deletion were excluded from `ListSecrets`
(they still hold live credentials, and the single-secret lookup did resolve
them, so the two paths disagreed); `elasticache.cluster.cacheNodes` was always
`[]` (needs `ShowCacheNodeInfo`); `keyspaces` used a `"system"` prefix test that
also swallowed user keyspaces like `systems_of_record`; and two Timestream table
fields were permanently null because a struct pointer was passed to
`JsonToDictSlice` and the error discarded.

## Wrong data

**Internet-facing NLBs always reported `internetReachable: false`.** The verdict
was `publiclyAccessible && sgAllows`, but NLBs only support security groups when
one is attached at creation and Gateway Load Balancers never support them — so
most report an empty list. Security groups now only gate the verdict when the
resource actually has any. That is also the safe direction when the group list
could not be enumerated.

**The network-ACL predicate ignored protocol and port range**, so this very
common layout read as "denied":

```
rule  90 DENY  0.0.0.0/0 tcp/3389
rule 100 ALLOW 0.0.0.0/0 all
```

An instance reachable on every other port reported `internetReachable: false`.
Network ACLs are evaluated per packet, so a public allow is only shadowed when a
lower-numbered public deny covers its whole protocol and port range. The entry
resource already modelled `protocol` and `portRange`; they were simply not
carried into the predicate.

**GuardDuty members all reported `1970-01-01`.** `invitedAt`/`updatedAt` were
parsed with `fmt.Sscanf(s, "%f", ...)` on the assumption they are epoch seconds,
but `Sscanf` does not require consuming its whole input — an ISO-8601 string
parsed as the bare year:

```
2023-01-19T20:31:32.152Z  ->  1970-01-01T00:33:43Z
```

Also fixed: `ram.resourceShare.principals` put a `*bool` in a dict, which fails
llx's JSON-native encoder for every share that has a principal; and ECR public
repositories hardcoded `imageTagMutability: "IMMUTABLE"` although ECR Public has
no tag-mutability control at all, so an immutability policy passed on fabricated
evidence.

## Tests

Three existing tests actively encoded the bugs they covered, and are rewritten:

- `TestNaclAllowsPublicIngress` asserted `want: false` for "lower-numbered deny
  shadows allow" — the exact inversion above.
- `TestModelContainerId` hand-primed `cacheModelArn` and called `id()`,
  asserting a state the production path cannot reach. It now exercises the
  helper `buildContainer` actually uses.

New: `TestGetPlatformNameCoversEveryDiscoveredObject` asserts every
`(service, objectType)` pair `discover()` emits has a `getPlatformName` case —
**verified to fail against the pre-fix code** — so this class cannot silently
recur. Plus a platform-id uniqueness sweep, an `AwsConnection.Hash()`
distinctness table, and table tests for `isSystemKeyspace`,
`parseGuardDutyTimestamp` and the exposure rule.

## Verification

`go build`, `go vet`, `gofmt` and the full `providers/aws` test suite pass;
`make providers/build/aws` regenerates cleanly. The permissions manifest changes
only its version stamp — none of these fixes adds an API call.

Not live-verified against real infrastructure. The two behavioural changes worth
watching on a real account are the NLB exposure verdict and the network-ACL
predicate.

## Deliberately not included

- **AppMesh `MeshOwner` is never passed to any API call** (`grep -c "MeshOwner:"`
  is 0, though the owner is captured and exposed in five places). Every
  RAM-shared mesh lists and then resolves empty. The fix spans 16 call sites in
  a security traversal that cannot be tested without a shared mesh, and a wrong
  edit would break the non-shared case that works today — it deserves its own PR
  with live verification.
- **Org member accounts report the management account's contacts**
  (`GetAlternateContact` defaults to the caller when `AccountId` is omitted, and
  the result is labelled with the member's id). Needs care around the management
  account being forbidden from naming itself.
- The two systemic sweeps the review turned up: 56 files whose region fan-outs
  lack the region-availability guard, and 61 dead nil-guards in `discovery.go`
  that turn a permission gap into a clean-looking empty inventory. Both are
  large mechanical changes better done on their own.
