### PR TITLE
🎉 gcp-13.34.0

### DIFF
--- a/providers/gcp/config/config.go
+++ b/providers/gcp/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "gcp",
 	ID:      "go.mondoo.com/cnquery/v9/providers/gcp",
-	Version: "13.33.3",
+	Version: "13.34.0",
 	ConnectionTypes: []string{
 		provider.ConnectionType,
 		string(gcpinstancesnapshot.SnapshotConnectionType),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### gcp (13.34.0)
- ✨ gcp: expose storage pool sharing, App Engine bundled services, and Dataproc SSH access (#9507)
- 🧹 Update deps for mql and providers 20260730 (#9506)
- 📄 expand provider help examples for sub-commands and missing usage (#9505)
- 🧹 Update deps for mql and providers 20260727 (#9455)