### PR TITLE
🎉 ms365-13.10.0

### DIFF
--- a/providers/ms365/config/config.go
+++ b/providers/ms365/config/config.go
@@ -13,7 +13,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "ms365",
 	ID:              "go.mondoo.com/cnquery/v9/providers/ms365",
-	Version:         "13.9.5",
+	Version:         "13.10.0",
 	ConnectionTypes: []string{provider.ConnectionType},
 	Platforms:       connection.Platforms,
 	Connectors: []plugin.Connector{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### ms365 (13.10.0)
- 🧹 Update deps for mql and providers 20260730 (#9506)
- 🐛 ms365: exclude free/self-service plans from paidLicenses (#9504)