### PR TITLE
🎉 stackit-13.5.0

### DIFF
--- a/providers/stackit/config/config.go
+++ b/providers/stackit/config/config.go
@@ -16,7 +16,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "stackit",
 	ID:              "go.mondoo.com/mql/providers/stackit",
-	Version:         "13.4.3",
+	Version:         "13.5.0",
 	ConnectionTypes: []string{provider.DefaultConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### stackit (13.5.0)
- ✨ stackit: expose SKE cluster labels and the application load balancer extension (#9510)
- 🧹 Update deps for mql and providers 20260730 (#9506)
- 🧹 Update deps for mql and providers 20260727 (#9455)