### PR TITLE
✨ gcp: expose storage pool sharing, App Engine bundled services, and Dataproc SSH access

### DIFF
--- a/providers/gcp/resources/appengine.go
+++ b/providers/gcp/resources/appengine.go
@@ -213,18 +213,19 @@ func (g *mqlGcpProjectAppEngineServiceService) versions() ([]any, error) {
 			}
 
 			mqlVersion, err := CreateResource(g.MqlRuntime, "gcp.project.appEngineService.version", map[string]*llx.RawData{
-				"projectId":          llx.StringData(projectId),
-				"serviceId":          llx.StringData(serviceId),
-				"id":                 llx.StringData(v.Id),
-				"name":               llx.StringData(v.Name),
-				"servingStatus":      llx.StringData(v.ServingStatus),
-				"runtime":            llx.StringData(v.Runtime),
-				"env":                llx.StringData(v.Env),
-				"createTime":         llx.TimeDataPtr(parseTime(v.CreateTime)),
-				"runtimeApiVersion":  llx.StringData(v.RuntimeApiVersion),
-				"vpcAccessConnector": llx.DictData(vpcConnector),
-				"handlers":           llx.ArrayData(handlers, types.Dict),
-				"inboundServices":    llx.ArrayData(convert.SliceAnyToInterface(v.InboundServices), types.String),
+				"projectId":                llx.StringData(projectId),
+				"serviceId":                llx.StringData(serviceId),
+				"id":                       llx.StringData(v.Id),
+				"name":                     llx.StringData(v.Name),
+				"servingStatus":            llx.StringData(v.ServingStatus),
+				"runtime":                  llx.StringData(v.Runtime),
+				"env":                      llx.StringData(v.Env),
+				"createTime":               llx.TimeDataPtr(parseTime(v.CreateTime)),
+				"runtimeApiVersion":        llx.StringData(v.RuntimeApiVersion),
+				"vpcAccessConnector":       llx.DictData(vpcConnector),
+				"handlers":                 llx.ArrayData(handlers, types.Dict),
+				"inboundServices":          llx.ArrayData(convert.SliceAnyToInterface(v.InboundServices), types.String),
+				"appEngineBundledServices": llx.ArrayData(convert.SliceAnyToInterface(v.AppEngineBundledServices), types.String),
 			})
 			if err != nil {
 				return err

--- a/providers/gcp/resources/compute.go
+++ b/providers/gcp/resources/compute.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -3789,6 +3790,22 @@ func (g *mqlGcpProjectComputeServiceStoragePool) id() (string, error) {
 	return g.Id.Data, g.Id.Error
 }
 
+// storagePoolSharedProjectIds returns the sorted project IDs a storage pool is
+// shared with. The share settings carry a project map whose values only repeat
+// the key, so the keys alone describe which projects may create disks from the
+// pool.
+func storagePoolSharedProjectIds(shareSettings *compute.StoragePoolShareSettings) []any {
+	if shareSettings == nil {
+		return []any{}
+	}
+	ids := make([]string, 0, len(shareSettings.ProjectMap))
+	for projectId := range shareSettings.ProjectMap {
+		ids = append(ids, projectId)
+	}
+	sort.Strings(ids)
+	return convert.SliceAnyToInterface(ids)
+}
+
 func (g *mqlGcpProjectComputeService) storagePools() ([]any, error) {
 	if !g.GetEnabled().Data {
 		return nil, nil
@@ -3831,6 +3848,7 @@ func (g *mqlGcpProjectComputeService) storagePools() ([]any, error) {
 					"state":                       llx.StringData(sp.State),
 					"storagePoolType":             llx.StringData(sp.StoragePoolType),
 					"zone":                        llx.StringData(sp.Zone),
+					"sharedWithProjectIds":        llx.ArrayData(storagePoolSharedProjectIds(sp.ShareSettings), types.String),
 				})
 				if err != nil {
 					return err

--- a/providers/gcp/resources/dataproc.go
+++ b/providers/gcp/resources/dataproc.go
@@ -491,10 +491,12 @@ func (g *mqlGcpProjectDataprocService) clusters() ([]any, error) {
 
 						componentGatewayEnabled := c.Config.EndpointConfig != nil && c.Config.EndpointConfig.EnableHttpPortAccess
 						kerberosEnabled := c.Config.SecurityConfig != nil && c.Config.SecurityConfig.KerberosConfig != nil && c.Config.SecurityConfig.KerberosConfig.EnableKerberos
+						sshEnabled := c.Config.SecurityConfig != nil && c.Config.SecurityConfig.IdentityConfig != nil && c.Config.SecurityConfig.IdentityConfig.EnableSsh
 						mqlConfig, err = CreateResource(g.MqlRuntime, "gcp.project.dataprocService.cluster.config", map[string]*llx.RawData{
 							"parentResourcePath":      llx.StringData(fmt.Sprintf("%s/dataproc/%s", projectId, c.ClusterName)),
 							"componentGatewayEnabled": llx.BoolData(componentGatewayEnabled),
 							"kerberosEnabled":         llx.BoolData(kerberosEnabled),
+							"sshEnabled":              llx.BoolData(sshEnabled),
 							"autoscaling":             llx.DictData(mqlAutoscalingCfg),
 							"configBucket":            llx.StringData(c.Config.ConfigBucket),
 							"metrics":                 llx.DictData(mqlMetricsCfg),

--- a/providers/gcp/resources/gcp.lr
+++ b/providers/gcp/resources/gcp.lr
@@ -1622,7 +1622,15 @@ gcp.project.computeService.instance @defaults("name id") {
   resourcePolicies []string
   // Resource status for physical host
   physicalHostResourceStatus string
-  // Scheduling options including preemptibility, automatic restart, and maintenance behavior
+  // Instance scheduling options
+  //
+  // Holds `preemptible`, `automaticRestart`, and `onHostMaintenance` for the
+  // instance's lifecycle behavior, `provisioningModel` and
+  // `instanceTerminationAction` for how the instance is provisioned and what
+  // happens when capacity is reclaimed, `gracefulShutdown` (whether the guest
+  // is signalled before termination, and the `maxDuration` it is given), and
+  // `preemptionNoticeDuration`, how much warning a Spot VM receives before the
+  // ACPI G2 soft-off signal fires.
   scheduling dict
   // Shielded Instance configuration
   shieldedInstanceConfig gcp.project.computeService.instance.shieldedInstanceConfig
@@ -7090,6 +7098,16 @@ private gcp.project.dataprocService.cluster.config {
   // authentication between daemons. Hoisted from the `security` dict's
   // kerberosConfig.enableKerberos key.
   kerberosEnabled bool
+  // Whether SSH access to the cluster nodes is enabled
+  //
+  // True when operators may open SSH sessions to the cluster's Compute Engine
+  // nodes, which is interactive access to the data plane rather than access
+  // mediated by the Dataproc jobs API. The platform default depends on the
+  // image: enabled for image versions before 3.1, disabled from 3.1 onward,
+  // and settable at creation time from image version 2.3.30. Hoisted from the
+  // `security` dict's identityConfig.enableSsh key, which omits the value when
+  // SSH is disabled.
+  sshEnabled bool
   // Shared Compute Engine configuration
   gceCluster gcp.project.dataprocService.cluster.config.gceCluster
   // Kubernetes Engine config for Dataproc clusters deployed to Kubernetes
@@ -7115,9 +7133,10 @@ private gcp.project.dataprocService.cluster.config {
   //
   // Holds `kerberosConfig` (Kerberos secure-mode settings including
   // `enableKerberos`, realm, KDC, cross-realm trust, and the KMS-encrypted
-  // key and keystore URIs) and `identityConfig` (the
-  // `userServiceAccountMapping` for workforce identity federation). See
-  // `kerberosEnabled` for the hoisted Kerberos enable flag.
+  // key and keystore URIs) and `identityConfig` (`userServiceAccountMapping`
+  // for workforce identity federation, and `enableSsh` for SSH access to the
+  // cluster nodes). See `kerberosEnabled` and `sshEnabled` for the hoisted
+  // flags, which stay set even when the underlying key is omitted.
   security dict
   // Cluster software configuration
   //
@@ -9697,7 +9716,8 @@ private gcp.project.computeService.vpnTunnel @defaults("name status") {
 // capacity provisioning type (`ADVANCED` or `STANDARD`), performance
 // provisioning type, provisioned capacity in GiB, IOPS, and throughput.
 // `storagePoolType` identifies the underlying disk technology, and `zone`
-// names the zone where the pool resides.
+// names the zone where the pool resides. `sharedWithProjectIds` reports the
+// projects outside the owning project that may create disks from the pool.
 private gcp.project.computeService.storagePool @defaults("name state") {
   // Unique identifier
   id string
@@ -9725,6 +9745,13 @@ private gcp.project.computeService.storagePool @defaults("name state") {
   storagePoolType string
   // Zone URL where the storage pool resides
   zone string
+  // Project IDs the storage pool is shared with
+  //
+  // Empty when the pool is consumable only from the project that owns it.
+  // Each entry is a project permitted to create disks backed by this pool,
+  // so a non-empty list widens the set of projects that can draw on the
+  // pool's provisioned capacity.
+  sharedWithProjectIds []string
 }
 
 // Google Cloud (GCP) Compute Cloud NAT configuration on a router
@@ -11007,6 +11034,20 @@ private gcp.project.appEngineService.version @defaults("id servingStatus") {
   handlers []dict
   // Inbound service channels the version accepts beyond HTTP (e.g. mail, XMPP, warmup); additional ingress surface
   inboundServices []string
+  // Legacy bundled services enabled for the version
+  //
+  // Second-generation runtimes reach the legacy App Engine APIs only when the
+  // corresponding service is listed here, so this names the older platform
+  // surface the version still depends on. Values are
+  // BUNDLED_SERVICE_TYPE_APP_IDENTITY_SERVICE, BUNDLED_SERVICE_TYPE_BLOBSTORE,
+  // BUNDLED_SERVICE_TYPE_CAPABILITY_SERVICE, BUNDLED_SERVICE_TYPE_DATASTORE_V3,
+  // BUNDLED_SERVICE_TYPE_DEFERRED, BUNDLED_SERVICE_TYPE_IMAGES,
+  // BUNDLED_SERVICE_TYPE_MAIL, BUNDLED_SERVICE_TYPE_MEMCACHE,
+  // BUNDLED_SERVICE_TYPE_MODULES, BUNDLED_SERVICE_TYPE_NAMESPACES,
+  // BUNDLED_SERVICE_TYPE_NDB, BUNDLED_SERVICE_TYPE_SEARCH,
+  // BUNDLED_SERVICE_TYPE_TASKQUEUES, BUNDLED_SERVICE_TYPE_URLFETCH,
+  // BUNDLED_SERVICE_TYPE_USERS, or BUNDLED_SERVICE_TYPE_UNSPECIFIED.
+  appEngineBundledServices []string
 }
 
 // Google Cloud (GCP) API Gateway

--- a/providers/gcp/resources/gcp.lr.go
+++ b/providers/gcp/resources/gcp.lr.go
@@ -8962,6 +8962,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.dataprocService.cluster.config.kerberosEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfig).GetKerberosEnabled()).ToDataRes(types.Bool)
 	},
+	"gcp.project.dataprocService.cluster.config.sshEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectDataprocServiceClusterConfig).GetSshEnabled()).ToDataRes(types.Bool)
+	},
 	"gcp.project.dataprocService.cluster.config.gceCluster": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectDataprocServiceClusterConfig).GetGceCluster()).ToDataRes(types.Resource("gcp.project.dataprocService.cluster.config.gceCluster"))
 	},
@@ -11248,6 +11251,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gcp.project.computeService.storagePool.zone": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceStoragePool).GetZone()).ToDataRes(types.String)
 	},
+	"gcp.project.computeService.storagePool.sharedWithProjectIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectComputeServiceStoragePool).GetSharedWithProjectIds()).ToDataRes(types.Array(types.String))
+	},
 	"gcp.project.computeService.router.nat.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectComputeServiceRouterNat).GetId()).ToDataRes(types.String)
 	},
@@ -12384,6 +12390,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"gcp.project.appEngineService.version.inboundServices": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectAppEngineServiceVersion).GetInboundServices()).ToDataRes(types.Array(types.String))
+	},
+	"gcp.project.appEngineService.version.appEngineBundledServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGcpProjectAppEngineServiceVersion).GetAppEngineBundledServices()).ToDataRes(types.Array(types.String))
 	},
 	"gcp.project.apiGatewayService.projectId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGcpProjectApiGatewayService).GetProjectId()).ToDataRes(types.String)
