### PR TITLE
🐛 azure: attribute the sign-in log line and stop probing past workload identity

### DIFF
--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -40,6 +40,12 @@ const (
 	CredentialMethodWorkloadIdentity CredentialMethod = "workload-identity"
 )
 
+// Name is the method's canonical name, which is both what auth-method accepts
+// and what the logs and error messages print.
+func (c CredentialMethod) Name() string {
+	return string(c)
+}
+
 // DefaultCredentialMethods is the chain we try when the caller does not name
 // any method, in order.
 //
@@ -71,7 +77,7 @@ func credentialMethodNames(methods []CredentialMethod) string {
 	}
 	names := make([]string, 0, len(methods))
 	for _, m := range methods {
-		names = append(names, string(m))
+		names = append(names, m.Name())
 	}
 	return strings.Join(names, ", ")
 }

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -46,6 +46,10 @@ func (c CredentialMethod) Name() string {
 	return string(c)
 }
 
+// CredentialMethods is a sign-in chain: the methods to try, in the order they
+// are tried. Empty means the default chain, which Effective resolves.
+type CredentialMethods []CredentialMethod
+
 // DefaultCredentialMethods is the chain we try when the caller does not name
 // any method, in order.
 //
@@ -61,35 +65,41 @@ func (c CredentialMethod) Name() string {
 //
 // This also matches azidentity's own DefaultAzureCredential, which orders
 // workload identity ahead of managed identity for the same reason.
-var DefaultCredentialMethods = []CredentialMethod{
+var DefaultCredentialMethods = CredentialMethods{
 	CredentialMethodCLI,
 	CredentialMethodEnv,
 	CredentialMethodWorkloadIdentity,
 	CredentialMethodManagedIdentity,
 }
 
-// effectiveMethods resolves a selection to the chain that will actually be
-// tried: empty means the default chain. Callers resolve once, at the point they
-// take the options, so that everything downstream -- the chain we build, the
-// line we log, the guidance we give when it fails -- is talking about the same
-// list rather than each re-deriving it.
-func effectiveMethods(methods []CredentialMethod) []CredentialMethod {
-	if len(methods) == 0 {
+// Effective resolves a selection to the chain that will actually be tried:
+// empty means the default chain. Callers resolve once, at the point they take
+// the options, so that everything downstream -- the chain we build, the line we
+// log, the guidance we give when it fails -- is talking about the same list
+// rather than each re-deriving it.
+func (c CredentialMethods) Effective() CredentialMethods {
+	if len(c) == 0 {
 		return DefaultCredentialMethods
 	}
-	return methods
+	return c
 }
 
-// credentialMethodNames renders a method selection as a plain list. These are
-// the names auth-method accepts, so a message built from them doubles as a
-// usage hint. It renders what it is given: an unresolved selection is an empty
-// list, not the default chain.
-func credentialMethodNames(methods []CredentialMethod) string {
-	names := make([]string, 0, len(methods))
-	for _, m := range methods {
+// Names renders the selection as a plain list. These are the names auth-method
+// accepts, so a message built from them doubles as a usage hint. It renders
+// what it is given: an unresolved selection is an empty list, not the default
+// chain.
+func (c CredentialMethods) Names() string {
+	names := make([]string, 0, len(c))
+	for _, m := range c {
 		names = append(names, m.Name())
 	}
 	return strings.Join(names, ", ")
+}
+
+// Allows reports whether m is permitted by the selection. An empty selection
+// permits everything.
+func (c CredentialMethods) Allows(m CredentialMethod) bool {
+	return len(c) == 0 || slices.Contains(c, m)
 }
 
 // credentialSource renders a caller name for the logs. Callers that do not name
@@ -111,8 +121,8 @@ func credentialSource(source string) string {
 // chain: the whole point of naming a method is to avoid the slow probing, so a
 // typo that quietly reinstates it would be invisible in exactly the deployment
 // that asked not to have it.
-func ParseCredentialMethods(s string) ([]CredentialMethod, error) {
-	var methods []CredentialMethod
+func ParseCredentialMethods(s string) (CredentialMethods, error) {
+	var methods CredentialMethods
 	for part := range strings.SplitSeq(s, ",") {
 		name := strings.ToLower(strings.TrimSpace(part))
 		name = strings.ReplaceAll(name, "_", "-")
@@ -124,19 +134,13 @@ func ParseCredentialMethods(s string) ([]CredentialMethod, error) {
 		method := CredentialMethod(name)
 		if !slices.Contains(DefaultCredentialMethods, method) {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				strings.TrimSpace(part), credentialMethodNames(DefaultCredentialMethods))
+				strings.TrimSpace(part), DefaultCredentialMethods.Names())
 		}
 		if !slices.Contains(methods, method) {
 			methods = append(methods, method)
 		}
 	}
 	return methods, nil
-}
-
-// AllowsMethod reports whether m is permitted by the selection. An empty
-// selection permits everything.
-func AllowsMethod(methods []CredentialMethod, m CredentialMethod) bool {
-	return len(methods) == 0 || slices.Contains(methods, m)
 }
 
 // ChainedTokenOptions configures the sign-in chain we fall back to when no
@@ -171,7 +175,7 @@ type ChainedTokenOptions struct {
 
 	// Methods restricts the chain to these sources, tried in the given order.
 	// Empty means DefaultCredentialMethods.
-	Methods []CredentialMethod
+	Methods CredentialMethods
 
 	// Source names the caller, e.g. "azure-connection". Sign-in happens in
 	// several places -- one per provider connection, plus helpers that
@@ -273,9 +277,9 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		}),
 	}
 
-	methods := effectiveMethods(options.Methods)
+	methods := options.Methods.Effective()
 	log.Debug().
-		Str("methods", credentialMethodNames(methods)).
+		Str("methods", methods.Names()).
 		Str("source", credentialSource(options.Source)).
 		Bool("federated-token-file", hasFederatedTokenFile(options)).
 		Msg("building the Azure sign-in chain")
@@ -286,7 +290,7 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		resolver, ok := resolvers[method]
 		if !ok {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				method, credentialMethodNames(DefaultCredentialMethods))
+				method, DefaultCredentialMethods.Names())
 		}
 		opts = append(opts, resolver)
 	}
@@ -379,11 +383,11 @@ func GetTokenFromCredential(credential *vault.Credential, options *ChainedTokenO
 	clientId := chainOpts.ClientID
 	// resolved here, once, so the chain we build, the line we log and the
 	// guidance a failure gives all name the same methods
-	chainOpts.Methods = effectiveMethods(chainOpts.Methods)
+	chainOpts.Methods = chainOpts.Methods.Effective()
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
 		log.Info().
-			Str("methods", credentialMethodNames(chainOpts.Methods)).
+			Str("methods", chainOpts.Methods.Names()).
 			Str("source", credentialSource(chainOpts.Source)).
 			Str("tenant-id", tenantId).
 			Str("client-id", clientId).
@@ -427,7 +431,7 @@ type guidedCredential struct {
 	usedDefaultChain bool
 	// methods records which sign-in sources the chain was restricted to, so the
 	// guidance names what we actually tried. Empty means the full chain.
-	methods []CredentialMethod
+	methods CredentialMethods
 }
 
 func (c *guidedCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
@@ -441,7 +445,7 @@ func (c *guidedCredential) GetToken(ctx context.Context, opts policy.TokenReques
 // enrichTokenError wraps a sign-in failure with guidance tailored to how the
 // credential was configured. The original error is always preserved so no
 // diagnostic detail is lost.
-func enrichTokenError(err error, usedDefaultChain bool, methods []CredentialMethod) error {
+func enrichTokenError(err error, usedDefaultChain bool, methods CredentialMethods) error {
 	if !usedDefaultChain {
 		return errors.Wrap(err, "Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret")
 	}
@@ -450,11 +454,11 @@ func enrichTokenError(err error, usedDefaultChain bool, methods []CredentialMeth
 	// credential, so this is normally already the concrete chain. Resolving again
 	// costs nothing and keeps the guidance honest for a credential assembled some
 	// other way, which would otherwise claim we tried nothing at all.
-	methods = effectiveMethods(methods)
+	methods = methods.Effective()
 
 	msg := "Azure sign-in failed. No credentials were provided, so we tried these sign-in methods: " +
-		credentialMethodNames(methods) + ". None of them worked. "
-	if AllowsMethod(methods, CredentialMethodCLI) {
+		methods.Names() + ". None of them worked. "
+	if methods.Allows(CredentialMethodCLI) {
 		msg += "Run `az login` and confirm `az account get-access-token` returns a token, or provide credentials "
 	} else {
 		msg += "Provide credentials "

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -68,13 +68,23 @@ var DefaultCredentialMethods = []CredentialMethod{
 	CredentialMethodManagedIdentity,
 }
 
-// credentialMethodNames renders a method selection as a plain list; an empty
-// selection renders the full default chain. These are the names auth-method
-// accepts, so a message built from them doubles as a usage hint.
-func credentialMethodNames(methods []CredentialMethod) string {
+// effectiveMethods resolves a selection to the chain that will actually be
+// tried: empty means the default chain. Callers resolve once, at the point they
+// take the options, so that everything downstream -- the chain we build, the
+// line we log, the guidance we give when it fails -- is talking about the same
+// list rather than each re-deriving it.
+func effectiveMethods(methods []CredentialMethod) []CredentialMethod {
 	if len(methods) == 0 {
-		methods = DefaultCredentialMethods
+		return DefaultCredentialMethods
 	}
+	return methods
+}
+
+// credentialMethodNames renders a method selection as a plain list. These are
+// the names auth-method accepts, so a message built from them doubles as a
+// usage hint. It renders what it is given: an unresolved selection is an empty
+// list, not the default chain.
+func credentialMethodNames(methods []CredentialMethod) string {
 	names := make([]string, 0, len(methods))
 	for _, m := range methods {
 		names = append(names, m.Name())
@@ -114,7 +124,7 @@ func ParseCredentialMethods(s string) ([]CredentialMethod, error) {
 		method := CredentialMethod(name)
 		if !slices.Contains(DefaultCredentialMethods, method) {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				strings.TrimSpace(part), credentialMethodNames(nil))
+				strings.TrimSpace(part), credentialMethodNames(DefaultCredentialMethods))
 		}
 		if !slices.Contains(methods, method) {
 			methods = append(methods, method)
@@ -263,10 +273,7 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		}),
 	}
 
-	methods := options.Methods
-	if len(methods) == 0 {
-		methods = DefaultCredentialMethods
-	}
+	methods := effectiveMethods(options.Methods)
 	log.Debug().
 		Str("methods", credentialMethodNames(methods)).
 		Str("source", credentialSource(options.Source)).
@@ -279,7 +286,7 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		resolver, ok := resolvers[method]
 		if !ok {
 			return nil, fmt.Errorf("unknown Azure credential method %q, expected one of %s",
-				method, credentialMethodNames(nil))
+				method, credentialMethodNames(DefaultCredentialMethods))
 		}
 		opts = append(opts, resolver)
 	}
@@ -370,6 +377,9 @@ func GetTokenFromCredential(credential *vault.Credential, options *ChainedTokenO
 	}
 	tenantId := chainOpts.TenantID
 	clientId := chainOpts.ClientID
+	// resolved here, once, so the chain we build, the line we log and the
+	// guidance a failure gives all name the same methods
+	chainOpts.Methods = effectiveMethods(chainOpts.Methods)
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
 		log.Info().
@@ -435,6 +445,12 @@ func enrichTokenError(err error, usedDefaultChain bool, methods []CredentialMeth
 	if !usedDefaultChain {
 		return errors.Wrap(err, "Azure sign-in with the provided credentials failed; double-check the tenant ID, client ID, and the certificate or client secret")
 	}
+
+	// GetTokenFromCredential resolves the selection before it builds the
+	// credential, so this is normally already the concrete chain. Resolving again
+	// costs nothing and keeps the guidance honest for a credential assembled some
+	// other way, which would otherwise claim we tried nothing at all.
+	methods = effectiveMethods(methods)
 
 	msg := "Azure sign-in failed. No credentials were provided, so we tried these sign-in methods: " +
 		credentialMethodNames(methods) + ". None of them worked. "

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -332,22 +332,23 @@ func GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile string) (az
 
 // GetTokenFromCredential builds a credential from an explicit client secret or
 // certificate. When there is none, it falls back to the sign-in chain described
-// by options (nil means the full default chain). tenantId and clientId are the
-// authoritative values for the connection and override anything options carries.
-func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId string, options *ChainedTokenOptions) (azcore.TokenCredential, error) {
+// by options (nil means the full default chain).
+//
+// The tenant and client come from options.TenantID and options.ClientID, which
+// both branches read. They used to arrive as positional arguments as well, so
+// the same two values had two homes and the ones passed alongside the options
+// quietly overrode the ones inside them -- a caller that set only the options
+// got them ignored on some paths and honored on others.
+func GetTokenFromCredential(credential *vault.Credential, options *ChainedTokenOptions) (azcore.TokenCredential, error) {
 	var azCred azcore.TokenCredential
 	var err error
 	usedDefaultChain := credential == nil
-	chainOpts := ChainedTokenOptions{}
+	chainOpts := &ChainedTokenOptions{}
 	if options != nil {
-		chainOpts = *options
+		chainOpts = options
 	}
-	if tenantId != "" {
-		chainOpts.TenantID = tenantId
-	}
-	if clientId != "" {
-		chainOpts.ClientID = clientId
-	}
+	tenantId := chainOpts.TenantID
+	clientId := chainOpts.ClientID
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
 		log.Info().
@@ -355,9 +356,9 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 			Str("source", credentialSource(chainOpts.Source)).
 			Str("tenant-id", tenantId).
 			Str("client-id", clientId).
-			Bool("federated-token-file", hasFederatedTokenFile(&chainOpts)).
+			Bool("federated-token-file", hasFederatedTokenFile(chainOpts)).
 			Msg("no Azure credentials were provided, trying the configured sign-in methods")
-		azCred, err = GetDefaultChainedToken(&chainOpts)
+		azCred, err = GetDefaultChainedToken(chainOpts)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating CLI credentials")
 		}

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -42,11 +42,24 @@ const (
 
 // DefaultCredentialMethods is the chain we try when the caller does not name
 // any method, in order.
+//
+// Managed identity goes last because it is the only method that cannot tell us
+// it will not work. The others self-select: NewEnvironmentCredential and
+// NewWorkloadIdentityCredential fail to construct when their configuration is
+// absent, so BuildChainedToken drops them, and the CLI credential fails in
+// milliseconds when `az` is not on PATH. NewManagedIdentityCredential always
+// constructs, and only discovers there is no instance metadata endpoint by
+// asking it -- 5 seconds a try, three tries. Ahead of a method that would have
+// answered, that is 15 seconds burned per connection, which a scan pays once
+// per asset. Behind them, nothing reaches it unless nothing else worked.
+//
+// This also matches azidentity's own DefaultAzureCredential, which orders
+// workload identity ahead of managed identity for the same reason.
 var DefaultCredentialMethods = []CredentialMethod{
 	CredentialMethodCLI,
 	CredentialMethodEnv,
-	CredentialMethodManagedIdentity,
 	CredentialMethodWorkloadIdentity,
+	CredentialMethodManagedIdentity,
 }
 
 // credentialMethodNames renders a method selection as a plain list; an empty
@@ -137,40 +150,15 @@ type ChainedTokenOptions struct {
 	Source string
 }
 
-// federatedTokenFile returns the OIDC token file the options name, falling back
-// to the variable azidentity itself reads. Its presence is what tells us a
-// deployment is set up for workload identity federation.
-func federatedTokenFile(opts *ChainedTokenOptions) string {
+// hasFederatedTokenFile reports whether an OIDC token file is available, from
+// the options or from the variable azidentity itself reads. It is only reported
+// in the logs: a sign-in that walked the whole chain reads very differently
+// depending on whether workload identity federation was even set up here.
+func hasFederatedTokenFile(opts *ChainedTokenOptions) bool {
 	if opts != nil && opts.FederatedTokenFile != "" {
-		return opts.FederatedTokenFile
+		return true
 	}
-	return os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
-}
-
-// resolveMethods decides which sources to try, and in which order. An explicit
-// selection is always honored as given.
-//
-// Without one, a federated token file is unambiguous evidence that this
-// deployment signs in with workload identity federation, so we try that first
-// instead of walking the chain in its default order. The managed identity probe
-// that sits ahead of it retries for up to 15 seconds before giving up, and every
-// connection in a scan pays that -- per asset -- for a source that was never
-// going to answer. The remaining methods stay in the chain behind it, so a
-// deployment that has a stale token file still falls back rather than failing.
-func resolveMethods(opts *ChainedTokenOptions) []CredentialMethod {
-	if opts != nil && len(opts.Methods) > 0 {
-		return opts.Methods
-	}
-	if federatedTokenFile(opts) == "" {
-		return nil
-	}
-	methods := []CredentialMethod{CredentialMethodWorkloadIdentity}
-	for _, m := range DefaultCredentialMethods {
-		if m != CredentialMethodWorkloadIdentity {
-			methods = append(methods, m)
-		}
-	}
-	return methods
+	return os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != ""
 }
 
 type TokenResolverFn (func() (azcore.TokenCredential, error))
@@ -254,14 +242,14 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		}),
 	}
 
-	methods := resolveMethods(options)
+	methods := options.Methods
 	if len(methods) == 0 {
 		methods = DefaultCredentialMethods
 	}
 	log.Debug().
 		Str("methods", credentialMethodNames(methods)).
 		Str("source", credentialSource(options.Source)).
-		Bool("federated-token-file", federatedTokenFile(options) != "").
+		Bool("federated-token-file", hasFederatedTokenFile(options)).
 		Msg("building the Azure sign-in chain")
 
 	// iterate the selection, not the map, so the chain keeps the caller's order
@@ -362,17 +350,12 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 	}
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		// log what will actually be tried, not what was asked for: with no
-		// explicit selection a federated token file moves workload identity to
-		// the front, and a line that still named the default order would send
-		// anyone reading it after the wrong problem
-		chainOpts.Methods = resolveMethods(&chainOpts)
 		log.Info().
 			Str("methods", credentialMethodNames(chainOpts.Methods)).
 			Str("source", credentialSource(chainOpts.Source)).
 			Str("tenant-id", tenantId).
 			Str("client-id", clientId).
-			Bool("federated-token-file", federatedTokenFile(&chainOpts) != "").
+			Bool("federated-token-file", hasFederatedTokenFile(&chainOpts)).
 			Msg("no Azure credentials were provided, trying the configured sign-in methods")
 		azCred, err = GetDefaultChainedToken(&chainOpts)
 		if err != nil {

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -60,6 +61,16 @@ func credentialMethodNames(methods []CredentialMethod) string {
 		names = append(names, string(m))
 	}
 	return strings.Join(names, ", ")
+}
+
+// credentialSource renders a caller name for the logs. Callers that do not name
+// themselves are reported as unknown rather than as an empty field, so a line
+// missing its source reads as a gap to fill instead of a value we chose.
+func credentialSource(source string) string {
+	if source == "" {
+		return "unknown"
+	}
+	return source
 }
 
 // ParseCredentialMethods reads a comma-separated method list, e.g.
@@ -117,6 +128,49 @@ type ChainedTokenOptions struct {
 	// Methods restricts the chain to these sources, tried in the given order.
 	// Empty means DefaultCredentialMethods.
 	Methods []CredentialMethod
+
+	// Source names the caller, e.g. "azure-connection". Sign-in happens in
+	// several places -- one per provider connection, plus helpers that
+	// authenticate alongside them -- and the log line they share otherwise
+	// cannot be attributed to any of them, which matters most in a scan where
+	// one connection is configured correctly and another is not.
+	Source string
+}
+
+// federatedTokenFile returns the OIDC token file the options name, falling back
+// to the variable azidentity itself reads. Its presence is what tells us a
+// deployment is set up for workload identity federation.
+func federatedTokenFile(opts *ChainedTokenOptions) string {
+	if opts != nil && opts.FederatedTokenFile != "" {
+		return opts.FederatedTokenFile
+	}
+	return os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
+}
+
+// resolveMethods decides which sources to try, and in which order. An explicit
+// selection is always honored as given.
+//
+// Without one, a federated token file is unambiguous evidence that this
+// deployment signs in with workload identity federation, so we try that first
+// instead of walking the chain in its default order. The managed identity probe
+// that sits ahead of it retries for up to 15 seconds before giving up, and every
+// connection in a scan pays that -- per asset -- for a source that was never
+// going to answer. The remaining methods stay in the chain behind it, so a
+// deployment that has a stale token file still falls back rather than failing.
+func resolveMethods(opts *ChainedTokenOptions) []CredentialMethod {
+	if opts != nil && len(opts.Methods) > 0 {
+		return opts.Methods
+	}
+	if federatedTokenFile(opts) == "" {
+		return nil
+	}
+	methods := []CredentialMethod{CredentialMethodWorkloadIdentity}
+	for _, m := range DefaultCredentialMethods {
+		if m != CredentialMethodWorkloadIdentity {
+			methods = append(methods, m)
+		}
+	}
+	return methods
 }
 
 type TokenResolverFn (func() (azcore.TokenCredential, error))
@@ -200,10 +254,15 @@ func GetDefaultChainedToken(options *ChainedTokenOptions) (*azidentity.ChainedTo
 		}),
 	}
 
-	methods := options.Methods
+	methods := resolveMethods(options)
 	if len(methods) == 0 {
 		methods = DefaultCredentialMethods
 	}
+	log.Debug().
+		Str("methods", credentialMethodNames(methods)).
+		Str("source", credentialSource(options.Source)).
+		Bool("federated-token-file", federatedTokenFile(options) != "").
+		Msg("building the Azure sign-in chain")
 
 	// iterate the selection, not the map, so the chain keeps the caller's order
 	opts := make([]TokenResolverFn, 0, len(methods))
@@ -303,7 +362,17 @@ func GetTokenFromCredential(credential *vault.Credential, tenantId, clientId str
 	}
 	// fallback to default authorizer if no credentials are specified
 	if credential == nil {
-		log.Info().Str("methods", credentialMethodNames(chainOpts.Methods)).
+		// log what will actually be tried, not what was asked for: with no
+		// explicit selection a federated token file moves workload identity to
+		// the front, and a line that still named the default order would send
+		// anyone reading it after the wrong problem
+		chainOpts.Methods = resolveMethods(&chainOpts)
+		log.Info().
+			Str("methods", credentialMethodNames(chainOpts.Methods)).
+			Str("source", credentialSource(chainOpts.Source)).
+			Str("tenant-id", tenantId).
+			Str("client-id", clientId).
+			Bool("federated-token-file", federatedTokenFile(&chainOpts) != "").
 			Msg("no Azure credentials were provided, trying the configured sign-in methods")
 		azCred, err = GetDefaultChainedToken(&chainOpts)
 		if err != nil {

--- a/providers-sdk/v1/util/azauth/token.go
+++ b/providers-sdk/v1/util/azauth/token.go
@@ -125,12 +125,27 @@ func AllowsMethod(methods []CredentialMethod, m CredentialMethod) bool {
 
 // ChainedTokenOptions configures the sign-in chain we fall back to when no
 // explicit credential (client secret or certificate) is available.
+//
+// This used to embed azidentity.DefaultAzureCredentialOptions, of which we only
+// ever read three fields, and the embed put TenantID a level down from the
+// ClientID sitting right beside it -- so callers set the two halves of one
+// identity in two different places, and only one of them could be written in
+// the struct literal.
 type ChainedTokenOptions struct {
-	azidentity.DefaultAzureCredentialOptions
+	// ClientOptions carries the cloud and transport configuration to give every
+	// credential in the chain, e.g. a sovereign cloud endpoint.
+	ClientOptions azcore.ClientOptions
+
+	// DisableInstanceDiscovery skips the Entra metadata request that validates
+	// the authority, for tenants in private clouds that cannot reach it.
+	DisableInstanceDiscovery bool
+
+	// TenantID of the Entra tenant to sign in to. Empty leaves each credential
+	// to its own default, which for workload identity is AZURE_TENANT_ID.
+	TenantID string
 
 	// ClientID of the service principal to sign in as. Workload identity needs
-	// it and errors out without one; empty falls back to AZURE_CLIENT_ID. The
-	// tenant comes from the embedded DefaultAzureCredentialOptions.TenantID.
+	// it and errors out without one; empty falls back to AZURE_CLIENT_ID.
 	ClientID string
 
 	// FederatedTokenFile is the path to the OIDC token that workload identity

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -113,6 +113,46 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 	})
 }
 
+func TestResolveMethods(t *testing.T) {
+	t.Run("an explicit selection is honored as given", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+		methods := resolveMethods(&ChainedTokenOptions{
+			Methods: []CredentialMethod{CredentialMethodManagedIdentity},
+		})
+		assert.Equal(t, []CredentialMethod{CredentialMethodManagedIdentity}, methods)
+	})
+
+	t.Run("no token file anywhere keeps the default order", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		assert.Nil(t, resolveMethods(&ChainedTokenOptions{}))
+		assert.Nil(t, resolveMethods(nil))
+	})
+
+	// the deployment this exists for: a WIF pod whose inventory never named a
+	// method. Probing our way down to workload identity costs ~15s on the
+	// managed identity step alone, once per connection, so it goes first.
+	t.Run("a token file in the options puts workload identity first", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		methods := resolveMethods(&ChainedTokenOptions{FederatedTokenFile: "/tmp/x.jwt"})
+		require.NotEmpty(t, methods)
+		assert.Equal(t, CredentialMethodWorkloadIdentity, methods[0])
+		// the rest stay as fallbacks, so a stale token file still degrades
+		assert.ElementsMatch(t, DefaultCredentialMethods, methods)
+	})
+
+	t.Run("the env var counts as a token file too", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+		methods := resolveMethods(&ChainedTokenOptions{})
+		require.NotEmpty(t, methods)
+		assert.Equal(t, CredentialMethodWorkloadIdentity, methods[0])
+	})
+}
+
+func TestCredentialSource(t *testing.T) {
+	assert.Equal(t, "azure-connection", credentialSource("azure-connection"))
+	assert.Equal(t, "unknown", credentialSource(""))
+}
+
 func TestCredentialMethodNames(t *testing.T) {
 	assert.Equal(t, "workload-identity", credentialMethodNames([]CredentialMethod{CredentialMethodWorkloadIdentity}))
 	// an empty selection stands for the whole chain

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -147,10 +147,20 @@ func TestHasFederatedTokenFile(t *testing.T) {
 	})
 }
 
+func TestEffectiveMethods(t *testing.T) {
+	assert.Equal(t, DefaultCredentialMethods, effectiveMethods(nil))
+	assert.Equal(t, DefaultCredentialMethods, effectiveMethods([]CredentialMethod{}))
+	assert.Equal(t,
+		[]CredentialMethod{CredentialMethodWorkloadIdentity},
+		effectiveMethods([]CredentialMethod{CredentialMethodWorkloadIdentity}))
+}
+
 func TestCredentialMethodNames(t *testing.T) {
 	assert.Equal(t, "workload-identity", credentialMethodNames([]CredentialMethod{CredentialMethodWorkloadIdentity}))
-	// an empty selection stands for the whole chain, in the order it is tried
-	assert.Equal(t, "cli, env, workload-identity, managed-identity", credentialMethodNames(nil))
+	assert.Equal(t, "cli, env, workload-identity, managed-identity", credentialMethodNames(DefaultCredentialMethods))
+	// it renders what it is given: resolving an empty selection is the caller's
+	// job, done once, rather than something this quietly repeats
+	assert.Equal(t, "", credentialMethodNames(nil))
 }
 
 func TestGuidedCredential_EnrichesErrors(t *testing.T) {

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -113,39 +113,22 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 	})
 }
 
