### PR TITLE
🐛 ms365: exclude free/self-service plans from paidLicenses

### DIFF
--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -243,11 +243,13 @@ microsoft.tenant @defaults("name") {
   // `servicePlans` (each with `servicePlanId`, `servicePlanName`,
   // `provisioningStatus`, and `appliesTo`).
   subscriptions() []dict
-  // Total billed license seats
+  // Total paid license seats
   //
   // Sum of `totalLicenses` across non-trial subscriptions that are still
   // being billed (status `Enabled` or `Warning`, the post-expiry grace
-  // period). Suspended, deleted, and locked-out subscriptions are excluded.
+  // period). Suspended, deleted, and locked-out subscriptions are excluded,
+  // as are free and self-service plans (such as `RIGHTSMANAGEMENT_ADHOC` and
+  // `FLOW_FREE`) that report sentinel seat counts.
   paidLicenses() int
   // Company-wide settings for apps and services.
   settings() microsoft.tenantSettings

--- a/providers/ms365/resources/tenant.go
+++ b/providers/ms365/resources/tenant.go
@@ -263,7 +263,13 @@ func (a *mqlMicrosoftTenant) paidLicenses() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	return sumPaidLicenses(subs), nil
+}
 
+// sumPaidLicenses totals the seats a tenant actually pays for, excluding
+// trials, subscriptions past their billing grace period, and free/self-service
+// plans.
+func sumPaidLicenses(subs []companySubscription) int64 {
 	var total int64
 	for _, sub := range subs {
 		if sub.IsTrial != nil && *sub.IsTrial {
@@ -275,11 +281,37 @@ func (a *mqlMicrosoftTenant) paidLicenses() (int64, error) {
 		if sub.Status != nil && *sub.Status != "Enabled" && *sub.Status != "Warning" {
 			continue
 		}
+		// Free and self-service plans are not paid seats and report sentinel
+		// license counts (e.g. RIGHTSMANAGEMENT_ADHOC reports 1,000,000).
+		if sub.SkuPartNumber != nil {
+			if _, free := selfServiceSkuPartNumbers[*sub.SkuPartNumber]; free {
+				continue
+			}
+		}
 		if sub.TotalLicenses != nil {
 			total += int64(*sub.TotalLicenses)
 		}
 	}
-	return total, nil
+	return total
+}
+
+// selfServiceSkuPartNumbers are free/self-service/viral Microsoft plans that a
+// tenant does not pay per-seat for. They surface in the subscription list with
+// status Enabled and isTrial false, and report sentinel license counts (10,000
+// or 1,000,000), so they must be excluded from paidLicenses. This list is
+// best-effort; Microsoft adds freemium products over time, so it may need
+// extending as new ones surface.
+var selfServiceSkuPartNumbers = map[string]struct{}{
+	"RIGHTSMANAGEMENT_ADHOC":         {}, // Rights Management Adhoc
+	"WINDOWS_STORE":                  {}, // Windows Store for Business
+	"FLOW_FREE":                      {}, // Power Automate Free
+	"POWERAPPS_VIRAL":                {}, // Power Apps Plan 2 Trial (viral)
+	"POWER_BI_STANDARD":              {}, // Power BI (free)
+	"CCIBOTS_PRIVPREV_VIRAL":         {}, // Power Virtual Agents Viral Trial
+	"TEAMS_EXPLORATORY":              {}, // Microsoft Teams Exploratory
+	"STREAM":                         {}, // Microsoft Stream Trial
+	"SPZA_IW":                        {}, // App Connect IW
+	"PROJECT_MADEIRA_PREVIEW_IW_SKU": {}, // Dynamics 365 Business Central preview
 }
 
 func (a *mqlMicrosoft) tenantDomainName() (string, error) {

--- a/providers/ms365/resources/tenant_test.go
+++ b/providers/ms365/resources/tenant_test.go
@@ -80,3 +80,70 @@ func TestEnabledServicePlanServices(t *testing.T) {
 		})
 	}
 }
