### PR TITLE
🌟 v14: asset tree relationships (ADR-030)

### DIFF
--- a/cli/printer/mql.go
+++ b/cli/printer/mql.go
@@ -834,6 +834,14 @@ func (print *Printer) data(typ types.Type, data any, checksum string, indent str
 			return "<bad range>"
 		}
 
+	case types.Asset:
+		v, ok := data.(*llx.AssetValue)
+		if !ok || v == nil {
+			return "null"
+		}
+		// TODO: store and retrieve more information about the referenced asset
+		return "asset"
+
 	default:
 		return indent + fmt.Sprintf("🤷 %#v", data)
 	}

--- a/docs/adr/030-asset-tree-anchored-relationships.md
+++ b/docs/adr/030-asset-tree-anchored-relationships.md
@@ -1,0 +1,220 @@
+# ADR 030: Asset relationships anchored to the resource tree
+
+## Status
+
+Proposed
+
+## Context
+
+The `os` provider models a large, growing family of developer/AI tools as
+first-class resources (see [ADR 028](028-tool-install-indicator.md)). Several of
+them expose configured **MCP (Model Context Protocol) servers** through per-tool
+accessors: `claude.code.mcpServers`, `openai.codex.mcpServers`, `cursor.mcpServers`,
+`github.copilot.mcpServers`, `gemini.mcpServers`, `windsurf.mcpServers`, each
+returning a tool-specific `*.mcpServer` resource parsed from that tool's own config
+files (`providers/os/resources/{claude_code,openai_codex,cursor,...}.go`, schema in
+`providers/os/resources/os.lr`).
+
+Today an MCP server is only a **leaf resource inside the host asset**. We want two
+new capabilities:
+
+1. **Discover MCP servers as their own assets** so cnspec can scan them (policies,
+   later capability enumeration). Discovery must be opt-in — off by default, off
+   under `auto`, on only when explicitly targeted or under `all` (that gating is a
+   separate, already-understood piece; see Follow-Ups).
+2. **Map the relationship back into the resource tree** so we know *which resource
+   node* a discovered asset came from — `mcp1` from `claude.code`, `mcp2` from
+   `openai.codex`, `mcp3` custom — not just "the host has some related assets."
+
+The **future** goal that shapes this decision is cross-asset traversal in a single
+query:
+
+```
+claude.code.mcpServers.first.running.tools
+```
+
+`.running` yields the MCP server as an asset; `.tools` resolves against *that
+asset's* resource tree. This is federation across assets inside one query, and it is
+what rules out the cheap options below.
+
+### What we learned tracing the code
+
+- **MRNs cannot be the join key.** Asset MRNs are assigned **upstream** by the
+  Mondoo platform (`providers-sdk/v1/recording/upstream_recording.go:42`); in a
+  local `mql` run there is no MRN at all
+  (`apps/mql/cmd/shell.go:80`; the correlation sentinel
+  `providers-sdk/v1/recording/recording.go:342` treats empty-MRN-with-platform-IDs
+  as normal). A provider emitting a reference never talks to upstream about the
+  referenced asset, so it cannot know that asset's MRN at emit time, and a
+  referenced (child) asset's MRN is on an independent timeline — it may be assigned
+  later, or never (if that discovery target is off).
+
+- **The platform already correlates related assets with no MRN — by platform ID.**
+  `inventory.Asset.RelatedAssets` (`inventory.proto:76`, field 33) is populated with
+  stub assets carrying only a platform ID
+  (`providers/os/provider/detector.go:138`: `&inventory.Asset{Id: ra.PlatformIDs[0]}`).
+  This is the shipped rail for docker→containers, k8s→pods/namespaces, gcp, and OS
+  cloud fingerprints.
+
+- **But `RelatedAssets` is provenance-blind.** A flat
+  `host.RelatedAssets: [{id: mcp1}, {id: mcp2}, {id: mcp3}]` records *that* the host
+  relates to three assets and nothing about *where each hangs in the resource tree*.
+  `RelatedAssets` is `[]*Asset` — the stub has only `Id`; there is no field that says
+  "this one hangs off `claude.code.mcpServer/X`." It is flat, undirected, populated
+  at connect/discovery time on the `Asset` struct, and shipped to the platform for
+  correlation. It was never built to be produced from a query-field result, nor to be
+  activated into a live connection.
+
+So the relationship must be **anchored to the producing resource node** — the pair
+`(resourceType, resourceID)` — carried on *both* sides of the join:
+
+```
+FORWARD (in-query, host policy):
+  claude.code.mcpServer/X  --.running-->  asset-ref
+      provenance is inherent: the field is defined ON that node, so the query path
+      IS the anchor.
+
+REVERSE (discovery, separate pass):
+  discovered asset mcp1  carries  boundTo = (hostAsset, claude.code.mcpServer, X)
+      provenance must be explicit, because the asset stands alone.
+
+JOIN = match on (hostAsset, resourceType, resourceID) + child platform ID,
+       NOT on a bare related-assets list.
+```
+
+The custom case (`mcp3`) is not special: any asset we support in discovery should,
+going forward, be produced from *some* node in the resource tree. Absence of a
+client anchor simply means it is a direct child of the host — the tuple degrades
+correctly. This "everything discoverable is tree-anchored" is a direction we are
+setting, not a state we reach overnight.
+
+## Decision
+
+Introduce a **first-class, directed asset relationship (edge)** anchored to the
+resource tree, and **deprecate `RelatedAssets` in favor of it** over time.
+
+### Edge shape (illustrative)
+
+```
+AssetRelationship {
+  // the tree anchor: the resource node that produced this edge
+  fromResource: { type: string, id: string }
+
+  // which asset the edge points at, and (later) how to reach it
+  toAsset: {
+    platformIds: []string        // the correlation key — reuses today's join
+    connection:  Config?         // deferred: how to activate into a runtime
+  }
+
+  relation: string               // e.g. "runs", "references"
+}
+```
+
+Key properties:
+
+- **The join stays platform-ID-based.** The edge still carries the child's platform
+  ID, so correlation reuses the existing, MRN-free pipeline. We are adding the
+  *anchor* and (later) the *connection handle* that `RelatedAssets` structurally
+  cannot hold — not inventing a new correlation primitive.
+
+- **Produced from both directions, from one source of truth.** The reverse
+  (discovery) side and the forward (`running` field) side must derive the identical
+  `(resourceType, resourceID)` anchor and child platform ID. This derivation MUST be
+  a single shared function called by both the resource's `__id` construction and the
+  discovery pass. Drift here = silent orphans (a `running` reference that never links
+  to the discovered asset). This is the single most important correctness
+  invariant.
+
+- **`RelatedAssets` becomes the degenerate edge** — no `fromResource` anchor, no
+  connection. Existing producers (docker, k8s, gcp, os) keep working unchanged and
+  migrate onto the new edge opportunistically. No big-bang proto break.
+
+### Scope of the first implementation slice
+
+Deliver only:
+
+1. **MCP-server discovery** for the `os` provider (opt-in gated per Follow-Ups).
+2. **The anchored relationship**: the reverse-side anchor on discovered MCP-server
+   assets, and the forward-side `running` field on the `*.mcpServer` resources
+   returning the asset-reference value, both keyed on the shared-function
+   `(resourceType, resourceID)` + parent-qualified platform ID.
+
+Explicitly **defer** (design for, do not build):
+
+- **Live cross-asset traversal** (`...running.tools`). This needs the engine to
+  activate an edge's `toAsset.connection` into a runtime and route field calls to the
+  referenced asset's provider (for MCP capability enumeration, the enterprise `ai`
+  provider — capability enumeration lives there, not in a standalone provider). The
+  edge is shaped so this is a later *capability on the same object* (populate
+  `toAsset.connection` and add engine-side activation), not a redesign.
+- **Full `RelatedAssets` migration** of existing providers.
+
+## Alternatives considered
+
+### A. Extend `RelatedAssets` in place
+
+Add a resource anchor to field 33. Rejected as the primary mechanism:
+
+- `RelatedAssets` is `[]*Asset`; adding an anchor means either polluting `Asset` with
+  parent-relative context or wrapping the element — a proto change to a shipped field
+  consumed by docker/k8s/gcp/os discovery and the platform, i.e. a broad, all-at-once
+  blast radius.
+- It is undirected, flat, and populated at connect time. It has no path to be
+  produced from a query-field result (the forward `running` direction), and no notion
+  of activation into a connection. Retrofitting `...running.tools` onto a static
+  correlation list is a semantic mismatch.
+
+The chosen approach still reuses the platform-ID *join* that `RelatedAssets` uses, so
+we keep the proven part and replace only the structure that can't carry the anchor.
+
+### B. Key the relationship on MRN
+
+Rejected. MRNs are upstream-assigned, absent locally, unknown to the emitting
+provider at emit time, and on an independent timeline for referenced assets. See
+Context. Platform IDs are local, deterministic, and already the primitive the join
+uses.
+
+### C. Encode the anchor only inside the child's platform-ID string
+
+Make the child platform ID the tree address
+(`.../host/<hostPlatformID>/claude.code.mcpServer/<id>`) and recover provenance by
+parsing it. Viable and cheap (rides `RelatedAssets` as-is), but the anchor is a
+string convention rather than structured data, brittle to parse, and still gives no
+home for the deferred connection handle. We adopt the parent-qualified platform ID as
+the child's **identity**, but carry the anchor as **structured fields** on the edge
+rather than relying on parsing.
+
+## Consequences
+
+- One new relationship concept to maintain alongside `RelatedAssets` during a
+  migration window; two mechanisms until the migration completes.
+- New plumbing on two sides: discovery emits the reverse anchor; query-field
+  resolution emits the forward edge. Lifting a *field value* into a stored
+  relationship is genuinely new (today relationships are only set at connect time).
+- The shared ID-derivation function is a hard dependency for correctness and must be
+  covered by tests on both the resource-creation and discovery paths.
+- The design keeps `...running.tools` reachable without a later redesign, at the cost
+  of specifying (but not building) `toAsset.connection` now.
+- Cross-provider references (e.g. host → GitHub repo, where the repo is discovered by
+  a different provider that never sees the host) join on the **target's own intrinsic
+  platform ID**, not a host-scoped anchor. The edge representation is uniform; the
+  key differs by mode (parent-qualified for parented children, target-intrinsic for
+  independent assets). The reference-builder must know which mode it is minting.
+
+## Follow-Ups
+
+- **Discovery gating** for `mcp-servers`: off by default and under `auto`, on only
+  when explicitly targeted or under `all`. In the `os` provider the default set lives
+  in `providers/os/config/config.go` and each resolver block gates on
+  `stringx.Contains(targets, "all") || stringx.Contains(targets, DiscoveryMCPServers)`
+  (mirrors `providers/os/resources/discovery/docker_engine/resolver.go`). Leave
+  `mcp-servers` out of the config default `Discovery` list.
+- Define the shared `(resourceType, resourceID)` + parent-qualified platform-ID
+  derivation function and unit-test the forward/reverse parity.
+- Decide `running` semantics: liveness-gated (null when the server is not actually
+  up — requires process/endpoint detection) vs. always-present reference (then the
+  field is `asset`/`target`, not `running`).
+- Sequence the `RelatedAssets` migration for docker/k8s/gcp/os.
+- Specify engine-side edge activation for the deferred `...running.tools` traversal
+  (runtime spin-up/reuse for the referenced asset, routing to the enterprise `ai`
+  provider).

--- a/llx/builtin.go
+++ b/llx/builtin.go
@@ -456,6 +456,12 @@ func init() {
 			string("unix"):    {f: timeUnixV2, Label: "unix"},
 			string("inRange"): {f: timeInRange, Label: "inRange"},
 		},
+		types.Asset: {
+			string("==" + types.Nil):   {f: assetCmpNilV2, Label: "=="},
+			string("!=" + types.Nil):   {f: assetNotNilV2, Label: "!="},
+			string("==" + types.Empty): {f: assetCmpNilV2, Label: "=="},
+			string("!=" + types.Empty): {f: assetNotNilV2, Label: "!="},
+		},
 		types.Dict: {
 			string("==" + types.Nil):                 {f: dictCmpNilV2, Label: "=="},
 			string("!=" + types.Nil):                 {f: dictNotNilV2, Label: "!="},

--- a/llx/builtin_simple.go
+++ b/llx/builtin_simple.go
@@ -732,6 +732,28 @@ func timeNotNilV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*R
 	return rawboolNotOpV2(e, bind, chunk, ref, opTimeCmpNil)
 }
 
+// The native `asset` primitive (types.Asset) carries an *AssetValue payload with
+// the anchor (resourceType, resourceId) that points at another asset. The anchor
+// is not introspectable from MQL; it is serialized out for the platform to
+// correlate against the separately-discovered asset. The only MQL-facing builtins
+// are nil comparisons. See ADR 030.
+
+func opAssetCmpNil(left *RawData, right *RawData) bool {
+	if left.Value == nil {
+		return true
+	}
+	v, ok := left.Value.(*AssetValue)
+	return !ok || v == nil
+}
+
+func assetCmpNilV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	return rawboolOpV2(e, bind, chunk, ref, opAssetCmpNil)
+}
+
+func assetNotNilV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {
+	return rawboolNotOpV2(e, bind, chunk, ref, opAssetCmpNil)
+}
+
 // string </>/<=/>= string
 
 func stringLTStringV2(e *blockExecutor, bind *RawData, chunk *Chunk, ref uint64) (*RawData, uint64, error) {

--- a/llx/data_conversions.go
+++ b/llx/data_conversions.go
@@ -47,6 +47,7 @@ func init() {
 		types.ResourceLike: resource2result,
 		types.FunctionLike: function2result,
 		types.Range:        range2result,
+		types.Asset:        asset2result,
 	}
 
 	primitiveConverters = map[types.Type]primitiveConverter{
@@ -70,6 +71,7 @@ func init() {
 		types.FunctionLike: pfunction2raw,
 		types.Ref:          pref2raw,
 		types.Range:        prange2raw,
+		types.Asset:        passet2raw,
 	}
 }
 
@@ -217,6 +219,35 @@ func dict2result(value any, typ types.Type) (*Primitive, error) {
 	}
 
 	return &Primitive{Type: string(types.Dict), Value: raw}, nil
+}
+
+func asset2result(value any, typ types.Type) (*Primitive, error) {
+	if value == nil {
+		return &Primitive{Type: string(types.Asset)}, nil
+	}
+	v, ok := value.(*AssetValue)
+	if !ok {
+		return nil, errInvalidConversion(value, typ)
+	}
+	if v == nil {
+		return &Primitive{Type: string(types.Asset)}, nil
+	}
+	raw, err := proto.MarshalOptions{Deterministic: true}.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return &Primitive{Type: string(types.Asset), Value: raw}, nil
+}
+
+func passet2raw(p *Primitive) *RawData {
+	if len(p.Value) == 0 {
+		return &RawData{Type: types.Asset, Value: (*AssetValue)(nil)}
+	}
+	v := AssetValue{}
+	if err := proto.Unmarshal(p.Value, &v); err != nil {
+		return &RawData{Error: err, Type: types.Asset}
+	}
+	return &RawData{Type: types.Asset, Value: &v}
 }
 
 func score2result(value any, typ types.Type) (*Primitive, error) {

--- a/llx/data_conversions_test.go
+++ b/llx/data_conversions_test.go
@@ -163,3 +163,35 @@ func TestMalformedElementKeepsCollection(t *testing.T) {
 		assert.Nil(t, got["bad"], "the malformed element is nulled out")
 	})
 }