@@ -27510,6 +27519,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectDataprocServiceClusterConfig).KerberosEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gcp.project.dataprocService.cluster.config.sshEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectDataprocServiceClusterConfig).SshEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"gcp.project.dataprocService.cluster.config.gceCluster": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectDataprocServiceClusterConfig).GceCluster, ok = plugin.RawToTValue[*mqlGcpProjectDataprocServiceClusterConfigGceCluster](v.Value, v.Error)
 		return
@@ -30834,6 +30847,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGcpProjectComputeServiceStoragePool).Zone, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"gcp.project.computeService.storagePool.sharedWithProjectIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectComputeServiceStoragePool).SharedWithProjectIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"gcp.project.computeService.router.nat.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectComputeServiceRouterNat).__id, ok = v.Value.(string)
 		return
@@ -32496,6 +32513,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"gcp.project.appEngineService.version.inboundServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGcpProjectAppEngineServiceVersion).InboundServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"gcp.project.appEngineService.version.appEngineBundledServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGcpProjectAppEngineServiceVersion).AppEngineBundledServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"gcp.project.apiGatewayService.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -63399,6 +63420,7 @@ type mqlGcpProjectDataprocServiceClusterConfig struct {
 	Endpoint                plugin.TValue[any]
 	ComponentGatewayEnabled plugin.TValue[bool]
 	KerberosEnabled         plugin.TValue[bool]
