### PR TITLE
📄 expand provider help examples for sub-commands and missing usage

### DIFF
--- a/providers/claude/config/config.go
+++ b/providers/claude/config/config.go
@@ -21,6 +21,20 @@ var Config = plugin.Provider{
 			Name:  "claude",
 			Use:   "claude",
 			Short: "a Claude AI platform account",
+			Long: `Use the claude provider to query organization, workspace, API key, and service account
+configuration in a Claude AI platform account.
+
+Examples:
+  cnspec shell claude --token <API-KEY>
+  cnspec scan claude --admin-token <ADMIN-API-KEY> --discover organization
+  cnspec scan claude --admin-token <ADMIN-API-KEY> --discover workspaces
+
+Notes:
+  If you set the ANTHROPIC_API_KEY environment variable, you can omit the token flag.
+
+  Organization and workspace resources require an Admin API key. Supply it with
+  --admin-token or by setting the ANTHROPIC_ADMIN_API_KEY environment variable.
+`,
 			Discovery: []string{
 				connection.DiscoveryAll,
 				connection.DiscoveryAuto,

--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -37,6 +37,13 @@ Note:
 Examples with the GCP project configured:
   cnspec scan gcp folder <FOLDER-ID>
   cnspec shell gcp project
+
+Examples for a single Compute Engine instance or snapshot:
+  cnspec scan gcp instance <INSTANCE-NAME> --project-id <PROJECT-ID> --zone <ZONE>
+  cnspec scan gcp snapshot <SNAPSHOT-NAME> --project-id <PROJECT-ID>
+
+Example for Google Container Registry:
+  cnspec scan gcp gcr <PROJECT-ID>
 `,
 			MaxArgs: 2,
 			Discovery: []string{

--- a/providers/github/config/config.go
+++ b/providers/github/config/config.go
@@ -25,11 +25,15 @@ var Config = plugin.Provider{
 Available commands:
   org                       GitHub organization
   repo                      GitHub repo
+  user                      GitHub user
 
 Examples:
   cnspec scan github org <ORG_NAME> --discover organization
   cnspec scan github org <ORG_NAME> --repos "<REPO1>,<REPO2>"
+  cnspec scan github repo <ORG_NAME>/<REPO_NAME>
+  cnspec scan github user <USERNAME>
   cnspec shell github org <ORG_NAME>
+  cnspec shell github repo <ORG_NAME>/<REPO_NAME>
   cnspec shell github org <YOUR-GITHUB-ORG> --app-id <YOUR-GITHUB-APP-ID> --app-installation-id <YOUR-GITHUB-APP-INSTALL-ID> --app-private-key <PATH-TO-PEM-FILE>
 
 Notes:

--- a/providers/huggingface/config/config.go
+++ b/providers/huggingface/config/config.go
@@ -17,9 +17,19 @@ var Config = plugin.Provider{
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
-			Name:      "huggingface",
-			Use:       "huggingface",
-			Short:     "Hugging Face",
+			Name:  "huggingface",
+			Use:   "huggingface",
+			Short: "Hugging Face",
+			Long: `Use the huggingface provider to query models, datasets, and spaces on Hugging Face.
+
+Examples:
+  cnspec shell huggingface --token <API-TOKEN>
+  cnspec shell huggingface --namespace openai --namespace-type org
+  cnspec scan huggingface --namespace <USERNAME> --namespace-type user
+
+Notes:
+  If you set the HF_TOKEN environment variable, you can omit the token flag.
+`,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{

--- a/providers/nmap/config/config.go
+++ b/providers/nmap/config/config.go
@@ -26,11 +26,17 @@ var Config = plugin.Provider{
 Requirement:
   Nmap must be installed on your system. To learn how, read https://nmap.org/download.html.
 
+Available sub-commands:
+  host <TARGET>             Scan a single host by IP address or hostname
+  domain <TARGET>           Scan a domain and the hosts behind it
+
 Examples:
   cnspec shell nmap host 192.168.1.1
+  cnspec shell nmap domain example.com
   cnspec shell nmap --networks 10.0.0.0/8,192.168.0.0/16
   cnspec shell nmap --networks "192.168.1.0/24" --discover hosts
   cnspec scan nmap host 192.168.1.1
+  cnspec scan nmap domain example.com
   cnspec shell nmap host 192.168.1.1 --ports 22,80,443
 `,
 			MinArgs: 0,

--- a/providers/ollama/config/config.go
+++ b/providers/ollama/config/config.go
@@ -17,9 +17,21 @@ var Config = plugin.Provider{
 	Platforms:       provider.Platforms,
 	Connectors: []plugin.Connector{
 		{
-			Name:      "ollama",
-			Use:       "ollama",
-			Short:     "an Ollama instance",
+			Name:  "ollama",
+			Use:   "ollama",
+			Short: "an Ollama instance",
+			Long: `Use the ollama provider to query the models and configuration of an Ollama instance.
+
+Examples:
+  cnspec shell ollama
+  cnspec shell ollama --host http://<HOST>:11434
+  cnspec scan ollama --token <API-TOKEN>
+
+Notes:
+  Without the host flag, Ollama is queried at http://localhost:11434. You can also set
+  the OLLAMA_HOST environment variable. Use the token flag, or OLLAMA_API_TOKEN, to
+  authenticate against a cloud-hosted Ollama instance.
+`,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{

--- a/providers/openai/config/config.go
+++ b/providers/openai/config/config.go
@@ -18,9 +18,22 @@ var Config = plugin.Provider{
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{
 		{
-			Name:      "openai",
-			Use:       "openai",
-			Short:     "an OpenAI account",
+			Name:  "openai",
+			Use:   "openai",
+			Short: "an OpenAI account",
+			Long: `Use the openai provider to query project, organization, and API key configuration
+in an OpenAI account.
+
+Examples:
+  cnspec shell openai --token <API-KEY>
+  cnspec scan openai --token <ADMIN-API-KEY> --organization <ORG-ID>
+  cnspec scan openai --project <PROJECT-ID>
+
+Notes:
+  If you set the OPENAI_API_KEY environment variable, you can omit the token flag. Both
+  project keys (sk-proj-...) and admin keys (sk-admin-...) are accepted and detected
+  automatically; organization resources require an admin key.
+`,
 			Discovery: []string{},
 			Flags: []plugin.Flag{
 				{

--- a/providers/openstack/config/config.go
+++ b/providers/openstack/config/config.go
@@ -32,6 +32,12 @@ Authentication options (in priority order):
 
 Application credentials are also supported via --application-credential-id
 and --application-credential-secret.
+
+Examples:
+  cnspec shell openstack --cloud <CLOUDS-YAML-ENTRY>
+  cnspec scan openstack --auth-url <KEYSTONE-URL> --username <USERNAME> --password <PASSWORD> --project-name <PROJECT-NAME>
+  cnspec scan openstack --auth-url <KEYSTONE-URL> --application-credential-id <ID> --application-credential-secret <SECRET>
+  cnspec scan openstack --cloud <CLOUDS-YAML-ENTRY> --discover security-groups
 `,
 			MinArgs: 0,
 			MaxArgs: 0,

--- a/providers/shodan/config/config.go
+++ b/providers/shodan/config/config.go
@@ -23,10 +23,18 @@ var Config = plugin.Provider{
 			Short: "a Shodan account",
 			Long: `Use the shodan provider to query domain and IP security information in the Shodan search engine.
 
+Available sub-commands:
+  host <TARGET>             Query a single host by IP address or hostname
+  domain <TARGET>           Query a domain and the hosts Shodan associates with it
+
 Examples:
   cnspec shell shodan --token <api-token>
+  cnspec shell shodan host example.com
+  cnspec shell shodan domain example.com
   cnspec shell shodan --networks <ip-range> --discover hosts
   cnspec scan shodan --token <api-token>
+  cnspec scan shodan host 192.168.1.1
+  cnspec scan shodan domain example.com
 
 Notes:
   If you set the SHODAN_TOKEN environment variable, you can omit the token flag.


### PR DESCRIPTION
## Summary

Expands the `--help` examples for provider connectors. Two classes of gap, both found by survey rather than by guessing.

Method: built cnspec at HEAD, ran `cnspec scan <connector> --help` for all **83 connectors**, and checked (a) whether the help shows any usage example at all, and (b) whether it demonstrates every positional sub-command the provider's `ParseCLI` actually accepts.

## Sub-commands that exist but were never shown in help

| Connector | Missing from examples | Notes |
|---|---|---|
| `shodan` | `host`, `domain` | Neither appeared. Examples only showed `--token` / `--networks`. |
| `github` | `repo`, `user` | `repo` was listed under "Available commands" but never demonstrated; `user` was absent entirely. |
| `nmap` | `domain` | `host` was shown, `domain` was not. |
| `gcp` | `gcr`, `snapshot`, `instance` | `organization` needs no example of its own, it is an alias of `org`. |

The shodan case is the one with a confirmed downstream cost. Because the help never showed the sub-command form, the docs page ended up documenting a `--targets` flag that has never existed:

```
$ cnspec scan shodan --targets example.com
Error: unknown flag: --targets

$ cnspec scan shodan example.com
invalid Shodan sub-command, supported are: host or domain

$ cnspec scan shodan host example.com
Asset: (Shodan Host) example.com     # the form that actually works
```

The corresponding docs fix is in mondoohq/docs#1731.

## Connectors whose help showed no usage example at all

`claude`, `huggingface`, `ollama`, `openai`, `openstack`.

Each now has an `Examples:` block. The four that had no `Long` at all (`claude`, `huggingface`, `ollama`, `openai`) also get a one-line summary of what the provider queries.

Note that `depsdev` and `hetzner` were **not** touched: an earlier pass flagged them because their help never uses the word "Example", but both already demonstrate usage inline.

## Accuracy

Every flag, env var, discovery target, and sub-command argument shape in the new text was read out of the provider source rather than assumed:

- claude `--discover` values (`organization`, `workspaces`) from `providers/claude/connection/platform.go`
- openstack `security-groups` from `providers/openstack/connection/platform.go`
- `OPENAI_API_KEY` from `providers/openai/connection/connection.go:52`, since that flag's own description does not mention the env var
- gcp `instance` / `snapshot` argument shapes from `providers/gcp/provider/provider.go`, cross-checked against the published docs

## Verification

- `gofmt -l` clean on all 9 files
- All 9 provider configs compile (`go build ./config/`)
- `typos` passes
- `go run ./gen/main.go .` for shodan regenerates `dist/shodan.json` with the new help text, confirming it reaches what `--help` renders
- No em dashes added

## Out of scope

Four connectors with no help examples live in `mql-enterprise-providers`, not here: `ciscocatalyst`, `fortios`, `nd-ssh` (networkdevices), and `mcp` (ai). Happy to open a matching PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
