### PR TITLE
os: collect AIX system model and processor type as platform labels

### DIFF
--- a/providers/os/detector/detector_aix_hardware.go
+++ b/providers/os/detector/detector_aix_hardware.go
@@ -1,0 +1,78 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package detector
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+)
+
+const (
+	// AixLabelSystemModel carries the machine type-model of the system, for
+	// example "IBM,9009-42A". It mirrors the "System Model" field of prtconf.
+	AixLabelSystemModel = "aix.mondoo.com/system-model"
+
+	// AixLabelProcessorType carries the processor implementation of the first
+	// processor, for example "PowerPC_POWER9". It mirrors the "Processor Type"
+	// field of prtconf.
+	AixLabelProcessorType = "aix.mondoo.com/processor-type"
+)
+
+// detectAixHardware records the machine type-model and the processor generation
+// of an AIX system as platform labels.
+//
+// Some IBM AIX security advisories are only applicable to a specific POWER
+// processor generation or to an explicit list of system models, and cannot be
+// evaluated from the installed fileset level alone. Two published examples:
+//
+//   - CVE-2020-4788 affects POWER9 processors only.
+//     https://aix.software.ibm.com/aix/efixes/security/power9_advisory.asc
+//   - The follow-up Spectre fix for CVE-2017-5715 is, in IBM's words, "only
+//     applicable to the following POWER9 systems: 9040-MR9, 9080-M9S".
+//     https://aix.software.ibm.com/aix/efixes/security/spectre_update_advisory.asc
+//
+// Both values are also reported by prtconf, but prtconf dumps the entire system
+// configuration and is comparatively expensive, so we read just the two fields
+// we need via uname and lsattr.
+//
+// Detection failures are non-fatal — the affected label is simply omitted.
+// Consumers must therefore treat a missing label as "unknown", never as
+// "does not match", so that an older agent or a restricted environment cannot
+// silently suppress a finding.
+func detectAixHardware(pf *inventory.Platform, osrd *OSReleaseDetector) {
+	// `uname -M` prints the machine type-model, e.g. "IBM,9009-42A".
+	if model, err := osrd.command("uname -M"); err != nil {
+		log.Debug().Err(err).Msg("could not detect aix system model")
+	} else {
+		setAixLabel(pf, AixLabelSystemModel, model)
+	}
+
+	// `lsattr -El proc0 -a type -F value` prints the processor implementation of
+	// the first processor, e.g. "PowerPC_POWER9". proc0 is absent inside a WPAR,
+	// in which case lsattr fails and the label stays unset.
+	if procType, err := osrd.command("lsattr -El proc0 -a type -F value"); err != nil {
+		log.Debug().Err(err).Msg("could not detect aix processor type")
+	} else {
+		setAixLabel(pf, AixLabelProcessorType, procType)
+	}
+}
+
+// setAixLabel stores value under key, provided the command actually returned a
+// value. Both fields are single whitespace-free tokens, so anything else is a
+// usage message or an error that the command printed to stdout rather than a
+// value we should record.
+func setAixLabel(pf *inventory.Platform, key string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, " \t\r\n") {
+		log.Debug().Str("label", key).Msg("ignoring unexpected aix hardware detection output")
+		return
+	}
+
+	if pf.Labels == nil {
+		pf.Labels = map[string]string{}
+	}
+	pf.Labels[key] = value
+}

--- a/providers/os/detector/detector_all.go
+++ b/providers/os/detector/detector_all.go
@@ -1545,6 +1545,8 @@ var aix = &PlatformResolver{
 			pf.Build = strings.TrimSpace(buildversion)
 		}
 
+		detectAixHardware(pf, osrd)
+
 		return true, nil
 	},
 }

--- a/providers/os/detector/detector_platform_test.go
+++ b/providers/os/detector/detector_platform_test.go
@@ -930,6 +930,38 @@ func TestSolaris11Detector(t *testing.T) {
 	assert.Equal(t, []string{"unix", "os"}, di.Family)
 }
 
