### PR TITLE
🐛 azure: stop five fields from crossing the plugin boundary unset

### DIFF
--- a/providers/azure/resources/aks.go
+++ b/providers/azure/resources/aks.go
@@ -114,8 +114,24 @@ func (a *mqlAzureSubscriptionAksServiceClusterAutoUpgradeProfile) id() (string, 
 	return a.Id.Data, nil
 }
 
+// See notReachableDirectly: the auto-upgrade profile is derived from a
+// cluster's ARM properties and has no lookup of its own.
+func initAzureSubscriptionAksServiceClusterAutoUpgradeProfile(_ *plugin.Runtime, _ map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return nil, nil, notReachableDirectly(
+		"azure.subscription.aksService.cluster.autoUpgradeProfile",
+		"azure.subscription.aksService.clusters { autoUpgradeProfile { upgradeChannel nodeOSUpgradeChannel } }")
+}
+
 func (a *mqlAzureSubscriptionAksServiceClusterAdvancedNetworking) id() (string, error) {
 	return a.Id.Data, nil
+}
+
+// See notReachableDirectly: the advanced networking profile is derived from a
+// cluster's network profile and has no lookup of its own.
+func initAzureSubscriptionAksServiceClusterAdvancedNetworking(_ *plugin.Runtime, _ map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return nil, nil, notReachableDirectly(
+		"azure.subscription.aksService.cluster.advancedNetworking",
+		"azure.subscription.aksService.clusters { advancedNetworking { enabled transitEncryptionType } }")
 }
 
 // aksSecurityFlags are the cluster security-profile toggles flattened out of

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -1149,7 +1149,7 @@ func init() {
 			Create: createAzureSubscriptionWebServiceAppsite,
 		},
 		"azure.subscription.webService.appsite.outboundVnetRouting": {
-			// to override args, implement: initAzureSubscriptionWebServiceAppsiteOutboundVnetRouting(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionWebServiceAppsiteOutboundVnetRouting,
 			Create: createAzureSubscriptionWebServiceAppsiteOutboundVnetRouting,
 		},
 		"azure.subscription.privateEndpointConnection": {
@@ -1709,11 +1709,11 @@ func init() {
 			Create: createAzureSubscriptionAksServiceClusterAadProfile,
 		},
 		"azure.subscription.aksService.cluster.autoUpgradeProfile": {
-			// to override args, implement: initAzureSubscriptionAksServiceClusterAutoUpgradeProfile(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionAksServiceClusterAutoUpgradeProfile,
 			Create: createAzureSubscriptionAksServiceClusterAutoUpgradeProfile,
 		},
 		"azure.subscription.aksService.cluster.advancedNetworking": {
-			// to override args, implement: initAzureSubscriptionAksServiceClusterAdvancedNetworking(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Init:   initAzureSubscriptionAksServiceClusterAdvancedNetworking,
 			Create: createAzureSubscriptionAksServiceClusterAdvancedNetworking,
 		},
 		"azure.subscription.aksService.cluster.identityBinding": {

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
-  "version": "13.33.5",
-  "generated_at": "2026-07-29T21:18:24-07:00",
+  "version": "13.33.6",
+  "generated_at": "2026-07-30T18:47:34+02:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",

--- a/providers/azure/resources/shared.go
+++ b/providers/azure/resources/shared.go
@@ -76,6 +76,33 @@ func missingResourceID(resourceName string) error {
 		resourceName, resourceName)
 }
 
+// notReachableDirectly reports that a sub-resource was queried by its own
+// dotted name instead of through the parent that builds it.
+//
+// These resources are named after the path that reaches them: the resource
+// `azure.subscription.aksService.cluster` plus its field `autoUpgradeProfile`
+// spells a name that is itself a resource. The compiler resolves the longest
+// matching resource name first (mqlc.compileResource), so writing the full
+// path compiles to a bare resource with no arguments rather than a field read
+// on a cluster. The runtime then builds that resource with no id and no fields
+// set, and every field read on it crosses the plugin boundary as an empty
+// DataRes:
+//
+//	provider returned no data and no error for a field ... field=upgradeChannel id=
+//	llx: encountered a primitive with no type information, coercing to null
+//
+// once per field, per asset, with an empty id to identify it by -- while the
+// query itself quietly evaluates against nulls. Failing here reports the real
+// problem once and names a query that works.
+//
+// Only the bare path reaches this: the parent builds these through
+// CreateResource, which does not run init.
+func notReachableDirectly(resourceName string, example string) error {
+	return fmt.Errorf(
+		"%s cannot be queried on its own, it is only available through the resource that owns it: try %s",
+		resourceName, example)
+}
+
 type assetIdentifier struct {
 	name string
 	id   string

--- a/providers/azure/resources/unset_fields_regression_test.go
+++ b/providers/azure/resources/unset_fields_regression_test.go
@@ -1,0 +1,159 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	web "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// staticFields reads azure.lr and returns the fields a resource's creator is
+// responsible for: everything declared in the schema that is not a computed
+// accessor (`field() type`, which the runtime resolves by calling a Go
+// method).
+//
+// A static field has no other source. If the creator leaves it out of the args
+// map it is never set -- not null, unset -- and every read of it crosses the
+// plugin boundary as an empty DataRes, which the client reports as "provider
+// returned no data and no error for a field" followed by "llx: encountered a
+// primitive with no type information, coercing to null".
+//
+// Scanned as text rather than parsed so the provider module does not take on
+// the schema parser as a dependency for one test.
+func staticFields(t *testing.T, resource string) []string {
+	t.Helper()
+
+	raw, err := os.ReadFile("azure.lr")
+	require.NoError(t, err)
+
+	var fields []string
+	inBody := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+
+		if !inBody {
+			// the header is `[private] <name> [@options] {`; match the name
+			// exactly so sub-resources sharing the prefix don't open the body
+			head := strings.TrimPrefix(line, "private ")
+			name, rest, ok := strings.Cut(head, " ")
+			inBody = ok && name == resource && strings.HasSuffix(rest, "{")
+			continue
+		}
+		if line == "}" {
+			return fields
+		}
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "embed ") {
+			continue
+		}
+
+		name, _, _ := strings.Cut(line, " ")
+		// `field() type` is computed, `init(...)` is not a field at all
+		if strings.Contains(name, "(") {
+			continue
+		}
+		fields = append(fields, name)
+	}
+
+	t.Fatalf("resource %q not found in azure.lr", resource)
+	return nil
+}
+
+// TestSiteConfigArgsSetsEveryStaticField guards the app-site configuration
+// creator against reintroducing conditional `args["x"] = ...` assignments.
+//
+// minTlsVersion, ftpsState, minTlsCipherSuite and scmMinTlsVersion used to be
+// assigned only when the SDK pointer was non-nil, and the nine booleans only
+// when Azure returned a properties block at all. Every app whose config omits
+// any of them logged two errors per field per scan and reported the field as a
+// typeless null.
+func TestSiteConfigArgsSetsEveryStaticField(t *testing.T) {
+	want := staticFields(t, "azure.subscription.webService.appsiteconfig")
+	// pin the scanner itself, so a silently-empty or over-eager field list
+	// cannot make the assertions below pass for the wrong reason
+	require.Subset(t, want, []string{
+		"id", "name", "kind", "type", "properties", "corsAllowedOrigins",
+		"minTlsVersion", "ftpsState", "minTlsCipherSuite", "scmMinTlsVersion",
+		"remoteDebuggingEnabled", "http20Enabled", "alwaysOn", "webSocketsEnabled",
+		"httpLoggingEnabled", "detailedErrorLoggingEnabled", "autoHealEnabled",
+	})
+	require.NotContains(t, want, "ipSecurityRestrictions", "computed accessors are not the creator's job")
+
+	t.Run("fully populated properties", func(t *testing.T) {
+		args, err := siteConfigArgs(&web.SiteConfigResource{
+			ID:   strp("/subscriptions/sub/sites/app/config/web"),
+			Name: strp("web"),
+			Properties: &web.SiteConfig{
+				MinTLSVersion:               ptr(web.SupportedTLSVersionsOne2),
+				FtpsState:                   ptr(web.FtpsStateDisabled),
+				MinTLSCipherSuite:           ptr(web.TLSCipherSuitesTLSAES128GCMSHA256),
+				ScmMinTLSVersion:            ptr(web.SupportedTLSVersionsOne2),
+				RemoteDebuggingEnabled:      boolp(false),
+				Http20Enabled:               boolp(true),
+				AlwaysOn:                    boolp(true),
+				WebSocketsEnabled:           boolp(false),
+				HTTPLoggingEnabled:          boolp(true),
+				DetailedErrorLoggingEnabled: boolp(true),
+				AutoHealEnabled:             boolp(false),
+			},
+		})
+		require.NoError(t, err)
+		for _, field := range want {
+			assert.Contains(t, args, field, "field %q must be set by the creator", field)
+		}
+		assert.Equal(t, "TLS_AES_128_GCM_SHA256", args["minTlsCipherSuite"].Value)
+		assert.Equal(t, "Disabled", args["ftpsState"].Value)
+	})
+
+	// Azure answers without a properties block for apps whose configuration
+	// has never been written. Every field is null then, and none is unset.
+	t.Run("nil properties", func(t *testing.T) {
+		args, err := siteConfigArgs(&web.SiteConfigResource{ID: strp("/subscriptions/sub/sites/app/config/web")})
+		require.NoError(t, err)
+		for _, field := range want {
+			assert.Contains(t, args, field, "field %q must be set by the creator", field)
+		}
+		assert.Nil(t, args["minTlsCipherSuite"].Value)
+		assert.Nil(t, args["alwaysOn"].Value)
+		assert.Equal(t, "/subscriptions/sub/sites/app/config/web", args["id"].Value)
+	})
+}
+
+// TestSubResourcesRejectDirectQueries covers the sub-resources whose name is
+// also the dotted path that reaches them, e.g. the cluster resource
+// azure.subscription.aksService.cluster plus its autoUpgradeProfile field.
+//
+// The compiler resolves the longest matching resource name first, so writing
+// the full path builds the sub-resource bare, with no id and no fields. Each
+// field read on that husk then reported an anonymous malformed-primitive error
+// rather than the mistake in the query. Their init must say what went wrong.
+func TestSubResourcesRejectDirectQueries(t *testing.T) {
+	t.Run("outboundVnetRouting", func(t *testing.T) {
+		_, res, err := initAzureSubscriptionWebServiceAppsiteOutboundVnetRouting(nil, nil)
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "azure.subscription.webService.appsite.outboundVnetRouting")
+		assert.Contains(t, err.Error(), "azure.subscription.webService.apps {")
+	})
+
+	t.Run("autoUpgradeProfile", func(t *testing.T) {
+		_, res, err := initAzureSubscriptionAksServiceClusterAutoUpgradeProfile(nil, nil)
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "azure.subscription.aksService.cluster.autoUpgradeProfile")
+		assert.Contains(t, err.Error(), "azure.subscription.aksService.clusters {")
+	})
+
+	t.Run("advancedNetworking", func(t *testing.T) {
+		_, res, err := initAzureSubscriptionAksServiceClusterAdvancedNetworking(nil, nil)
+		require.Error(t, err)
+		assert.Nil(t, res)
+		assert.Contains(t, err.Error(), "azure.subscription.aksService.cluster.advancedNetworking")
+		assert.Contains(t, err.Error(), "azure.subscription.aksService.clusters {")
+	})
+}