+
+func TestSumPaidLicenses(t *testing.T) {
+	sub := func(sku, status string, trial bool, seats int32) companySubscription {
+		return companySubscription{
+			SkuPartNumber: ptr(sku),
+			Status:        ptr(status),
+			IsTrial:       ptr(trial),
+			TotalLicenses: ptr(seats),
+		}
+	}
+
+	tests := []struct {
+		name string
+		in   []companySubscription
+		want int64
+	}{
+		{
+			name: "free/self-service plans do not inflate the total",
+			// Reproduces the observed 1,010,091: two sentinel free SKUs plus
+			// 91 real paid seats. Only the 91 should count.
+			in: []companySubscription{
+				sub("RIGHTSMANAGEMENT_ADHOC", "Enabled", false, 1000000),
+				sub("FLOW_FREE", "Enabled", false, 10000),
+				sub("ENTERPRISEPREMIUM", "Enabled", false, 91),
+			},
+			want: 91,
+		},
+		{
+			name: "trials are excluded",
+			in: []companySubscription{
+				sub("ENTERPRISEPREMIUM", "Enabled", false, 100),
+				sub("SPE_E3", "Enabled", true, 50),
+			},
+			want: 100,
+		},
+		{
+			name: "Warning (grace period) counts, Suspended/Deleted/LockedOut do not",
+			in: []companySubscription{
+				sub("ENTERPRISEPREMIUM", "Enabled", false, 100),
+				sub("SPE_E3", "Warning", false, 40),
+				sub("SPB", "Suspended", false, 30),
+				sub("EMS", "Deleted", false, 20),
+				sub("SPE_E5", "LockedOut", false, 10),
+			},
+			want: 140,
+		},
+		{
+			name: "nil pointers are tolerated",
+			in: []companySubscription{
+				{TotalLicenses: ptr(int32(25))},                                   // nil status/trial/sku
+				{SkuPartNumber: ptr("ENTERPRISEPREMIUM"), Status: ptr("Enabled")}, // nil seats
+			},
+			want: 25,
+		},
+		{
+			name: "empty input is zero",
+			in:   nil,
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sumPaidLicenses(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`microsoft.tenant.paidLicenses` summed `totalLicenses` across every non-trial, actively-billed subscription. But **free/self-service Microsoft plans are `isTrial=false`, `status=Enabled`**, and report *sentinel* license counts rather than real seats:

- `RIGHTSMANAGEMENT_ADHOC` → `1,000,000`
- `FLOW_FREE` / `POWERAPPS_VIRAL` / `POWER_BI_STANDARD` / … → `10,000`

So they sailed past the trial + status filters and dwarfed the real number. A tenant with ~91 real paid seats plus `RIGHTSMANAGEMENT_ADHOC` and one viral plan reported **`1,010,091`** (= 1,000,000 + 10,000 + 91). Screenshot of the bad value that kicked this off is on the linked overview PR.

## Fix

Exclude a set of known free/self-service SKU part numbers (`selfServiceSkuPartNumbers`) in addition to the existing trial + active-status filters. The summing logic is extracted into a pure `sumPaidLicenses` helper and covered by a unit test that reproduces the `1,010,091 → 91` case plus trial/status/nil edge cases.

## Caveat

I don't have a live M365 tenant to verify against, so the exclusion list is **best-effort** — it covers the well-documented sentinel offenders, but Microsoft adds freemium products over time and the list may need extending as new ones surface. There is no clean `isPaid`/`isFree` flag on the Graph `companySubscription` object, which is why a name-based exclusion (the standard approach for this data) is used rather than a heuristic threshold. The list lives in one place and is trivial to extend.

## Notes

- Behavior/doc change to an existing field — no type change, no new `.lr.versions` entry.
- The asset-overview surfaces this field (server#17905); once this ships in a released ms365 provider, the overview number corrects itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)