+
+// TestAssetValueRoundTrip proves the native `asset` primitive payload survives
+// the RawData -> Primitive -> RawData (gRPC-boundary) encoding. See ADR 030.
+func TestAssetValueRoundTrip(t *testing.T) {
+	t.Run("populated", func(t *testing.T) {
+		rd := llx.AssetData(&llx.AssetValue{
+			ResourceType: "claude.code.mcpServer",
+			ResourceId:   "claude.code.mcpServer/context7",
+		})
+		assert.Equal(t, types.Asset, rd.Type)
+
+		prim := rd.Result().Data
+		require.Equal(t, string(types.Asset), prim.Type)
+
+		back := prim.RawData()
+		require.NoError(t, back.Error)
+		av, ok := back.Value.(*llx.AssetValue)
+		require.True(t, ok)
+		require.NotNil(t, av)
+		assert.Equal(t, "claude.code.mcpServer", av.ResourceType)
+		assert.Equal(t, "claude.code.mcpServer/context7", av.ResourceId)
+	})
+
+	t.Run("nil value", func(t *testing.T) {
+		prim := llx.AssetData(nil).Result().Data
+		require.Equal(t, string(types.Asset), prim.Type)
+		back := prim.RawData()
+		require.NoError(t, back.Error)
+		av, _ := back.Value.(*llx.AssetValue)
+		assert.Nil(t, av)
+	})
+}

--- a/llx/llx.pb.go
+++ b/llx/llx.pb.go
@@ -72,7 +72,7 @@ func (x Chunk_Call) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use Chunk_Call.Descriptor instead.
 func (Chunk_Call) EnumDescriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{2, 0}