--- a/providers/azure/resources/web.go
+++ b/providers/azure/resources/web.go
@@ -519,6 +519,14 @@ func (a *mqlAzureSubscriptionWebServiceAppsiteOutboundVnetRouting) id() (string,
 	return a.Id.Data, nil
 }
 
+// See notReachableDirectly: outbound VNet routing is part of a web app's site
+// properties and has no lookup of its own.
+func initAzureSubscriptionWebServiceAppsiteOutboundVnetRouting(_ *plugin.Runtime, _ map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	return nil, nil, notReachableDirectly(
+		"azure.subscription.webService.appsite.outboundVnetRouting",
+		"azure.subscription.webService.apps { outboundVnetRouting { allTrafficEnabled } }")
+}
+
 func (a *mqlAzureSubscriptionWebServiceAppsite) diagnosticSettings() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AzureConnection)
 	return getDiagnosticSettings(a.Id.Data, a.MqlRuntime, conn)
@@ -777,6 +785,53 @@ func siteConfigCorsAllowedOrigins(props *web.SiteConfig) []any {
 	return origins
 }
 
+// siteConfigArgs maps a site configuration resource into the args for
+// azure.subscription.webService.appsiteconfig.
+//
+// Every declared field is assigned on every path, including when Azure
+// answers with no `properties` block at all. A field omitted from the args
+// map is never set on the resource, and an unset field is not the same as a
+// null one: it crosses the plugin boundary as an empty DataRes and surfaces
+// client-side as
+//
+//	provider returned no data and no error for a field ... field=minTlsCipherSuite
+//	llx: encountered a primitive with no type information, coercing to null
+//
+// once per field, per app, for every scan. Assigning the null says the same
+// thing once, and lets `minTlsCipherSuite == null` behave the way an author
+// writing that check expects.
+func siteConfigArgs(entry *web.SiteConfigResource) (map[string]*llx.RawData, error) {
+	properties, err := convert.JsonToDict(entry.Properties)
+	if err != nil {
+		return nil, err
+	}
+
+	props := entry.Properties
+	if props == nil {
+		props = &web.SiteConfig{}
+	}
+
+	return map[string]*llx.RawData{
+		"id":                          llx.StringDataPtr(entry.ID),
+		"name":                        llx.StringDataPtr(entry.Name),
+		"kind":                        llx.StringDataPtr(entry.Kind),
+		"type":                        llx.StringDataPtr(entry.Type),
+		"properties":                  llx.DictData(properties),
+		"corsAllowedOrigins":          llx.ArrayData(siteConfigCorsAllowedOrigins(entry.Properties), types.String),
+		"minTlsVersion":               llx.StringDataPtr(stringEnumPtr(props.MinTLSVersion)),
+		"ftpsState":                   llx.StringDataPtr(stringEnumPtr(props.FtpsState)),
+		"minTlsCipherSuite":           llx.StringDataPtr(stringEnumPtr(props.MinTLSCipherSuite)),
+		"scmMinTlsVersion":            llx.StringDataPtr(stringEnumPtr(props.ScmMinTLSVersion)),
+		"remoteDebuggingEnabled":      llx.BoolDataPtr(props.RemoteDebuggingEnabled),
+		"http20Enabled":               llx.BoolDataPtr(props.Http20Enabled),
+		"alwaysOn":                    llx.BoolDataPtr(props.AlwaysOn),
+		"webSocketsEnabled":           llx.BoolDataPtr(props.WebSocketsEnabled),
+		"httpLoggingEnabled":          llx.BoolDataPtr(props.HTTPLoggingEnabled),
+		"detailedErrorLoggingEnabled": llx.BoolDataPtr(props.DetailedErrorLoggingEnabled),
+		"autoHealEnabled":             llx.BoolDataPtr(props.AutoHealEnabled),
+	}, nil
+}
+
 func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnection, id string) (*mqlAzureSubscriptionWebServiceAppsiteconfig, error) {
 	ctx := context.Background()
 	token := conn.Token()
@@ -804,40 +859,9 @@ func webAppSiteConfigToMql(runtime *plugin.Runtime, conn *connection.AzureConnec
 	}
 
 	entry := configuration
-	properties, err := convert.JsonToDict(entry.Properties)
+	args, err := siteConfigArgs(&entry.SiteConfigResource)
 	if err != nil {
 		return nil, err
-	}
-
-	args := map[string]*llx.RawData{
-		"id":                 llx.StringDataPtr(entry.ID),
-		"name":               llx.StringDataPtr(entry.Name),
-		"kind":               llx.StringDataPtr(entry.Kind),
-		"type":               llx.StringDataPtr(entry.Type),
-		"properties":         llx.DictData(properties),
-		"corsAllowedOrigins": llx.ArrayData(siteConfigCorsAllowedOrigins(entry.Properties), types.String),
-	}
-
-	if entry.Properties != nil {
-		if entry.Properties.MinTLSVersion != nil {
-			args["minTlsVersion"] = llx.StringData(string(*entry.Properties.MinTLSVersion))
-		}
-		if entry.Properties.FtpsState != nil {
-			args["ftpsState"] = llx.StringData(string(*entry.Properties.FtpsState))
-		}
-		args["remoteDebuggingEnabled"] = llx.BoolDataPtr(entry.Properties.RemoteDebuggingEnabled)
-		args["http20Enabled"] = llx.BoolDataPtr(entry.Properties.Http20Enabled)
-		args["alwaysOn"] = llx.BoolDataPtr(entry.Properties.AlwaysOn)
-		args["webSocketsEnabled"] = llx.BoolDataPtr(entry.Properties.WebSocketsEnabled)
-		args["httpLoggingEnabled"] = llx.BoolDataPtr(entry.Properties.HTTPLoggingEnabled)
-		args["detailedErrorLoggingEnabled"] = llx.BoolDataPtr(entry.Properties.DetailedErrorLoggingEnabled)
-		args["autoHealEnabled"] = llx.BoolDataPtr(entry.Properties.AutoHealEnabled)
-		if entry.Properties.MinTLSCipherSuite != nil {
-			args["minTlsCipherSuite"] = llx.StringData(string(*entry.Properties.MinTLSCipherSuite))
-		}
-		if entry.Properties.ScmMinTLSVersion != nil {
-			args["scmMinTlsVersion"] = llx.StringData(string(*entry.Properties.ScmMinTLSVersion))
-		}
 	}
 
 	res, err := CreateResource(runtime, ResourceAzureSubscriptionWebServiceAppsiteconfig, args)
@@ -1271,44 +1295,9 @@ func (a *mqlAzureSubscriptionWebServiceAppslot) configuration() (*mqlAzureSubscr
 		return nil, err
 	}
 
-	properties := map[string]any{}
-	if configuration.Properties != nil {
-		props, err := convert.JsonToDict(configuration.Properties)
-		if err != nil {
-			return nil, err
-		}
-		properties = props
-	}
-
-	args := map[string]*llx.RawData{
-		"id":                 llx.StringDataPtr(configuration.ID),
-		"name":               llx.StringDataPtr(configuration.Name),
-		"kind":               llx.StringDataPtr(configuration.Kind),
-		"type":               llx.StringDataPtr(configuration.Type),
-		"properties":         llx.DictData(properties),
-		"corsAllowedOrigins": llx.ArrayData(siteConfigCorsAllowedOrigins(configuration.Properties), types.String),
-	}
-
-	if configuration.Properties != nil {
-		if configuration.Properties.MinTLSVersion != nil {
-			args["minTlsVersion"] = llx.StringData(string(*configuration.Properties.MinTLSVersion))
-		}
-		if configuration.Properties.FtpsState != nil {
-			args["ftpsState"] = llx.StringData(string(*configuration.Properties.FtpsState))
-		}
-		args["remoteDebuggingEnabled"] = llx.BoolDataPtr(configuration.Properties.RemoteDebuggingEnabled)
-		args["http20Enabled"] = llx.BoolDataPtr(configuration.Properties.Http20Enabled)
-		args["alwaysOn"] = llx.BoolDataPtr(configuration.Properties.AlwaysOn)
-		args["webSocketsEnabled"] = llx.BoolDataPtr(configuration.Properties.WebSocketsEnabled)
-		args["httpLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.HTTPLoggingEnabled)
-		args["detailedErrorLoggingEnabled"] = llx.BoolDataPtr(configuration.Properties.DetailedErrorLoggingEnabled)
-		args["autoHealEnabled"] = llx.BoolDataPtr(configuration.Properties.AutoHealEnabled)
-		if configuration.Properties.MinTLSCipherSuite != nil {
-			args["minTlsCipherSuite"] = llx.StringData(string(*configuration.Properties.MinTLSCipherSuite))
-		}
-		if configuration.Properties.ScmMinTLSVersion != nil {
-			args["scmMinTlsVersion"] = llx.StringData(string(*configuration.Properties.ScmMinTLSVersion))
-		}
+	args, err := siteConfigArgs(&configuration.SiteConfigResource)
+	if err != nil {
+		return nil, err
 	}
 
 	res, err := CreateResource(a.MqlRuntime, ResourceAzureSubscriptionWebServiceAppsiteconfig, args)


### PR DESCRIPTION
## What

A day of production scan logs carried **73 paired errors**, each one a

```
provider returned no data and no error for a field; the field was never set on the resource (provider bug)
llx: encountered a primitive with no type information, coercing to null
```

The second line is anonymous, but the first carries structured `provider`/`resource`/`field`/`id` attribution. Grouping on it resolves all 73 to exactly five resource/field pairs, every one in the azure provider:

| count | resource | field | logged `id` |
|---|---|---|---|
| 24 | `azure.subscription.webService.appsite.outboundVnetRouting` | `allTrafficEnabled` | empty |
| 21 | `azure.subscription.webService.appsiteconfig` | `minTlsCipherSuite` | real |
| 14 | `azure.subscription.aksService.cluster.autoUpgradeProfile` | `nodeOSUpgradeChannel` | empty |
| 7 | `azure.subscription.aksService.cluster.advancedNetworking` | `transitEncryptionType` | empty |
| 7 | `azure.subscription.aksService.cluster.autoUpgradeProfile` | `upgradeChannel` | empty |

The empty-vs-real `id` split separates two different bugs.

## Cause 1 — conditionally-assigned args (21 errors, real ids)

Both `appsiteconfig` creators assigned `minTlsVersion`, `ftpsState`, `minTlsCipherSuite` and `scmMinTlsVersion` only when the SDK pointer was non-nil, and skipped nine more fields entirely when Azure returned no `properties` block:

```go
if entry.Properties.MinTLSCipherSuite != nil {
    args["minTlsCipherSuite"] = llx.StringData(string(*entry.Properties.MinTLSCipherSuite))
}
```

A field omitted from the args map is never *set* on the resource — not null, unset — so `TValue.ToDataRes` encodes it as an empty `DataRes`, and the client logs the pair above once per field, per app, per scan while reporting a typeless null.

Both creators now share `siteConfigArgs`, which assigns every declared field on every path (using the existing `stringEnumPtr` helper, which already carries a doc comment about this exact trap).

## Cause 2 — resources named after the path that reaches them (52 errors, empty ids)

`azure.subscription.aksService.cluster` plus its field `autoUpgradeProfile` spells a name that is itself a resource. `mqlc.compileResource` resolves the longest matching resource name first, so the full dotted path compiles to a **bare resource creation**, not a field read on a cluster:

```
azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel
  c1 FUNCTION id="azure.subscription.aksService.cluster.autoUpgradeProfile" bind=0   <- no args
  c2 FUNCTION id="upgradeChannel"
```

The runtime builds that resource with no id and no fields set — which is why every one of these logged with `id=` empty — and each field read on the husk reports anonymously while the query quietly evaluates against nulls. This is the anti-pattern already documented in `CLAUDE.md` ("a resource named `<parent>.<field>` queried by its dotted path becomes an empty husk").

The three affected sub-resources now fail in `init` with the resource name and a query that works. Only the bare path reaches this — parents build them through `CreateResource`, which does not run `init`.

## Verification

Live against a Mondoo tenant, all three bare paths now return their own error instead of the anonymous pair:

```
$ mql run azure --subscription ... -c 'azure.subscription.aksService.cluster.autoUpgradeProfile.upgradeChannel'
azure.subscription.aksService.cluster.autoUpgradeProfile cannot be queried on its own,
it is only available through the resource that owns it: try
azure.subscription.aksService.clusters { autoUpgradeProfile { upgradeChannel nodeOSUpgradeChannel } }
```

and the correct nested forms still run clean.

`siteConfigArgs` is covered by a unit test that reads `azure.lr`, derives the set of non-computed fields, and asserts the creator sets all of them — with populated properties and with nil properties. The tenant has no App Service or AKS instances, so the mapping itself was not exercised against live data; it is a pure function over the SDK model and the test covers both branches.

## Notes

- No `.lr` schema changes, so no `.lr.versions` entries and no version bump.
- `azure.permissions.json` picks up the already-shipped `13.33.6` version stamp; the permission set is unchanged.
- The compiler's greedy longest-name resolution is the underlying footgun and applies to every provider with a `<parent>.<field>`-named sub-resource. Fixing it centrally (e.g. not extending the path into a `private` resource) is a broader change than this bugfix warrants, but worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)