### PR TITLE
🐛 os: drop the zero epoch from rpm versions read from the rpmdb

### DIFF
--- a/providers/os/resources/packages/rpm_packages.go
+++ b/providers/os/resources/packages/rpm_packages.go
@@ -44,14 +44,11 @@ func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 		m := RPM_REGEX.FindStringSubmatch(line)
 		if m != nil {
 			name := m[1]
-			epoch := m[2]
+			epoch := normalizeRpmEpoch(m[2])
 			version := m[3]
 
-			// trim epoch if it is 0 or "(none)"
-			if epoch == "0" || strings.TrimSpace(epoch) == "(none)" {
-				epoch = ""
-			} else {
-				// only append the epoch if we have a non-zero value
+			// only prefix the epoch if we have a non-zero value
+			if epoch != "" {
 				version = epoch + ":" + version
 			}
 
@@ -92,6 +89,49 @@ func ParseRpmPackages(pf *inventory.Platform, input io.Reader) []Package {
 		}
 	}
 	return pkgs
+}
+
+// normalizeRpmEpoch collapses rpm's spellings of "this package has no epoch"
+// -- "0", "(none)" and the empty string -- to the empty string.
+//
+// Zero is rpm's default epoch and carries no information, so it belongs in
+// neither the version string nor the purl. Both collection paths (the rpm
+// command and the rpmdb parser) must agree on this: the version ends up in the
+// purl, so a package that renders as "0:3.9.25-7.el9" when read from an image
+// and "3.9.25-7.el9" when read from a live host looks like two different
+// packages to everything downstream.
+func normalizeRpmEpoch(epoch string) string {
+	epoch = strings.TrimSpace(epoch)
+	if epoch == "0" || epoch == "(none)" {
+		return ""
+	}
+	return epoch
+}
+
+// newRpmPackageFromDB builds a Package from an rpmdb entry. This is the static
+// analysis path, used whenever the rpm command is unavailable -- container
+// images, filesystem and device scans.
+func newRpmPackageFromDB(pf *inventory.Platform, pkg *rpmdb.PackageInfo, rpmDBPath string) Package {
+	epoch := normalizeRpmEpoch(strconv.Itoa(pkg.EpochNum()))
+
+	version := pkg.Version
+	if epoch != "" {
+		version = epoch + ":" + version
+	}
+	if pkg.Release != "" {
+		version = version + "-" + pkg.Release
+	}
+
+	rpmPkg := newRpmPackage(pf, pkg.Name, version, pkg.Arch, epoch, cleanupVendorName(pkg.Vendor),
+		pkg.Summary, pkg.License, pkg.Modularitylabel, int64(pkg.InstallTime))
+
+	rpmPkg.FilesAvailable = PkgFilesIncluded
+	rpmPkg.Files = []FileRecord{
+		{
+			Path: rpmDBPath,
+		},
+	}
+	return rpmPkg
 }
 
 func newRpmPackage(pf *inventory.Platform, name, version, arch, epoch, vendor, description, license, modularity string, installTime int64) Package {
@@ -328,22 +368,7 @@ func (rpm *RpmPkgManager) staticList() ([]Package, error) {
 
 	resultList := []Package{}
 	for _, pkg := range pkgList {
-		version := pkg.Version
-		epoch := strconv.Itoa(pkg.EpochNum())
-		version = epoch + ":" + version
-		if pkg.Release != "" {
-			version = version + "-" + pkg.Release
-		}
-
-		rpmPkg := newRpmPackage(rpm.platform, pkg.Name, version, pkg.Arch, epoch, cleanupVendorName(pkg.Vendor), pkg.Summary, pkg.License, pkg.Modularitylabel, int64(pkg.InstallTime))
-
-		rpmPkg.FilesAvailable = PkgFilesIncluded
-		rpmPkg.Files = []FileRecord{
-			{
-				Path: detectedPath,
-			},
-		}
-		resultList = append(resultList, rpmPkg)
+		resultList = append(resultList, newRpmPackageFromDB(rpm.platform, pkg, detectedPath))
 	}
 
 	return resultList, nil

--- a/providers/os/resources/packages/rpm_packages_test.go
+++ b/providers/os/resources/packages/rpm_packages_test.go
@@ -660,3 +660,114 @@ func TestRpmQueryFormatRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeRpmEpoch(t *testing.T) {
+	tests := []struct {
+		epoch    string
+		expected string
+	}{
+		// rpm's three spellings of "no epoch"
+		{"0", ""},
+		{"(none)", ""},
+		{" (none) ", ""},
+		{"", ""},
+		// a real epoch survives
+		{"1", "1"},
+		{"2", "2"},
+		{"10", "10"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.epoch, func(t *testing.T) {
+			assert.Equal(t, test.expected, normalizeRpmEpoch(test.epoch))
+		})
+	}
+}
+
+// The rpmdb path (container images, filesystem scans) and the rpm command path
+// (live hosts) must render identical versions and purls for the same package.
+//
+// They did not: the rpmdb path prefixed the epoch unconditionally, so a package
+// with no epoch — the overwhelming majority — came out as "0:3.9.25-7.el9_8.2"
+// from an image and "3.9.25-7.el9_8.2" from a live host. The purl differed with
+// it, so the same package looked like two different packages depending on how
+// the asset was scanned. Consumers that match a version by prefix rather than
+// by rpm version comparison found nothing at all for rpm images.
+//
+// Verified against registry.access.redhat.com/ubi9/ubi:latest, scanned both as
+// `docker image` (rpmdb) and `docker container` (rpm command).
+func TestRpmEpochParityAcrossCollectionPaths(t *testing.T) {
+	pf := &inventory.Platform{
+		Name:    "redhat",
+		Version: "9",
+		Arch:    "aarch64",
+		Family:  []string{"linux", "unix", "os"},
+		Labels: map[string]string{
+			"distro-id": "rhel",
+		},
+	}
+
+	zero, one := 0, 1
+	tests := []struct {
+		name            string
+		pkg             *rpmdb.PackageInfo
+		expectedVersion string
+	}{
+		{
+			name: "no epoch",
+			pkg: &rpmdb.PackageInfo{
+				Name: "python3", Epoch: &zero, Version: "3.9.25", Release: "7.el9_8.2",
+				Arch: "aarch64", Vendor: "Red Hat, Inc.", License: "Python-2.0.1",
+				Summary: "Python 3 interpreter",
+			},
+			expectedVersion: "3.9.25-7.el9_8.2",
+		},
+		{
+			// Epoch is a nil pointer when rpm never recorded one at all;
+			// EpochNum() reports 0 for it, same as an explicit zero.
+			name: "epoch absent entirely",
+			pkg: &rpmdb.PackageInfo{
+				Name: "glibc", Epoch: nil, Version: "2.34", Release: "274.el9_8",
+				Arch: "aarch64", Vendor: "Red Hat, Inc.", License: "LGPLv2+",
+				Summary: "The GNU libc libraries",
+			},
+			expectedVersion: "2.34-274.el9_8",
+		},
+		{
+			// A real epoch belongs in the version, and both paths already agreed here.
+			name: "non-zero epoch",
+			pkg: &rpmdb.PackageInfo{
+				Name: "gmp", Epoch: &one, Version: "6.1.2", Release: "11.el8",
+				Arch: "aarch64", Vendor: "Red Hat, Inc.", License: "LGPLv3+",
+				Summary: "A GNU arbitrary precision library",
+			},
+			expectedVersion: "1:6.1.2-11.el8",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fromDB := newRpmPackageFromDB(pf, test.pkg, "/var/lib/rpm/rpmdb.sqlite")
+
+			// Render the same package the way `rpm -qa --queryformat` would,
+			// then read it back through the command path.
+			var out bytes.Buffer
+			fmt.Fprintf(&out, "%s %d:%s-%s %s__%s__%s__%s__%d\n",
+				test.pkg.Name, test.pkg.EpochNum(), test.pkg.Version, test.pkg.Release,
+				test.pkg.Arch, test.pkg.Vendor, test.pkg.Summary, test.pkg.License, 0)
+			fromCmd := ParseRpmPackages(pf, &out)
+			require.Len(t, fromCmd, 1)
+
+			assert.Equal(t, test.expectedVersion, fromDB.Version, "rpmdb path version")
+			assert.Equal(t, test.expectedVersion, fromCmd[0].Version, "command path version")
+			assert.Equal(t, fromCmd[0].Version, fromDB.Version, "versions must agree across paths")
+			assert.Equal(t, fromCmd[0].PUrl, fromDB.PUrl, "purls must agree across paths")
+			assert.Equal(t, fromCmd[0].Epoch, fromDB.Epoch, "epochs must agree across paths")
+			assert.Equal(t, fromCmd[0].CPEs, fromDB.CPEs, "cpes must agree across paths")
+
+			// The rpmdb path additionally carries the database as evidence.
+			assert.Equal(t, PkgFilesIncluded, fromDB.FilesAvailable)
+			assert.Equal(t, []FileRecord{{Path: "/var/lib/rpm/rpmdb.sqlite"}}, fromDB.Files)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The same rpm package reports two different versions depending on how the asset was reached:

| Collection path | Used for | `version` |
|---|---|---|
| `rpm -qa --queryformat` | live hosts (local / ssh) | `3.9.25-7.el9_8.2` |
| rpmdb parse | container images, filesystem/device scans | `0:3.9.25-7.el9_8.2` |

The purl differs with it, so downstream the same package looks like two different packages purely as a function of scan type. Consumers that compare with proper rpm version semantics are unaffected (`0:x` and `x` are equal there), but anything matching a version by prefix finds nothing at all for rpm images.

## Cause

`ParseRpmPackages` has normalized a zero epoch away since 2022 — zero is rpm's default and carries no information, so it belongs in neither the version nor the purl. #4255 later added the epoch to the rpmdb path so real epochs would show up there too, but applied the prefix unconditionally:

```go
epoch := strconv.Itoa(pkg.EpochNum())   // EpochNum() returns 0 when there is no epoch
version = epoch + ":" + version         // ...so every package gets "0:"
```

`ParseApkDbPackages` already gets this right, and guards it the same way.

## Change

- `normalizeRpmEpoch` collapses rpm's three spellings of "no epoch" (`0`, `(none)`, empty) in one place, used by both paths.
- The rpmdb loop body moves into `newRpmPackageFromDB`, which makes the static path unit-testable — it had no coverage at all, which is how this survived. (`TestPhoton4ImageParser` and `TestSuSEParser` build `rpmdb.PackageInfo` fixtures but then serialize them into the command format and assert on `ParseRpmPackages`.)

Only the zero-epoch case changes. Packages with a real epoch were already consistent between the two paths.

## Verification

`registry.access.redhat.com/ubi9/ubi:latest`, scanned both ways with a locally built provider:

```
docker image     python3  3.9.25-7.el9_8.2  pkg:rpm/redhat/python3@3.9.25-7.el9_8.2?arch=aarch64&distro=rhel-9.8
docker container python3  3.9.25-7.el9_8.2  pkg:rpm/redhat/python3@3.9.25-7.el9_8.2?arch=aarch64&distro=rhel-9.8
```

Identical; before the change the image row read `0:3.9.25-7.el9_8.2`. Non-zero epochs on `ubi8` (`gmp 1:6.1.2-11.el8`, `dmidecode 1:3.5-1.el8`) are byte-for-byte unchanged.

`TestRpmEpochParityAcrossCollectionPaths` pins the invariant by running one fixture through both paths and asserting version, purl, epoch and CPEs agree. Reverting the fix fails it on the two zero-epoch cases and leaves the non-zero case passing.

## Note for consumers

Assets scanned from images will report new purls for their rpm packages once this ships, since the `0:` disappears. Any stored data keyed by purl will see those as new packages on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)