+	SshEnabled              plugin.TValue[bool]
 	GceCluster              plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceCluster]
 	GkeCluster              plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGkeCluster]
 	InitializationActions   plugin.TValue[[]any]
@@ -63528,6 +63550,10 @@ func (c *mqlGcpProjectDataprocServiceClusterConfig) GetComponentGatewayEnabled()
 
 func (c *mqlGcpProjectDataprocServiceClusterConfig) GetKerberosEnabled() *plugin.TValue[bool] {
 	return &c.KerberosEnabled
+}
+
+func (c *mqlGcpProjectDataprocServiceClusterConfig) GetSshEnabled() *plugin.TValue[bool] {
+	return &c.SshEnabled
 }
 
 func (c *mqlGcpProjectDataprocServiceClusterConfig) GetGceCluster() *plugin.TValue[*mqlGcpProjectDataprocServiceClusterConfigGceCluster] {
@@ -71190,6 +71216,7 @@ type mqlGcpProjectComputeServiceStoragePool struct {
 	State                       plugin.TValue[string]
 	StoragePoolType             plugin.TValue[string]
 	Zone                        plugin.TValue[string]
+	SharedWithProjectIds        plugin.TValue[[]any]
 }
 
 // createGcpProjectComputeServiceStoragePool creates a new instance of this resource
@@ -71279,6 +71306,10 @@ func (c *mqlGcpProjectComputeServiceStoragePool) GetStoragePoolType() *plugin.TV
 
 func (c *mqlGcpProjectComputeServiceStoragePool) GetZone() *plugin.TValue[string] {
 	return &c.Zone
+}
+
+func (c *mqlGcpProjectComputeServiceStoragePool) GetSharedWithProjectIds() *plugin.TValue[[]any] {
+	return &c.SharedWithProjectIds
 }
 
 // mqlGcpProjectComputeServiceRouterNat for the gcp.project.computeService.router.nat resource
@@ -75142,18 +75173,19 @@ type mqlGcpProjectAppEngineServiceVersion struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGcpProjectAppEngineServiceVersionInternal it will be used here
-	ProjectId          plugin.TValue[string]
-	ServiceId          plugin.TValue[string]
-	Id                 plugin.TValue[string]
-	Name               plugin.TValue[string]
-	ServingStatus      plugin.TValue[string]
-	Runtime            plugin.TValue[string]
-	Env                plugin.TValue[string]
-	CreateTime         plugin.TValue[*time.Time]
-	RuntimeApiVersion  plugin.TValue[string]
-	VpcAccessConnector plugin.TValue[any]
-	Handlers           plugin.TValue[[]any]
-	InboundServices    plugin.TValue[[]any]
+	ProjectId                plugin.TValue[string]
+	ServiceId                plugin.TValue[string]
+	Id                       plugin.TValue[string]
+	Name                     plugin.TValue[string]
+	ServingStatus            plugin.TValue[string]
+	Runtime                  plugin.TValue[string]
+	Env                      plugin.TValue[string]
+	CreateTime               plugin.TValue[*time.Time]
+	RuntimeApiVersion        plugin.TValue[string]
+	VpcAccessConnector       plugin.TValue[any]
+	Handlers                 plugin.TValue[[]any]
+	InboundServices          plugin.TValue[[]any]
+	AppEngineBundledServices plugin.TValue[[]any]
 }
 
 // createGcpProjectAppEngineServiceVersion creates a new instance of this resource
