### PR TITLE
✨ ms365: add microsoft.users.count and speed up users/groups fetches

### DIFF
--- a/providers/ms365/resources/groups.go
+++ b/providers/ms365/resources/groups.go
@@ -34,7 +34,7 @@ func (a *mqlMicrosoftGroup) members() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	top := int32(200)
+	top := int32(999)
 
 	// Pull the same fields the rest of the user resource consumes so
 	// accessing member.displayName/mail/userPrincipalName is served from
@@ -127,7 +127,7 @@ func (a *mqlMicrosoftGroups) list() ([]any, error) {
 		return nil, err
 	}
 
-	top := int32(200)
+	top := int32(999)
 	queryParams := &groups.GroupsRequestBuilderGetQueryParameters{
 		Top: &top,
 	}

--- a/providers/ms365/resources/microsoft.go
+++ b/providers/ms365/resources/microsoft.go
@@ -147,9 +147,9 @@ func (a *mqlMicrosoft) indexedUserIDs() []string {
 }
 
 // loadMfaResp lazily fetches user MFA registration details from the beta
-// Graph API and caches the result on a.mfaResp. Both microsoft.users.list
-// (eager batch) and microsoft.user.mfaEnabled (per-user lookup) call this
-// so the data is available regardless of which path was queried first.
+// Graph API and caches the result on a.mfaResp. It's called on demand by
+// microsoft.user.mfaEnabled; the sync.Once ensures the whole-tenant fetch
+// runs only once no matter how many users' mfaEnabled is accessed.
 func (a *mqlMicrosoft) loadMfaResp() *mfaResp {
 	a.mfaOnce.Do(func() {
 		conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)

--- a/providers/ms365/resources/ms365.lr
+++ b/providers/ms365/resources/ms365.lr
@@ -340,7 +340,8 @@ private microsoft.tenantFormsSettings @defaults("isExternalSendFormEnabled isBin
 // optional `filter` (OData property filter) and `search` (keyword search)
 // parameters to narrow results. Each entry is a `microsoft.user` exposing
 // account status, contact details, job information, MFA state, assigned
-// licenses, sign-in history, and authentication method registration.
+// licenses, sign-in history, and authentication method registration, and
+// `count` reports the total number of users.
 microsoft.users {
   []microsoft.user
 
@@ -349,6 +350,8 @@ microsoft.users {
   filter string
   // Search users by search phrases
   search string
+  // Total number of Microsoft Entra ID users
+  count() int
 }
 
 // Microsoft Entra identity and access management

--- a/providers/ms365/resources/ms365.lr.go
+++ b/providers/ms365/resources/ms365.lr.go
@@ -1279,6 +1279,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"microsoft.users.search": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUsers).GetSearch()).ToDataRes(types.String)
 	},
+	"microsoft.users.count": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMicrosoftUsers).GetCount()).ToDataRes(types.Int)
+	},
 	"microsoft.users.list": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMicrosoftUsers).GetList()).ToDataRes(types.Array(types.Resource("microsoft.user")))
 	},
@@ -6227,6 +6230,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"microsoft.users.search": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMicrosoftUsers).Search, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"microsoft.users.count": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMicrosoftUsers).Count, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"microsoft.users.list": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -14215,6 +14222,7 @@ type mqlMicrosoftUsers struct {
 	// optional: if you define mqlMicrosoftUsersInternal it will be used here
 	Filter plugin.TValue[string]
 	Search plugin.TValue[string]
+	Count  plugin.TValue[int64]
 	List   plugin.TValue[[]any]
 }
 
