### PR TITLE
🧹 azure: log when a cached credential is reused

### DIFF
--- a/providers/azure/connection/connection.go
+++ b/providers/azure/connection/connection.go
@@ -100,6 +100,10 @@ func selectAzureCredential(conf *inventory.Config) (azcore.TokenCredential, erro
 	credentialMu.Lock()
 	defer credentialMu.Unlock()
 	if cached, ok := credentialCache[identity]; ok {
+		log.Debug().
+			Str("tenant-id", tenantId).
+			Str("client-id", clientId).
+			Msg("azure: reusing cached credential")
 		return cached, nil
 	}
 


### PR DESCRIPTION
The per-identity credential cache in the Azure connection is silent: a connection that reused an already-built credential looked exactly like one that never authenticated, which makes sign-in behavior hard to diagnose (especially for inventories spanning multiple tenants).

Adds a `Debug` log on the cache-hit path with the identity components (`tenant-id` / `client-id`). No token material is logged.

```
DBG azure: reusing cached credential client-id=... tenant-id=...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)