@@ -75239,6 +75271,10 @@ func (c *mqlGcpProjectAppEngineServiceVersion) GetHandlers() *plugin.TValue[[]an
 
 func (c *mqlGcpProjectAppEngineServiceVersion) GetInboundServices() *plugin.TValue[[]any] {
 	return &c.InboundServices
+}
+
+func (c *mqlGcpProjectAppEngineServiceVersion) GetAppEngineBundledServices() *plugin.TValue[[]any] {
+	return &c.AppEngineBundledServices
 }
 
 // mqlGcpProjectApiGatewayService for the gcp.project.apiGatewayService resource

--- a/providers/gcp/resources/gcp.lr.versions
+++ b/providers/gcp/resources/gcp.lr.versions
@@ -445,6 +445,7 @@ gcp.project.appEngineService.service.split 11.6.6
 gcp.project.appEngineService.service.versions 11.6.6
 gcp.project.appEngineService.services 11.6.6
 gcp.project.appEngineService.version 11.6.6
+gcp.project.appEngineService.version.appEngineBundledServices 13.33.4
 gcp.project.appEngineService.version.createTime 11.6.6
 gcp.project.appEngineService.version.env 11.6.6
 gcp.project.appEngineService.version.handlers 13.15.1
@@ -2382,6 +2383,7 @@ gcp.project.computeService.storagePool.performanceProvisioningType 11.6.6
 gcp.project.computeService.storagePool.poolProvisionedCapacityGb 11.6.6
 gcp.project.computeService.storagePool.poolProvisionedIops 11.6.6
 gcp.project.computeService.storagePool.poolProvisionedThroughput 11.6.6
+gcp.project.computeService.storagePool.sharedWithProjectIds 13.33.4
 gcp.project.computeService.storagePool.state 11.6.6
 gcp.project.computeService.storagePool.storagePoolType 11.6.6
 gcp.project.computeService.storagePool.zone 11.6.6
@@ -2782,6 +2784,7 @@ gcp.project.dataprocService.cluster.config.parentResourcePath 9.0.0
 gcp.project.dataprocService.cluster.config.secondaryWorker 9.0.0
 gcp.project.dataprocService.cluster.config.security 9.0.0
 gcp.project.dataprocService.cluster.config.software 9.0.0
+gcp.project.dataprocService.cluster.config.sshEnabled 13.33.4
 gcp.project.dataprocService.cluster.config.tempBucket 9.0.0
 gcp.project.dataprocService.cluster.config.tempBucketRef 13.27.2
 gcp.project.dataprocService.cluster.config.worker 9.0.0

--- a/providers/gcp/resources/gcp.permissions.json
+++ b/providers/gcp/resources/gcp.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "gcp",
-  "version": "13.33.2",
-  "generated_at": "2026-07-25T20:59:25-07:00",
+  "version": "13.33.3",
+  "generated_at": "2026-07-29T19:45:16-07:00",
   "permissions": [
     "accessapproval.settings.get",
     "aiplatform.batchPredictionJobs.list",


### PR DESCRIPTION
Picks up three fields that became available in `google.golang.org/api` v0.291.0 (vendored by #9506), and corrects two dict doc-comments the bump silently widened.

## New fields

**`gcp.project.computeService.storagePool.sharedWithProjectIds`** — the projects outside the owning project permitted to create disks from a pool, i.e. who else can draw on its provisioned capacity.

The SDK models this as `shareSettings.projectMap`, a map whose values only repeat the key, so the sorted key set is the entire signal. Kept as a raw ID list rather than a typed `[]gcp.project` on purpose: `initGcpProject` (`project.go:45`) resolves `conn.ResourceID()` and ignores any `id` argument, so a typed ref would silently return the *connected* project's data instead of the share target.

**`gcp.project.appEngineService.version.appEngineBundledServices`** — the legacy bundled services a second-generation runtime is allowed to reach. Sits next to the existing `inboundServices`; both describe older platform surface a version still depends on. The lister already requests the `FULL` view, so no extra call.

**`gcp.project.dataprocService.cluster.config.sshEnabled`** — whether operators can open SSH sessions to the cluster's Compute Engine nodes, which is interactive data-plane access rather than access mediated by the jobs API.

Hoisting this one matters beyond convenience. `IdentityConfig.EnableSsh` is a non-pointer `bool` with `omitempty`, so when SSH is disabled the key is dropped from the `security` dict altogether. An assertion written against the dict key sees `null`, not `false` — and in MQL's three-valued logic that does not fail closed. The hoisted field is always set, matching the existing `kerberosEnabled` treatment.

The platform default is version-dependent (enabled before image 3.1, disabled from 3.1 onward, settable at creation from 2.3.30), which is documented on the field.

## Doc-comment corrections

Both dicts already carried the new keys via `convert.JsonToDict`, so the data was correct while the enumerated comments had gone stale:

- instance `scheduling` now documents `gracefulShutdown` and `preemptionNoticeDuration`. All keys named in the comment were verified against the SDK's `Scheduling` struct.
- cluster config `security` now documents `enableSsh` under `identityConfig`.

## Verification

`mqlr generate` + `make providers/build/gcp` clean; `gofmt` applied. `gcp.permissions.json` is regenerated and its only change is provider-version and timestamp metadata, since no new API calls were added.

Not yet exercised against live GCP infrastructure; queued for the next batched live-verification pass.
