### PR TITLE
✨ stackit: expose SKE cluster labels and the application load balancer extension

### DIFF
--- a/providers/stackit/resources/ske.go
+++ b/providers/stackit/resources/ske.go
@@ -89,7 +89,7 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 		hibernations = anySliceToDict(h.GetSchedules())
 	}
 
-	var aclEnabled, obsEnabled, dnsEnabled, dnsGatewayApi bool
+	var aclEnabled, obsEnabled, dnsEnabled, dnsGatewayApi, albEnabled bool
 	var obsInstanceId string
 	allowedCidrs := []string{}
 	dnsZones := []string{}
@@ -110,6 +110,9 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 			if z, ok := dns.GetZonesOk(); ok {
 				dnsZones = z
 			}
+		}
+		if alb, ok := ext.GetApplicationLoadBalancerOk(); ok {
+			albEnabled = alb.GetEnabled()
 		}
 	}
 
@@ -157,6 +160,8 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 		"dnsEnabled":                       llx.BoolData(dnsEnabled),
 		"dnsGatewayApi":                    llx.BoolData(dnsGatewayApi),
 		"dnsZones":                         strSliceData(dnsZones),
+		"applicationLoadBalancerEnabled":   llx.BoolData(albEnabled),
+		"labels":                           stringMapData(cluster.GetLabels()),
 	}
 	res, err := CreateResource(runtime, "stackit.ske.cluster", args)
 	if err != nil {

--- a/providers/stackit/resources/stackit.lr
+++ b/providers/stackit/resources/stackit.lr
@@ -879,8 +879,9 @@ stackit.ske {
 // the project and region). Exposes the `status` (aggregated lifecycle),
 // the Kubernetes version, the node pools (with their flavor, OS, taints,
 // autoscaling, labels), the hibernation and maintenance windows, network
-// and DNS overrides, extensions (ACL, observability), whether API server
-// audit logging is enabled, and the creation and update timestamps.
+// and DNS overrides, extensions (ACL, observability, application load
+// balancer), whether API server audit logging is enabled, the cluster-level
+// `labels`, and the creation and update timestamps.
 private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   init(name? string)
   // Cluster name
@@ -899,14 +900,22 @@ private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   hibernations []dict
   // Maintenance window {timeWindow, autoUpdate: {kubernetesVersion, machineImageVersion}}
   maintenance dict
-  // Extension add-ons keyed by acl, observability, and dns
+  // Extension add-ons keyed by acl, observability, dns, and applicationLoadBalancer
   //
   // Dict of the cluster's enabled add-ons. The `acl` key holds the
   // kube-apiserver access ACL (enabled, allowedCidrs); `observability`
   // holds the metrics and logs integration (enabled, instanceId); `dns`
-  // holds the managed-DNS extension (enabled, gatewayApi, zones).
+  // holds the managed-DNS extension (enabled, gatewayApi, zones);
+  // `applicationLoadBalancer` holds the application load balancer extension
+  // (enabled). See `apiServerAclEnabled`, `observabilityEnabled`, `dnsEnabled`,
+  // and `applicationLoadBalancerEnabled` for the hoisted flags.
   extensions dict
-  // Network association: the STACKIT network id and control-plane access scope
+  // Network association: the STACKIT network id, control-plane access scope, and CNI configuration
+  //
+  // Holds `id` (the STACKIT network the cluster is attached to, resolved by
+  // `networkRef`) and `cni`, the container network interface configuration.
+  // The `cni` object carries a `calico` key whose contents are the
+  // provider-defined Calico options and are not a fixed set.
   network dict
   // Creation timestamp
   creationTime time
@@ -944,6 +953,17 @@ private stackit.ske.cluster @defaults("name kubernetesVersion status") {
   dnsGatewayApi bool
   // DNS zones managed by the DNS extension
   dnsZones []string
+  // Whether the application load balancer extension is enabled
+  //
+  // STACKIT gates this extension to accounts explicitly enabled for it and
+  // may still change its shape, so treat the field as provisional.
+  applicationLoadBalancerEnabled @maturity("preview") bool
+  // Labels applied to the cluster
+  //
+  // Key-value pairs set on the cluster itself, distinct from the labels on
+  // each node pool. Keys may carry a domain prefix separated by a slash and
+  // values may be empty.
+  labels map[string]string
   // STACKIT network the cluster is attached to
   networkRef() stackit.network
 }

--- a/providers/stackit/resources/stackit.lr.go
+++ b/providers/stackit/resources/stackit.lr.go
@@ -1420,6 +1420,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"stackit.ske.cluster.dnsZones": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSkeCluster).GetDnsZones()).ToDataRes(types.Array(types.String))
 	},
