### PR TITLE
🐛 azure: report a missing id instead of building a resource without one

### DIFF
--- a/providers/azure/resources/appcontainers.go
+++ b/providers/azure/resources/appcontainers.go
@@ -209,7 +209,7 @@ func initAzureSubscriptionContainerAppServiceContainerApp(runtime *plugin.Runtim
 	}
 
 	if args["id"] == nil {
-		return args, nil, nil
+		return nil, nil, missingResourceID("azure.subscription.containerAppService.containerApp")
 	}
 
 	conn, ok := runtime.Connection.(*connection.AzureConnection)

--- a/providers/azure/resources/functions.go
+++ b/providers/azure/resources/functions.go
@@ -69,7 +69,7 @@ func initAzureSubscriptionFunctionsServiceFunctionApp(runtime *plugin.Runtime, a
 	}
 
 	if args["id"] == nil {
-		return args, nil, nil
+		return nil, nil, missingResourceID("azure.subscription.functionsService.functionApp")
 	}
 
 	conn, ok := runtime.Connection.(*connection.AzureConnection)

--- a/providers/azure/resources/init_missing_id_test.go
+++ b/providers/azure/resources/init_missing_id_test.go
@@ -1,0 +1,81 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+// runtimeForAsset builds a runtime whose connection reports the given asset.
+// Nothing here reaches the network: the inits under test bail out before they
+// build a client, and constructing an Azure credential only assembles the
+// sign-in chain.
+func runtimeForAsset(t *testing.T, platformIds []string) *plugin.Runtime {
+	t.Helper()
+	asset := &inventory.Asset{Name: "some asset", PlatformIds: platformIds}
+	conf := &inventory.Config{Options: map[string]string{"tenant-id": "tid", "client-id": "cid"}}
+	conn, err := connection.NewAzureConnection(1, asset, conf)
+	require.NoError(t, err)
+	return &plugin.Runtime{Connection: conn}
+}
+
+// A resource queried bare -- no id, and a scanned asset that is not itself that
+// resource -- used to fall through and hand the runtime a blank resource. Every
+// field of it then came back as neither data nor error, which the client logs
+// once per field as an untyped primitive coerced to null, with an empty id to
+// identify it by. The init has to say so instead.
+//
+// A subscription asset is the case that reaches this: its platform ids carry
+// only the //platformid.api.mondoo.app form, never the /subscriptions/... ARM id
+// that getAssetIdentifier looks for.
+func TestInitsReportAMissingID(t *testing.T) {
+	inits := []struct {
+		resource string
+		init     func(*plugin.Runtime, map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+	}{
+		{"azure.subscription.networkService.firewall", initAzureSubscriptionNetworkServiceFirewall},
+		{"azure.subscription.networkService.applicationGateway", initAzureSubscriptionNetworkServiceApplicationGateway},
+		{"azure.subscription.containerAppService.containerApp", initAzureSubscriptionContainerAppServiceContainerApp},
+		{"azure.subscription.functionsService.functionApp", initAzureSubscriptionFunctionsServiceFunctionApp},
+	}
+
+	subscriptionAsset := []string{"//platformid.api.mondoo.app/runtime/azure/subscriptions/sub-1"}
+
+	for _, tc := range inits {
+		t.Run(tc.resource, func(t *testing.T) {
+			runtime := runtimeForAsset(t, subscriptionAsset)
+
+			args, res, err := tc.init(runtime, map[string]*llx.RawData{})
+			require.Error(t, err, "a bare init with no asset id must not report success")
+			require.Nil(t, res, "no resource may be built without an id")
+			require.Nil(t, args, "returning args would let the runtime build a blank resource")
+			require.Contains(t, err.Error(), tc.resource)
+		})
+	}
+}
+
+// The asset-scoped path still works: scanning the resource itself supplies the
+// ARM id, and the init gets far enough to want a client.
+func TestInitsAcceptTheAssetsArmID(t *testing.T) {
+	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Network/azureFirewalls/fw-1"
+	runtime := runtimeForAsset(t, []string{
+		"//platformid.api.mondoo.app/runtime/azure" + armID,
+		armID,
+	})
+
+	args := map[string]*llx.RawData{}
+	_, _, err := initAzureSubscriptionNetworkServiceFirewall(runtime, args)
+	// the id was taken from the asset, so this got past the guard and only
+	// failed later, on the call we deliberately cannot make in a test
+	require.Equal(t, armID, args["id"].Value)
+	if err != nil {
+		require.NotContains(t, err.Error(), "requires an id")
+	}
+}

--- a/providers/azure/resources/network.go
+++ b/providers/azure/resources/network.go
@@ -6377,7 +6377,7 @@ func initAzureSubscriptionNetworkServiceApplicationGateway(runtime *plugin.Runti
 	}
 
 	if args["id"] == nil {
-		return args, nil, nil
+		return nil, nil, missingResourceID("azure.subscription.networkService.applicationGateway")
 	}
 
 	conn, ok := runtime.Connection.(*connection.AzureConnection)

--- a/providers/azure/resources/network_expansion.go
+++ b/providers/azure/resources/network_expansion.go
@@ -800,7 +800,7 @@ func initAzureSubscriptionNetworkServiceFirewall(runtime *plugin.Runtime, args m
 		}
 	}
 	if args["id"] == nil {
-		return args, nil, nil
+		return nil, nil, missingResourceID("azure.subscription.networkService.firewall")
 	}
 	conn, ok := runtime.Connection.(*connection.AzureConnection)
 	if !ok {

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -5,6 +5,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -48,6 +49,31 @@ func isAzureNotConfigured(err error) bool {
 		return false
 	}
 	return respErr.StatusCode == http.StatusNotFound || respErr.StatusCode == http.StatusForbidden
+}
+
+// missingResourceID reports that a resource was asked for without an id, and
+// the scanned asset could not supply one either.
+//
+// An init in that position used to fall through with `return args, nil, nil`,
+// which is not the harmless no-op it reads as: the runtime takes it as
+// permission to build the resource from the args it has, so it creates one with
+// no id and no fields set. Every field then crosses the plugin boundary as an
+// empty DataRes and surfaces client-side as
+//
+//	provider returned no data and no error for a field ... field=tags id=
+//	llx: encountered a primitive with no type information, coercing to null
+//
+// once per field, per asset, with an empty id to identify it by. An error says
+// what actually happened and says it once.
+//
+// This is reachable whenever one of these resources is queried bare against an
+// asset that is not itself that resource -- a subscription asset, for instance,
+// whose platform ids carry only the //platformid.api.mondoo.app form and never
+// the /subscriptions/... ARM id getAssetIdentifier looks for.
+func missingResourceID(resourceName string) error {
+	return fmt.Errorf(
+		"%s requires an id: reach it from the list it belongs to, or scan the %s itself",
+		resourceName, resourceName)
 }
 
 type assetIdentifier struct {


### PR DESCRIPTION
## The log

Every asset in a scan produced a run of these:

```
x provider returned no data and no error for a field; the field was never set on the resource (provider bug)
    field=tags id= provider=azure resource=azure.subscription.networkService.firewall
x llx: encountered a primitive with no type information, coercing to null
```

Four resources, once per field, per asset: `networkService.firewall`, `networkService.applicationGateway`, `containerAppService.containerApp`, `functionsService.functionApp`.

## What was happening

Each of those inits ends its lookup with:

```go
if args["id"] == nil {
    return args, nil, nil
}
```

That reads like a no-op, but the runtime takes `args` back with no error as permission to build the resource from whatever args exist — so it creates one with **no id and no fields set**. Every field then crosses the plugin boundary as an empty `DataRes`, which llx coerces to null, one message per field. The `id=` in the log is empty because the resource genuinely has no id.

The path is reachable whenever one of these is queried bare — no arguments — against an asset that is not itself that resource. A **subscription asset** does exactly that: `subToAsset` gives it only the `//platformid.api.mondoo.app/...` platform id and never the `/subscriptions/...` ARM id that `getAssetIdentifier` looks for, so the asset lookup comes back empty and the fall-through builds the husk.

## The change

A shared `missingResourceID` helper, and the four inits return it instead of falling through:

```go
if args["id"] == nil {
    return nil, nil, missingResourceID("azure.subscription.networkService.firewall")
}
```

One error naming the resource, instead of a blank one that fails a field at a time with nothing to attribute it to. This is the pattern CLAUDE.md already documents for singular-resource inits.

The asset-scoped path is untouched: scanning a firewall *as an asset* still supplies the ARM id and populates normally.

## Not in this PR

The same fall-through exists in roughly 22 other azure inits. These four are the ones the logs prove are being reached, so they are what this fixes. Happy to sweep the rest in a follow-up — it is the same one-line change each, and it converts silent nulls into honest errors wherever else this is happening.

## Tests

`init_missing_id_test.go` drives the real init path with a runtime whose asset carries only a subscription platform id, and asserts all four return an error, no resource, and **nil args** — returning args is precisely what let the runtime build the husk. A second test proves the asset-scoped path still picks up the ARM id. Nothing reaches the network: the inits bail before building a client.

Full azure provider suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)