### PR TITLE
⚡ azure: share one credential per identity across a scan

### DIFF
--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -6,6 +6,7 @@ package connection
 import (
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -44,6 +45,28 @@ type AzureConnection struct {
 	Filters DiscoveryFilters
 }
 
+// The credentials this process has built, by the identity each signs in as.
+//
+// Each discovered asset gets its own connection, and a credential built per
+// connection carries its own token cache, so a scan asked Entra for a fresh
+// token once per asset for an identity that already had a perfectly good one.
+// Discovery found these assets with this credential; it can scan them with it
+// too.
+//
+// Keyed by identity rather than shared outright because an inventory can hold
+// Azure assets under several tenants, and handing tenant A's token to tenant B's
+// asset would not fail cleanly -- it would scan as the wrong principal. Every
+// identity gets the same reuse, so an inventory spanning tenants is one
+// credential per tenant rather than one per asset.
+//
+// The map is bounded by the number of identities a process scans, which is the
+// number of Azure assets in its inventory, not the number of assets discovered
+// beneath them.
+var (
+	credentialMu    sync.Mutex
+	credentialCache = map[string]azcore.TokenCredential{}
+)
+
 // selectAzureCredential chooses the appropriate Azure token credential based on
 // the connection configuration. When a federated token file is provided (via
 // option or env var) and no explicit vault credential is present, it returns a
@@ -51,14 +74,15 @@ type AzureConnection struct {
 // the standard cert/secret/default-chain path.
 //
 // The default chain is the expensive branch: it probes every sign-in method in
-// turn, and the managed identity probe alone burns ~15s before giving up. That
-// cost is paid per asset, since every discovered asset gets its own connection.
-// A caller that knows how it authenticates can say so with OptionAuthMethod and
-// skip straight to the method that works.
+// turn. A caller that knows how it authenticates can say so with
+// OptionAuthMethod and skip straight to the method that works.
 func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, error) {
 	tenantId := conf.Options[OptionTenantID]
 	clientId := conf.Options[OptionClientID]
 
+	// parsed before the cache is consulted: an unusable auth-method is an error
+	// for the connection that names it, whether or not this identity already has
+	// a credential someone else built
 	methods, err := azauth.ParseCredentialMethods(conf.Options[OptionAuthMethod])
 	if err != nil {
 		return nil, err
@@ -67,6 +91,16 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	var cred *vault.Credential
 	if len(conf.Credentials) > 0 {
 		cred = conf.Credentials[0]
+	}
+
+	// held across the build, which is local -- constructing a credential
+	// contacts nothing -- so concurrent connects queue briefly rather than
+	// each building a chain of their own
+	identity := tenantId + "/" + clientId
+	credentialMu.Lock()
+	defer credentialMu.Unlock()
+	if cached, ok := credentialCache[identity]; ok {
+		return cached, nil
 	}
 
 	federatedTokenFile := conf.Options[OptionFederatedTokenFile]
@@ -85,13 +119,21 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	// The chain is cheap to walk now that the managed identity probe sits at the
 	// end of it (see azauth.DefaultCredentialMethods), so there is nothing left
 	// to shortcut past.
-	return azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
+	token, err := azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
 		TenantID:           tenantId,
 		ClientID:           clientId,
 		FederatedTokenFile: federatedTokenFile,
 		Methods:            methods,
 		Source:             "azure-connection",
 	})
+	if err != nil {
+		// a failed build is not worth remembering: the next connection may be
+		// configured differently, and caching the failure would deny it its own try
+		return nil, err
+	}
+
+	credentialCache[identity] = token
+	return token, nil
 }
 
 func NewAzureConnection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*AzureConnection, error) {

--- a/providers/azure/connection/connection_test.go
+++ b/providers/azure/connection/connection_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSelectAzureCredential_WorkloadIdentity(t *testing.T) {
+	resetCredentialCache()
 	// Set up an env var pointing to a (non-existent) token file.
 	// Construction of WorkloadIdentityCredential does not read the file —
 	// it is read lazily at GetToken time — so the file need not exist.
@@ -34,6 +35,7 @@ func TestSelectAzureCredential_WorkloadIdentity(t *testing.T) {
 }
 
 func TestSelectAzureCredential_WorkloadIdentity_ViaOption(t *testing.T) {
+	resetCredentialCache()
 	// Ensure env var is not set so we test the option path exclusively.
 	// Save and restore to avoid permanently clobbering the env for later tests.
 	prev, ok := os.LookupEnv("AZURE_FEDERATED_TOKEN_FILE")
@@ -66,6 +68,7 @@ func TestSelectAzureCredential_WorkloadIdentity_ViaOption(t *testing.T) {
 // AZURE_FEDERATED_TOKEN_FILE is set, the vault credential path must be taken,
 // so the returned credential must not be a WorkloadIdentityCredential.
 func TestSelectAzureCredential_VaultCredWins(t *testing.T) {
+	resetCredentialCache()
 	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
 
 	conf := &inventory.Config{
@@ -90,6 +93,7 @@ func TestSelectAzureCredential_VaultCredWins(t *testing.T) {
 // falls through to the default credential chain — which must not be a
 // WorkloadIdentityCredential.
 func TestSelectAzureCredential_DefaultChain(t *testing.T) {
+	resetCredentialCache()
 	// Unset the env var and restore it after the test.
 	prev, ok := os.LookupEnv("AZURE_FEDERATED_TOKEN_FILE")
 	os.Unsetenv("AZURE_FEDERATED_TOKEN_FILE")
@@ -116,6 +120,14 @@ func TestSelectAzureCredential_DefaultChain(t *testing.T) {
 	require.False(t, isWIF, "no vault cred + no token file must fall through to the default chain, not WorkloadIdentityCredential")
 }
 
+// resetCredentialCache drops every cached credential. Tests need it because the
+// cache outlives any one of them.
+func resetCredentialCache() {
+	credentialMu.Lock()
+	defer credentialMu.Unlock()
+	clear(credentialCache)
+}
+
 // unsetFederatedTokenFile clears AZURE_FEDERATED_TOKEN_FILE for the duration of
 // the test and restores whatever was there before.
 func unsetFederatedTokenFile(t *testing.T) {
@@ -138,6 +150,7 @@ func unsetFederatedTokenFile(t *testing.T) {
 // A chain that had quietly kept the CLI and managed identity probes would have
 // succeeded instead — and gone on to burn ~15s per asset probing them.
 func TestSelectAzureCredential_AuthMethodRestrictsChain(t *testing.T) {
+	resetCredentialCache()
 	unsetFederatedTokenFile(t)
 
 	conf := &inventory.Config{
@@ -158,6 +171,7 @@ func TestSelectAzureCredential_AuthMethodRestrictsChain(t *testing.T) {
 // this option exists for: the inventory names workload identity, the pod's
 // webhook supplies the token file, and no client secret is in play.
 func TestSelectAzureCredential_AuthMethodWorkloadIdentity(t *testing.T) {
+	resetCredentialCache()
 	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
 
 	conf := &inventory.Config{
@@ -181,6 +195,7 @@ func TestSelectAzureCredential_AuthMethodWorkloadIdentity(t *testing.T) {
 // that and the chain comes back empty. The env-var version passes either way,
 // because azidentity reads that variable itself.
 func TestSelectAzureCredential_AuthMethodWorkloadIdentity_TokenFileFromOption(t *testing.T) {
+	resetCredentialCache()
 	unsetFederatedTokenFile(t)
 
 	conf := &inventory.Config{
@@ -227,6 +242,107 @@ func TestSelectAzureCredential_InvalidAuthMethod(t *testing.T) {
 	}
 
 	_, err := selectAzureCredential(conf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service-principal")
+}
+
+// The credential is built once and shared: every discovered asset gets its own
+// connection, and one credential per connection means one token request per
+// asset for an identity that already had a token.
+func TestSelectAzureCredential_CachesAcrossConnections(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	conf := &inventory.Config{
+		Options: map[string]string{"tenant-id": "tid", "client-id": "cid"},
+	}
+	first, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+
+	// a discovered asset: same identity, its own config
+	child := &inventory.Config{
+		Options: map[string]string{"tenant-id": "tid", "client-id": "cid", "subscription-id": "sub"},
+	}
+	second, err := selectAzureCredential(child)
+	require.NoError(t, err)
+	require.Same(t, first, second, "an asset under the same identity must reuse the credential")
+}
+
+// An inventory can hold Azure assets under different tenants. Reusing the first
+// tenant's credential for the second would not fail -- it would quietly scan as
+// the wrong principal -- so each identity gets its own entry, and each of those
+// is reused the same way.
+func TestSelectAzureCredential_CachesPerIdentity(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	first, err := selectAzureCredential(&inventory.Config{
+		Options: map[string]string{"tenant-id": "tenant-a", "client-id": "cid"},
+	})
+	require.NoError(t, err)
+
+	second, err := selectAzureCredential(&inventory.Config{
+		Options: map[string]string{"tenant-id": "tenant-b", "client-id": "cid"},
+	})
+	require.NoError(t, err)
+	require.NotSame(t, first, second, "a different tenant must get its own credential")
+
+	// both entries survive each other, and both are reused
+	againA, err := selectAzureCredential(&inventory.Config{
+		Options: map[string]string{"tenant-id": "tenant-a", "client-id": "cid"},
+	})
+	require.NoError(t, err)
+	require.Same(t, first, againA)
+
+	againB, err := selectAzureCredential(&inventory.Config{
+		Options: map[string]string{"tenant-id": "tenant-b", "client-id": "cid"},
+	})
+	require.NoError(t, err)
+	require.Same(t, second, againB)
+}
+
+// A build that fails must not be remembered as the answer for that identity.
+func TestSelectAzureCredential_DoesNotCacheFailures(t *testing.T) {
+	resetCredentialCache()
+	unsetFederatedTokenFile(t)
+
+	conf := &inventory.Config{
+		Options: map[string]string{
+			"tenant-id":   "tid",
+			"client-id":   "cid",
+			"auth-method": "workload-identity",
+		},
+	}
+	_, err := selectAzureCredential(conf)
+	require.Error(t, err)
+
+	// with a token file in place the same identity builds fine, which it could
+	// not do if the failure had been cached
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+	cred, err := selectAzureCredential(conf)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+}
+
+// An unusable auth-method belongs to the connection that named it. Consulting
+// the cache first would let a typo through on every connection after the one
+// that built the credential.
+func TestSelectAzureCredential_RejectsBadAuthMethodEvenWhenCached(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	_, err := selectAzureCredential(&inventory.Config{
+		Options: map[string]string{"tenant-id": "tid", "client-id": "cid"},
+	})
+	require.NoError(t, err)
+
+	_, err = selectAzureCredential(&inventory.Config{
+		Options: map[string]string{
+			"tenant-id":   "tid",
+			"client-id":   "cid",
+			"auth-method": "service-principal",
+		},
+	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service-principal")
 }

--- a/providers/ms365/connection/connection.go
+++ b/providers/ms365/connection/connection.go
@@ -67,34 +67,80 @@ func (p *Ms365Connection) AdminPrincipalIDs(load func() (map[string]struct{}, er
 	return set, nil
 }
 
-func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*Ms365Connection, error) {
+// The credentials this process has built, by the identity each signs in as.
+//
+// A credential owns its token cache -- azidentity keeps it inside the instance
+// -- so building one per connection asks Entra for a token per connection, for
+// an identity that already had a perfectly good one.
+//
+// Keyed by identity rather than shared outright: an inventory can hold Microsoft
+// 365 assets under several tenants, and handing tenant A's token to tenant B's
+// asset would not fail cleanly, it would read the wrong tenant. The map is
+// bounded by the identities a process signs in as.
+var (
+	credentialMu    sync.Mutex
+	credentialCache = map[string]azcore.TokenCredential{}
+)
+
+// selectMs365Credential builds the credential this connection signs in with, or
+// hands back the one already built for the same tenant and client.
+//
+// Without a client secret or certificate it falls back to the sign-in chain,
+// which probes every method in turn. A keyless connection that knows how it
+// authenticates can name the method with auth-method and skip straight to it.
+func selectMs365Credential(conf *inventory.Config) (azcore.TokenCredential, error) {
 	tenantId := conf.Options[OptionTenantID]
 	clientId := conf.Options[OptionClientID]
-	organization := conf.Options[OptionOrganization]
-	sharepointUrl := conf.Options[OptionSharepointUrl]
+
+	// parsed before the cache is consulted: an unusable auth-method is an error
+	// for the connection that names it, whether or not this identity already has
+	// a credential someone else built
+	methods, err := azauth.ParseCredentialMethods(conf.Options[OptionAuthMethod])
+	if err != nil {
+		return nil, err
+	}
+
 	var cred *vault.Credential
 	if len(conf.Credentials) > 0 {
 		cred = conf.Credentials[0]
 	}
 
-	if len(tenantId) == 0 {
-		return nil, errors.New("ms365 provider requires a tenant-id")
+	// held across the build, which is local -- constructing a credential
+	// contacts nothing -- so concurrent connects queue briefly rather than each
+	// building a chain of their own
+	identity := tenantId + "/" + clientId
+	credentialMu.Lock()
+	defer credentialMu.Unlock()
+	if cached, ok := credentialCache[identity]; ok {
+		return cached, nil
 	}
 
-	// Without a client secret or certificate we fall back to the sign-in chain,
-	// which probes every method in turn; the managed identity probe alone burns
-	// ~15s before giving up. A keyless connection that knows how it
-	// authenticates can name the method and skip straight to it.
-	methods, err := azauth.ParseCredentialMethods(conf.Options[OptionAuthMethod])
-	if err != nil {
-		return nil, err
-	}
 	token, err := azauth.GetTokenFromCredential(cred, &azauth.ChainedTokenOptions{
 		TenantID: tenantId,
 		ClientID: clientId,
 		Methods:  methods,
 		Source:   "ms365-connection",
 	})
+	if err != nil {
+		// a failed build is not worth remembering: the next connection may be
+		// configured differently, and caching the failure would deny it its own try
+		return nil, err
+	}
+
+	credentialCache[identity] = token
+	return token, nil
+}
+
+func NewMs365Connection(id uint32, asset *inventory.Asset, conf *inventory.Config) (*Ms365Connection, error) {
+	tenantId := conf.Options[OptionTenantID]
+	clientId := conf.Options[OptionClientID]
+	organization := conf.Options[OptionOrganization]
+	sharepointUrl := conf.Options[OptionSharepointUrl]
+	if len(tenantId) == 0 {
+		return nil, errors.New("ms365 provider requires a tenant-id")
+	}
+
+	token, err := selectMs365Credential(conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot fetch credentials for ms365 provider")
 	}

--- a/providers/ms365/connection/credential_cache_test.go
+++ b/providers/ms365/connection/credential_cache_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+// resetCredentialCache drops every cached credential. Tests need it because the
+// cache outlives any one of them.
+func resetCredentialCache() {
+	credentialMu.Lock()
+	defer credentialMu.Unlock()
+	clear(credentialCache)
+}
+
+// The credential is built once per identity and shared: a scan opens a
+// connection per asset, and one credential per connection is a token request per
+// asset for a tenant that already had a token.
+func TestSelectMs365Credential_CachesAcrossConnections(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	first, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tid", OptionClientID: "cid"},
+	})
+	require.NoError(t, err)
+
+	second, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tid", OptionClientID: "cid", OptionOrganization: "org"},
+	})
+	require.NoError(t, err)
+	require.Same(t, first, second, "a connection under the same identity must reuse the credential")
+}
+
+// Handing tenant A's token to tenant B would not fail cleanly -- it would read
+// the wrong tenant -- so each identity gets its own entry, and each is reused.
+func TestSelectMs365Credential_CachesPerIdentity(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	first, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tenant-a", OptionClientID: "cid"},
+	})
+	require.NoError(t, err)
+
+	second, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tenant-b", OptionClientID: "cid"},
+	})
+	require.NoError(t, err)
+	require.NotSame(t, first, second, "a different tenant must get its own credential")
+
+	againA, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tenant-a", OptionClientID: "cid"},
+	})
+	require.NoError(t, err)
+	require.Same(t, first, againA)
+}
+
+// An unusable auth-method belongs to the connection that named it. Consulting
+// the cache first would let a typo through on every connection after the one
+// that built the credential.
+func TestSelectMs365Credential_RejectsBadAuthMethodEvenWhenCached(t *testing.T) {
+	resetCredentialCache()
+	t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/tmp/x.jwt")
+
+	_, err := selectMs365Credential(&inventory.Config{
+		Options: map[string]string{OptionTenantID: "tid", OptionClientID: "cid"},
+	})
+	require.NoError(t, err)
+
+	_, err = selectMs365Credential(&inventory.Config{
+		Options: map[string]string{
+			OptionTenantID:   "tid",
+			OptionClientID:   "cid",
+			OptionAuthMethod: "service-principal",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service-principal")
+}


### PR DESCRIPTION
**The credential is what owns the token cache** — azidentity keeps the MSAL cache inside the instance, and `guidedCredential` adds none of its own. Every discovered asset gets its own connection, and each one built its own credential, so a scan asked Entra for a fresh token once per asset for an identity that already had a perfectly good one. A subscription with a few hundred assets asked a few hundred times; before [#9496](https://github.com/mondoohq/mql/pull/9496) reordered the chain, each of those also paid the 15s managed identity probe.

Credentials are now cached by the identity they sign in as, so every connection under one tenant and client shares one. Discovery found these assets with that credential; it can scan them with it too.

```go
var (
    credentialMu    sync.Mutex
    credentialCache = map[string]azcore.TokenCredential{}
)
```

The connections each keep their own `token` field, but they all hold the same pointer, so the second connection's first API call finds a live token in the shared MSAL cache and makes no request.

**Keyed by identity, not shared outright.** An inventory can hold Azure assets under several tenants, and `getSubConfig` overwrites the tenant per subscription. Handing tenant A's token to tenant B's asset would not fail cleanly — it would scan as the wrong principal. Every identity gets the same reuse, so an inventory spanning tenants is one credential per tenant rather than one per asset. The map is bounded by the identities a process scans: the Azure assets in its inventory, not the assets discovered beneath them.

A failed build is not cached, so a connection configured differently still gets its own attempt. The mutex is held across the build, which contacts nothing, so concurrent connects queue briefly instead of each building a chain of their own.

## Tests

- reused across connections under one identity (`require.Same` — pointer identity, not equality)
- each identity cached separately, and both survive and are reused after the other is built
- failures not cached
- existing `selectAzureCredential` tests reset the cache first, since it outlives any one of them

`-race` clean; full azure provider suite passes.

## Not included

An earlier revision also made discovered assets children of the discovering connection (`WithParentConnectionId`), which would share the parent's resource cache. That is dropped from this PR — it needs its own investigation before it goes anywhere near a scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)