### PR TITLE
🎉 os-13.40.0

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -14,7 +14,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.39.0",
+	Version: "13.40.0",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.40.0)
- ⭐ os: add mysql and mariadb option file resources (#9508)
- ✨ os: collect AIX system model and processor type as platform labels (#9503)
- 🐛 os: drop the zero epoch from rpm versions read from the rpmdb (#9500)
- 🐛 azure: attribute the sign-in log line and stop probing past workload identity (#9496)
- 🐛 os: close docker exec hijacked connection to prevent fd leak (#9120)
- 🐛 os: close source stream in StreamToTmpFile on copy error (#9121)