### PR TITLE
os: warn that the AIX processor type is a compatibility mode

### DIFF
--- a/providers/os/detector/detector_aix_hardware.go
+++ b/providers/os/detector/detector_aix_hardware.go
@@ -13,11 +13,22 @@ import (
 const (
 	// AixLabelSystemModel carries the machine type-model of the system, for
 	// example "IBM,9009-42A". It mirrors the "System Model" field of prtconf.
+	//
+	// This describes the physical machine, so it is the value to decide
+	// hardware applicability from.
 	AixLabelSystemModel = "aix.mondoo.com/system-model"
 
-	// AixLabelProcessorType carries the processor implementation of the first
-	// processor, for example "PowerPC_POWER9". It mirrors the "Processor Type"
+	// AixLabelProcessorType carries the processor implementation the partition
+	// reports, for example "PowerPC_POWER9". It mirrors the "Processor Type"
 	// field of prtconf.
+	//
+	// This is the partition's processor *compatibility mode*, not the physical
+	// chip. An LPAR on POWER9 hardware configured in POWER8 mode reports
+	// PowerPC_POWER8, which is routine because Live Partition Mobility to an
+	// older host requires it. Anything deciding whether a silicon defect
+	// applies must use AixLabelSystemModel, which compatibility mode does not
+	// change; treating this value as the silicon would hide such a defect on a
+	// machine that genuinely has it.
 	AixLabelProcessorType = "aix.mondoo.com/processor-type"
 )
 


### PR DESCRIPTION
Follow-up to #9503, which added the two AIX hardware labels. Documentation only — no behaviour change.

## Why

`lsattr -El proc0 -a type` reports the partition's **processor compatibility mode**, not the physical chip. An LPAR on POWER9 hardware configured in POWER8 mode reports `PowerPC_POWER8`, and that configuration is routine — Live Partition Mobility to an older host requires it.

That matters because #9503 introduced these labels specifically so that consumers could scope POWER-gated security advisories. A consumer reading `aix.mondoo.com/processor-type` as the silicon would conclude a POWER9 defect does not apply to a POWER9 machine, and silently drop a real finding. I made exactly that mistake in the first consumer of this label, and it took an adversarial review to catch it.

`uname -M` is unaffected by compatibility mode, so the machine type-model is the value to decide hardware applicability from.

## What

Say so at both definitions: mark `AixLabelSystemModel` as the value that describes the physical machine, and warn on `AixLabelProcessorType` that it is a compatibility mode and must not be used to decide whether a silicon defect applies.

Both labels remain collected and unchanged — the processor type is still accurate inventory, it just is not what it looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)