### PR TITLE
✨ Apply discovery tag filters to SQS queues and SNS topics. 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,34 @@ Multiple computed methods can share the same fetch function to batch-load relate
   ```
   The asset name is a display name (often a `Name` tag), never a resource key — don't use it for lookups. The one exception: when an init's underlying API call is name-driven (e.g. IAM `GetUser`/`GetGroup`) and discovery sets the asset name to the resource's own name, use `getAssetName(runtime)` to inject `args["name"]` instead.
 
+### Step 3.5: Discovery-filter gate (do this whenever you add a discovery target)
+
+**If a resource becomes a discovery target, its lister must consult `conn.Filters`.** Wiring the `case Discovery<Thing>:` branch in `discovery.go` and wiring the filters are separate edits in separate files, and only the first one is what the ticket asks for — so the second is the one that gets forgotten. Adding a discovery target without filter support ships a service that accepts `--filters tag:...` and silently ignores it.
+
+Apply filters in the **lister** (`get<Thing>`), never in `discovery.go`. Discovery reaches assets through the same `GetQueues()`/`GetTopics()` accessor a plain MQL query uses, so one check covers both paths and keeps them consistent.
+
+```go
+// gate the tag lookup so it stays lazy when no tag filter is set
+if conn.Filters.General.HasTags() {
+    tags := /* fetch tags for this resource */
+    if conn.Filters.General.IsFilteredOutByTags(tags) {
+        continue
+    }
+}
+```
+
+- **Cheap shape** (tags already in hand, or one call): copy `aws_s3.go`.
+- **No batch tags endpoint** (one call per resource): use `fetchTagsConcurrently` in `aws.go` — bounded concurrency, per-item failures tolerated. Seed the fetched tags onto the resource so discovery's immediate read doesn't re-fetch, but **only for a tag set you actually read**; publishing an empty map for a resource whose tag call failed reports "no tags" as fact. Use the comma-ok form on the result map: present means read, absent means failed.
+- **Region filters need nothing** — `conn.Regions()` already applies them.
+- Services with a service-specific filter struct (`conn.Filters.Ecr`, `conn.Filters.S3`) consult that instead; that's correct.
+
+This is a manual gate, not a build-time one. Because the bug is an *absence*, you can't spot it by reading — grep for listers that never mention `conn.Filters` and intersect with the discovery targets:
+
+```bash
+grep -rL "conn\.Filters" providers/<provider>/resources/*.go | grep -v _test
+grep -n "case Discovery" providers/<provider>/resources/discovery.go
+```
+
 ### Step 4: Verification (Interactive)
 Automated tests are rare for MQL resources (thin wrappers). **Interactive testing is standard.**
 

--- a/providers/aws/resources/aws.go
+++ b/providers/aws/resources/aws.go
@@ -5,12 +5,14 @@ package resources
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	smithy "github.com/aws/smithy-go"
@@ -22,6 +24,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/providers/network/resources/certificates"
 	"go.mondoo.com/mql/v13/types"
+	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/util/cert"
 )
 
@@ -349,6 +352,65 @@ func mapStringInterfaceToStringString(m map[string]any) map[string]string {
 		newM[k] = v.(string)
 	}
 	return newM
+}
+
+// fetchTagsConcurrency bounds the in-flight per-item tag calls made by
+// fetchTagsConcurrently. It is deliberately small: tag lookups are a means to
+// evaluate discovery filters, not the workload, and every provider job already
+// runs inside a region-level worker pool.
+const fetchTagsConcurrency = 10
+
+// fetchTagsConcurrently resolves tags for a set of keys and returns them keyed by
+// the same value. It exists for services whose tags can only be read one resource
+// at a time (SQS, SNS, and Lambda have no batch tags endpoint), where evaluating
+// a tag filter would otherwise serialize one round trip per resource. Services
+// that do offer a plural tags endpoint should call that instead; see
+// batchFetchTags in aws_route53.go.
+//
+// Per-item failures are tolerated rather than fatal, and presence in the result
+// map is what distinguishes them from a resource that simply has no tags:
+//
+//   - key present, map non-nil (possibly empty) - tags were read successfully
+//   - key absent - the fetch failed for that resource
+//
+// Callers must use the comma-ok form to tell those apart. A resource whose tags
+// could not be read yields a nil map, which
+// GeneralDiscoveryFilters.IsFilteredOutByTags treats the same as an empty tag
+// set: it is dropped when an include filter is set and kept when only exclude
+// filters are set. That is the established behavior across the provider - an
+// unreadable tag set cannot prove a match, so we do not claim one. Callers that
+// seed the fetched tags onto a resource must only do so for keys that are
+// present, or an unreadable tag set gets published as an authoritative empty one.
+func fetchTagsConcurrently[K comparable](ctx context.Context, keys []K, fetch func(context.Context, K) (map[string]string, error)) map[K]map[string]string {
+	result := make(map[K]map[string]string, len(keys))
+	if len(keys) == 0 {
+		return result
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(fetchTagsConcurrency)
+	for _, key := range keys {
+		g.Go(func() error {
+			tags, err := fetch(gctx, key)
+			if err != nil {
+				log.Debug().Err(err).Interface("key", key).Msg("could not fetch tags for filter evaluation")
+				return nil
+			}
+			if tags == nil {
+				// Normalize so a successful fetch is always a non-nil map and
+				// absence unambiguously means failure.
+				tags = map[string]string{}
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			result[key] = tags
+			return nil
+		})
+	}
+	// The worker func never returns an error, so Wait only drains the pool.
+	_ = g.Wait()
+	return result
 }
 
 // securityGroupIdHandler is a helper struct to handle security group ids and convert them to resources

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
-  "version": "13.50.3",
-  "generated_at": "2026-07-25T14:16:51-07:00",
+  "version": "13.51.0",
+  "generated_at": "2026-07-29T10:07:53+03:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",

--- a/providers/aws/resources/aws_lambda.go
+++ b/providers/aws/resources/aws_lambda.go
@@ -23,7 +23,6 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/types"
-	"golang.org/x/sync/errgroup"
 )
 
 func (a *mqlAwsLambda) id() (string, error) {
@@ -79,16 +78,33 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 				// per-function call into bounded concurrent calls.
 				var tagsByArn map[string]map[string]string
 				if conn.Filters.General.HasTags() {
-					tagsByArn = batchFetchLambdaTags(ctx, svc, functionsResp.Functions)
+					arns := make([]string, 0, len(functionsResp.Functions))
+					for _, function := range functionsResp.Functions {
+						if function.FunctionArn != nil {
+							arns = append(arns, *function.FunctionArn)
+						}
+					}
+					tagsByArn = fetchTagsConcurrently(ctx, arns, func(ctx context.Context, functionArn string) (map[string]string, error) {
+						resp, err := svc.ListTags(ctx, &lambda.ListTagsInput{Resource: &functionArn})
+						if err != nil {
+							return nil, err
+						}
+						if resp == nil {
+							return nil, errors.New("empty ListTags response")
+						}
+						return resp.Tags, nil
+					})
 				}
 				for _, function := range functionsResp.Functions {
 					var tags map[string]string
+					var fetched bool
 					if conn.Filters.General.HasTags() {
-						// nil means batchFetchLambdaTags hit a per-function error;
-						// IsFilteredOutByTags treats nil identically to an empty map
-						// (no include-filter match → drop), preserving the
-						// pre-parallelization best-effort behavior.
-						tags = tagsByArn[convert.ToValue(function.FunctionArn)]
+						// An absent entry means the ListTags call failed for this
+						// function; IsFilteredOutByTags treats the resulting nil
+						// identically to an empty map (no include-filter match →
+						// drop), preserving the pre-parallelization best-effort
+						// behavior.
+						tags, fetched = tagsByArn[convert.ToValue(function.FunctionArn)]
 						if conn.Filters.General.IsFilteredOutByTags(tags) {
 							log.Debug().Interface("function", function.FunctionArn).Msg("excluding function due to filters")
 							continue
@@ -99,7 +115,11 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 					if err != nil {
 						return nil, err
 					}
-					if tags != nil {
+					// Only cache a tag set we actually read. Caching for a function
+					// whose ListTags call failed would report "no tags" as fact;
+					// leaving tagsFetched false lets the accessor retry and surface
+					// the real error.
+					if fetched {
 						f.cacheTags = tags
 						f.tagsFetched = true
 					}
@@ -111,40 +131,6 @@ func (a *mqlAwsLambda) getFunctions(conn *connection.AwsConnection) []*jobpool.J
 		tasks = append(tasks, jobpool.NewJob(f))
 	}
 	return tasks
-}
-
-// batchFetchLambdaTags resolves tags for a slice of Lambda functions concurrently.
-// Lambda's API has no batch tags endpoint, so this bounds the per-function ListTags
-// calls with a small worker pool. Errors and missing tag responses are tolerated:
-// the resulting map will simply not contain an entry for those ARNs, matching the
-// previous best-effort sequential behavior.
-func batchFetchLambdaTags(ctx context.Context, svc *lambda.Client, fns []lambdatypes.FunctionConfiguration) map[string]map[string]string {
-	result := make(map[string]map[string]string, len(fns))
-	if len(fns) == 0 {
-		return result
-	}
-	var mu sync.Mutex
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(10)
-	for _, fn := range fns {
-		if fn.FunctionArn == nil {
-			continue
-		}
-		arnVal := *fn.FunctionArn
-		input := &lambda.ListTagsInput{Resource: fn.FunctionArn}
-		g.Go(func() error {
-			resp, err := svc.ListTags(gctx, input)
-			if err != nil || resp == nil {
-				return nil
-			}
-			mu.Lock()
-			result[arnVal] = resp.Tags
-			mu.Unlock()
-			return nil
-		})
-	}
-	_ = g.Wait()
-	return result
 }
 
 func getLambdaArn(name string, region string, accountId string) string {

--- a/providers/aws/resources/aws_sns.go
+++ b/providers/aws/resources/aws_sns.go
@@ -18,6 +18,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
+	mqltypes "go.mondoo.com/mql/v13/types"
 )
 
 func (a *mqlAwsSns) id() (string, error) {
@@ -106,14 +107,50 @@ func (a *mqlAwsSns) getTopics(conn *connection.AwsConnection) []*jobpool.Job {
 					}
 					return nil, err
 				}
+				// Pre-fetch tags in parallel when tag-based filters are configured.
+				// SNS has no batch tags endpoint, so this turns a sequential
+				// per-topic call into bounded concurrent calls.
+				var tagsByArn map[string]map[string]string
+				if conn.Filters.General.HasTags() {
+					arns := make([]string, 0, len(topics.Topics))
+					for _, topic := range topics.Topics {
+						if topic.TopicArn != nil {
+							arns = append(arns, *topic.TopicArn)
+						}
+					}
+					tagsByArn = fetchTagsConcurrently(ctx, arns, func(ctx context.Context, topicArn string) (map[string]string, error) {
+						tags, err := getSNSTags(ctx, svc, &topicArn)
+						if err != nil {
+							return nil, err
+						}
+						return mapStringInterfaceToStringString(tags), nil
+					})
+				}
+
 				for _, topic := range topics.Topics {
-					mqlTopic, err := CreateResource(a.MqlRuntime, "aws.sns.topic",
-						map[string]*llx.RawData{
-							"__id":   llx.StringDataPtr(topic.TopicArn),
-							"arn":    llx.StringDataPtr(topic.TopicArn),
-							"region": llx.StringData(region),
-						},
-					)
+					args := map[string]*llx.RawData{
+						"__id":   llx.StringDataPtr(topic.TopicArn),
+						"arn":    llx.StringDataPtr(topic.TopicArn),
+						"region": llx.StringData(region),
+					}
+					if conn.Filters.General.HasTags() {
+						tags, fetched := tagsByArn[convert.ToValue(topic.TopicArn)]
+						if conn.Filters.General.IsFilteredOutByTags(tags) {
+							log.Debug().Interface("topic", topic.TopicArn).Msg("excluding sns topic due to filters")
+							continue
+						}
+						// Seed the tags we already paid for; discovery reads them
+						// back immediately and would otherwise re-fetch. Only seed
+						// a tag set we actually read - publishing an empty map for
+						// a topic whose ListTagsForResource call failed would
+						// report "no tags" as fact. Leaving it unset keeps the
+						// field lazy.
+						if fetched {
+							args["tags"] = llx.MapData(stringMapToAny(tags), mqltypes.String)
+						}
+					}
+
+					mqlTopic, err := CreateResource(a.MqlRuntime, "aws.sns.topic", args)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/aws/resources/aws_sqs.go
+++ b/providers/aws/resources/aws_sqs.go
@@ -23,6 +23,7 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
+	mqltypes "go.mondoo.com/mql/v13/types"
 )
 
 func (a *mqlAwsSqs) id() (string, error) {
@@ -174,17 +175,46 @@ func (a *mqlAwsSqs) getQueues(conn *connection.AwsConnection) []*jobpool.Job {
 					}
 					return nil, err
 				}
+				// Pre-fetch tags in parallel when tag-based filters are configured.
+				// SQS has no batch tags endpoint, so this turns a sequential
+				// per-queue call into bounded concurrent calls.
+				var tagsByUrl map[string]map[string]string
+				if conn.Filters.General.HasTags() {
+					tagsByUrl = fetchTagsConcurrently(ctx, qs.QueueUrls, func(ctx context.Context, queueUrl string) (map[string]string, error) {
+						resp, err := svc.ListQueueTags(ctx, &sqs.ListQueueTagsInput{QueueUrl: aws.String(queueUrl)})
+						if err != nil {
+							return nil, err
+						}
+						return resp.Tags, nil
+					})
+				}
+
 				for _, q := range qs.QueueUrls {
-					mqlTopic, err := CreateResource(a.MqlRuntime, "aws.sqs.queue",
-						map[string]*llx.RawData{
-							"url":    llx.StringData(q),
-							"region": llx.StringData(region),
-						},
-					)
+					args := map[string]*llx.RawData{
+						"url":    llx.StringData(q),
+						"region": llx.StringData(region),
+					}
+					if conn.Filters.General.HasTags() {
+						tags, fetched := tagsByUrl[q]
+						if conn.Filters.General.IsFilteredOutByTags(tags) {
+							log.Debug().Str("queue", q).Msg("excluding sqs queue due to filters")
+							continue
+						}
+						// Seed the tags we already paid for; discovery reads them
+						// back immediately and would otherwise re-fetch. Only seed
+						// a tag set we actually read - publishing an empty map for
+						// a queue whose ListQueueTags call failed would report "no
+						// tags" as fact. Leaving it unset keeps the field lazy.
+						if fetched {
+							args["tags"] = llx.MapData(stringMapToAny(tags), mqltypes.String)
+						}
+					}
+
+					mqlQueue, err := CreateResource(a.MqlRuntime, "aws.sqs.queue", args)
 					if err != nil {
 						return nil, err
 					}
-					res = append(res, mqlTopic)
+					res = append(res, mqlQueue)
 				}
 			}
 			return jobpool.JobResult(res), nil

--- a/providers/aws/resources/aws_test.go
+++ b/providers/aws/resources/aws_test.go
@@ -4,10 +4,13 @@
 package resources
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	nethttp "net/http"
+	"sync"
 	"testing"
+	"time"
 
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
@@ -110,5 +113,119 @@ func TestIsMacieNotEnabledError(t *testing.T) {
 	t.Run("404 with Macie message", func(t *testing.T) {
 		assert.True(t, IsMacieNotEnabledError(macieHTTPError(404,
 			"ResourceNotFoundException: Amazon Macie isn't enabled for your account")))
+	})
+}
+
+func TestFetchTagsConcurrently(t *testing.T) {
+	t.Run("no keys makes no calls", func(t *testing.T) {
+		called := false
+		res := fetchTagsConcurrently(context.Background(), []string{}, func(context.Context, string) (map[string]string, error) {
+			called = true
+			return nil, nil
+		})
+		assert.Empty(t, res)
+		assert.False(t, called)
+	})
+
+	t.Run("nil keys returns an empty, usable map", func(t *testing.T) {
+		res := fetchTagsConcurrently(context.Background(), nil, func(context.Context, string) (map[string]string, error) {
+			return map[string]string{"env": "prod"}, nil
+		})
+		assert.Empty(t, res)
+		assert.Nil(t, res["anything"])
+	})
+
+	t.Run("resolves every key", func(t *testing.T) {
+		keys := []string{"a", "b", "c"}
+		res := fetchTagsConcurrently(context.Background(), keys, func(_ context.Context, k string) (map[string]string, error) {
+			return map[string]string{"name": k}, nil
+		})
+		assert.Len(t, res, 3)
+		for _, k := range keys {
+			assert.Equal(t, map[string]string{"name": k}, res[k])
+		}
+	})
+
+	t.Run("a failing key is absent, the rest still resolve", func(t *testing.T) {
+		res := fetchTagsConcurrently(context.Background(), []string{"ok", "boom", "fine"}, func(_ context.Context, k string) (map[string]string, error) {
+			if k == "boom" {
+				return nil, errors.New("access denied")
+			}
+			return map[string]string{"name": k}, nil
+		})
+
+		// An errored key yields a nil map, which IsFilteredOutByTags treats as
+		// an empty tag set rather than aborting the whole listing.
+		assert.Len(t, res, 2)
+		assert.Nil(t, res["boom"])
+		assert.Equal(t, map[string]string{"name": "ok"}, res["ok"])
+		assert.Equal(t, map[string]string{"name": "fine"}, res["fine"])
+	})
+
+	// Callers seed the fetched tags onto the resource, so "we read it and there
+	// were none" must stay distinguishable from "we could not read it". Presence
+	// in the map is the signal; a successful fetch is never a nil map.
+	t.Run("untagged resolves to an empty map, not absence", func(t *testing.T) {
+		res := fetchTagsConcurrently(context.Background(), []string{"untagged", "failed"}, func(_ context.Context, k string) (map[string]string, error) {
+			if k == "failed" {
+				return nil, errors.New("access denied")
+			}
+			return nil, nil // successful call, resource simply has no tags
+		})
+
+		untagged, ok := res["untagged"]
+		assert.True(t, ok, "a successful fetch must be present in the map")
+		assert.NotNil(t, untagged, "a successful fetch must never yield a nil map")
+		assert.Empty(t, untagged)
+
+		_, ok = res["failed"]
+		assert.False(t, ok, "a failed fetch must be absent from the map")
+	})
+
+	t.Run("every key failing is not fatal", func(t *testing.T) {
+		res := fetchTagsConcurrently(context.Background(), []string{"a", "b"}, func(context.Context, string) (map[string]string, error) {
+			return nil, errors.New("access denied")
+		})
+		assert.Empty(t, res)
+	})
+
+	t.Run("duplicate keys are tolerated", func(t *testing.T) {
+		res := fetchTagsConcurrently(context.Background(), []string{"dup", "dup"}, func(_ context.Context, k string) (map[string]string, error) {
+			return map[string]string{"name": k}, nil
+		})
+		assert.Len(t, res, 1)
+		assert.Equal(t, map[string]string{"name": "dup"}, res["dup"])
+	})
+
+	t.Run("concurrency stays within the bound", func(t *testing.T) {
+		keys := make([]string, 100)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("key-%d", i)
+		}
+
+		var mu sync.Mutex
+		inFlight, maxInFlight := 0, 0
+
+		res := fetchTagsConcurrently(context.Background(), keys, func(_ context.Context, k string) (map[string]string, error) {
+			mu.Lock()
+			inFlight++
+			if inFlight > maxInFlight {
+				maxInFlight = inFlight
+			}
+			mu.Unlock()
+
+			// Hold the slot long enough that the pool saturates.
+			time.Sleep(2 * time.Millisecond)
+
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			return map[string]string{"name": k}, nil
+		})
+
+		assert.Len(t, res, len(keys))
+		assert.LessOrEqual(t, maxInFlight, fetchTagsConcurrency)
+		// Guard against the bound silently collapsing to serial execution.
+		assert.Greater(t, maxInFlight, 1)
 	})
 }


### PR DESCRIPTION
#### In this PR:
There is no bulk-fetch endpoint for Tags of SQS queues/SNS topics so we follow the same convention as the Lambda and fetch tags in parallel. The batched function is extracted as a helper and used for both Lambda, SQS and SNS.

Tested with live data (SQS queues/SNS topics/Lambdas) in an AWS account.