### PR TITLE
🎉 os-13.40.3

### DIFF
--- a/providers/os/config/config.go
+++ b/providers/os/config/config.go
@@ -15,7 +15,7 @@ import (
 var Config = plugin.Provider{
 	Name:    "os",
 	ID:      "go.mondoo.com/cnquery/v9/providers/os",
-	Version: "13.40.2",
+	Version: "13.40.3",
 	ConnectionTypes: []string{
 		shared.Type_Local.String(),
 		shared.Type_SSH.String(),


### PR DESCRIPTION
This release was created by mql's provider versioning bot.

You can find me under: `providers-sdk/v1/util/version`.

### os (13.40.3)
- ⭐ add AI Agent models (usage) (#9542)