-func TestResolveMethods(t *testing.T) {
-	t.Run("an explicit selection is honored as given", func(t *testing.T) {
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
-		methods := resolveMethods(&ChainedTokenOptions{
-			Methods: []CredentialMethod{CredentialMethodManagedIdentity},
-		})
-		assert.Equal(t, []CredentialMethod{CredentialMethodManagedIdentity}, methods)
-	})
-
-	t.Run("no token file anywhere keeps the default order", func(t *testing.T) {
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
-		assert.Nil(t, resolveMethods(&ChainedTokenOptions{}))
-		assert.Nil(t, resolveMethods(nil))
-	})
-
-	// the deployment this exists for: a WIF pod whose inventory never named a
-	// method. Probing our way down to workload identity costs ~15s on the
-	// managed identity step alone, once per connection, so it goes first.
-	t.Run("a token file in the options puts workload identity first", func(t *testing.T) {
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
-		methods := resolveMethods(&ChainedTokenOptions{FederatedTokenFile: "/tmp/x.jwt"})
-		require.NotEmpty(t, methods)
-		assert.Equal(t, CredentialMethodWorkloadIdentity, methods[0])
-		// the rest stay as fallbacks, so a stale token file still degrades
-		assert.ElementsMatch(t, DefaultCredentialMethods, methods)
-	})
-
-	t.Run("the env var counts as a token file too", func(t *testing.T) {
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
-		methods := resolveMethods(&ChainedTokenOptions{})
-		require.NotEmpty(t, methods)
-		assert.Equal(t, CredentialMethodWorkloadIdentity, methods[0])
-	})
+// Managed identity is the only method that cannot fail fast: the others drop
+// out of the chain at construction (env, workload identity) or in milliseconds
+// (cli), while this one asks the instance metadata endpoint and waits 5s a try,
+// three tries. Anywhere but last, a connection that had a working credential
+// further down the chain still pays those 15 seconds -- once per asset, all
+// scan long.
+func TestDefaultCredentialMethods_ManagedIdentityIsLast(t *testing.T) {
+	require.NotEmpty(t, DefaultCredentialMethods)
+	assert.Equal(t, CredentialMethodManagedIdentity, DefaultCredentialMethods[len(DefaultCredentialMethods)-1])
+	assert.ElementsMatch(t,
+		[]CredentialMethod{
+			CredentialMethodCLI, CredentialMethodEnv,
+			CredentialMethodWorkloadIdentity, CredentialMethodManagedIdentity,
+		},
+		DefaultCredentialMethods,
+		"every method still has to be in the default chain, only the order changed")
 }
 
 func TestCredentialSource(t *testing.T) {
@@ -153,10 +136,24 @@ func TestCredentialSource(t *testing.T) {
 	assert.Equal(t, "unknown", credentialSource(""))
 }
 
+func TestHasFederatedTokenFile(t *testing.T) {
+	t.Run("from the options", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		assert.True(t, hasFederatedTokenFile(&ChainedTokenOptions{FederatedTokenFile: "/tmp/x.jwt"}))
+		assert.False(t, hasFederatedTokenFile(&ChainedTokenOptions{}))
+		assert.False(t, hasFederatedTokenFile(nil))
+	})
+
+	t.Run("from the environment azidentity reads", func(t *testing.T) {
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+		assert.True(t, hasFederatedTokenFile(&ChainedTokenOptions{}))
+	})
+}
+
 func TestCredentialMethodNames(t *testing.T) {
 	assert.Equal(t, "workload-identity", credentialMethodNames([]CredentialMethod{CredentialMethodWorkloadIdentity}))
-	// an empty selection stands for the whole chain
-	assert.Equal(t, "cli, env, managed-identity, workload-identity", credentialMethodNames(nil))
+	// an empty selection stands for the whole chain, in the order it is tried
+	assert.Equal(t, "cli, env, workload-identity, managed-identity", credentialMethodNames(nil))
 }
 
 func TestGuidedCredential_EnrichesErrors(t *testing.T) {

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -36,7 +36,7 @@ func TestParseCredentialMethods(t *testing.T) {
 		methods, err := ParseCredentialMethods("")
 		require.NoError(t, err)
 		assert.Nil(t, methods)
-		assert.True(t, AllowsMethod(methods, CredentialMethodManagedIdentity))
+		assert.True(t, methods.Allows(CredentialMethodManagedIdentity))
 	})
 
 	t.Run("default and auto also mean every method", func(t *testing.T) {
@@ -50,20 +50,20 @@ func TestParseCredentialMethods(t *testing.T) {
 	t.Run("single method", func(t *testing.T) {
 		methods, err := ParseCredentialMethods("workload-identity")
 		require.NoError(t, err)
-		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity}, methods)
-		assert.False(t, AllowsMethod(methods, CredentialMethodManagedIdentity))
+		assert.Equal(t, CredentialMethods{CredentialMethodWorkloadIdentity}, methods)
+		assert.False(t, methods.Allows(CredentialMethodManagedIdentity))
 	})
 
 	t.Run("list keeps the caller's order", func(t *testing.T) {
 		methods, err := ParseCredentialMethods("workload-identity,cli")
 		require.NoError(t, err)
-		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity, CredentialMethodCLI}, methods)
+		assert.Equal(t, CredentialMethods{CredentialMethodWorkloadIdentity, CredentialMethodCLI}, methods)
 	})
 
 	t.Run("normalizes case, spacing, underscores, and duplicates", func(t *testing.T) {
 		methods, err := ParseCredentialMethods(" Workload_Identity , workload-identity ")
 		require.NoError(t, err)
-		assert.Equal(t, []CredentialMethod{CredentialMethodWorkloadIdentity}, methods)
+		assert.Equal(t, CredentialMethods{CredentialMethodWorkloadIdentity}, methods)
 	})
 
 	// a real Azure auth concept that is simply not one of ours, which is the
