### PR TITLE
🐛 azure: resolve ML datastore storage account when scope is implicit

### DIFF
--- a/providers/azure/resources/machinelearning_data.go
+++ b/providers/azure/resources/machinelearning_data.go
@@ -194,21 +194,57 @@ func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceDatastore) systemMet
 // storageAccount resolves the account behind the datastore. The datastore
 // records the account's subscription, resource group, and name rather than its
 // resource ID, so the ID is rebuilt from those three.
+//
+// A datastore may omit the subscription and resource group, in which case the
+// account sits alongside the workspace; both are then taken from the
+// datastore's own resource ID. Because that is an inference rather than a value
+// the API supplied, an account that does not resolve there reports no account
+// instead of failing the query.
 func (a *mqlAzureSubscriptionMachineLearningServiceWorkspaceDatastore) storageAccount() (*mqlAzureSubscriptionStorageServiceAccount, error) {
 	accountName := a.AccountName.Data
-	subscriptionId := a.SubscriptionId.Data
-	resourceGroup := a.ResourceGroup.Data
-	if accountName == "" || subscriptionId == "" || resourceGroup == "" {
+	if accountName == "" {
 		a.StorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
 		return nil, nil
 	}
+
+	subscriptionId := a.SubscriptionId.Data
+	resourceGroup := a.ResourceGroup.Data
+	inferredScope := subscriptionId == "" || resourceGroup == ""
+	if inferredScope {
+		parsed, err := ParseResourceID(a.Id.Data)
+		if err != nil {
+			a.StorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		if subscriptionId == "" {
+			subscriptionId = parsed.SubscriptionID
+		}
+		if resourceGroup == "" {
+			resourceGroup = parsed.ResourceGroup
+		}
+	}
+	if subscriptionId == "" || resourceGroup == "" {
+		a.StorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
 	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	if !ok {
 		return nil, errors.New("invalid connection provided, it is not an Azure connection")
 	}
 	accountId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s",
 		subscriptionId, resourceGroup, accountName)
-	return getStorageAccount(accountId, a.MqlRuntime, conn)
+	res, err := getStorageAccount(accountId, a.MqlRuntime, conn)
+	if err != nil {
+		if inferredScope && isAzureNotFoundOrBadRequest(err) {
+			log.Debug().Str("datastore", a.Id.Data).Str("account", accountName).
+				Msg("storage account for datastore not found in the workspace scope")
+			a.StorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
+			return nil, nil
+		}
+		return nil, err
+	}
+	return res, nil
 }
 
 // --- Workspace connections ---


### PR DESCRIPTION
Found while live-verifying #9519 against a real Azure subscription.

## Problem

An Azure ML datastore may omit `subscriptionId` and `resourceGroup`. When it
does, the storage account sits alongside the workspace. `storageAccount()`
required all three of account name, subscription, and resource group to be
present and returned no account otherwise:

```go
if accountName == "" || subscriptionId == "" || resourceGroup == "" {
    a.StorageAccount.State = plugin.StateIsSet | plugin.StateIsNull
    return nil, nil
}
```

So any datastore created without an explicit scope reported no storage account
at all, even though the account was right there in the same resource group.

Observed on a datastore created through `azurerm_machine_learning_datastore_blobstorage`,
where the API returns `subscriptionId: null` and `resourceGroup: null` but
`accountName` is set:

```
0: {
    name: "mqlv0730_ds"
    accountName: "mqlv0730samnzap0"
    subscriptionId: ""
    resourceGroup: ""
    storageAccount: null      <-- account exists, in the workspace's own RG
}
```

This makes any audit that pivots from a datastore to its storage account
(public access, encryption, TLS version, network rules) silently skip those
datastores.

## Fix

Take the subscription and resource group from the datastore's own resource ID
when the API omits them. Because that is an inference rather than a value the
API supplied, an account that does not resolve in the workspace scope reports
no account instead of failing the query — an explicitly scoped datastore still
surfaces its error, so a genuine permission or lookup failure is not hidden.

The raw `subscriptionId` and `resourceGroup` fields keep reporting exactly what
the API returned; only the typed accessor infers.

## Verification

Against the live workspace, before and after, same query:

```
mql run azure -c 'azure.subscription.machineLearningService.workspaces.where(name == /mqlv/) {
  datastores { name accountName subscriptionId resourceGroup storageAccount { name id } } }'
```

Before — the explicitly created datastore resolves to nothing:

```
0: { name: "mqlv0730_ds"  subscriptionId: ""  resourceGroup: ""  storageAccount: null }
```

After — it resolves, while the raw fields stay faithful:

```
0: { name: "mqlv0730_ds"  subscriptionId: ""  resourceGroup: ""
     storageAccount: { name: "mqlv0730samnzap0"
                       id: ".../resourceGroups/mqlv0730-rg/providers/Microsoft.Storage/storageAccounts/mqlv0730samnzap0" } }
```

The four workspace-provisioned datastores (`workspaceblobstore`,
`workspacefilestore`, `workspaceartifactstore`, `workspaceworkingdirectory`)
already carried an explicit scope and are unchanged.

No schema change, so no `.lr.versions` entry. `azure.permissions.json` is
unchanged (no new API calls).
