### PR TITLE
✨ google-workspace: attribute audit activity to AI agents and actor devices

### DIFF
--- a/providers/google-workspace/resources/google-workspace.lr
+++ b/providers/google-workspace/resources/google-workspace.lr
@@ -747,8 +747,11 @@ private googleworkspace.report.activity {
   // `email` (primary email of the actor, absent when none is associated),
   // `profileId` (unique Google Workspace profile ID of the actor), `key`
   // (present only when `callerType` is KEY, the OAuth consumer key or robot
-  // account identifier), and `applicationInfo` (details of the application when
-  // an app performed the action).
+  // account identifier), `applicationInfo` (details of the application when
+  // an app performed the action), and `agentAttributionInfo` (present when an
+  // AI agent was the actor, carrying `agentId`, `agentName`, `agentType`, and
+  // an `agentOwner` object whose `email` names the account answerable for the
+  // agent). See `isAgenticAction` for the hoisted agent flag.
   actor dict
   // Events recorded within the activity
   //
@@ -758,6 +761,23 @@ private googleworkspace.report.activity {
   // `resourceIds` (resource IDs associated with the event), and `status` (event
   // status, absent for events that do not report one).
   events []dict
+  // Whether an AI agent performed the activity
+  //
+  // True when the action was taken by an agent rather than directly by the
+  // named user, which separates agent-driven changes from human ones when
+  // reviewing an audit trail. The agent's identity and the account answerable
+  // for it are in the `actor` dict under `agentAttributionInfo`.
+  isAgenticAction bool
+  // Identifier of the device the actor used
+  //
+  // Empty for activities the API does not attribute to a device. This is a
+  // Reports API device identifier and does not necessarily match the Cloud
+  // Identity device id on `googleworkspace.endpoint`.
+  deviceId string
+  // Type of device the actor used
+  deviceType string
+  // Operating system version reported by the actor's device
+  deviceOsVersion string
 }
 
 // Google Workspace user usage reports

--- a/providers/google-workspace/resources/google-workspace.lr.go
+++ b/providers/google-workspace/resources/google-workspace.lr.go
@@ -863,6 +863,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"googleworkspace.report.activity.events": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceReportActivity).GetEvents()).ToDataRes(types.Array(types.Dict))
 	},
+	"googleworkspace.report.activity.isAgenticAction": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceReportActivity).GetIsAgenticAction()).ToDataRes(types.Bool)
+	},
+	"googleworkspace.report.activity.deviceId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceReportActivity).GetDeviceId()).ToDataRes(types.String)
+	},
+	"googleworkspace.report.activity.deviceType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceReportActivity).GetDeviceType()).ToDataRes(types.String)
+	},
+	"googleworkspace.report.activity.deviceOsVersion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGoogleworkspaceReportActivity).GetDeviceOsVersion()).ToDataRes(types.String)
+	},
 	"googleworkspace.report.users.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGoogleworkspaceReportUsers).GetList()).ToDataRes(types.Array(types.Resource("googleworkspace.report.usage")))
 	},
@@ -2182,6 +2194,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"googleworkspace.report.activity.events": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGoogleworkspaceReportActivity).Events, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.report.activity.isAgenticAction": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceReportActivity).IsAgenticAction, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.report.activity.deviceId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceReportActivity).DeviceId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.report.activity.deviceType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceReportActivity).DeviceType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"googleworkspace.report.activity.deviceOsVersion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGoogleworkspaceReportActivity).DeviceOsVersion, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"googleworkspace.report.users.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -5054,11 +5082,15 @@ type mqlGoogleworkspaceReportActivity struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	// optional: if you define mqlGoogleworkspaceReportActivityInternal it will be used here
-	Id          plugin.TValue[int64]
-	IpAddress   plugin.TValue[string]
-	OwnerDomain plugin.TValue[string]
-	Actor       plugin.TValue[any]
-	Events      plugin.TValue[[]any]
+	Id              plugin.TValue[int64]
+	IpAddress       plugin.TValue[string]
+	OwnerDomain     plugin.TValue[string]
+	Actor           plugin.TValue[any]
+	Events          plugin.TValue[[]any]
+	IsAgenticAction plugin.TValue[bool]
+	DeviceId        plugin.TValue[string]
+	DeviceType      plugin.TValue[string]
+	DeviceOsVersion plugin.TValue[string]
 }
 
 // createGoogleworkspaceReportActivity creates a new instance of this resource