@@ -85,7 +85,7 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 			TenantID:           "aba673d8-12f8-4315-90c1-848f09d747f1",
 			ClientID:           "f424bc0b-7f95-4270-8ffc-694a52e60b9f",
 			FederatedTokenFile: "/var/run/secrets/azure/tokens/azure-identity-token",
-			Methods:            []CredentialMethod{CredentialMethodWorkloadIdentity},
+			Methods:            CredentialMethods{CredentialMethodWorkloadIdentity},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, cred)
@@ -96,7 +96,7 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 		// and we report the constructor error instead of the SDK's bare
 		// "at least one credential required"
 		_, err := GetDefaultChainedToken(&ChainedTokenOptions{
-			Methods: []CredentialMethod{CredentialMethodWorkloadIdentity},
+			Methods: CredentialMethods{CredentialMethodWorkloadIdentity},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no Azure credential source could be configured")
@@ -104,7 +104,7 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 	})
 
 	t.Run("unknown method is rejected", func(t *testing.T) {
-		_, err := GetDefaultChainedToken(&ChainedTokenOptions{Methods: []CredentialMethod{"nope"}})
+		_, err := GetDefaultChainedToken(&ChainedTokenOptions{Methods: CredentialMethods{"nope"}})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nope")
 	})
@@ -120,7 +120,7 @@ func TestDefaultCredentialMethods_ManagedIdentityIsLast(t *testing.T) {
 	require.NotEmpty(t, DefaultCredentialMethods)
 	assert.Equal(t, CredentialMethodManagedIdentity, DefaultCredentialMethods[len(DefaultCredentialMethods)-1])
 	assert.ElementsMatch(t,
-		[]CredentialMethod{
+		CredentialMethods{
 			CredentialMethodCLI, CredentialMethodEnv,
 			CredentialMethodWorkloadIdentity, CredentialMethodManagedIdentity,
 		},
@@ -147,20 +147,27 @@ func TestHasFederatedTokenFile(t *testing.T) {
 	})
 }
 
-func TestEffectiveMethods(t *testing.T) {
-	assert.Equal(t, DefaultCredentialMethods, effectiveMethods(nil))
-	assert.Equal(t, DefaultCredentialMethods, effectiveMethods([]CredentialMethod{}))
+func TestCredentialMethods_Effective(t *testing.T) {
+	assert.Equal(t, DefaultCredentialMethods, CredentialMethods(nil).Effective())
+	assert.Equal(t, DefaultCredentialMethods, CredentialMethods{}.Effective())
 	assert.Equal(t,
-		[]CredentialMethod{CredentialMethodWorkloadIdentity},
-		effectiveMethods([]CredentialMethod{CredentialMethodWorkloadIdentity}))
+		CredentialMethods{CredentialMethodWorkloadIdentity},
+		CredentialMethods{CredentialMethodWorkloadIdentity}.Effective())
 }
 
-func TestCredentialMethodNames(t *testing.T) {
-	assert.Equal(t, "workload-identity", credentialMethodNames([]CredentialMethod{CredentialMethodWorkloadIdentity}))
-	assert.Equal(t, "cli, env, workload-identity, managed-identity", credentialMethodNames(DefaultCredentialMethods))
+func TestCredentialMethods_Allows(t *testing.T) {
+	// an empty selection is not yet resolved, so it permits everything
+	assert.True(t, CredentialMethods(nil).Allows(CredentialMethodManagedIdentity))
+	assert.True(t, DefaultCredentialMethods.Allows(CredentialMethodCLI))
+	assert.False(t, CredentialMethods{CredentialMethodWorkloadIdentity}.Allows(CredentialMethodCLI))
+}
+
+func TestCredentialMethods_Names(t *testing.T) {
+	assert.Equal(t, "workload-identity", CredentialMethods{CredentialMethodWorkloadIdentity}.Names())
+	assert.Equal(t, "cli, env, workload-identity, managed-identity", DefaultCredentialMethods.Names())
 	// it renders what it is given: resolving an empty selection is the caller's
 	// job, done once, rather than something this quietly repeats
-	assert.Equal(t, "", credentialMethodNames(nil))
+	assert.Equal(t, "", CredentialMethods(nil).Names())
 }
 
 func TestGuidedCredential_EnrichesErrors(t *testing.T) {
@@ -191,7 +198,7 @@ func TestGuidedCredential_EnrichesErrors(t *testing.T) {
 		cred := &guidedCredential{
 			inner:            &fakeCredential{err: errors.New("boom")},
 			usedDefaultChain: true,
-			methods:          []CredentialMethod{CredentialMethodWorkloadIdentity},
+			methods:          CredentialMethods{CredentialMethodWorkloadIdentity},
 		}
 		_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
 		require.Error(t, err)

--- a/providers-sdk/v1/util/azauth/token_test.go
+++ b/providers-sdk/v1/util/azauth/token_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,9 +82,7 @@ func TestGetDefaultChainedToken_RestrictsChain(t *testing.T) {
 		// credential coming back at all proves ClientID was passed through
 		// rather than left to AZURE_CLIENT_ID.
 		cred, err := GetDefaultChainedToken(&ChainedTokenOptions{
-			DefaultAzureCredentialOptions: azidentity.DefaultAzureCredentialOptions{
-				TenantID: "aba673d8-12f8-4315-90c1-848f09d747f1",
-			},
+			TenantID:           "aba673d8-12f8-4315-90c1-848f09d747f1",
 			ClientID:           "f424bc0b-7f95-4270-8ffc-694a52e60b9f",
 			FederatedTokenFile: "/var/run/secrets/azure/tokens/azure-identity-token",
 			Methods:            []CredentialMethod{CredentialMethodWorkloadIdentity},

--- a/providers/azure/config/config.go
+++ b/providers/azure/config/config.go
@@ -121,7 +121,7 @@ Examples run in the Azure CLI:
 					Long:    "auth-method",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, managed-identity, workload-identity (default: try all)",
+					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, workload-identity, managed-identity (default: try all, in that order)",
 				},
 				{
 					Long:    "filters",

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -91,14 +91,13 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 	}
 	// an empty token file leaves azidentity to fall back to
 	// AZURE_FEDERATED_TOKEN_FILE, so only the option needs forwarding here
-	chainOpts := &azauth.ChainedTokenOptions{
+	token, err := azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
+		TenantID:           conf.Options["tenant-id"],
 		ClientID:           conf.Options["client-id"],
 		FederatedTokenFile: conf.Options["azure-federated-token-file"],
 		Methods:            methods,
 		Source:             "azure-snapshot-connection",
-	}
-	chainOpts.TenantID = conf.Options["tenant-id"]
-	token, err := azauth.GetTokenFromCredential(cred, chainOpts)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -91,12 +91,14 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 	}
 	// an empty token file leaves azidentity to fall back to
 	// AZURE_FEDERATED_TOKEN_FILE, so only the option needs forwarding here
-	token, err := azauth.GetTokenFromCredential(cred, conf.Options["tenant-id"], conf.Options["client-id"],
-		&azauth.ChainedTokenOptions{
-			FederatedTokenFile: conf.Options["azure-federated-token-file"],
-			Methods:            methods,
-			Source:             "azure-snapshot-connection",
-		})
+	chainOpts := &azauth.ChainedTokenOptions{
+		ClientID:           conf.Options["client-id"],
+		FederatedTokenFile: conf.Options["azure-federated-token-file"],
+		Methods:            methods,
+		Source:             "azure-snapshot-connection",
+	}
+	chainOpts.TenantID = conf.Options["tenant-id"]
+	token, err := azauth.GetTokenFromCredential(cred, chainOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/connection/azureinstancesnapshot/provider.go
+++ b/providers/azure/connection/azureinstancesnapshot/provider.go
@@ -95,6 +95,7 @@ func NewAzureSnapshotConnection(id uint32, conf *inventory.Config, asset *invent
 		&azauth.ChainedTokenOptions{
 			FederatedTokenFile: conf.Options["azure-federated-token-file"],
 			Methods:            methods,
+			Source:             "azure-snapshot-connection",
 		})
 	if err != nil {
 		return nil, err

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -74,14 +74,17 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 		federatedTokenFile = os.Getenv("AZURE_FEDERATED_TOKEN_FILE")
 	}
 
-	// A token file with no method selection is unambiguously workload identity
-	// federation; azauth puts that method first rather than probing its way
-	// down to it. This used to shortcut straight to a bare workload identity
-	// credential here, which skipped the sign-in log line entirely -- so a
-	// connection that authenticated this way was invisible, and the only
-	// connections that showed up in the logs were the ones configured
-	// differently. Every path now goes through GetTokenFromCredential and says
-	// who it was.
+	// A token file with no method selection used to shortcut straight to a bare
+	// workload identity credential here, on the grounds that there was nothing
+	// left to probe. It cost more than it saved: the shortcut logged nothing, so
+	// a connection that authenticated this way was invisible and the only
+	// sign-ins in the logs were the ones configured some other way -- and the
+	// credential it returned had no chain behind it, so a stale token file was
+	// the end of the road rather than a fall back to the remaining methods.
+	//
+	// The chain is cheap to walk now that the managed identity probe sits at the
+	// end of it (see azauth.DefaultCredentialMethods), so there is nothing left
+	// to shortcut past.
 	return azauth.GetTokenFromCredential(cred, tenantId, clientId, &azauth.ChainedTokenOptions{
 		FederatedTokenFile: federatedTokenFile,
 		Methods:            methods,

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -65,7 +65,7 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	}
 
 	var cred *vault.Credential
-	if len(conf.Credentials) != 0 {
+	if len(conf.Credentials) > 0 {
 		cred = conf.Credentials[0]
 	}
 

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -75,15 +75,17 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	}
 
 	// A token file with no method selection is unambiguously workload identity
-	// federation, so there is nothing to probe. Once a selection exists it
-	// decides instead: the file can be a leftover env var from the pod spec,
-	// and a selection that rules workload identity out has to be honored.
-	if cred == nil && federatedTokenFile != "" && len(methods) == 0 {
-		return azauth.GetWorkloadIdentityToken(tenantId, clientId, federatedTokenFile)
-	}
+	// federation; azauth puts that method first rather than probing its way
+	// down to it. This used to shortcut straight to a bare workload identity
+	// credential here, which skipped the sign-in log line entirely -- so a
+	// connection that authenticated this way was invisible, and the only
+	// connections that showed up in the logs were the ones configured
+	// differently. Every path now goes through GetTokenFromCredential and says
+	// who it was.
 	return azauth.GetTokenFromCredential(cred, tenantId, clientId, &azauth.ChainedTokenOptions{
 		FederatedTokenFile: federatedTokenFile,
 		Methods:            methods,
+		Source:             "azure-connection",
 	})
 }
 

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -85,11 +85,14 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	// The chain is cheap to walk now that the managed identity probe sits at the
 	// end of it (see azauth.DefaultCredentialMethods), so there is nothing left
 	// to shortcut past.
-	return azauth.GetTokenFromCredential(cred, tenantId, clientId, &azauth.ChainedTokenOptions{
+	chainOpts := &azauth.ChainedTokenOptions{
+		ClientID:           clientId,
 		FederatedTokenFile: federatedTokenFile,
 		Methods:            methods,
 		Source:             "azure-connection",
-	})
+	}
+	chainOpts.TenantID = tenantId
+	return azauth.GetTokenFromCredential(cred, chainOpts)
 }
 
 func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {

--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -85,14 +85,13 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	// The chain is cheap to walk now that the managed identity probe sits at the
 	// end of it (see azauth.DefaultCredentialMethods), so there is nothing left
 	// to shortcut past.
-	chainOpts := &azauth.ChainedTokenOptions{
+	return azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
+		TenantID:           tenantId,
 		ClientID:           clientId,
 		FederatedTokenFile: federatedTokenFile,
 		Methods:            methods,
 		Source:             "azure-connection",
-	}
-	chainOpts.TenantID = tenantId
-	return azauth.GetTokenFromCredential(cred, chainOpts)
+	})
 }
 
 func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {

--- a/providers/k8s/connection/api/aks_auth.go
+++ b/providers/k8s/connection/api/aks_auth.go
@@ -48,6 +48,7 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 		DefaultAzureCredentialOptions: azidentity.DefaultAzureCredentialOptions{
 			ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
 		},
+		Source: "k8s-aks-kubelogin",
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to get chained token credential for Azure AKS authentication")

--- a/providers/k8s/connection/api/aks_auth.go
+++ b/providers/k8s/connection/api/aks_auth.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
@@ -45,10 +44,8 @@ func attemptKubeloginAuthFlow(asset *inventory.Asset, config *rest.Config) error
 
 	// the managed identity token credential is used for AKS authentication
 	chainedToken, err := azauth.GetDefaultChainedToken(&azauth.ChainedTokenOptions{
-		DefaultAzureCredentialOptions: azidentity.DefaultAzureCredentialOptions{
-			ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
-		},
-		Source: "k8s-aks-kubelogin",
+		ClientOptions: azcore.ClientOptions{Cloud: cloud.AzurePublic},
+		Source:        "k8s-aks-kubelogin",
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to get chained token credential for Azure AKS authentication")

--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -81,7 +81,7 @@ Notes:
 					Long:    "auth-method",
 					Type:    plugin.FlagType_String,
 					Default: "",
-					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, managed-identity, workload-identity (default: try all)",
+					Desc:    "Comma-separated sign-in methods to use when no client secret or certificate is given: cli, env, workload-identity, managed-identity (default: try all, in that order)",
 				},
 			},
 		},

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -73,7 +73,7 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 	organization := conf.Options[OptionOrganization]
 	sharepointUrl := conf.Options[OptionSharepointUrl]
 	var cred *vault.Credential
-	if len(conf.Credentials) != 0 {
+	if len(conf.Credentials) > 0 {
 		cred = conf.Credentials[0]
 	}
 

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -89,8 +89,13 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 	if err != nil {
 		return nil, err
 	}
-	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId,
-		&azauth.ChainedTokenOptions{Methods: methods, Source: "ms365-connection"})
+	chainOpts := &azauth.ChainedTokenOptions{
+		ClientID: clientId,
+		Methods:  methods,
+		Source:   "ms365-connection",
+	}
+	chainOpts.TenantID = tenantId
+	token, err := azauth.GetTokenFromCredential(cred, chainOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -90,7 +90,7 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 		return nil, err
 	}
 	token, err := azauth.GetTokenFromCredential(cred, tenantId, clientId,
-		&azauth.ChainedTokenOptions{Methods: methods})
+		&azauth.ChainedTokenOptions{Methods: methods, Source: "ms365-connection"})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -89,13 +89,12 @@ func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Confi
 	if err != nil {
 		return nil, err
 	}
-	chainOpts := &azauth.ChainedTokenOptions{
+	token, err := azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
+		TenantID: tenantId,
 		ClientID: clientId,
 		Methods:  methods,
 		Source:   "ms365-connection",
-	}
-	chainOpts.TenantID = tenantId
-	token, err := azauth.GetTokenFromCredential(cred, chainOpts)
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}

--- a/providers/os/connection/container/acr/acr_auth_helper.go
+++ b/providers/os/connection/container/acr/acr_auth_helper.go
@@ -42,7 +42,7 @@ func NewAcrAuthHelperFromToken(tokenFn azauth.TokenResolverFn) *acrAuthHelper {
 
 func NewAcrAuthHelper() *acrAuthHelper {
 	fn := func() (azcore.TokenCredential, error) {
-		return azauth.GetDefaultChainedToken(nil)
+		return azauth.GetDefaultChainedToken(&azauth.ChainedTokenOptions{Source: "acr-auth-helper"})
 	}
 	return NewAcrAuthHelperFromToken(fn)
 }


### PR DESCRIPTION
## Problem

A workload-identity Azure scan logs a sign-in **per asset** that names no method, and pays for it:

```
scan for asset runner-ubk-Etac-Dev-208314 (Azure Compute VM) completed
+0.4s   → no Azure credentials were provided, trying the configured sign-in methods methods=workload-identity
+7.5s   → no Azure credentials were provided, trying the configured sign-in methods methods="cli, env, managed-identity, workload-identity"
+15.0s  x failed to get managed identity token (max retries reached) num_attempts=3
scan for asset agent-uiit-yeah-Dev (Azure Compute VM) completed
```

Two connections per asset, only one carrying `auth-method`. The one without it walks the chain in default order and burns 15s on the managed identity probe before reaching a credential that was always going to answer — once per asset, for the length of the scan.

Working out *which* connection that is was not possible from the logs. The line named neither its caller nor the connection it belonged to, and worse, the connections configured correctly were the only ones it could ever describe: `selectAzureCredential` had a shortcut where a token file with no method selection returned a bare workload identity credential and **logged nothing at all**. So every line came from a connection configured some other way, with no way to tell which one.

## Changes

**Managed identity goes last in the default chain.** It is the only method that cannot tell us it will not work. The others self-select — `NewEnvironmentCredential` and `NewWorkloadIdentityCredential` fail to construct without their configuration and `BuildChainedToken` drops them; the CLI credential fails in milliseconds when `az` is not on PATH. `NewManagedIdentityCredential` always constructs and only discovers there is no instance metadata endpoint by asking it: 5s a try, three tries. Behind the others, nothing reaches it unless nothing else worked. This is also the order azidentity's own `DefaultAzureCredential` uses.

That fixes the 15s stall for any deployment with a working credential earlier in the chain, whether or not `auth-method` ever arrives.

**Attribution.** `ChainedTokenOptions.Source` names the caller, and the log line now carries `source`, `tenant-id`, `client-id`, and whether a federated token file was found:

```
no Azure credentials were provided, trying the configured sign-in methods
  methods="cli, env, workload-identity, managed-identity"
  source=azure-connection tenant-id=… client-id=… federated-token-file=false
```

Sources are set at all five call sites — `azure-connection`, `azure-snapshot-connection`, `ms365-connection`, `k8s-aks-kubelogin`, `acr-auth-helper`. Anything still logging `source=unknown` is a caller left to wire up (cnspec-runner's extended Azure scanner is the remaining one, in the server repo).

**No more silent path.** The shortcut in `selectAzureCredential` is gone; every sign-in goes through `GetTokenFromCredential` and says who it was. This also means the fallback keeps its chain instead of collapsing to a workload-identity-only credential, so a stale token file degrades rather than hard-fails.

**One home for the tenant and client.** `GetTokenFromCredential` took `tenantId` and `clientId` positionally *and* a `ChainedTokenOptions` carrying `ClientID` and (through the embedded `DefaultAzureCredentialOptions`) `TenantID`. The positional pair overrode the options when non-empty, so a caller that set only the options had them honored on the chain path and ignored on the certificate and secret paths. They now come from the options alone.

An explicit `auth-method` selection is still honored exactly as given, in the order given.

## Breaking change for callers outside this repo

`GetTokenFromCredential(cred, tenantId, clientId, opts)` → `GetTokenFromCredential(cred, opts)`. One caller outside mql: `apps/cnspec-runner/extendedscanner/extended_azure.go` in the server repo, which needs the tenant and client moved into the options struct (and can set `Source: "extended-scanner"` while it is there).

## What this does not fix

The second connection per asset still has no `auth-method`, and this PR does not find it — it makes it name itself. Whatever it is, it no longer costs 15s to get past a managed identity endpoint that isn't there.

## Tests

- default chain keeps every method but pins managed identity last
- `hasFederatedTokenFile`: option and `AZURE_FEDERATED_TOKEN_FILE`, nil-safe
- `credentialSource`: passthrough, `unknown` when unset
- existing `providers/azure/connection` tests pass unchanged (vault credential still wins over a token file; a named method still narrows the chain rather than reordering it)

Help text for `--auth-method` in both providers now lists the methods in the order they are tried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)