@@ -14256,6 +14264,12 @@ func (c *mqlMicrosoftUsers) GetFilter() *plugin.TValue[string] {
 
 func (c *mqlMicrosoftUsers) GetSearch() *plugin.TValue[string] {
 	return &c.Search
+}
+
+func (c *mqlMicrosoftUsers) GetCount() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.Count, func() (int64, error) {
+		return c.count()
+	})
 }
 
 func (c *mqlMicrosoftUsers) GetList() *plugin.TValue[[]any] {

--- a/providers/ms365/resources/ms365.lr.versions
+++ b/providers/ms365/resources/ms365.lr.versions
@@ -1275,6 +1275,7 @@ microsoft.user.usageLocation 11.2.1
 microsoft.user.userPrincipalName 9.0.0
 microsoft.user.userType 9.0.0
 microsoft.users 11.1.15
+microsoft.users.count 13.10.1
 microsoft.users.filter 11.1.15
 microsoft.users.list 11.1.15
 microsoft.users.search 11.1.15

--- a/providers/ms365/resources/users.go
+++ b/providers/ms365/resources/users.go
@@ -124,10 +124,6 @@ func (a *mqlMicrosoftUsers) list() ([]any, error) {
 		return nil, transformError(err)
 	}
 
-	// prefetch the MFA map so per-user mfaEnabled() lookups hit cached data
-	// instead of triggering N+1 calls; lazy fallback lives on the loader.
-	microsoft.loadMfaResp()
-
 	// construct the result
 	res := []any{}
 	for _, u := range users {
@@ -141,6 +137,30 @@ func (a *mqlMicrosoftUsers) list() ([]any, error) {
 	}
 
 	return res, nil
+}
+
+// count returns the total number of users in the tenant via the Graph
+// $count endpoint, avoiding a full user-list fetch (which is prohibitively
+// slow on large tenants).
+func (a *mqlMicrosoftUsers) count() (int64, error) {
+	conn := a.MqlRuntime.Connection.(*connection.Ms365Connection)
+	graphClient, err := conn.GraphClient()
+	if err != nil {
+		return 0, err
+	}
+
+	opts := &users.CountRequestBuilderGetRequestConfiguration{Headers: abstractions.NewRequestHeaders()}
+	opts.Headers.Add("ConsistencyLevel", "eventual")
+	count, err := graphClient.Users().Count().Get(context.Background(), opts)
+	if err != nil {
+		return 0, transformError(err)
+	}
+	if count == nil {
+		// This should never happen, but we better check
+		return 0, errors.New("unable to count users, counter parameter API returned nil")
+	}
+
+	return int64(*count), nil
 }
 
 func initMicrosoftUser(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {


### PR DESCRIPTION
## Overview

Adds a dedicated user-count field and two fetch optimizations to the ms365 provider.

### `microsoft.users.count`

New field that reads the Microsoft Graph `/users/$count` endpoint (with `ConsistencyLevel: eventual`), returning a single server-computed integer rather than enumerating the entire user list to derive a total. This mirrors the existing `microsoft.groups.count` field.

```
microsoft.users.count
microsoft.groups.count
```

### Optimizations

- **Drop the eager MFA prefetch from `microsoft.users.list`.** It fetched the whole tenant's MFA registration report on every users query, even when `mfaEnabled` was never selected. The loader is `sync.Once`-guarded and `mfaEnabled()` already calls it lazily, so removing the eager call is pure deferral with no N+1 regression — queries that don't touch `mfaEnabled` skip the report fetch entirely.
- **Raise groups pagination from `$top=200` to `999`** in `groups.list` and `group.members`, matching the users list and cutting the number of paginated round trips.

### Behavioral note

With the eager prefetch removed, the first user whose `mfaEnabled` is accessed now pays the MFA-registration fetch inline rather than during `list()`. The `sync.Once` still guarantees exactly one fetch per connection regardless of how many users' `mfaEnabled` is read, so total work is unchanged — it's just deferred to first use.

## Context

Enables reverting the temporary count removal in https://github.com/mondoohq/server/pull/10071, this time using count endpoints that return only the total instead of the full object list.

## Testing

- `go build ./resources/...` passes for the ms365 module.
- Generated code (`.lr.go`, `.lr.versions`) regenerated via `mqlr generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)