+func TestAix72Detector(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-aix72.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "aix", di.Name, "os name should be identified")
+	assert.Equal(t, "AIX", di.Title, "os title should be identified")
+	assert.Equal(t, "7.2", di.Version, "os version should be identified")
+	assert.Equal(t, "powerpc", di.Arch, "os arch should be identified")
+	assert.Equal(t, "7200-05-02-2114", di.Build, "os build should be identified")
+	assert.Equal(t, []string{"unix", "os"}, di.Family)
+
+	// hardware facts required to scope POWER-gated security advisories
+	assert.Equal(t, "IBM,9009-42A", di.Labels[AixLabelSystemModel])
+	assert.Equal(t, "PowerPC_POWER9", di.Labels[AixLabelProcessorType])
+}
+
+func TestAixDetectorWithoutHardwareFacts(t *testing.T) {
+	di, err := detectPlatformFromMock("./testdata/detect-aix71-no-hardware.toml")
+	assert.Nil(t, err, "was able to create the provider")
+
+	assert.Equal(t, "aix", di.Name, "os name should be identified")
+	assert.Equal(t, "7.1", di.Version, "os version should be identified")
+
+	// uname -M and lsattr are unavailable here. The labels must stay absent rather
+	// than be recorded as empty, so that consumers can tell "unknown" apart from a
+	// value that genuinely does not match.
+	_, hasModel := di.Labels[AixLabelSystemModel]
+	assert.False(t, hasModel, "system model label should be absent")
+	_, hasProcType := di.Labels[AixLabelProcessorType]
+	assert.False(t, hasProcType, "processor type label should be absent")
+}
+
 func TestNetbsd8Detector(t *testing.T) {
 	di, err := detectPlatformFromMock("./testdata/detect-netbsd8.toml")
 	assert.Nil(t, err, "was able to create the provider")

--- a/providers/os/detector/testdata/detect-aix71-no-hardware.toml
+++ b/providers/os/detector/testdata/detect-aix71-no-hardware.toml
@@ -1,0 +1,8 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."uname -rvp"]
+stdout = "1 7 powerpc"
+
+[commands."oslevel -s"]
+stdout = "7100-05-08-2016"

--- a/providers/os/detector/testdata/detect-aix72.toml
+++ b/providers/os/detector/testdata/detect-aix72.toml
@@ -1,0 +1,14 @@
+[commands."uname -s"]
+stdout = "AIX"
+
+[commands."uname -rvp"]
+stdout = "2 7 powerpc"
+
+[commands."oslevel -s"]
+stdout = "7200-05-02-2114"
+
+[commands."uname -M"]
+stdout = "IBM,9009-42A"
+
+[commands."lsattr -El proc0 -a type -F value"]
+stdout = "PowerPC_POWER9"


### PR DESCRIPTION
## Why

Some IBM AIX security advisories are gated on hardware, not just on the installed fileset level. Two published examples:

| Advisory | CVE | Applicability |
|---|---|---|
| [`power9_advisory.asc`](https://aix.software.ibm.com/aix/efixes/security/power9_advisory.asc) | CVE-2020-4788 | `IBM Power9 processors could allow a local user to obtain sensitive information from the data in the L1 cache` |
| [`spectre_update_advisory.asc`](https://aix.software.ibm.com/aix/efixes/security/spectre_update_advisory.asc) | CVE-2017-5715 | `only applicable to the following POWER9 systems: 9040-MR9, 9080-M9S` |

Both advisories list wide `bos.mp64` fileset ranges (the second covers 6.1.9.0–7.2.2.16), so a version-only check matches plenty of machines that the advisory explicitly excludes — POWER8 hardware in the first case, and any POWER9 system other than the E950/E980 in the second.

The AIX detector recorded nothing that could express either gate. `uname -p` reports `powerpc` for every POWER generation, and no label was set at all.

## What

Record two facts as platform labels during AIX platform detection:

| Label | Source | Example |
|---|---|---|
| `aix.mondoo.com/system-model` | `uname -M` | `IBM,9009-42A` |
| `aix.mondoo.com/processor-type` | `lsattr -El proc0 -a type -F value` | `PowerPC_POWER9` |

Both values also appear in `prtconf`, but `prtconf` dumps the entire system configuration, so we read just the two fields we need.

Platform labels already flow into the SBOM and into the vulnerability report input, so no other plumbing is needed — this follows the same pattern as the existing `windows.mondoo.com/*` labels.

## Notes for reviewers

- **Missing means unknown, not "no match".** If `uname -M` or `lsattr` fails — for example `proc0` does not exist inside a WPAR — the label is left unset rather than written as an empty string. That distinction matters downstream: a consumer must not treat a restricted environment or an older agent as hardware that does not match, or it would suppress a genuine finding.
- The commands are guarded against a non-zero exit that still writes to stdout: a value containing whitespace is a usage or error message, not a model number, and is discarded.
- The new file is named `detector_aix_hardware.go` rather than `detector_aix.go` on purpose — `aix` is a valid `GOOS`, so a `_aix.go` suffix is an implicit build constraint and the file would compile only on AIX.

## Test plan

- `TestAix72Detector` — asserts both labels on a POWER9 S924 mock, alongside the existing name/version/arch/build assertions (AIX had no detector test before this).
- `TestAixDetectorWithoutHardwareFacts` — asserts both labels are *absent* when the commands are unavailable.
- `go test ./providers/os/detector/...` and `golangci-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)