@@ -5116,6 +5148,22 @@ func (c *mqlGoogleworkspaceReportActivity) GetActor() *plugin.TValue[any] {
 
 func (c *mqlGoogleworkspaceReportActivity) GetEvents() *plugin.TValue[[]any] {
 	return &c.Events
+}
+
+func (c *mqlGoogleworkspaceReportActivity) GetIsAgenticAction() *plugin.TValue[bool] {
+	return &c.IsAgenticAction
+}
+
+func (c *mqlGoogleworkspaceReportActivity) GetDeviceId() *plugin.TValue[string] {
+	return &c.DeviceId
+}
+
+func (c *mqlGoogleworkspaceReportActivity) GetDeviceType() *plugin.TValue[string] {
+	return &c.DeviceType
+}
+
+func (c *mqlGoogleworkspaceReportActivity) GetDeviceOsVersion() *plugin.TValue[string] {
+	return &c.DeviceOsVersion
 }
 
 // mqlGoogleworkspaceReportUsers for the googleworkspace.report.users resource

--- a/providers/google-workspace/resources/google-workspace.lr.versions
+++ b/providers/google-workspace/resources/google-workspace.lr.versions
@@ -202,9 +202,13 @@ googleworkspace.policy.type 13.1.5
 googleworkspace.policy.value 13.1.5
 googleworkspace.report.activity 9.0.0
 googleworkspace.report.activity.actor 9.0.0
+googleworkspace.report.activity.deviceId 13.2.9
+googleworkspace.report.activity.deviceOsVersion 13.2.9
+googleworkspace.report.activity.deviceType 13.2.9
 googleworkspace.report.activity.events 9.0.0
 googleworkspace.report.activity.id 9.0.0
 googleworkspace.report.activity.ipAddress 9.0.0
+googleworkspace.report.activity.isAgenticAction 13.2.9
 googleworkspace.report.activity.ownerDomain 9.0.0
 googleworkspace.report.apps 9.0.0
 googleworkspace.report.apps.admin 9.0.0

--- a/providers/google-workspace/resources/reports.go
+++ b/providers/google-workspace/resources/reports.go
@@ -155,13 +155,24 @@ func newMqlGoogleWorkspaceReportActivity(runtime *plugin.Runtime, entry *reports
 		activityID = "googleworkspace.report.activity/nil/" + hashActivity(entry)
 	}
 
+	var deviceId, deviceType, deviceOsVersion string
+	if entry.UserDeviceInfo != nil {
+		deviceId = entry.UserDeviceInfo.DeviceId
+		deviceType = entry.UserDeviceInfo.DeviceType
+		deviceOsVersion = entry.UserDeviceInfo.DeviceOsVersion
+	}
+
 	return CreateResource(runtime, "googleworkspace.report.activity", map[string]*llx.RawData{
-		"__id":        llx.StringData(activityID),
-		"id":          llx.IntData(uniqueQualifier),
-		"ipAddress":   llx.StringData(entry.IpAddress),
-		"ownerDomain": llx.StringData(entry.OwnerDomain),
-		"actor":       llx.MapData(actor, types.Any),
-		"events":      llx.ArrayData(events, types.Any),
+		"__id":            llx.StringData(activityID),
+		"id":              llx.IntData(uniqueQualifier),
+		"ipAddress":       llx.StringData(entry.IpAddress),
+		"ownerDomain":     llx.StringData(entry.OwnerDomain),
+		"actor":           llx.MapData(actor, types.Any),
+		"events":          llx.ArrayData(events, types.Any),
+		"isAgenticAction": llx.BoolData(entry.IsAgenticAction),
+		"deviceId":        llx.StringData(deviceId),
+		"deviceType":      llx.StringData(deviceType),
+		"deviceOsVersion": llx.StringData(deviceOsVersion),
 	})
 }
 


### PR DESCRIPTION
The `admin/reports` API gained AI-agent attribution and actor device details in `google.golang.org/api` v0.291.0 (vendored by #9506). This exposes them on `googleworkspace.report.activity`, so an audit trail can separate agent-driven changes from human ones and see which device an action came from.

## New fields

**`isAgenticAction`** — true when an agent, rather than the named user directly, performed the activity.

Hoisted as an always-set bool rather than left to the `actor` dict. `Activity.IsAgenticAction` is a non-pointer `bool` with `omitempty`, so "not an agent" serializes to a *missing key*; an assertion written against that key would see `null`, and in MQL's three-valued logic that does not fail closed.

**`deviceId`, `deviceType`, `deviceOsVersion`** — flatten the new `userDeviceInfo` object.

Three flat scalars do not clear the sub-resource bar. A typed reference isn't appropriate either: `googleworkspace.endpoint` has no id-keyed `init`, and the Reports API device id is a different identifier namespace from the Cloud Identity device id that keys `endpoint`. That caveat is documented on `deviceId` so the two don't get joined by accident. All three are free-form strings in the discovery document, so no enum values are claimed.

## Already flowing, now documented

The agent's own identity arrives *inside* the existing `actor` dict as `agentAttributionInfo` — `agentId`, `agentName`, `agentType`, and an `agentOwner` object whose `email` names the account answerable for the agent. Because `actor` is built with `convert.JsonToDict` (`reports.go:133`), that key needed no code change and is already queryable.

What did need fixing is the doc-comment: it enumerates the actor keys, so the bump silently made it incomplete. It now documents `agentAttributionInfo` and cross-references `isAgenticAction`.

## Verification

`mqlr generate` + `make providers/build/google-workspace` clean; `gofmt` applied. No new API calls, so no permissions change.

Not yet exercised against a live Workspace tenant; queued for the next batched live-verification pass.