+	"stackit.ske.cluster.applicationLoadBalancerEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSkeCluster).GetApplicationLoadBalancerEnabled()).ToDataRes(types.Bool)
+	},
+	"stackit.ske.cluster.labels": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlStackitSkeCluster).GetLabels()).ToDataRes(types.Map(types.String, types.String))
+	},
 	"stackit.ske.cluster.networkRef": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlStackitSkeCluster).GetNetworkRef()).ToDataRes(types.Resource("stackit.network"))
 	},
@@ -4049,6 +4055,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"stackit.ske.cluster.dnsZones": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlStackitSkeCluster).DnsZones, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"stackit.ske.cluster.applicationLoadBalancerEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSkeCluster).ApplicationLoadBalancerEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"stackit.ske.cluster.labels": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlStackitSkeCluster).Labels, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
 	"stackit.ske.cluster.networkRef": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -9379,6 +9393,8 @@ type mqlStackitSkeCluster struct {
 	DnsEnabled                       plugin.TValue[bool]
 	DnsGatewayApi                    plugin.TValue[bool]
 	DnsZones                         plugin.TValue[[]any]
+	ApplicationLoadBalancerEnabled   plugin.TValue[bool]
+	Labels                           plugin.TValue[map[string]any]
 	NetworkRef                       plugin.TValue[*mqlStackitNetwork]
 }
 
@@ -9545,6 +9561,14 @@ func (c *mqlStackitSkeCluster) GetDnsGatewayApi() *plugin.TValue[bool] {
 
 func (c *mqlStackitSkeCluster) GetDnsZones() *plugin.TValue[[]any] {
 	return &c.DnsZones
+}
+
+func (c *mqlStackitSkeCluster) GetApplicationLoadBalancerEnabled() *plugin.TValue[bool] {
+	return &c.ApplicationLoadBalancerEnabled
+}
+
+func (c *mqlStackitSkeCluster) GetLabels() *plugin.TValue[map[string]any] {
+	return &c.Labels
 }
 
 func (c *mqlStackitSkeCluster) GetNetworkRef() *plugin.TValue[*mqlStackitNetwork] {

--- a/providers/stackit/resources/stackit.lr.versions
+++ b/providers/stackit/resources/stackit.lr.versions
@@ -635,6 +635,7 @@ stackit.ske 13.0.0
 stackit.ske.cluster 13.0.0
 stackit.ske.cluster.apiServerAclAllowedCidrs 13.1.1
 stackit.ske.cluster.apiServerAclEnabled 13.1.1
+stackit.ske.cluster.applicationLoadBalancerEnabled 13.4.4
 stackit.ske.cluster.auditEnabled 13.4.2
 stackit.ske.cluster.creationTime 13.0.0
 stackit.ske.cluster.credentialsRotationLastCompleted 13.1.1
@@ -649,6 +650,7 @@ stackit.ske.cluster.hibernations 13.0.0
 stackit.ske.cluster.idpEnabled 13.1.1
 stackit.ske.cluster.idpType 13.1.1
 stackit.ske.cluster.kubernetesVersion 13.0.0
+stackit.ske.cluster.labels 13.4.4
 stackit.ske.cluster.maintenance 13.0.0
 stackit.ske.cluster.name 13.0.0
 stackit.ske.cluster.network 13.0.0


### PR DESCRIPTION
The `ske` SDK reached v1.21.0 in #9506, adding cluster-level labels, an application load balancer extension, and CNI configuration on the network object.

## New fields on `stackit.ske.cluster`

**`labels`** closes a real gap rather than adding a nicety: the cluster carried no labels field at all, even though every node pool already exposes its own. Those are distinct sets, so the doc-comment says so explicitly to head off the obvious confusion.

**`applicationLoadBalancerEnabled`** hoists the new extension flag, matching how this resource already hoists `apiServerAclEnabled`, `observabilityEnabled`, and `dnsEnabled`. Marked `@maturity("preview")` — STACKIT gates the extension to accounts explicitly enabled for it and the SDK comment warns the shape may still change, so callers should treat it as provisional.

## Doc-comment corrections

Both dicts are built with `toDict`, so the new keys already flowed through and the data was correct. What broke is that these comments *enumerate* their keys, which the bump silently made incomplete:

- **`extensions`** now documents `applicationLoadBalancer` and cross-references all four hoisted flags.
- **`network`** now documents `cni`. Its `calico` value is an untyped `map[string]interface{}` in the SDK, so the comment states the contents are provider-defined instead of inventing a key list.

## Follow-up worth tracking separately

The `ske` root SDK layer we import is marked **deprecated for removal after 2026-09-30**, in favor of the per-version `v1api`/`v2api` packages:

```
// Deprecated: Will be removed after 2026-09-30. Move to the packages
// generated for each available API version instead
```

All three fields above exist in the root layer, so this change does not depend on that migration. But the migration is now on a clock and is worth its own PR before the deadline.

## Verification

`mqlr generate` + `make providers/build/stackit` clean; `gofmt` applied. No new API calls.

Not yet exercised against a live STACKIT project; queued for the next batched live-verification pass.