+	return file_llx_proto_rawDescGZIP(), []int{3, 0}
 }
 
 type Primitive struct {
@@ -149,6 +149,63 @@ func (x *Primitive) GetMap() map[string]*Primitive {
 	return nil
 }
 
+// AssetValue is the payload of the native `asset` primitive type. It points at
+// another asset by the resource that anchors it in the current asset's resource
+// tree: the anchor is `(resource_type, resource_id)`. The owning asset id is
+// contextual (the caller knows which asset it is evaluating), so it is NOT part
+// of this value. See ADR 030.
+type AssetValue struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ResourceType  string                 `protobuf:"bytes,1,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	ResourceId    string                 `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetValue) Reset() {
+	*x = AssetValue{}
+	mi := &file_llx_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetValue) ProtoMessage() {}
+
+func (x *AssetValue) ProtoReflect() protoreflect.Message {
+	mi := &file_llx_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetValue.ProtoReflect.Descriptor instead.
+func (*AssetValue) Descriptor() ([]byte, []int) {
+	return file_llx_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *AssetValue) GetResourceType() string {
+	if x != nil {
+		return x.ResourceType
+	}
+	return ""
+}
+
+func (x *AssetValue) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
 type Function struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Type  string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
@@ -162,7 +219,7 @@ type Function struct {
 
 func (x *Function) Reset() {
 	*x = Function{}
-	mi := &file_llx_proto_msgTypes[1]
+	mi := &file_llx_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -174,7 +231,7 @@ func (x *Function) String() string {
 func (*Function) ProtoMessage() {}
 
 func (x *Function) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[1]
+	mi := &file_llx_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -187,7 +244,7 @@ func (x *Function) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Function.ProtoReflect.Descriptor instead.
 func (*Function) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{1}
+	return file_llx_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Function) GetType() string {
@@ -223,7 +280,7 @@ type Chunk struct {
 
 func (x *Chunk) Reset() {
 	*x = Chunk{}
-	mi := &file_llx_proto_msgTypes[2]
+	mi := &file_llx_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -235,7 +292,7 @@ func (x *Chunk) String() string {
 func (*Chunk) ProtoMessage() {}
 
 func (x *Chunk) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[2]
+	mi := &file_llx_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -248,7 +305,7 @@ func (x *Chunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Chunk.ProtoReflect.Descriptor instead.
 func (*Chunk) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{2}
+	return file_llx_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Chunk) GetCall() Chunk_Call {
@@ -291,7 +348,7 @@ type AssertionMessage struct {
 
 func (x *AssertionMessage) Reset() {
 	*x = AssertionMessage{}
-	mi := &file_llx_proto_msgTypes[3]
+	mi := &file_llx_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +360,7 @@ func (x *AssertionMessage) String() string {
 func (*AssertionMessage) ProtoMessage() {}
 
 func (x *AssertionMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[3]
+	mi := &file_llx_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +373,7 @@ func (x *AssertionMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssertionMessage.ProtoReflect.Descriptor instead.
 func (*AssertionMessage) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{3}
+	return file_llx_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AssertionMessage) GetTemplate() string {
@@ -365,7 +422,7 @@ type CodeV1 struct {
 
 func (x *CodeV1) Reset() {
 	*x = CodeV1{}
-	mi := &file_llx_proto_msgTypes[4]
+	mi := &file_llx_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -377,7 +434,7 @@ func (x *CodeV1) String() string {
 func (*CodeV1) ProtoMessage() {}
 
 func (x *CodeV1) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[4]
+	mi := &file_llx_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -390,7 +447,7 @@ func (x *CodeV1) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeV1.ProtoReflect.Descriptor instead.
 func (*CodeV1) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{4}
+	return file_llx_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CodeV1) GetId() string {
@@ -474,7 +531,7 @@ type Block struct {
 
 func (x *Block) Reset() {
 	*x = Block{}
-	mi := &file_llx_proto_msgTypes[5]
+	mi := &file_llx_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -486,7 +543,7 @@ func (x *Block) String() string {
 func (*Block) ProtoMessage() {}
 
 func (x *Block) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[5]
+	mi := &file_llx_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -499,7 +556,7 @@ func (x *Block) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Block.ProtoReflect.Descriptor instead.
 func (*Block) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{5}
+	return file_llx_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Block) GetChunks() []*Chunk {
@@ -549,7 +606,7 @@ type CodeV2 struct {
 
 func (x *CodeV2) Reset() {
 	*x = CodeV2{}
-	mi := &file_llx_proto_msgTypes[6]
+	mi := &file_llx_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -561,7 +618,7 @@ func (x *CodeV2) String() string {
 func (*CodeV2) ProtoMessage() {}
 
 func (x *CodeV2) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[6]
+	mi := &file_llx_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -574,7 +631,7 @@ func (x *CodeV2) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeV2.ProtoReflect.Descriptor instead.
 func (*CodeV2) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{6}
+	return file_llx_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CodeV2) GetId() string {
@@ -614,7 +671,7 @@ type Labels struct {
 
 func (x *Labels) Reset() {
 	*x = Labels{}
-	mi := &file_llx_proto_msgTypes[7]
+	mi := &file_llx_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -626,7 +683,7 @@ func (x *Labels) String() string {
 func (*Labels) ProtoMessage() {}
 
 func (x *Labels) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[7]
+	mi := &file_llx_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -639,7 +696,7 @@ func (x *Labels) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Labels.ProtoReflect.Descriptor instead.
 func (*Labels) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{7}
+	return file_llx_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Labels) GetLabels() map[string]string {
@@ -661,7 +718,7 @@ type Documentation struct {
 
 func (x *Documentation) Reset() {
 	*x = Documentation{}
-	mi := &file_llx_proto_msgTypes[8]
+	mi := &file_llx_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -673,7 +730,7 @@ func (x *Documentation) String() string {
 func (*Documentation) ProtoMessage() {}
 
 func (x *Documentation) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[8]
+	mi := &file_llx_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -686,7 +743,7 @@ func (x *Documentation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Documentation.ProtoReflect.Descriptor instead.
 func (*Documentation) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{8}
+	return file_llx_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Documentation) GetField() string {
@@ -738,7 +795,7 @@ type CodeBundle struct {
 
 func (x *CodeBundle) Reset() {
 	*x = CodeBundle{}
-	mi := &file_llx_proto_msgTypes[9]
+	mi := &file_llx_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -750,7 +807,7 @@ func (x *CodeBundle) String() string {
 func (*CodeBundle) ProtoMessage() {}
 
 func (x *CodeBundle) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[9]
+	mi := &file_llx_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -763,7 +820,7 @@ func (x *CodeBundle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CodeBundle.ProtoReflect.Descriptor instead.
 func (*CodeBundle) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{9}
+	return file_llx_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *CodeBundle) GetCodeV2() *CodeV2 {
@@ -847,7 +904,7 @@ type Result struct {
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_llx_proto_msgTypes[10]
+	mi := &file_llx_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -859,7 +916,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[10]
+	mi := &file_llx_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -872,7 +929,7 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{10}
+	return file_llx_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Result) GetData() *Primitive {
@@ -909,7 +966,7 @@ type ResourceRecording struct {
 
 func (x *ResourceRecording) Reset() {
 	*x = ResourceRecording{}
-	mi := &file_llx_proto_msgTypes[11]
+	mi := &file_llx_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -921,7 +978,7 @@ func (x *ResourceRecording) String() string {
 func (*ResourceRecording) ProtoMessage() {}
 
 func (x *ResourceRecording) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[11]
+	mi := &file_llx_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -934,7 +991,7 @@ func (x *ResourceRecording) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceRecording.ProtoReflect.Descriptor instead.
 func (*ResourceRecording) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{11}
+	return file_llx_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ResourceRecording) GetResource() string {
@@ -986,7 +1043,7 @@ type Rating struct {
 
 func (x *Rating) Reset() {
 	*x = Rating{}
-	mi := &file_llx_proto_msgTypes[12]
+	mi := &file_llx_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -998,7 +1055,7 @@ func (x *Rating) String() string {
 func (*Rating) ProtoMessage() {}
 
 func (x *Rating) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[12]
+	mi := &file_llx_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1011,7 +1068,7 @@ func (x *Rating) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Rating.ProtoReflect.Descriptor instead.
 func (*Rating) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{12}
+	return file_llx_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Rating) GetId() string {
@@ -1075,7 +1132,7 @@ type AssessmentItem struct {
 
 func (x *AssessmentItem) Reset() {
 	*x = AssessmentItem{}
-	mi := &file_llx_proto_msgTypes[13]
+	mi := &file_llx_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1087,7 +1144,7 @@ func (x *AssessmentItem) String() string {
 func (*AssessmentItem) ProtoMessage() {}
 
 func (x *AssessmentItem) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[13]
+	mi := &file_llx_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1100,7 +1157,7 @@ func (x *AssessmentItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssessmentItem.ProtoReflect.Descriptor instead.
 func (*AssessmentItem) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{13}
+	return file_llx_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AssessmentItem) GetSuccess() bool {
@@ -1192,7 +1249,7 @@ type Assessment struct {
 
 func (x *Assessment) Reset() {
 	*x = Assessment{}
-	mi := &file_llx_proto_msgTypes[14]
+	mi := &file_llx_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1261,7 @@ func (x *Assessment) String() string {
 func (*Assessment) ProtoMessage() {}
 
 func (x *Assessment) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[14]
+	mi := &file_llx_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1274,7 @@ func (x *Assessment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Assessment.ProtoReflect.Descriptor instead.
 func (*Assessment) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{14}
+	return file_llx_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Assessment) GetChecksum() string {
@@ -1259,7 +1316,7 @@ type IP struct {
 
 func (x *IP) Reset() {
 	*x = IP{}
-	mi := &file_llx_proto_msgTypes[15]
+	mi := &file_llx_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1271,7 +1328,7 @@ func (x *IP) String() string {
 func (*IP) ProtoMessage() {}
 
 func (x *IP) ProtoReflect() protoreflect.Message {
-	mi := &file_llx_proto_msgTypes[15]
+	mi := &file_llx_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1284,7 +1341,7 @@ func (x *IP) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IP.ProtoReflect.Descriptor instead.
 func (*IP) Descriptor() ([]byte, []int) {
-	return file_llx_proto_rawDescGZIP(), []int{15}
+	return file_llx_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *IP) GetAddress() []byte {
@@ -1320,7 +1377,12 @@ const file_llx_proto_rawDesc = "" +
 	"\x03map\x18\x04 \x03(\v2\x1b.mql.llx.Primitive.MapEntryR\x03map\x1aJ\n" +
 	"\bMapEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12(\n" +
-	"\x05value\x18\x02 \x01(\v2\x12.mql.llx.PrimitiveR\x05value:\x028\x01\"`\n" +
+	"\x05value\x18\x02 \x01(\v2\x12.mql.llx.PrimitiveR\x05value:\x028\x01\"R\n" +
+	"\n" +
+	"AssetValue\x12#\n" +
+	"\rresource_type\x18\x01 \x01(\tR\fresourceType\x12\x1f\n" +
+	"\vresource_id\x18\x02 \x01(\tR\n" +
+	"resourceId\"`\n" +
 	"\bFunction\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12&\n" +
 	"\x04args\x18\x03 \x03(\v2\x12.mql.llx.PrimitiveR\x04args\x12\x18\n" +
@@ -1481,71 +1543,72 @@ func file_llx_proto_rawDescGZIP() []byte {
 }
 
 var file_llx_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_llx_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_llx_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
 var file_llx_proto_goTypes = []any{
 	(Chunk_Call)(0),           // 0: mql.llx.Chunk.Call
 	(*Primitive)(nil),         // 1: mql.llx.Primitive
-	(*Function)(nil),          // 2: mql.llx.Function
-	(*Chunk)(nil),             // 3: mql.llx.Chunk
-	(*AssertionMessage)(nil),  // 4: mql.llx.AssertionMessage
-	(*CodeV1)(nil),            // 5: mql.llx.CodeV1
-	(*Block)(nil),             // 6: mql.llx.Block
-	(*CodeV2)(nil),            // 7: mql.llx.CodeV2
-	(*Labels)(nil),            // 8: mql.llx.Labels
-	(*Documentation)(nil),     // 9: mql.llx.Documentation
-	(*CodeBundle)(nil),        // 10: mql.llx.CodeBundle
-	(*Result)(nil),            // 11: mql.llx.Result
-	(*ResourceRecording)(nil), // 12: mql.llx.ResourceRecording
-	(*Rating)(nil),            // 13: mql.llx.Rating
-	(*AssessmentItem)(nil),    // 14: mql.llx.AssessmentItem
-	(*Assessment)(nil),        // 15: mql.llx.Assessment
-	(*IP)(nil),                // 16: mql.llx.IP
-	nil,                       // 17: mql.llx.Primitive.MapEntry
-	nil,                       // 18: mql.llx.CodeV1.ChecksumsEntry
-	nil,                       // 19: mql.llx.CodeV1.AssertionsEntry
-	nil,                       // 20: mql.llx.CodeV2.ChecksumsEntry
-	nil,                       // 21: mql.llx.CodeV2.AssertionsEntry
-	nil,                       // 22: mql.llx.Labels.LabelsEntry
-	nil,                       // 23: mql.llx.CodeBundle.PropsEntry
-	nil,                       // 24: mql.llx.CodeBundle.AssertionsEntry
-	nil,                       // 25: mql.llx.CodeBundle.AutoExpandEntry
-	nil,                       // 26: mql.llx.CodeBundle.VarsEntry
-	nil,                       // 27: mql.llx.ResourceRecording.FieldsEntry
+	(*AssetValue)(nil),        // 2: mql.llx.AssetValue
+	(*Function)(nil),          // 3: mql.llx.Function
+	(*Chunk)(nil),             // 4: mql.llx.Chunk
+	(*AssertionMessage)(nil),  // 5: mql.llx.AssertionMessage
+	(*CodeV1)(nil),            // 6: mql.llx.CodeV1
+	(*Block)(nil),             // 7: mql.llx.Block
+	(*CodeV2)(nil),            // 8: mql.llx.CodeV2
+	(*Labels)(nil),            // 9: mql.llx.Labels
+	(*Documentation)(nil),     // 10: mql.llx.Documentation
+	(*CodeBundle)(nil),        // 11: mql.llx.CodeBundle
+	(*Result)(nil),            // 12: mql.llx.Result
+	(*ResourceRecording)(nil), // 13: mql.llx.ResourceRecording
+	(*Rating)(nil),            // 14: mql.llx.Rating
+	(*AssessmentItem)(nil),    // 15: mql.llx.AssessmentItem
+	(*Assessment)(nil),        // 16: mql.llx.Assessment
+	(*IP)(nil),                // 17: mql.llx.IP
+	nil,                       // 18: mql.llx.Primitive.MapEntry
+	nil,                       // 19: mql.llx.CodeV1.ChecksumsEntry
+	nil,                       // 20: mql.llx.CodeV1.AssertionsEntry
+	nil,                       // 21: mql.llx.CodeV2.ChecksumsEntry
+	nil,                       // 22: mql.llx.CodeV2.AssertionsEntry
+	nil,                       // 23: mql.llx.Labels.LabelsEntry
+	nil,                       // 24: mql.llx.CodeBundle.PropsEntry
+	nil,                       // 25: mql.llx.CodeBundle.AssertionsEntry
+	nil,                       // 26: mql.llx.CodeBundle.AutoExpandEntry
+	nil,                       // 27: mql.llx.CodeBundle.VarsEntry
+	nil,                       // 28: mql.llx.ResourceRecording.FieldsEntry
 }
 var file_llx_proto_depIdxs = []int32{
 	1,  // 0: mql.llx.Primitive.array:type_name -> mql.llx.Primitive
-	17, // 1: mql.llx.Primitive.map:type_name -> mql.llx.Primitive.MapEntry
+	18, // 1: mql.llx.Primitive.map:type_name -> mql.llx.Primitive.MapEntry
 	1,  // 2: mql.llx.Function.args:type_name -> mql.llx.Primitive
 	0,  // 3: mql.llx.Chunk.call:type_name -> mql.llx.Chunk.Call
 	1,  // 4: mql.llx.Chunk.primitive:type_name -> mql.llx.Primitive
-	2,  // 5: mql.llx.Chunk.function:type_name -> mql.llx.Function
-	3,  // 6: mql.llx.CodeV1.code:type_name -> mql.llx.Chunk
-	18, // 7: mql.llx.CodeV1.checksums:type_name -> mql.llx.CodeV1.ChecksumsEntry
-	5,  // 8: mql.llx.CodeV1.functions:type_name -> mql.llx.CodeV1
-	19, // 9: mql.llx.CodeV1.assertions:type_name -> mql.llx.CodeV1.AssertionsEntry
-	3,  // 10: mql.llx.Block.chunks:type_name -> mql.llx.Chunk
-	6,  // 11: mql.llx.CodeV2.blocks:type_name -> mql.llx.Block
-	20, // 12: mql.llx.CodeV2.checksums:type_name -> mql.llx.CodeV2.ChecksumsEntry
-	21, // 13: mql.llx.CodeV2.assertions:type_name -> mql.llx.CodeV2.AssertionsEntry
-	22, // 14: mql.llx.Labels.labels:type_name -> mql.llx.Labels.LabelsEntry
-	7,  // 15: mql.llx.CodeBundle.code_v2:type_name -> mql.llx.CodeV2
-	9,  // 16: mql.llx.CodeBundle.suggestions:type_name -> mql.llx.Documentation
-	8,  // 17: mql.llx.CodeBundle.labels:type_name -> mql.llx.Labels
-	23, // 18: mql.llx.CodeBundle.props:type_name -> mql.llx.CodeBundle.PropsEntry
-	24, // 19: mql.llx.CodeBundle.assertions:type_name -> mql.llx.CodeBundle.AssertionsEntry
-	25, // 20: mql.llx.CodeBundle.auto_expand:type_name -> mql.llx.CodeBundle.AutoExpandEntry
-	26, // 21: mql.llx.CodeBundle.vars:type_name -> mql.llx.CodeBundle.VarsEntry
+	3,  // 5: mql.llx.Chunk.function:type_name -> mql.llx.Function
+	4,  // 6: mql.llx.CodeV1.code:type_name -> mql.llx.Chunk
+	19, // 7: mql.llx.CodeV1.checksums:type_name -> mql.llx.CodeV1.ChecksumsEntry
+	6,  // 8: mql.llx.CodeV1.functions:type_name -> mql.llx.CodeV1
+	20, // 9: mql.llx.CodeV1.assertions:type_name -> mql.llx.CodeV1.AssertionsEntry
+	4,  // 10: mql.llx.Block.chunks:type_name -> mql.llx.Chunk
+	7,  // 11: mql.llx.CodeV2.blocks:type_name -> mql.llx.Block
+	21, // 12: mql.llx.CodeV2.checksums:type_name -> mql.llx.CodeV2.ChecksumsEntry
+	22, // 13: mql.llx.CodeV2.assertions:type_name -> mql.llx.CodeV2.AssertionsEntry
+	23, // 14: mql.llx.Labels.labels:type_name -> mql.llx.Labels.LabelsEntry
+	8,  // 15: mql.llx.CodeBundle.code_v2:type_name -> mql.llx.CodeV2
+	10, // 16: mql.llx.CodeBundle.suggestions:type_name -> mql.llx.Documentation
+	9,  // 17: mql.llx.CodeBundle.labels:type_name -> mql.llx.Labels
+	24, // 18: mql.llx.CodeBundle.props:type_name -> mql.llx.CodeBundle.PropsEntry
+	25, // 19: mql.llx.CodeBundle.assertions:type_name -> mql.llx.CodeBundle.AssertionsEntry
+	26, // 20: mql.llx.CodeBundle.auto_expand:type_name -> mql.llx.CodeBundle.AutoExpandEntry
+	27, // 21: mql.llx.CodeBundle.vars:type_name -> mql.llx.CodeBundle.VarsEntry
 	1,  // 22: mql.llx.Result.data:type_name -> mql.llx.Primitive
-	27, // 23: mql.llx.ResourceRecording.fields:type_name -> mql.llx.ResourceRecording.FieldsEntry
+	28, // 23: mql.llx.ResourceRecording.fields:type_name -> mql.llx.ResourceRecording.FieldsEntry
 	1,  // 24: mql.llx.AssessmentItem.expected:type_name -> mql.llx.Primitive
 	1,  // 25: mql.llx.AssessmentItem.actual:type_name -> mql.llx.Primitive
 	1,  // 26: mql.llx.AssessmentItem.data:type_name -> mql.llx.Primitive
-	14, // 27: mql.llx.Assessment.results:type_name -> mql.llx.AssessmentItem
+	15, // 27: mql.llx.Assessment.results:type_name -> mql.llx.AssessmentItem
 	1,  // 28: mql.llx.Primitive.MapEntry.value:type_name -> mql.llx.Primitive
-	4,  // 29: mql.llx.CodeV1.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	4,  // 30: mql.llx.CodeV2.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	4,  // 31: mql.llx.CodeBundle.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
-	11, // 32: mql.llx.ResourceRecording.FieldsEntry.value:type_name -> mql.llx.Result
+	5,  // 29: mql.llx.CodeV1.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	5,  // 30: mql.llx.CodeV2.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	5,  // 31: mql.llx.CodeBundle.AssertionsEntry.value:type_name -> mql.llx.AssertionMessage
+	12, // 32: mql.llx.ResourceRecording.FieldsEntry.value:type_name -> mql.llx.Result
 	33, // [33:33] is the sub-list for method output_type
 	33, // [33:33] is the sub-list for method input_type
 	33, // [33:33] is the sub-list for extension type_name
@@ -1564,7 +1627,7 @@ func file_llx_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_llx_proto_rawDesc), len(file_llx_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   27,
+			NumMessages:   28,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/llx/llx.proto
+++ b/llx/llx.proto
@@ -23,6 +23,16 @@ message Primitive {
   map<string, Primitive> map = 4;
 }
 
+// AssetValue is the payload of the native `asset` primitive type. It points at
+// another asset by the resource that anchors it in the current asset's resource
+// tree: the anchor is `(resource_type, resource_id)`. The owning asset id is
+// contextual (the caller knows which asset it is evaluating), so it is NOT part
+// of this value. See ADR 030.
+message AssetValue {
+  string resource_type = 1;
+  string resource_id = 2;
+}
+
 message Function {
   string type = 1;
   repeated Primitive args = 3;

--- a/llx/llx_vtproto.pb.go
+++ b/llx/llx_vtproto.pb.go
@@ -99,6 +99,53 @@ func (m *Primitive) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *AssetValue) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AssetValue) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AssetValue) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ResourceId) > 0 {
+		i -= len(m.ResourceId)
+		copy(dAtA[i:], m.ResourceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ResourceType) > 0 {
+		i -= len(m.ResourceType)
+		copy(dAtA[i:], m.ResourceType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceType)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Function) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1433,6 +1480,24 @@ func (m *Primitive) SizeVT() (n int) {
 	return n
 }
 
+func (m *AssetValue) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ResourceType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ResourceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *Function) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2217,6 +2282,121 @@ func (m *Primitive) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Map[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AssetValue) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AssetValue: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AssetValue: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/llx/rawdata.go
+++ b/llx/rawdata.go
@@ -657,6 +657,14 @@ func ResourceData(v Resource, name string) *RawData {
 	}
 }
 
+// AssetData creates a rawdata struct from a native asset reference value
+func AssetData(v *AssetValue) *RawData {
+	return &RawData{
+		Type:  types.Asset,
+		Value: v,
+	}
+}
+
 // FunctionData creates a rawdata struct from a function reference
 func FunctionData(v int32, sig string) *RawData {
 	return &RawData{

--- a/llx/rawdata_json.go
+++ b/llx/rawdata_json.go
@@ -443,6 +443,27 @@ func rawDataJSON(typ types.Type, data any, codeID string, bundle *CodeBundle, bu
 		buf.WriteString(str)
 		return nil
 
+	case types.Asset:
+		v, ok := data.(*AssetValue)
+		if !ok || v == nil {
+			buf.WriteString("null")
+			return nil
+		}
+		rt, err := string2json(v.ResourceType)
+		if err != nil {
+			return err
+		}
+		rid, err := string2json(v.ResourceId)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(`{"resourceType":`)
+		buf.WriteString(rt)
+		buf.WriteString(`,"resourceId":`)
+		buf.WriteString(rid)
+		buf.WriteString("}")
+		return nil
+
 	default:
 		b, err := json.Marshal(data)
 		buf.Write(b)

--- a/mqlx/private_test.go
+++ b/mqlx/private_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/mqlx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/testutils/mockprovider"
@@ -88,4 +89,33 @@ func TestPrivateProviderValidation(t *testing.T) {
 	schema := testutils.MustLoadSchema(testutils.SchemaProvider{Provider: "mockprovider"})
 	_, err = mqlx.NewEnv(mqlx.WithPrivateProvider(mockprovider.Config, schema, nil))
 	require.ErrorContains(t, err, "no plugin provided")
+}
+
+// TestAssetPrimitive exercises the native `asset` primitive end-to-end through a
+// real (in-process) provider: compile -> serialize (asset2result) -> wire ->
+// deserialize (passet2raw) -> return to caller. muser.running returns an asset
+// value anchored on the muser resource. The anchor is not introspectable from
+// MQL (no field accessors); only the value and nil comparisons are exposed.
+// See ADR 030.
+func TestAssetPrimitive(t *testing.T) {
+	env := privateEnv(t)
+	ctx := context.Background()
+
+	t.Run("running returns an asset value carrying the anchor", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob").running`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		av, ok := res.Value().(*llx.AssetValue)
+		require.True(t, ok, "expected *llx.AssetValue, got %T", res.Value())
+		require.NotNil(t, av)
+		assert.Equal(t, "muser", av.ResourceType)
+		assert.NotEmpty(t, av.ResourceId)
+	})
+
+	t.Run("running is not null", func(t *testing.T) {
+		res, err := env.MustCompile(`muser(name: "bob").running != null`).Eval(ctx)
+		require.NoError(t, err)
+		require.NoError(t, res.Err())
+		assert.Equal(t, true, res.Value())
+	})
 }

--- a/providers-sdk/v1/inventory/inventory.pb.go
+++ b/providers-sdk/v1/inventory/inventory.pb.go
@@ -360,14 +360,20 @@ type Asset struct {
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	IdDetector []string `protobuf:"bytes,31,rep,name=id_detector,json=idDetector,proto3" json:"id_detector,omitempty"`
 	// indicator is this is an inventory object or a CI/CD run
-	Category      AssetCategory `protobuf:"varint,32,opt,name=category,proto3,enum=cnquery.providers.v1.AssetCategory" json:"category,omitempty"`
-	RelatedAssets []*Asset      `protobuf:"bytes,33,rep,name=related_assets,json=relatedAssets,proto3" json:"related_assets,omitempty"`
-	ManagedBy     string        `protobuf:"bytes,34,opt,name=managed_by,json=managedBy,proto3" json:"managed_by,omitempty"`
+	Category AssetCategory `protobuf:"varint,32,opt,name=category,proto3,enum=cnquery.providers.v1.AssetCategory" json:"category,omitempty"`
+	// Deprecated: flat, provenance-blind list of related assets, consumed
+	// server-side. Superseded by `relationships` (ADR 030), which anchors each
+	// edge to the resource that produced it. Kept for backward compatibility.
+	RelatedAssets []*Asset `protobuf:"bytes,33,rep,name=related_assets,json=relatedAssets,proto3" json:"related_assets,omitempty"`
+	ManagedBy     string   `protobuf:"bytes,34,opt,name=managed_by,json=managedBy,proto3" json:"managed_by,omitempty"`
 	// optional url that can be used to access the asset via a browser
-	Url           string `protobuf:"bytes,35,opt,name=url,proto3" json:"url,omitempty"`
-	KindString    string `protobuf:"bytes,36,opt,name=kind_string,json=kindString,proto3" json:"kind_string,omitempty"`
-	Fqdn          string `protobuf:"bytes,37,opt,name=fqdn,proto3" json:"fqdn,omitempty"`
-	TraceId       string `protobuf:"bytes,38,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
+	Url        string `protobuf:"bytes,35,opt,name=url,proto3" json:"url,omitempty"`
+	KindString string `protobuf:"bytes,36,opt,name=kind_string,json=kindString,proto3" json:"kind_string,omitempty"`
+	Fqdn       string `protobuf:"bytes,37,opt,name=fqdn,proto3" json:"fqdn,omitempty"`
+	TraceId    string `protobuf:"bytes,38,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
+	// Resource-anchored relationships to other assets (ADR 030). Each edge names
+	// the counterparty asset and the resource on it that anchors the relationship.
+	Relationships []*AssetRelationship `protobuf:"bytes,39,rep,name=relationships,proto3" json:"relationships,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -528,6 +534,81 @@ func (x *Asset) GetTraceId() string {
 	return ""
 }
 
+func (x *Asset) GetRelationships() []*AssetRelationship {
+	if x != nil {
+		return x.Relationships
+	}
+	return nil
+}
+
+// AssetRelationship is a directed, resource-anchored edge to another asset. An
+// edge has two ends, and the anchor resource is meaningless without the asset
+// that owns it, so the message names both: the counterparty `asset` (a full
+// Asset, like `related_assets`, so identity is unrestricted) and the resource
+// on that asset that anchors the relationship. See ADR 030.
+type AssetRelationship struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// the asset at the other end of the edge (e.g. the parent/host that owns the
+	// anchor resource), referenced as an Asset (stub or full)
+	Asset *Asset `protobuf:"bytes,1,opt,name=asset,proto3" json:"asset,omitempty"`
+	// the anchor resource on `asset`
+	ResourceType  string `protobuf:"bytes,2,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	ResourceId    string `protobuf:"bytes,3,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssetRelationship) Reset() {
+	*x = AssetRelationship{}
+	mi := &file_inventory_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssetRelationship) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssetRelationship) ProtoMessage() {}
+
+func (x *AssetRelationship) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssetRelationship.ProtoReflect.Descriptor instead.
+func (*AssetRelationship) Descriptor() ([]byte, []int) {
+	return file_inventory_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *AssetRelationship) GetAsset() *Asset {
+	if x != nil {
+		return x.Asset
+	}
+	return nil
+}
+
+func (x *AssetRelationship) GetResourceType() string {
+	if x != nil {
+		return x.ResourceType
+	}
+	return ""
+}
+
+func (x *AssetRelationship) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
 // AssetUrlBranch defines the hierarchy into which an asset can be placed. It
 // makes it easier to find and group assets. Typically this is a subset of all
 // possible asset relationships used to generate an opinionated view on an
@@ -565,7 +646,7 @@ type AssetUrlBranch struct {
 
 func (x *AssetUrlBranch) Reset() {
 	*x = AssetUrlBranch{}
-	mi := &file_inventory_proto_msgTypes[1]
+	mi := &file_inventory_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -577,7 +658,7 @@ func (x *AssetUrlBranch) String() string {
 func (*AssetUrlBranch) ProtoMessage() {}
 
 func (x *AssetUrlBranch) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[1]
+	mi := &file_inventory_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -590,7 +671,7 @@ func (x *AssetUrlBranch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetUrlBranch.ProtoReflect.Descriptor instead.
 func (*AssetUrlBranch) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{1}
+	return file_inventory_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *AssetUrlBranch) GetPathSegments() []string {
@@ -688,7 +769,7 @@ type Config struct {
 
 func (x *Config) Reset() {
 	*x = Config{}
-	mi := &file_inventory_proto_msgTypes[2]
+	mi := &file_inventory_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -700,7 +781,7 @@ func (x *Config) String() string {
 func (*Config) ProtoMessage() {}
 
 func (x *Config) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[2]
+	mi := &file_inventory_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +794,7 @@ func (x *Config) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Config.ProtoReflect.Descriptor instead.
 func (*Config) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{2}
+	return file_inventory_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Config) GetBackend() ProviderType {
@@ -847,7 +928,7 @@ type Sudo struct {
 
 func (x *Sudo) Reset() {
 	*x = Sudo{}
-	mi := &file_inventory_proto_msgTypes[3]
+	mi := &file_inventory_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -859,7 +940,7 @@ func (x *Sudo) String() string {
 func (*Sudo) ProtoMessage() {}
 
 func (x *Sudo) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[3]
+	mi := &file_inventory_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -872,7 +953,7 @@ func (x *Sudo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Sudo.ProtoReflect.Descriptor instead.
 func (*Sudo) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{3}
+	return file_inventory_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Sudo) GetActive() bool {
@@ -913,7 +994,7 @@ type Discovery struct {
 
 func (x *Discovery) Reset() {
 	*x = Discovery{}
-	mi := &file_inventory_proto_msgTypes[4]
+	mi := &file_inventory_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -925,7 +1006,7 @@ func (x *Discovery) String() string {
 func (*Discovery) ProtoMessage() {}
 
 func (x *Discovery) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[4]
+	mi := &file_inventory_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -938,7 +1019,7 @@ func (x *Discovery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Discovery.ProtoReflect.Descriptor instead.
 func (*Discovery) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{4}
+	return file_inventory_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Discovery) GetTargets() []string {
@@ -978,7 +1059,7 @@ type Platform struct {
 
 func (x *Platform) Reset() {
 	*x = Platform{}
-	mi := &file_inventory_proto_msgTypes[5]
+	mi := &file_inventory_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1071,7 @@ func (x *Platform) String() string {
 func (*Platform) ProtoMessage() {}
 
 func (x *Platform) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[5]
+	mi := &file_inventory_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1084,7 @@ func (x *Platform) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Platform.ProtoReflect.Descriptor instead.
 func (*Platform) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{5}
+	return file_inventory_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Platform) GetName() string {
@@ -1111,7 +1192,7 @@ type TypeMeta struct {
 
 func (x *TypeMeta) Reset() {
 	*x = TypeMeta{}
-	mi := &file_inventory_proto_msgTypes[6]
+	mi := &file_inventory_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1123,7 +1204,7 @@ func (x *TypeMeta) String() string {
 func (*TypeMeta) ProtoMessage() {}
 
 func (x *TypeMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[6]
+	mi := &file_inventory_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1136,7 +1217,7 @@ func (x *TypeMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TypeMeta.ProtoReflect.Descriptor instead.
 func (*TypeMeta) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{6}
+	return file_inventory_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *TypeMeta) GetKind() string {
@@ -1204,7 +1285,7 @@ type ObjectMeta struct {
 
 func (x *ObjectMeta) Reset() {
 	*x = ObjectMeta{}
-	mi := &file_inventory_proto_msgTypes[7]
+	mi := &file_inventory_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1297,7 @@ func (x *ObjectMeta) String() string {
 func (*ObjectMeta) ProtoMessage() {}
 
 func (x *ObjectMeta) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[7]
+	mi := &file_inventory_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1229,7 +1310,7 @@ func (x *ObjectMeta) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ObjectMeta.ProtoReflect.Descriptor instead.
 func (*ObjectMeta) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{7}
+	return file_inventory_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ObjectMeta) GetName() string {
@@ -1291,7 +1372,7 @@ type Time struct {
 
 func (x *Time) Reset() {
 	*x = Time{}
-	mi := &file_inventory_proto_msgTypes[8]
+	mi := &file_inventory_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1303,7 +1384,7 @@ func (x *Time) String() string {
 func (*Time) ProtoMessage() {}
 
 func (x *Time) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[8]
+	mi := &file_inventory_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1316,7 +1397,7 @@ func (x *Time) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Time.ProtoReflect.Descriptor instead.
 func (*Time) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{8}
+	return file_inventory_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Time) GetSeconds() int64 {
@@ -1359,7 +1440,7 @@ type OwnerReference struct {
 
 func (x *OwnerReference) Reset() {
 	*x = OwnerReference{}
-	mi := &file_inventory_proto_msgTypes[9]
+	mi := &file_inventory_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1371,7 +1452,7 @@ func (x *OwnerReference) String() string {
 func (*OwnerReference) ProtoMessage() {}
 
 func (x *OwnerReference) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[9]
+	mi := &file_inventory_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1384,7 +1465,7 @@ func (x *OwnerReference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OwnerReference.ProtoReflect.Descriptor instead.
 func (*OwnerReference) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{9}
+	return file_inventory_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *OwnerReference) GetApiVersion() string {
@@ -1433,7 +1514,7 @@ type Inventory struct {
 
 func (x *Inventory) Reset() {
 	*x = Inventory{}
-	mi := &file_inventory_proto_msgTypes[10]
+	mi := &file_inventory_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1445,7 +1526,7 @@ func (x *Inventory) String() string {
 func (*Inventory) ProtoMessage() {}
 
 func (x *Inventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[10]
+	mi := &file_inventory_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1458,7 +1539,7 @@ func (x *Inventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Inventory.ProtoReflect.Descriptor instead.
 func (*Inventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{10}
+	return file_inventory_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Inventory) GetMetadata() *ObjectMeta {
@@ -1496,7 +1577,7 @@ type InventorySpec struct {
 
 func (x *InventorySpec) Reset() {
 	*x = InventorySpec{}
-	mi := &file_inventory_proto_msgTypes[11]
+	mi := &file_inventory_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1508,7 +1589,7 @@ func (x *InventorySpec) String() string {
 func (*InventorySpec) ProtoMessage() {}
 
 func (x *InventorySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[11]
+	mi := &file_inventory_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1521,7 +1602,7 @@ func (x *InventorySpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InventorySpec.ProtoReflect.Descriptor instead.
 func (*InventorySpec) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{11}
+	return file_inventory_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *InventorySpec) GetAssets() []*Asset {
@@ -1567,7 +1648,7 @@ type InventoryStatus struct {
 
 func (x *InventoryStatus) Reset() {
 	*x = InventoryStatus{}
-	mi := &file_inventory_proto_msgTypes[12]
+	mi := &file_inventory_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1579,7 +1660,7 @@ func (x *InventoryStatus) String() string {
 func (*InventoryStatus) ProtoMessage() {}
 
 func (x *InventoryStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[12]
+	mi := &file_inventory_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1592,14 +1673,14 @@ func (x *InventoryStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InventoryStatus.ProtoReflect.Descriptor instead.
 func (*InventoryStatus) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{12}
+	return file_inventory_proto_rawDescGZIP(), []int{13}
 }
 
 var File_inventory_proto protoreflect.FileDescriptor
 
 const file_inventory_proto_rawDesc = "" +
 	"\n" +
-	"\x0finventory.proto\x12\x14cnquery.providers.v1\x1a(providers-sdk/v1/upstream/upstream.proto\x1a\"providers-sdk/v1/vault/vault.proto\"\xc8\a\n" +
+	"\x0finventory.proto\x12\x14cnquery.providers.v1\x1a(providers-sdk/v1/upstream/upstream.proto\x1a\"providers-sdk/v1/vault/vault.proto\"\x97\b\n" +
 	"\x05Asset\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x10\n" +
 	"\x03mrn\x18\x02 \x01(\tR\x03mrn\x12\x12\n" +
@@ -1621,7 +1702,8 @@ const file_inventory_proto_rawDesc = "" +
 	"\vkind_string\x18$ \x01(\tR\n" +
 	"kindString\x12\x12\n" +
 	"\x04fqdn\x18% \x01(\tR\x04fqdn\x12\x19\n" +
-	"\btrace_id\x18& \x01(\tR\atraceId\x1a9\n" +
+	"\btrace_id\x18& \x01(\tR\atraceId\x12M\n" +
+	"\rrelationships\x18' \x03(\v2'.cnquery.providers.v1.AssetRelationshipR\rrelationships\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
@@ -1630,7 +1712,12 @@ const file_inventory_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
 	"\fOptionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x1e\x10\x1f\"\x9f\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01J\x04\b\x1e\x10\x1f\"\x8c\x01\n" +
+	"\x11AssetRelationship\x121\n" +
+	"\x05asset\x18\x01 \x01(\v2\x1b.cnquery.providers.v1.AssetR\x05asset\x12#\n" +
+	"\rresource_type\x18\x02 \x01(\tR\fresourceType\x12\x1f\n" +
+	"\vresource_id\x18\x03 \x01(\tR\n" +
+	"resourceId\"\x9f\x03\n" +
 	"\x0eAssetUrlBranch\x12#\n" +
 	"\rpath_segments\x18\x01 \x03(\tR\fpathSegments\x12\x10\n" +
 	"\x03key\x18\x02 \x01(\tR\x03key\x12H\n" +
@@ -1814,75 +1901,78 @@ func file_inventory_proto_rawDescGZIP() []byte {
 }
 
 var file_inventory_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_inventory_proto_goTypes = []any{
 	(State)(0),                       // 0: cnquery.providers.v1.State
 	(AssetCategory)(0),               // 1: cnquery.providers.v1.AssetCategory
 	(ProviderType)(0),                // 2: cnquery.providers.v1.ProviderType
 	(*Asset)(nil),                    // 3: cnquery.providers.v1.Asset
-	(*AssetUrlBranch)(nil),           // 4: cnquery.providers.v1.AssetUrlBranch
-	(*Config)(nil),                   // 5: cnquery.providers.v1.Config
-	(*Sudo)(nil),                     // 6: cnquery.providers.v1.Sudo
-	(*Discovery)(nil),                // 7: cnquery.providers.v1.Discovery
-	(*Platform)(nil),                 // 8: cnquery.providers.v1.Platform
-	(*TypeMeta)(nil),                 // 9: cnquery.providers.v1.TypeMeta
-	(*ObjectMeta)(nil),               // 10: cnquery.providers.v1.ObjectMeta
-	(*Time)(nil),                     // 11: cnquery.providers.v1.Time
-	(*OwnerReference)(nil),           // 12: cnquery.providers.v1.OwnerReference
-	(*Inventory)(nil),                // 13: cnquery.providers.v1.Inventory
-	(*InventorySpec)(nil),            // 14: cnquery.providers.v1.InventorySpec
-	(*InventoryStatus)(nil),          // 15: cnquery.providers.v1.InventoryStatus
-	nil,                              // 16: cnquery.providers.v1.Asset.LabelsEntry
-	nil,                              // 17: cnquery.providers.v1.Asset.AnnotationsEntry
-	nil,                              // 18: cnquery.providers.v1.Asset.OptionsEntry
-	nil,                              // 19: cnquery.providers.v1.AssetUrlBranch.ValuesEntry
-	nil,                              // 20: cnquery.providers.v1.Config.OptionsEntry
-	nil,                              // 21: cnquery.providers.v1.Discovery.FilterEntry
-	nil,                              // 22: cnquery.providers.v1.Platform.LabelsEntry
-	nil,                              // 23: cnquery.providers.v1.Platform.MetadataEntry
-	nil,                              // 24: cnquery.providers.v1.ObjectMeta.LabelsEntry
-	nil,                              // 25: cnquery.providers.v1.ObjectMeta.AnnotationsEntry
-	nil,                              // 26: cnquery.providers.v1.InventorySpec.CredentialsEntry
-	(*vault.Credential)(nil),         // 27: cnquery.providers.v1.Credential
-	(*vault.VaultConfiguration)(nil), // 28: cnquery.providers.v1.VaultConfiguration
-	(*upstream.ServiceAccountCredentials)(nil), // 29: mondoo.mql.upstream.v1.ServiceAccountCredentials
+	(*AssetRelationship)(nil),        // 4: cnquery.providers.v1.AssetRelationship
+	(*AssetUrlBranch)(nil),           // 5: cnquery.providers.v1.AssetUrlBranch
+	(*Config)(nil),                   // 6: cnquery.providers.v1.Config
+	(*Sudo)(nil),                     // 7: cnquery.providers.v1.Sudo
+	(*Discovery)(nil),                // 8: cnquery.providers.v1.Discovery
+	(*Platform)(nil),                 // 9: cnquery.providers.v1.Platform
+	(*TypeMeta)(nil),                 // 10: cnquery.providers.v1.TypeMeta
+	(*ObjectMeta)(nil),               // 11: cnquery.providers.v1.ObjectMeta
+	(*Time)(nil),                     // 12: cnquery.providers.v1.Time
+	(*OwnerReference)(nil),           // 13: cnquery.providers.v1.OwnerReference
+	(*Inventory)(nil),                // 14: cnquery.providers.v1.Inventory
+	(*InventorySpec)(nil),            // 15: cnquery.providers.v1.InventorySpec
+	(*InventoryStatus)(nil),          // 16: cnquery.providers.v1.InventoryStatus
+	nil,                              // 17: cnquery.providers.v1.Asset.LabelsEntry
+	nil,                              // 18: cnquery.providers.v1.Asset.AnnotationsEntry
+	nil,                              // 19: cnquery.providers.v1.Asset.OptionsEntry
+	nil,                              // 20: cnquery.providers.v1.AssetUrlBranch.ValuesEntry
+	nil,                              // 21: cnquery.providers.v1.Config.OptionsEntry
+	nil,                              // 22: cnquery.providers.v1.Discovery.FilterEntry
+	nil,                              // 23: cnquery.providers.v1.Platform.LabelsEntry
+	nil,                              // 24: cnquery.providers.v1.Platform.MetadataEntry
+	nil,                              // 25: cnquery.providers.v1.ObjectMeta.LabelsEntry
+	nil,                              // 26: cnquery.providers.v1.ObjectMeta.AnnotationsEntry
+	nil,                              // 27: cnquery.providers.v1.InventorySpec.CredentialsEntry
+	(*vault.Credential)(nil),         // 28: cnquery.providers.v1.Credential
+	(*vault.VaultConfiguration)(nil), // 29: cnquery.providers.v1.VaultConfiguration
+	(*upstream.ServiceAccountCredentials)(nil), // 30: mondoo.mql.upstream.v1.ServiceAccountCredentials
 }
 var file_inventory_proto_depIdxs = []int32{
 	0,  // 0: cnquery.providers.v1.Asset.state:type_name -> cnquery.providers.v1.State
-	8,  // 1: cnquery.providers.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
-	5,  // 2: cnquery.providers.v1.Asset.connections:type_name -> cnquery.providers.v1.Config
-	16, // 3: cnquery.providers.v1.Asset.labels:type_name -> cnquery.providers.v1.Asset.LabelsEntry
-	17, // 4: cnquery.providers.v1.Asset.annotations:type_name -> cnquery.providers.v1.Asset.AnnotationsEntry
-	18, // 5: cnquery.providers.v1.Asset.options:type_name -> cnquery.providers.v1.Asset.OptionsEntry
+	9,  // 1: cnquery.providers.v1.Asset.platform:type_name -> cnquery.providers.v1.Platform
+	6,  // 2: cnquery.providers.v1.Asset.connections:type_name -> cnquery.providers.v1.Config
+	17, // 3: cnquery.providers.v1.Asset.labels:type_name -> cnquery.providers.v1.Asset.LabelsEntry
+	18, // 4: cnquery.providers.v1.Asset.annotations:type_name -> cnquery.providers.v1.Asset.AnnotationsEntry
+	19, // 5: cnquery.providers.v1.Asset.options:type_name -> cnquery.providers.v1.Asset.OptionsEntry
 	1,  // 6: cnquery.providers.v1.Asset.category:type_name -> cnquery.providers.v1.AssetCategory
 	3,  // 7: cnquery.providers.v1.Asset.related_assets:type_name -> cnquery.providers.v1.Asset
-	19, // 8: cnquery.providers.v1.AssetUrlBranch.values:type_name -> cnquery.providers.v1.AssetUrlBranch.ValuesEntry
-	4,  // 9: cnquery.providers.v1.AssetUrlBranch.parent:type_name -> cnquery.providers.v1.AssetUrlBranch
-	2,  // 10: cnquery.providers.v1.Config.backend:type_name -> cnquery.providers.v1.ProviderType
-	27, // 11: cnquery.providers.v1.Config.credentials:type_name -> cnquery.providers.v1.Credential
-	6,  // 12: cnquery.providers.v1.Config.sudo:type_name -> cnquery.providers.v1.Sudo
-	20, // 13: cnquery.providers.v1.Config.options:type_name -> cnquery.providers.v1.Config.OptionsEntry
-	7,  // 14: cnquery.providers.v1.Config.discover:type_name -> cnquery.providers.v1.Discovery
-	21, // 15: cnquery.providers.v1.Discovery.filter:type_name -> cnquery.providers.v1.Discovery.FilterEntry
-	22, // 16: cnquery.providers.v1.Platform.labels:type_name -> cnquery.providers.v1.Platform.LabelsEntry
-	23, // 17: cnquery.providers.v1.Platform.metadata:type_name -> cnquery.providers.v1.Platform.MetadataEntry
-	24, // 18: cnquery.providers.v1.ObjectMeta.labels:type_name -> cnquery.providers.v1.ObjectMeta.LabelsEntry
-	25, // 19: cnquery.providers.v1.ObjectMeta.annotations:type_name -> cnquery.providers.v1.ObjectMeta.AnnotationsEntry
-	12, // 20: cnquery.providers.v1.ObjectMeta.ownerReferences:type_name -> cnquery.providers.v1.OwnerReference
-	10, // 21: cnquery.providers.v1.Inventory.metadata:type_name -> cnquery.providers.v1.ObjectMeta
-	14, // 22: cnquery.providers.v1.Inventory.spec:type_name -> cnquery.providers.v1.InventorySpec
-	15, // 23: cnquery.providers.v1.Inventory.status:type_name -> cnquery.providers.v1.InventoryStatus
-	3,  // 24: cnquery.providers.v1.InventorySpec.assets:type_name -> cnquery.providers.v1.Asset
-	26, // 25: cnquery.providers.v1.InventorySpec.credentials:type_name -> cnquery.providers.v1.InventorySpec.CredentialsEntry
-	28, // 26: cnquery.providers.v1.InventorySpec.vault:type_name -> cnquery.providers.v1.VaultConfiguration
-	29, // 27: cnquery.providers.v1.InventorySpec.upstream_credentials:type_name -> mondoo.mql.upstream.v1.ServiceAccountCredentials
-	4,  // 28: cnquery.providers.v1.AssetUrlBranch.ValuesEntry.value:type_name -> cnquery.providers.v1.AssetUrlBranch
-	27, // 29: cnquery.providers.v1.InventorySpec.CredentialsEntry.value:type_name -> cnquery.providers.v1.Credential
-	30, // [30:30] is the sub-list for method output_type
-	30, // [30:30] is the sub-list for method input_type
-	30, // [30:30] is the sub-list for extension type_name
-	30, // [30:30] is the sub-list for extension extendee
-	0,  // [0:30] is the sub-list for field type_name
+	4,  // 8: cnquery.providers.v1.Asset.relationships:type_name -> cnquery.providers.v1.AssetRelationship
+	3,  // 9: cnquery.providers.v1.AssetRelationship.asset:type_name -> cnquery.providers.v1.Asset
+	20, // 10: cnquery.providers.v1.AssetUrlBranch.values:type_name -> cnquery.providers.v1.AssetUrlBranch.ValuesEntry
+	5,  // 11: cnquery.providers.v1.AssetUrlBranch.parent:type_name -> cnquery.providers.v1.AssetUrlBranch
+	2,  // 12: cnquery.providers.v1.Config.backend:type_name -> cnquery.providers.v1.ProviderType
+	28, // 13: cnquery.providers.v1.Config.credentials:type_name -> cnquery.providers.v1.Credential
+	7,  // 14: cnquery.providers.v1.Config.sudo:type_name -> cnquery.providers.v1.Sudo
+	21, // 15: cnquery.providers.v1.Config.options:type_name -> cnquery.providers.v1.Config.OptionsEntry
+	8,  // 16: cnquery.providers.v1.Config.discover:type_name -> cnquery.providers.v1.Discovery
+	22, // 17: cnquery.providers.v1.Discovery.filter:type_name -> cnquery.providers.v1.Discovery.FilterEntry
+	23, // 18: cnquery.providers.v1.Platform.labels:type_name -> cnquery.providers.v1.Platform.LabelsEntry
+	24, // 19: cnquery.providers.v1.Platform.metadata:type_name -> cnquery.providers.v1.Platform.MetadataEntry
+	25, // 20: cnquery.providers.v1.ObjectMeta.labels:type_name -> cnquery.providers.v1.ObjectMeta.LabelsEntry
+	26, // 21: cnquery.providers.v1.ObjectMeta.annotations:type_name -> cnquery.providers.v1.ObjectMeta.AnnotationsEntry
+	13, // 22: cnquery.providers.v1.ObjectMeta.ownerReferences:type_name -> cnquery.providers.v1.OwnerReference
+	11, // 23: cnquery.providers.v1.Inventory.metadata:type_name -> cnquery.providers.v1.ObjectMeta
+	15, // 24: cnquery.providers.v1.Inventory.spec:type_name -> cnquery.providers.v1.InventorySpec
+	16, // 25: cnquery.providers.v1.Inventory.status:type_name -> cnquery.providers.v1.InventoryStatus
+	3,  // 26: cnquery.providers.v1.InventorySpec.assets:type_name -> cnquery.providers.v1.Asset
+	27, // 27: cnquery.providers.v1.InventorySpec.credentials:type_name -> cnquery.providers.v1.InventorySpec.CredentialsEntry
+	29, // 28: cnquery.providers.v1.InventorySpec.vault:type_name -> cnquery.providers.v1.VaultConfiguration
+	30, // 29: cnquery.providers.v1.InventorySpec.upstream_credentials:type_name -> mondoo.mql.upstream.v1.ServiceAccountCredentials
+	5,  // 30: cnquery.providers.v1.AssetUrlBranch.ValuesEntry.value:type_name -> cnquery.providers.v1.AssetUrlBranch
+	28, // 31: cnquery.providers.v1.InventorySpec.CredentialsEntry.value:type_name -> cnquery.providers.v1.Credential
+	32, // [32:32] is the sub-list for method output_type
+	32, // [32:32] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_inventory_proto_init() }
@@ -1896,7 +1986,7 @@ func file_inventory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_inventory_proto_rawDesc), len(file_inventory_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/providers-sdk/v1/inventory/inventory.proto
+++ b/providers-sdk/v1/inventory/inventory.proto
@@ -73,6 +73,9 @@ message Asset {
   // indicator is this is an inventory object or a CI/CD run
   AssetCategory category = 32;
 
+  // DEPRECATED in v14: flat, provenance-blind list of related assets, consumed
+  // server-side. Superseded by `relationships` (ADR 030), which anchors each
+  // edge to the resource that produced it. Kept for backward compatibility.
   repeated Asset related_assets = 33;
 
   string managed_by = 34;
@@ -83,6 +86,24 @@ message Asset {
   string kind_string = 36;
   string fqdn = 37;
   string trace_id = 38;
+
+  // Resource-anchored relationships to other assets (ADR 030). Each edge names
+  // the counterparty asset and the resource on it that anchors the relationship.
+  repeated AssetRelationship relationships = 39;
+}
+
+// AssetRelationship is a directed, resource-anchored edge to another asset. An
+// edge has two ends, and the anchor resource is meaningless without the asset
+// that owns it, so the message names both: the counterparty `asset` (a full
+// Asset, like `related_assets`, so identity is unrestricted) and the resource
+// on that asset that anchors the relationship. See ADR 030.
+message AssetRelationship {
+  // the asset at the other end of the edge (e.g. the parent/host that owns the
+  // anchor resource), referenced as an Asset (stub or full)
+  Asset asset = 1;
+  // the anchor resource on `asset`
+  string resource_type = 2;
+  string resource_id = 3;
 }
 
 // AssetUrlBranch defines the hierarchy into which an asset can be placed. It

--- a/providers-sdk/v1/inventory/inventory.proto
+++ b/providers-sdk/v1/inventory/inventory.proto
@@ -87,8 +87,8 @@ message Asset {
   string fqdn = 37;
   string trace_id = 38;
 
-  // Resource-anchored relationships to other assets (ADR 030). Each edge names
-  // the counterparty asset and the resource on it that anchors the relationship.
+  // Resource-anchored relationships to other assets (ADR 030). Each edge
+  // names the counterparty asset and the resource on it that anchors the edge.
   repeated AssetRelationship relationships = 39;
 }
 

--- a/providers-sdk/v1/inventory/inventory_vtproto.pb.go
+++ b/providers-sdk/v1/inventory/inventory_vtproto.pb.go
@@ -82,6 +82,13 @@ func (m *Asset) CloneVT() *Asset {
 		}
 		r.RelatedAssets = tmpContainer
 	}
+	if rhs := m.Relationships; rhs != nil {
+		tmpContainer := make([]*AssetRelationship, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Relationships = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -90,6 +97,25 @@ func (m *Asset) CloneVT() *Asset {
 }
 
 func (m *Asset) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *AssetRelationship) CloneVT() *AssetRelationship {
+	if m == nil {
+		return (*AssetRelationship)(nil)
+	}
+	r := new(AssetRelationship)
+	r.Asset = m.Asset.CloneVT()
+	r.ResourceType = m.ResourceType
+	r.ResourceId = m.ResourceId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *AssetRelationship) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -476,6 +502,20 @@ func (m *Asset) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.Relationships) > 0 {
+		for iNdEx := len(m.Relationships) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Relationships[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x2
+			i--
+			dAtA[i] = 0xba
+		}
+	}
 	if len(m.TraceId) > 0 {
 		i -= len(m.TraceId)
 		copy(dAtA[i:], m.TraceId)
@@ -672,6 +712,63 @@ func (m *Asset) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.Id)
 		copy(dAtA[i:], m.Id)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *AssetRelationship) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *AssetRelationship) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *AssetRelationship) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ResourceId) > 0 {
+		i -= len(m.ResourceId)
+		copy(dAtA[i:], m.ResourceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceId)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.ResourceType) > 0 {
+		i -= len(m.ResourceType)
+		copy(dAtA[i:], m.ResourceType)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ResourceType)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Asset != nil {
+		size, err := m.Asset.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -1807,6 +1904,34 @@ func (m *Asset) SizeVT() (n int) {
 	l = len(m.TraceId)
 	if l > 0 {
 		n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Relationships) > 0 {
+		for _, e := range m.Relationships {
+			l = e.SizeVT()
+			n += 2 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *AssetRelationship) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Asset != nil {
+		l = m.Asset.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ResourceType)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ResourceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3110,6 +3235,191 @@ func (m *Asset) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.TraceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 39:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Relationships", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Relationships = append(m.Relationships, &AssetRelationship{})
+			if err := m.Relationships[len(m.Relationships)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *AssetRelationship) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: AssetRelationship: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: AssetRelationship: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Asset", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Asset == nil {
+				m.Asset = &Asset{}
+			}
+			if err := m.Asset.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceType", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceType = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ResourceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ResourceId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/providers-sdk/v1/mqlr/lrcore/go.go
+++ b/providers-sdk/v1/mqlr/lrcore/go.go
@@ -665,6 +665,8 @@ func (t *SimpleType) typeItems(ast *LR) types.Type {
 		return types.IP
 	case "range":
 		return types.Range
+	case "asset":
+		return types.Asset
 	case "any":
 		return types.Any
 	default:
@@ -737,6 +739,8 @@ func (t *SimpleType) mondooTypeItems(b *goBuilder) string {
 		return "types.Time"
 	case "range":
 		return "types.Range"
+	case "asset":
+		return "types.Asset"
 	case "dict":
 		return "types.Dict"
 	case "version":
@@ -809,6 +813,7 @@ var primitiveTypes = map[string]string{
 	"dict":    "any",
 	"version": "string",
 	"ip":      "llx.RawIP",
+	"asset":   "*llx.AssetValue",
 	"any":     "any",
 }
 
@@ -843,6 +848,7 @@ var primitiveZeros = map[string]string{
 	"dict":    "nil",
 	"version": "\"\"",
 	"ip":      "nil",
+	"asset":   "nil",
 	"any":     "nil",
 }
 

--- a/providers-sdk/v1/testutils/mockprovider/resources/all.go
+++ b/providers-sdk/v1/testutils/mockprovider/resources/all.go
@@ -14,6 +14,13 @@ func (c *mqlMuser) id() (string, error) {
 	return c.Name.Data, nil
 }
 
+func (c *mqlMuser) running() (*llx.AssetValue, error) {
+	return &llx.AssetValue{
+		ResourceType: c.MqlName(),
+		ResourceId:   c.MqlID(),
+	}, nil
+}
+
 func (c *mqlMuser) group() (*mqlMgroup, error) {
 	o, err := CreateResource(c.MqlRuntime, "mgroup", map[string]*llx.RawData{
 		"name": llx.StringData("group one"),

--- a/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr
+++ b/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr
@@ -12,6 +12,7 @@ muser {
   groups() []mgroup
   dict() dict
   error() string
+  running() asset
 }
 
 mgroup {

--- a/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
+++ b/providers-sdk/v1/testutils/mockprovider/resources/mockprovider.lr.go
@@ -138,6 +138,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"muser.error": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMuser).GetError()).ToDataRes(types.String)
 	},
+	"muser.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlMuser).GetRunning()).ToDataRes(types.Asset)
+	},
 	"mgroup.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlMgroup).GetName()).ToDataRes(types.String)
 	},
@@ -195,6 +198,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"muser.error": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlMuser).Error, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"muser.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlMuser).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
 		return
 	},
 	"mgroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -269,6 +276,7 @@ type mqlMuser struct {
 	Groups     plugin.TValue[[]any]
 	Dict       plugin.TValue[any]
 	Error      plugin.TValue[string]
+	Running    plugin.TValue[*llx.AssetValue]
 }
 
 // createMuser creates a new instance of this resource
@@ -375,6 +383,12 @@ func (c *mqlMuser) GetDict() *plugin.TValue[any] {
 func (c *mqlMuser) GetError() *plugin.TValue[string] {
 	return plugin.GetOrCompute[string](&c.Error, func() (string, error) {
 		return c.error()
+	})
+}
+
+func (c *mqlMuser) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
 	})
 }
 

--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -9,6 +9,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/connection/shared"
 	"go.mondoo.com/mql/v13/providers/os/detector"
 	"go.mondoo.com/mql/v13/providers/os/resources/discovery/docker_engine"
+	"go.mondoo.com/mql/v13/providers/os/resources/discovery/mcp_servers"
 )
 
 var Config = plugin.Provider{
@@ -48,6 +49,9 @@ Examples:
 			Discovery: []string{
 				docker_engine.DiscoveryContainerRunning,
 				docker_engine.DiscoveryContainerImages,
+				// advertising the target in --discover help does NOT enable it
+				// (opt-in only).
+				mcp_servers.DiscoveryMCPServers,
 			},
 			Flags: []plugin.Flag{
 				{

--- a/providers/os/provider/provider.go
+++ b/providers/os/provider/provider.go
@@ -37,6 +37,7 @@ import (
 	"go.mondoo.com/mql/v13/providers/os/id"
 	"go.mondoo.com/mql/v13/providers/os/resources"
 	"go.mondoo.com/mql/v13/providers/os/resources/discovery/docker_engine"
+	"go.mondoo.com/mql/v13/providers/os/resources/discovery/mcp_servers"
 	"go.mondoo.com/mql/v13/utils/stringx"
 )
 
@@ -304,6 +305,16 @@ func (s *Service) Connect(req *plugin.ConnectReq, callback plugin.ProviderCallba
 		inv, err = s.discoverLocalContainers(conn.Asset().Connections[0])
 		if err != nil {
 			return nil, err
+		}
+		mcpInv, err := s.discoverMCPServers(conn)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to discover mcp servers")
+		} else if mcpInv != nil {
+			if inv == nil {
+				inv = mcpInv
+			} else {
+				inv.AddAssets(mcpInv.Spec.GetAssets()...)
+			}
 		}
 	}
 
@@ -622,6 +633,35 @@ func (s *Service) discoverLocalContainers(conf *inventory.Config) (*inventory.In
 	inventory.AddAssets(resolvedAssets...)
 
 	return inventory, nil
+}
+
+// discoverMCPServers discovers MCP servers configured on the host as their own
+// assets. It is opt-in: it runs only when the `mcp-servers` target (or `all`) is
+// explicitly requested, so it stays off by default and under `auto`. The os
+// provider emits the connection info the AI provider needs; it never connects to
+// the MCP server itself. See ADR 030.
+func (s *Service) discoverMCPServers(conn shared.Connection) (*inventory.Inventory, error) {
+	conf := conn.Asset().Connections[0]
+	if conf == nil || conf.Discover == nil {
+		return nil, nil
+	}
+	if !stringx.ContainsAnyOf(conf.Discover.Targets, "all", mcp_servers.DiscoveryMCPServers) {
+		return nil, nil
+	}
+
+	runtime, err := s.GetRuntime(uint32(conn.ID()))
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedAssets, err := resources.DiscoverMCPServerAssets(runtime, conn.Asset())
+	if err != nil {
+		return nil, err
+	}
+
+	inv := &inventory.Inventory{}
+	inv.AddAssets(resolvedAssets...)
+	return inv, nil
 }
 
 // parseContainerSubcommand translates one of the shared `image|registry|tar|container`

--- a/providers/os/resources/claude_code.go
+++ b/providers/os/resources/claude_code.go
@@ -412,3 +412,7 @@ func (r *mqlClaudeCodeProject) id() (string, error) {
 func (r *mqlClaudeCodeMcpServer) id() (string, error) {
 	return "claude.code.mcpServer/" + r.Name.Data, nil
 }
+
+func (r *mqlClaudeCodeMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}

--- a/providers/os/resources/cursor.go
+++ b/providers/os/resources/cursor.go
@@ -113,6 +113,10 @@ func (r *mqlCursor) skills() ([]interface{}, error) {
 
 // Child resource ID methods
 
+func (r *mqlCursorMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}
+
 func (r *mqlCursorMcpServer) id() (string, error) {
 	return "cursor.mcpServer/" + r.Name.Data, nil
 }

--- a/providers/os/resources/discovery/mcp_servers/mcp_servers.go
+++ b/providers/os/resources/discovery/mcp_servers/mcp_servers.go
@@ -12,8 +12,8 @@ package mcp_servers
 // host. It is opt-in: off by default and under `auto`, on only when explicitly
 // requested or under `all`.
 //
-// Env-carrying: discovery reads each server's declared env (often secrets) and
-// passes it in the connection Config Options["env"] as JSON so the AI provider
-// can set cmd.Env and actually start a dormant stdio server. This is a
-// deliberate tradeoff: secrets land in the inventory/asset. See ADR 030.
+// No secrets: discovery emits only how to start each server (protocol + target)
+// and never the server's declared env. Secrets are supplied explicitly at
+// connect time via the AI provider's `--env` flag, so they never enter the
+// inventory/asset. See ADR 030.
 const DiscoveryMCPServers = "mcp-servers"

--- a/providers/os/resources/discovery/mcp_servers/mcp_servers.go
+++ b/providers/os/resources/discovery/mcp_servers/mcp_servers.go
@@ -1,0 +1,19 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package mcp_servers holds the shared discovery-target constant for MCP-server
+// discovery. It lives in its own leaf package (like docker_engine) so both the
+// provider config and the provider's discovery gate reference one source. The
+// resolver itself lives in the resources package, where the concrete
+// *.mcpServer types are defined. See ADR 030.
+package mcp_servers
+
+// DiscoveryMCPServers is the discovery target for MCP servers configured on a
+// host. It is opt-in: off by default and under `auto`, on only when explicitly
+// requested or under `all`.
+//
+// Env-carrying: discovery reads each server's declared env (often secrets) and
+// passes it in the connection Config Options["env"] as JSON so the AI provider
+// can set cmd.Env and actually start a dormant stdio server. This is a
+// deliberate tradeoff: secrets land in the inventory/asset. See ADR 030.
+const DiscoveryMCPServers = "mcp-servers"

--- a/providers/os/resources/gemini.go
+++ b/providers/os/resources/gemini.go
@@ -98,6 +98,10 @@ func (r *mqlGemini) skills() ([]interface{}, error) {
 
 // Child resource ID methods
 
+func (r *mqlGeminiMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}
+
 func (r *mqlGeminiMcpServer) id() (string, error) {
 	return "gemini.mcpServer/" + r.Name.Data, nil
 }

--- a/providers/os/resources/github_copilot.go
+++ b/providers/os/resources/github_copilot.go
@@ -111,6 +111,10 @@ func (r *mqlGithubCopilotAccount) id() (string, error) {
 	return "github.copilot.account/" + r.User.Data, nil
 }
 
+func (r *mqlGithubCopilotMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}
+
 func (r *mqlGithubCopilotMcpServer) id() (string, error) {
 	return "github.copilot.mcpServer/" + r.Name.Data, nil
 }

--- a/providers/os/resources/mcp.go
+++ b/providers/os/resources/mcp.go
@@ -5,8 +5,21 @@ package resources
 
 import (
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
 )
+
+// mcpServerAsset builds the native `asset` value that anchors an MCP server
+// resource to the asset discovered for it. The anchor is the resource's own
+// (type, id); the owning host asset is contextual. Both this forward accessor
+// and the mcp-servers discovery resolver derive the anchor the same way (from
+// the resource identity), so they stay in lockstep. See ADR 030.
+func mcpServerAsset(r plugin.Resource) *llx.AssetValue {
+	return &llx.AssetValue{
+		ResourceType: r.MqlName(),
+		ResourceId:   r.MqlID(),
+	}
+}
 
 // MCP transport types. These mirror the values AI tools write into their MCP
 // config files; when a config omits the type we infer it from the connection

--- a/providers/os/resources/mcp.go
+++ b/providers/os/resources/mcp.go
@@ -4,6 +4,8 @@
 package resources
 
 import (
+	"strings"
+
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -30,12 +32,14 @@ const (
 )
 
 // deriveMcpTransport returns the transport type for an MCP server. An explicit
-// value from the config wins; otherwise it is inferred from the connection
-// shape: a local launch command implies stdio, a remote endpoint URL implies
-// http. Returns an empty string when neither is present.
+// value from the config wins (lowercased, since transport names are a
+// conventionally-lowercase set and configs may spell them any case); otherwise
+// it is inferred from the connection shape: a local launch command implies
+// stdio, a remote endpoint URL implies http. Returns an empty string when
+// neither is present.
 func deriveMcpTransport(explicitType, command, url string) string {
 	if explicitType != "" {
-		return explicitType
+		return strings.ToLower(explicitType)
 	}
 	if command != "" {
 		return mcpTransportStdio

--- a/providers/os/resources/mcp_discovery.go
+++ b/providers/os/resources/mcp_discovery.go
@@ -82,6 +82,9 @@ func DiscoverMCPServerAssets(runtime *plugin.Runtime, host *inventory.Asset) ([]
 				// no usable connection info (neither command nor url)
 				continue
 			}
+			// No PlatformIds here: identity is assigned by the AI provider's
+			// Connect() at connect time. The relationship back to the host is
+			// resource-anchored on (type, id), not platform-ID-based. See ADR 030.
 			assets = append(assets, &inventory.Asset{
 				Name:        srv.GetName().Data,
 				State:       inventory.State_STATE_ONLINE,
@@ -106,12 +109,25 @@ func DiscoverMCPServerAssets(runtime *plugin.Runtime, host *inventory.Asset) ([]
 func mcpConnectionConfig(srv mcpServerLike) *inventory.Config {
 	command := srv.GetCommand().Data
 	url := srv.GetUrl().Data
-	switch deriveMcpTransport(srv.GetType().Data, command, url) {
-	case mcpTransportStdio:
+
+	// stdio is the only local transport. Every other transport (http, https,
+	// sse, streamable-http, ...) is a remote, URL-based one, so we classify by
+	// whether a URL is present rather than enumerating names, so a config with a
+	// transport we don't recognize by name is not silently dropped.
+	if deriveMcpTransport(srv.GetType().Data, command, url) == mcpTransportStdio {
 		if command == "" {
 			return nil
 		}
-		parts := append([]string{command}, anySliceToStrings(srv.GetArgs().Data)...)
+		args := srv.GetArgs()
+		if args.Error != nil {
+			// Args failed to resolve: emit the bare command rather than silently
+			// dropping arguments, and leave a trace so a broken target is explained.
+			log.Warn().Err(args.Error).Str("server", srv.GetName().Data).
+				Msg("mcp discovery: failed to read server args, emitting command without arguments")
+		}
+		parts := make([]string, 0, 1+len(args.Data))
+		parts = append(parts, command)
+		parts = append(parts, anySliceToStrings(args.Data)...)
 		// We deliberately do NOT carry the server's env (secrets). Discovery
 		// emits only how to start the server; secrets are supplied explicitly at
 		// connect time via the AI provider's `--env` flag, so they never enter
@@ -123,23 +139,22 @@ func mcpConnectionConfig(srv mcpServerLike) *inventory.Config {
 				"target":   shellQuoteJoin(parts),
 			},
 		}
-	case mcpTransportHTTP:
-		if url == "" {
-			return nil
-		}
-		protocol := "http"
-		if strings.HasPrefix(strings.ToLower(url), "https://") {
-			protocol = "https"
-		}
-		return &inventory.Config{
-			Type: "mcp",
-			Options: map[string]string{
-				"protocol": protocol,
-				"target":   url,
-			},
-		}
-	default:
+	}
+
+	// Remote transport: needs a URL to reach the server.
+	if url == "" {
 		return nil
+	}
+	protocol := "http"
+	if strings.HasPrefix(strings.ToLower(url), "https://") {
+		protocol = "https"
+	}
+	return &inventory.Config{
+		Type: "mcp",
+		Options: map[string]string{
+			"protocol": protocol,
+			"target":   url,
+		},
 	}
 }
 

--- a/providers/os/resources/mcp_discovery.go
+++ b/providers/os/resources/mcp_discovery.go
@@ -1,0 +1,175 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// mcpClientResources are the AI tool resources that declare MCP servers. Each
+// exposes a `mcpServers()` accessor; discovery reuses those accessors (rather
+// than re-parsing configs) so the discovered assets stay in lockstep with the
+// `running` field on each server resource.
+var mcpClientResources = []string{
+	"claude.code",
+	"openai.codex",
+	"cursor",
+	"github.copilot",
+	"gemini",
+	"windsurf",
+}
+
+// mcpClientLike is satisfied by every AI tool resource that lists MCP servers.
+type mcpClientLike interface {
+	GetMcpServers() *plugin.TValue[[]any]
+}
+
+// mcpServerLike is satisfied by every *.mcpServer resource. The field names are
+// identical across tools, so one interface covers all six concrete types.
+type mcpServerLike interface {
+	plugin.Resource
+	GetName() *plugin.TValue[string]
+	GetType() *plugin.TValue[string]
+	GetCommand() *plugin.TValue[string]
+	GetArgs() *plugin.TValue[[]any]
+	GetUrl() *plugin.TValue[string]
+}
+
+// DiscoverMCPServerAssets enumerates the MCP servers configured on the host and
+// returns one asset per server. Each asset carries:
+//   - a `mcp` connection Config (protocol + target) with everything the AI
+//     provider's MCP connector needs to connect. The os provider never connects
+//     to the MCP server itself.
+//   - a resource-anchored relationship back to the host: the anchor is the
+//     mcpServer resource's own (type, id), matching the `running` field. See ADR 030.
+func DiscoverMCPServerAssets(runtime *plugin.Runtime, host *inventory.Asset) ([]*inventory.Asset, error) {
+	hostRef := &inventory.Asset{
+		Id:          host.GetId(),
+		Mrn:         host.GetMrn(),
+		PlatformIds: host.GetPlatformIds(),
+	}
+
+	var assets []*inventory.Asset
+	for _, clientName := range mcpClientResources {
+		res, err := NewResource(runtime, clientName, map[string]*llx.RawData{})
+		if err != nil {
+			log.Debug().Err(err).Str("client", clientName).Msg("mcp discovery: skipping client")
+			continue
+		}
+		client, ok := res.(mcpClientLike)
+		if !ok {
+			continue
+		}
+		servers := client.GetMcpServers()
+		if servers.Error != nil {
+			log.Debug().Err(servers.Error).Str("client", clientName).Msg("mcp discovery: failed to list servers")
+			continue
+		}
+
+		for _, raw := range servers.Data {
+			srv, ok := raw.(mcpServerLike)
+			if !ok {
+				continue
+			}
+			conf := mcpConnectionConfig(srv)
+			if conf == nil {
+				// no usable connection info (neither command nor url)
+				continue
+			}
+			assets = append(assets, &inventory.Asset{
+				Name:        srv.GetName().Data,
+				State:       inventory.State_STATE_ONLINE,
+				Connections: []*inventory.Config{conf},
+				Relationships: []*inventory.AssetRelationship{
+					{
+						Asset:        hostRef,
+						ResourceType: srv.MqlName(),
+						ResourceId:   srv.MqlID(),
+					},
+				},
+			})
+		}
+	}
+	return assets, nil
+}
+
+// mcpConnectionConfig builds the `mcp` connection Config the AI provider needs.
+// It reads `Options["protocol"]` ("stdio"|"http"|"https") and `Options["target"]`
+// (a shell command for stdio, a URL for http/https). Returns nil when the server
+// exposes neither a command nor a url.
+func mcpConnectionConfig(srv mcpServerLike) *inventory.Config {
+	command := srv.GetCommand().Data
+	url := srv.GetUrl().Data
+	switch deriveMcpTransport(srv.GetType().Data, command, url) {
+	case mcpTransportStdio:
+		if command == "" {
+			return nil
+		}
+		parts := append([]string{command}, anySliceToStrings(srv.GetArgs().Data)...)
+		// We deliberately do NOT carry the server's env (secrets). Discovery
+		// emits only how to start the server; secrets are supplied explicitly at
+		// connect time via the AI provider's `--env` flag, so they never enter
+		// the inventory. See ADR 030.
+		return &inventory.Config{
+			Type: "mcp",
+			Options: map[string]string{
+				"protocol": "stdio",
+				"target":   shellQuoteJoin(parts),
+			},
+		}
+	case mcpTransportHTTP:
+		if url == "" {
+			return nil
+		}
+		protocol := "http"
+		if strings.HasPrefix(strings.ToLower(url), "https://") {
+			protocol = "https"
+		}
+		return &inventory.Config{
+			Type: "mcp",
+			Options: map[string]string{
+				"protocol": protocol,
+				"target":   url,
+			},
+		}
+	default:
+		return nil
+	}
+}
+
+func anySliceToStrings(in []any) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// shellQuoteJoin joins a command and its args into a single string that a POSIX
+// shell-word splitter (the AI provider uses shellquote.Split) reparses into the
+// original tokens. Tokens with shell-special characters are single-quoted.
+func shellQuoteJoin(parts []string) string {
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = shellQuote(p)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(s, " \t\n\r'\"\\$`&|;<>()*?[]#~=%!{}") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/providers/os/resources/mcp_discovery_test.go
+++ b/providers/os/resources/mcp_discovery_test.go
@@ -1,0 +1,44 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// TestMcpConnectionConfig verifies that discovery emits how to start the server
+// (protocol + target) and, crucially, never the server's env/secrets — those are
+// supplied explicitly at connect time via the AI provider's `--env`. See ADR 030.
+func TestMcpConnectionConfig(t *testing.T) {
+	t.Run("stdio emits protocol+target and no env", func(t *testing.T) {
+		srv := &mqlClaudeCodeMcpServer{
+			Type:    plugin.TValue[string]{Data: "stdio", State: plugin.StateIsSet},
+			Command: plugin.TValue[string]{Data: "npx", State: plugin.StateIsSet},
+			Args:    plugin.TValue[[]any]{Data: []any{"-y", "@scope/server", "run"}, State: plugin.StateIsSet},
+		}
+
+		conf := mcpConnectionConfig(srv)
+		require.NotNil(t, conf)
+		assert.Equal(t, "mcp", conf.Type)
+		assert.Equal(t, "stdio", conf.Options["protocol"])
+		assert.Equal(t, "npx -y @scope/server run", conf.Options["target"])
+		_, hasEnv := conf.Options["env"]
+		assert.False(t, hasEnv, "discovery must not carry env/secrets")
+	})
+
+	t.Run("http server uses url target", func(t *testing.T) {
+		srv := &mqlClaudeCodeMcpServer{
+			Type: plugin.TValue[string]{Data: "http", State: plugin.StateIsSet},
+			Url:  plugin.TValue[string]{Data: "https://mcp.example.com/mcp", State: plugin.StateIsSet},
+		}
+		conf := mcpConnectionConfig(srv)
+		require.NotNil(t, conf)
+		assert.Equal(t, "https", conf.Options["protocol"])
+		assert.Equal(t, "https://mcp.example.com/mcp", conf.Options["target"])
+	})
+}

--- a/providers/os/resources/mcp_discovery_test.go
+++ b/providers/os/resources/mcp_discovery_test.go
@@ -41,4 +41,30 @@ func TestMcpConnectionConfig(t *testing.T) {
 		assert.Equal(t, "https", conf.Options["protocol"])
 		assert.Equal(t, "https://mcp.example.com/mcp", conf.Options["target"])
 	})
+
+	t.Run("sse server is a remote transport, not dropped", func(t *testing.T) {
+		// Cursor remote servers declare `type: "sse"`; it is URL-based like http,
+		// so discovery must emit it rather than silently drop it. See ADR 030.
+		srv := &mqlClaudeCodeMcpServer{
+			Type: plugin.TValue[string]{Data: "sse", State: plugin.StateIsSet},
+			Url:  plugin.TValue[string]{Data: "https://mcp.example.com/sse", State: plugin.StateIsSet},
+		}
+		conf := mcpConnectionConfig(srv)
+		require.NotNil(t, conf)
+		assert.Equal(t, "https", conf.Options["protocol"])
+		assert.Equal(t, "https://mcp.example.com/sse", conf.Options["target"])
+	})
+
+	t.Run("transport type is matched case-insensitively", func(t *testing.T) {
+		// A config that spells the type in any case must still be recognized as
+		// stdio rather than falling through to the URL branch and being dropped.
+		srv := &mqlClaudeCodeMcpServer{
+			Type:    plugin.TValue[string]{Data: "STDIO", State: plugin.StateIsSet},
+			Command: plugin.TValue[string]{Data: "npx", State: plugin.StateIsSet},
+		}
+		conf := mcpConnectionConfig(srv)
+		require.NotNil(t, conf)
+		assert.Equal(t, "stdio", conf.Options["protocol"])
+		assert.Equal(t, "npx", conf.Options["target"])
+	})
 }

--- a/providers/os/resources/openai_codex.go
+++ b/providers/os/resources/openai_codex.go
@@ -379,6 +379,10 @@ func (r *mqlOpenaiCodexSkill) sha256() (string, error) {
 	return contentSHA256(r.Content.Data), nil
 }
 
+func (r *mqlOpenaiCodexMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}
+
 func (r *mqlOpenaiCodexMcpServer) id() (string, error) {
 	return "openai.codex.mcpServer/" + r.Plugin.Data + "/" + r.Name.Data, nil
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -11424,6 +11424,11 @@ private claude.code.mcpServer @defaults("name") @maturity("preview") {
   needsAuth bool
   // Timestamp of last authentication check
   lastChecked string
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // OpenAI Codex CLI instance
@@ -11557,6 +11562,11 @@ private openai.codex.mcpServer @defaults("name") @maturity("preview") {
   note string
   // Plugin that provides this MCP server
   plugin string
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // OpenAI Codex OAuth app connector
@@ -11634,6 +11644,11 @@ private cursor.mcpServer @defaults("name") @maturity("preview") {
   url string
   // Whether environment variables (for example API keys) are configured
   hasEnv bool
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // Cursor rule file
@@ -11747,6 +11762,11 @@ private github.copilot.mcpServer @defaults("name") @maturity("preview") {
   url string
   // Whether environment variables (for example API keys) are configured
   hasEnv bool
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // GitHub Copilot skill
@@ -11923,6 +11943,11 @@ private gemini.mcpServer @defaults("name") @maturity("preview") {
   url string
   // Whether environment variables (for example API keys) are configured
   hasEnv bool
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // Gemini skill
@@ -12021,6 +12046,11 @@ private windsurf.mcpServer @defaults("name") @maturity("preview") {
   url string
   // Whether environment variables (for example API keys) are configured
   hasEnv bool
+  // Discovered MCP server asset
+  //
+  // Points at the asset discovered for this MCP server, anchored on this
+  // resource. See ADR 030.
+  running() asset
 }
 
 // Windsurf skill

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -11738,6 +11738,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"claude.code.mcpServer.lastChecked": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlClaudeCodeMcpServer).GetLastChecked()).ToDataRes(types.String)
 	},
+	"claude.code.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlClaudeCodeMcpServer).GetRunning()).ToDataRes(types.Asset)
+	},
 	"openai.codex.configPath": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodex).GetConfigPath()).ToDataRes(types.String)
 	},
@@ -11837,6 +11840,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"openai.codex.mcpServer.plugin": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexMcpServer).GetPlugin()).ToDataRes(types.String)
 	},
+	"openai.codex.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlOpenaiCodexMcpServer).GetRunning()).ToDataRes(types.Asset)
+	},
 	"openai.codex.connector.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlOpenaiCodexConnector).GetName()).ToDataRes(types.String)
 	},
@@ -11881,6 +11887,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"cursor.mcpServer.hasEnv": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCursorMcpServer).GetHasEnv()).ToDataRes(types.Bool)
+	},
+	"cursor.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlCursorMcpServer).GetRunning()).ToDataRes(types.Asset)
 	},
 	"cursor.rule.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlCursorRule).GetName()).ToDataRes(types.String)
@@ -11953,6 +11962,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"github.copilot.mcpServer.hasEnv": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCopilotMcpServer).GetHasEnv()).ToDataRes(types.Bool)
+	},
+	"github.copilot.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGithubCopilotMcpServer).GetRunning()).ToDataRes(types.Asset)
 	},
 	"github.copilot.skill.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGithubCopilotSkill).GetName()).ToDataRes(types.String)
@@ -12077,6 +12089,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"gemini.mcpServer.hasEnv": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGeminiMcpServer).GetHasEnv()).ToDataRes(types.Bool)
 	},
+	"gemini.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlGeminiMcpServer).GetRunning()).ToDataRes(types.Asset)
+	},
 	"gemini.skill.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlGeminiSkill).GetName()).ToDataRes(types.String)
 	},
@@ -12142,6 +12157,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"windsurf.mcpServer.hasEnv": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindsurfMcpServer).GetHasEnv()).ToDataRes(types.Bool)
+	},
+	"windsurf.mcpServer.running": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlWindsurfMcpServer).GetRunning()).ToDataRes(types.Asset)
 	},
 	"windsurf.skill.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlWindsurfSkill).GetName()).ToDataRes(types.String)
@@ -26741,6 +26759,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlClaudeCodeMcpServer).LastChecked, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"claude.code.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlClaudeCodeMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
+		return
+	},
 	"openai.codex.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenaiCodex).__id, ok = v.Value.(string)
 		return
@@ -26889,6 +26911,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlOpenaiCodexMcpServer).Plugin, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"openai.codex.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlOpenaiCodexMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
+		return
+	},
 	"openai.codex.connector.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlOpenaiCodexConnector).__id, ok = v.Value.(string)
 		return
@@ -26959,6 +26985,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"cursor.mcpServer.hasEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlCursorMcpServer).HasEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"cursor.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlCursorMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
 		return
 	},
 	"cursor.rule.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27075,6 +27105,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"github.copilot.mcpServer.hasEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGithubCopilotMcpServer).HasEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"github.copilot.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGithubCopilotMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
 		return
 	},
 	"github.copilot.skill.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -27265,6 +27299,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlGeminiMcpServer).HasEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"gemini.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlGeminiMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
+		return
+	},
 	"gemini.skill.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlGeminiSkill).__id, ok = v.Value.(string)
 		return
@@ -27367,6 +27405,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"windsurf.mcpServer.hasEnv": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlWindsurfMcpServer).HasEnv, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"windsurf.mcpServer.running": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlWindsurfMcpServer).Running, ok = plugin.RawToTValue[*llx.AssetValue](v.Value, v.Error)
 		return
 	},
 	"windsurf.skill.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -70889,6 +70931,7 @@ type mqlClaudeCodeMcpServer struct {
 	HasEnv      plugin.TValue[bool]
 	NeedsAuth   plugin.TValue[bool]
 	LastChecked plugin.TValue[string]
+	Running     plugin.TValue[*llx.AssetValue]
 }
 
 // createClaudeCodeMcpServer creates a new instance of this resource
@@ -70958,6 +71001,12 @@ func (c *mqlClaudeCodeMcpServer) GetNeedsAuth() *plugin.TValue[bool] {
 
 func (c *mqlClaudeCodeMcpServer) GetLastChecked() *plugin.TValue[string] {
 	return &c.LastChecked
+}
+
+func (c *mqlClaudeCodeMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlOpenaiCodex for the openai.codex resource
@@ -71310,6 +71359,7 @@ type mqlOpenaiCodexMcpServer struct {
 	HasEnv  plugin.TValue[bool]
 	Note    plugin.TValue[string]
 	Plugin  plugin.TValue[string]
+	Running plugin.TValue[*llx.AssetValue]
 }
 
 // createOpenaiCodexMcpServer creates a new instance of this resource
@@ -71379,6 +71429,12 @@ func (c *mqlOpenaiCodexMcpServer) GetNote() *plugin.TValue[string] {
 
 func (c *mqlOpenaiCodexMcpServer) GetPlugin() *plugin.TValue[string] {
 	return &c.Plugin
+}
+
+func (c *mqlOpenaiCodexMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlOpenaiCodexConnector for the openai.codex.connector resource
@@ -71585,6 +71641,7 @@ type mqlCursorMcpServer struct {
 	Args    plugin.TValue[[]any]
 	Url     plugin.TValue[string]
 	HasEnv  plugin.TValue[bool]
+	Running plugin.TValue[*llx.AssetValue]
 }
 
 // createCursorMcpServer creates a new instance of this resource
@@ -71646,6 +71703,12 @@ func (c *mqlCursorMcpServer) GetUrl() *plugin.TValue[string] {
 
 func (c *mqlCursorMcpServer) GetHasEnv() *plugin.TValue[bool] {
 	return &c.HasEnv
+}
+
+func (c *mqlCursorMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlCursorRule for the cursor.rule resource
@@ -71987,6 +72050,7 @@ type mqlGithubCopilotMcpServer struct {
 	Args    plugin.TValue[[]any]
 	Url     plugin.TValue[string]
 	HasEnv  plugin.TValue[bool]
+	Running plugin.TValue[*llx.AssetValue]
 }
 
 // createGithubCopilotMcpServer creates a new instance of this resource
@@ -72048,6 +72112,12 @@ func (c *mqlGithubCopilotMcpServer) GetUrl() *plugin.TValue[string] {
 
 func (c *mqlGithubCopilotMcpServer) GetHasEnv() *plugin.TValue[bool] {
 	return &c.HasEnv
+}
+
+func (c *mqlGithubCopilotMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlGithubCopilotSkill for the github.copilot.skill resource
@@ -72566,6 +72636,7 @@ type mqlGeminiMcpServer struct {
 	Args    plugin.TValue[[]any]
 	Url     plugin.TValue[string]
 	HasEnv  plugin.TValue[bool]
+	Running plugin.TValue[*llx.AssetValue]
 }
 
 // createGeminiMcpServer creates a new instance of this resource
@@ -72627,6 +72698,12 @@ func (c *mqlGeminiMcpServer) GetUrl() *plugin.TValue[string] {
 
 func (c *mqlGeminiMcpServer) GetHasEnv() *plugin.TValue[bool] {
 	return &c.HasEnv
+}
+
+func (c *mqlGeminiMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlGeminiSkill for the gemini.skill resource
@@ -72914,6 +72991,7 @@ type mqlWindsurfMcpServer struct {
 	Args    plugin.TValue[[]any]
 	Url     plugin.TValue[string]
 	HasEnv  plugin.TValue[bool]
+	Running plugin.TValue[*llx.AssetValue]
 }
 
 // createWindsurfMcpServer creates a new instance of this resource
@@ -72975,6 +73053,12 @@ func (c *mqlWindsurfMcpServer) GetUrl() *plugin.TValue[string] {
 
 func (c *mqlWindsurfMcpServer) GetHasEnv() *plugin.TValue[bool] {
 	return &c.HasEnv
+}
+
+func (c *mqlWindsurfMcpServer) GetRunning() *plugin.TValue[*llx.AssetValue] {
+	return plugin.GetOrCompute[*llx.AssetValue](&c.Running, func() (*llx.AssetValue, error) {
+		return c.running()
+	})
 }
 
 // mqlWindsurfSkill for the windsurf.skill resource

--- a/providers/os/resources/os.lr.versions
+++ b/providers/os/resources/os.lr.versions
@@ -293,6 +293,7 @@ claude.code.mcpServer.hasEnv 13.39.1
 claude.code.mcpServer.lastChecked 13.8.2
 claude.code.mcpServer.name 13.8.2
 claude.code.mcpServer.needsAuth 13.8.2
+claude.code.mcpServer.running 13.40.1
 claude.code.mcpServer.type 13.39.1
 claude.code.mcpServer.url 13.39.1
 claude.code.mcpServers 13.8.2
@@ -419,6 +420,7 @@ cursor.mcpServer.args 13.10.1
 cursor.mcpServer.command 13.10.1
 cursor.mcpServer.hasEnv 13.10.1
 cursor.mcpServer.name 13.10.1
+cursor.mcpServer.running 13.40.1
 cursor.mcpServer.type 13.39.1
 cursor.mcpServer.url 13.10.1
 cursor.mcpServers 13.10.1
@@ -765,6 +767,7 @@ gemini.mcpServer.args 13.13.1
 gemini.mcpServer.command 13.13.1
 gemini.mcpServer.hasEnv 13.13.1
 gemini.mcpServer.name 13.13.1
+gemini.mcpServer.running 13.40.1
 gemini.mcpServer.type 13.39.1
 gemini.mcpServer.url 13.39.1
 gemini.mcpServers 13.13.1
@@ -791,6 +794,7 @@ github.copilot.mcpServer.args 13.12.1
 github.copilot.mcpServer.command 13.12.1
 github.copilot.mcpServer.hasEnv 13.39.1
 github.copilot.mcpServer.name 13.12.1
+github.copilot.mcpServer.running 13.40.1
 github.copilot.mcpServer.type 13.12.1
 github.copilot.mcpServer.url 13.39.1
 github.copilot.mcpServers 13.12.1
@@ -2181,6 +2185,7 @@ openai.codex.mcpServer.hasEnv 13.39.1
 openai.codex.mcpServer.name 13.8.2
 openai.codex.mcpServer.note 13.8.2
 openai.codex.mcpServer.plugin 13.8.2
+openai.codex.mcpServer.running 13.40.1
 openai.codex.mcpServer.type 13.8.2
 openai.codex.mcpServer.url 13.8.2
 openai.codex.mcpServers 13.8.2
@@ -3751,6 +3756,7 @@ windsurf.mcpServer.args 13.13.1
 windsurf.mcpServer.command 13.13.1
 windsurf.mcpServer.hasEnv 13.13.1
 windsurf.mcpServer.name 13.13.1
+windsurf.mcpServer.running 13.40.1
 windsurf.mcpServer.type 13.39.1
 windsurf.mcpServer.url 13.39.1
 windsurf.mcpServers 13.13.1

--- a/providers/os/resources/windsurf.go
+++ b/providers/os/resources/windsurf.go
@@ -121,6 +121,10 @@ func (r *mqlWindsurfRule) id() (string, error) {
 	return "windsurf.rule/" + r.Name.Data, nil
 }
 
+func (r *mqlWindsurfMcpServer) running() (*llx.AssetValue, error) {
+	return mcpServerAsset(r), nil
+}
+
 func (r *mqlWindsurfMcpServer) id() (string, error) {
 	return "windsurf.mcpServer/" + r.Name.Data, nil
 }

--- a/test/commands/testdata/mql_run.ct
+++ b/test/commands/testdata/mql_run.ct
@@ -21,7 +21,7 @@ Available Commands:
 Flags:
       --ast                     Parse the query and return the abstract syntax tree (AST)
   -c, --command string          MQL query to execute
-      --discover strings        Enable the discovery of nested assets. Supports: all, auto, container, container-images
+      --discover strings        Enable the discovery of nested assets. Supports: all, auto, container, container-images, mcp-servers
       --exit-1-on-failure       Exit with error code 1 if one or more query results fail
   -h, --help                    help for run
       --info                    Parse the query and provide information about it

--- a/types/types.go
+++ b/types/types.go
@@ -55,6 +55,7 @@ const (
 	byteFunction
 	byteStringSlice
 	byteRange
+	byteAsset
 )
 
 // NoType type is one whose type information is not available at all
@@ -116,6 +117,11 @@ const (
 	// or lines and columns combined. We use a special type for a very
 	// efficient storage and transmission structure.
 	Range = Type(rune(byteRange))
+
+	// Asset is a native value pointing at another asset by the resource that
+	// anchors it in the current asset's resource tree. Its payload is an
+	// llx.AssetValue holding the anchor `(resourceType, resourceId)`. See ADR 030.
+	Asset = Type(rune(byteAsset))
 )
 
 // All returns a list of all types available
@@ -141,6 +147,7 @@ func All() []Type {
 		MapLike,
 		ResourceLike,
 		FunctionLike,
+		Asset,
 	}
 }
 
@@ -183,6 +190,14 @@ func (typ Type) IsResource() bool {
 		return false
 	}
 	return typ[0] == byteResource
+}
+
+// IsAsset checks if this type is a native asset reference
+func (typ Type) IsAsset() bool {
+	if typ.NotSet() {
+		return false
+	}
+	return typ[0] == byteAsset
 }
 
 // ContainsResource checks if this or any child type has a resource
@@ -291,6 +306,7 @@ var labels = map[byte]string{
 	byteIP:          "ip",
 	byteStringSlice: "stringslice",
 	byteRange:       "range",
+	byteAsset:       "asset",
 }
 
 var labelfun map[byte]func(Type) string


### PR DESCRIPTION
This is a v14 feature that provides Asset Relationships, anchored in the resource-tree. It deprecates the traditional (flat) relationships in favor of these relationships which point to schema anchors that can be used to tie it all together. The follow-up ADR-031 will allow us to run queries across this connection.

Since it is v14 and we are just opening the v14-pre (and in 2 weeks v14-rc) do not consider this stable - it is subject to change until v14 is released fully (in 4 weeks from writing this)