### PR TITLE
🎉 aws-13.51.1

### DIFF
--- a/providers/aws/config/config.go
+++ b/providers/aws/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:            "aws",
 	ID:              "go.mondoo.com/cnquery/v9/providers/aws",
-	Version:         "13.51.0",
+	Version:         "13.51.1",
 	ConnectionTypes: []string{provider.DefaultConnectionType, string(awsec2ebsconn.EBSConnectionType)},
 	Connectors: []plugin.Connector{
 		{


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### aws (13.51.1)
- ✨ aws: expose Bedrock agent guardrail posture, RAG data lineage, and model-training provenance (#9518)
- 🧹 Update deps for mql and providers 20260730 (#9506)
- 🐛 aws: fix silent data loss, wrong data, and cache-key collisions (#9478)
- ✨ Apply discovery tag filters to SQS queues and SNS topics.  (#9499)
- 🧹 Update deps for mql and providers 20260727 (#9455)