### PR TITLE
🐛 don't exit the provider on the first missed heartbeat

### DIFF
--- a/providers-sdk/v1/plugin/grpc.go
+++ b/providers-sdk/v1/plugin/grpc.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"runtime/debug"
+	"time"
 	"unicode/utf8"
 
 	plugin "github.com/hashicorp/go-plugin"
@@ -32,8 +33,19 @@ type GRPCClient struct {
 	client ProviderPluginClient
 }
 
+// Heartbeat sends one beat to the provider. The requested interval doubles as
+// the call deadline: a beat that cannot be delivered within the window the
+// provider is holding us to is worthless, and blocking on it forever would stop
+// the beat stream entirely — which is precisely what makes the provider's
+// watchdog reap a healthy process.
 func (m *GRPCClient) Heartbeat(req *HeartbeatReq) (*HeartbeatRes, error) {
-	return m.client.Heartbeat(context.Background(), req)
+	if req.Interval == 0 {
+		return m.client.Heartbeat(context.Background(), req)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(req.Interval))
+	defer cancel()
+	return m.client.Heartbeat(ctx, req)
 }
 
 func (m *GRPCClient) ParseCLI(req *ParseCLIReq) (*ParseCLIRes, error) {
@@ -107,16 +119,35 @@ type GRPCServer struct {
 	UnimplementedProviderPluginServer
 }
 
+// requestTracker is implemented by every provider service that embeds
+// *plugin.Service. It lets us tell the heartbeat watchdog that the parent
+// process is alive because it is, right now, waiting on us.
+type requestTracker interface {
+	TrackRequest() func()
+}
+
+// trackRequest marks a request as in flight and returns the function that marks
+// it as done. Heartbeat and Shutdown are deliberately not tracked: the former is
+// the liveness signal itself, the latter means we are going away anyway.
+func (m *GRPCServer) trackRequest() func() {
+	if t, ok := m.Impl.(requestTracker); ok {
+		return t.TrackRequest()
+	}
+	return func() {}
+}
+
 func (m *GRPCServer) Heartbeat(ctx context.Context, req *HeartbeatReq) (*HeartbeatRes, error) {
 	return m.Impl.Heartbeat(req)
 }
 
 func (m *GRPCServer) ParseCLI(ctx context.Context, req *ParseCLIReq) (resp *ParseCLIRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("ParseCLI", &err)
 	return m.Impl.ParseCLI(req)
 }
 
 func (m *GRPCServer) Connect(ctx context.Context, req *ConnectReq) (resp *ConnectRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("Connect", &err)
 	conn, err := m.broker.Dial(req.CallbackServer)
 	if err != nil {
@@ -131,11 +162,13 @@ func (m *GRPCServer) Connect(ctx context.Context, req *ConnectReq) (resp *Connec
 }
 
 func (m *GRPCServer) Disconnect(ctx context.Context, req *DisconnectReq) (resp *DisconnectRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("Disconnect", &err)
 	return m.Impl.Disconnect(req)
 }
 
 func (m *GRPCServer) MockConnect(ctx context.Context, req *ConnectReq) (resp *ConnectRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("MockConnect", &err)
 	conn, err := m.broker.Dial(req.CallbackServer)
 	if err != nil {
@@ -155,6 +188,7 @@ func (m *GRPCServer) Shutdown(ctx context.Context, req *ShutdownReq) (resp *Shut
 }
 
 func (m *GRPCServer) GetData(ctx context.Context, req *DataReq) (resp *DataRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("GetData", &err)
 	resp, err = m.Impl.GetData(req)
 	if err != nil {
@@ -165,6 +199,7 @@ func (m *GRPCServer) GetData(ctx context.Context, req *DataReq) (resp *DataRes, 
 }
 
 func (m *GRPCServer) StoreData(ctx context.Context, req *StoreReq) (resp *StoreRes, err error) {
+	defer m.trackRequest()()
 	defer recoverPanic("StoreData", &err)
 	return m.Impl.StoreData(req)
 }

--- a/providers-sdk/v1/plugin/service.go
+++ b/providers-sdk/v1/plugin/service.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	sync "sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -28,11 +29,47 @@ type Service struct {
 	lastConnectionID uint32
 	runtimesLock     sync.RWMutex
 
-	lastHeartbeat int64
-	heartbeatLock sync.Mutex
+	// lastHeartbeat is the wall clock time (unix nanos) at which we last saw a
+	// heartbeat from the parent process.
+	lastHeartbeat atomic.Int64
+	// heartbeatWindow is the tolerance (in nanos) the parent asked us to apply,
+	// i.e. how long it intends to let pass between two heartbeats at most.
+	heartbeatWindow atomic.Int64
+	// inflightRequests counts the requests we are currently serving. A provider
+	// that is working on a request has a live parent by definition, which is
+	// what the watchdog is looking for.
+	inflightRequests atomic.Int64
+	// watchdogOnce guards starting the watchdog, which only makes sense once we
+	// know the parent speaks the heartbeat protocol.
+	watchdogOnce sync.Once
+	// watchdogStop retires the watchdog on shutdown, so a teardown that outlives
+	// the last heartbeat cannot be reported as a crash.
+	watchdogStop     chan struct{}
+	watchdogStopOnce sync.Once
 
 	memoize.Memoizer
 }
+
+const (
+	// heartbeatMissesBeforeExit is how many heartbeat windows may pass without
+	// a heartbeat before we treat the parent as gone. A single missed window is
+	// not evidence of death: on a loaded host, scheduling jitter, GC and paging
+	// routinely delay either side by seconds.
+	heartbeatMissesBeforeExit = 3
+	// heartbeatBusyMissesBeforeExit is the same budget for a provider that is
+	// actively serving requests. Exiting then is the expensive case — it throws
+	// away the whole scan's in-flight work and reports every field being
+	// resolved as a crash — while the requests themselves prove the parent was
+	// alive when it sent them, so we hold out considerably longer.
+	heartbeatBusyMissesBeforeExit = 6
+	// minHeartbeatPollInterval keeps the watchdog from spinning if a parent
+	// requests a very small window.
+	minHeartbeatPollInterval = 250 * time.Millisecond
+)
+
+// watchdogExit terminates the process when the parent is gone. It is a variable
+// so tests can observe the decision without ending the test binary.
+var watchdogExit = os.Exit
 
 var (
 	cacheExpirationTime = 3 * time.Hour
@@ -41,8 +78,9 @@ var (
 
 func NewService() *Service {
 	return &Service{
-		runtimes: make(map[uint32]*Runtime),
-		Memoizer: memoize.New(cacheExpirationTime, cacheCleanupTime),
+		runtimes:     make(map[uint32]*Runtime),
+		watchdogStop: make(chan struct{}),
+		Memoizer:     memoize.New(cacheExpirationTime, cacheCleanupTime),
 	}
 }
 
@@ -316,33 +354,110 @@ func (s *Service) StoreData(req *StoreReq) (*StoreRes, error) {
 	return &StoreRes{}, nil
 }
 
+// Heartbeat records that the parent process is alive and arms the watchdog that
+// reaps this provider if the parent disappears without shutting us down.
 func (s *Service) Heartbeat(req *HeartbeatReq) (*HeartbeatRes, error) {
 	if req.Interval == 0 {
 		return nil, errors.New("heartbeat failed, requested interval is 0")
 	}
 
-	now := time.Now().UnixNano()
-	s.heartbeatLock.Lock()
-	s.lastHeartbeat = now
-	s.heartbeatLock.Unlock()
-
-	go func() {
-		time.Sleep(time.Duration(req.Interval))
-
-		s.heartbeatLock.Lock()
-		isDead := s.lastHeartbeat == now
-		s.heartbeatLock.Unlock()
-
-		if isDead {
-			// use 4 since we actually do not want to reach the point, see tetraphobia
-			os.Exit(4)
-		}
-	}()
+	s.heartbeatWindow.Store(int64(req.Interval))
+	s.lastHeartbeat.Store(time.Now().UnixNano())
+	s.watchdogOnce.Do(func() {
+		go s.heartbeatWatchdog()
+	})
 
 	return &heartbeatRes, nil
 }
 
+// TrackRequest marks the beginning of a request served for the parent process
+// and returns the function that marks its end. Requests are liveness evidence
+// for the watchdog: whatever else is true of a provider that is answering a
+// request, it has not been abandoned.
+func (s *Service) TrackRequest() func() {
+	s.inflightRequests.Add(1)
+	return func() {
+		s.inflightRequests.Add(-1)
+	}
+}
+
+// heartbeatWatchdog is the dead-man's switch for an abandoned provider: when the
+// parent process dies without shutting us down, nothing else would ever stop
+// this process. It deliberately does *not* try to detect a slow or wedged
+// provider — the parent kills us for that, and it has the context to decide.
+func (s *Service) heartbeatWatchdog() {
+	late := false
+	for {
+		window := time.Duration(s.heartbeatWindow.Load())
+		poll := max(window/2, minHeartbeatPollInterval)
+		select {
+		case <-s.watchdogStop:
+			return
+		case <-time.After(poll):
+		}
+
+		// re-read: the parent may have changed the window in the meantime
+		window = time.Duration(s.heartbeatWindow.Load())
+		silence := time.Since(time.Unix(0, s.lastHeartbeat.Load()))
+		inflight := s.inflightRequests.Load()
+
+		if silence <= window {
+			late = false
+			continue
+		}
+
+		if !late {
+			// This is the point at which we used to exit. Log it so a fleet
+			// that is merely slow is distinguishable from one that is dying.
+			late = true
+			log.Warn().
+				Str("silence", silence.String()).
+				Str("window", window.String()).
+				Int64("inflight", inflight).
+				Msg("no heartbeat from the parent process, still working")
+		}
+
+		if !watchdogShouldExit(silence, window, inflight) {
+			continue
+		}
+
+		// The parent is gone. Say so on stderr: it is the only channel that
+		// survives into the crash report the parent's supervisor writes, and
+		// without it this exit is indistinguishable from a hard kill.
+		fmt.Fprintf(os.Stderr,
+			"provider watchdog: no heartbeat from parent process for %s (window %s, %d requests in flight), exiting\n",
+			silence.Round(time.Millisecond), window, inflight)
+		// use 4 since we actually do not want to reach the point, see tetraphobia
+		watchdogExit(4)
+		return
+	}
+}
+
+// stopWatchdog retires the heartbeat watchdog. It is safe to call more than once
+// and on a Service that never started one.
+func (s *Service) stopWatchdog() {
+	s.watchdogStopOnce.Do(func() {
+		if s.watchdogStop != nil {
+			close(s.watchdogStop)
+		}
+	})
+}
+
+// watchdogShouldExit reports whether the silence has lasted long enough that the
+// parent has to be considered gone rather than late.
+func watchdogShouldExit(silence, window time.Duration, inflight int64) bool {
+	misses := int64(heartbeatMissesBeforeExit)
+	if inflight > 0 {
+		misses = heartbeatBusyMissesBeforeExit
+	}
+	return silence > time.Duration(misses)*window
+}
+
 func (s *Service) Shutdown(req *ShutdownReq) (*ShutdownRes, error) {
+	// The parent is done with us: stop watching for its heartbeat, or a
+	// teardown that takes longer than the window would exit as a crash.
+	s.stopWatchdog()
+
 	s.runtimesLock.Lock()
 	defer s.runtimesLock.Unlock()
 

--- a/providers-sdk/v1/plugin/service_test.go
+++ b/providers-sdk/v1/plugin/service_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -369,5 +370,133 @@ func TestShutdown_Closer(t *testing.T) {
 	// Verify that all runtimes are closed
 	for _, runtime := range runtimes {
 		assert.True(t, runtime.Connection.(*TestConnectionWithClose).closed)
+	}
+}
+
+// The provider used to exit on the first missed heartbeat window. On a loaded
+// host that window is routinely missed by a provider that is perfectly healthy,
+// and the exit throws away the whole scan's in-flight work.
+func TestWatchdogShouldExit(t *testing.T) {
+	window := 5 * time.Second
+
+	t.Run("idle", func(t *testing.T) {
+		assert.False(t, watchdogShouldExit(window+time.Second, window, 0), "one missed window is not death")
+		assert.False(t, watchdogShouldExit(heartbeatMissesBeforeExit*window, window, 0))
+		assert.True(t, watchdogShouldExit(heartbeatMissesBeforeExit*window+time.Second, window, 0))
+	})
+
+	t.Run("serving requests", func(t *testing.T) {
+		// a request in flight proves the parent was there to send it
+		assert.False(t, watchdogShouldExit(heartbeatMissesBeforeExit*window+time.Second, window, 1))
+		assert.False(t, watchdogShouldExit(heartbeatBusyMissesBeforeExit*window, window, 3))
+		assert.True(t, watchdogShouldExit(heartbeatBusyMissesBeforeExit*window+time.Second, window, 3))
+	})
+}
+
+func TestHeartbeat(t *testing.T) {
+	s := NewService()
+	t.Cleanup(s.stopWatchdog)
+
+	_, err := s.Heartbeat(&HeartbeatReq{})
+	require.Error(t, err, "an interval of 0 has no tolerance to apply")
+
+	before := time.Now().UnixNano()
+	_, err = s.Heartbeat(&HeartbeatReq{Interval: uint64(time.Hour)})
+	require.NoError(t, err)
+	assert.Equal(t, int64(time.Hour), s.heartbeatWindow.Load())
+	assert.GreaterOrEqual(t, s.lastHeartbeat.Load(), before)
+}
+
+func TestTrackRequest(t *testing.T) {
+	s := NewService()
+	done := s.TrackRequest()
+	assert.Equal(t, int64(1), s.inflightRequests.Load())
+	done()
+	assert.Equal(t, int64(0), s.inflightRequests.Load())
+}
+
+// captureWatchdogExit replaces the process exit with a recorder. The fake exit
+// parks its goroutine like a real exit would, so the watchdog cannot loop and
+// report twice.
+func captureWatchdogExit(t *testing.T) <-chan int {
+	t.Helper()
+	exited := make(chan int, 1)
+	parked := make(chan struct{})
+	original := watchdogExit
+	watchdogExit = func(code int) {
+		select {
+		case exited <- code:
+		default:
+		}
+		<-parked
+	}
+	t.Cleanup(func() {
+		watchdogExit = original
+		close(parked)
+	})
+	return exited
+}
+
+func TestHeartbeatWatchdog_ExitsWhenParentIsGone(t *testing.T) {
+	exited := captureWatchdogExit(t)
+
+	s := NewService()
+	t.Cleanup(s.stopWatchdog)
+	// poll interval is floored, so the effective tolerance here is
+	// heartbeatMissesBeforeExit * 100ms, noticed on the next poll
+	_, err := s.Heartbeat(&HeartbeatReq{Interval: uint64(100 * time.Millisecond)})
+	require.NoError(t, err)
+
+	select {
+	case code := <-exited:
+		assert.Equal(t, 4, code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog did not reap an abandoned provider")
+	}
+}
+
+func TestHeartbeatWatchdog_HoldsOutWhileServingRequests(t *testing.T) {
+	exited := captureWatchdogExit(t)
+
+	s := NewService()
+	t.Cleanup(s.stopWatchdog)
+	done := s.TrackRequest()
+
+	// A 300ms window puts the idle tolerance at 900ms and the busy tolerance at
+	// 1.8s, so surviving 1.3s of silence can only come from the in-flight request.
+	const window = 300 * time.Millisecond
+	_, err := s.Heartbeat(&HeartbeatReq{Interval: uint64(window)})
+	require.NoError(t, err)
+
+	select {
+	case <-exited:
+		t.Fatal("watchdog reaped a provider that was serving a request")
+	case <-time.After(heartbeatMissesBeforeExit*window + 400*time.Millisecond):
+	}
+
+	// once the request is done, the same silence is fatal
+	done()
+	select {
+	case code := <-exited:
+		assert.Equal(t, 4, code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog did not reap an abandoned provider")
+	}
+}
+
+func TestHeartbeatWatchdog_StopsOnShutdown(t *testing.T) {
+	exited := captureWatchdogExit(t)
+
+	s := NewService()
+	_, err := s.Heartbeat(&HeartbeatReq{Interval: uint64(10 * time.Millisecond)})
+	require.NoError(t, err)
+
+	_, err = s.Shutdown(&ShutdownReq{})
+	require.NoError(t, err)
+
+	select {
+	case <-exited:
+		t.Fatal("watchdog reported a crash during a graceful shutdown")
+	case <-time.After(minHeartbeatPollInterval * 3):
 	}
 }

--- a/providers/os/resources/os.lr
+++ b/providers/os/resources/os.lr
@@ -7751,9 +7751,15 @@ private windows.optionalFeature @defaults("name") {
   // Feature name (ID) of the optional feature (for example "SMB1Protocol")
   name string
   // Human-readable display name of the feature
-  displayName string
+  //
+  // Loaded on demand: DISM only reports it for a named feature, which costs an
+  // extra image query.
+  displayName() string
   // Feature description
-  description string
+  //
+  // Loaded on demand: DISM only reports it for a named feature, which costs an
+  // extra image query.
+  description() string
   // Whether the feature is enabled
   enabled bool
   // Feature state

--- a/providers/os/resources/os.lr.go
+++ b/providers/os/resources/os.lr.go
@@ -55887,7 +55887,7 @@ func (c *mqlWindowsServerFeature) GetInstallState() *plugin.TValue[int64] {
 type mqlWindowsOptionalFeature struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlWindowsOptionalFeatureInternal it will be used here
+	mqlWindowsOptionalFeatureInternal
 	Name        plugin.TValue[string]
 	DisplayName plugin.TValue[string]
 	Description plugin.TValue[string]
@@ -55937,11 +55937,15 @@ func (c *mqlWindowsOptionalFeature) GetName() *plugin.TValue[string] {
 }
 
 func (c *mqlWindowsOptionalFeature) GetDisplayName() *plugin.TValue[string] {
-	return &c.DisplayName
+	return plugin.GetOrCompute[string](&c.DisplayName, func() (string, error) {
+		return c.displayName()
+	})
 }
 
 func (c *mqlWindowsOptionalFeature) GetDescription() *plugin.TValue[string] {
-	return &c.Description
+	return plugin.GetOrCompute[string](&c.Description, func() (string, error) {
+		return c.description()
+	})
 }
 
 func (c *mqlWindowsOptionalFeature) GetEnabled() *plugin.TValue[bool] {

--- a/providers/os/resources/windows.go
+++ b/providers/os/resources/windows.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"errors"
 	"io"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -295,6 +296,24 @@ func initWindowsOptionalFeature(runtime *plugin.Runtime, args map[string]*llx.Ra
 	return nil, nil, errors.New("could not find feature " + name)
 }
 
+// optionalFeatureDetails carries the display name and description of every
+// feature in one enumeration. DISM only reports those for a named feature, so
+// they cost an extra image query — one for the whole enumeration, taken the
+// first time a query actually asks for them.
+type optionalFeatureDetails struct {
+	lock   sync.Mutex
+	loaded bool
+	byName map[string]windows.WindowsOptionalFeature
+}
+
+// mqlWindowsOptionalFeatureInternal shares the lazily loaded details with the
+// other features from the same windows.optionalFeatures enumeration. It is nil
+// for a feature looked up by name, where the init function has already filled
+// every field in from its single-feature query.
+type mqlWindowsOptionalFeatureInternal struct {
+	details *optionalFeatureDetails
+}
+
 func (w *mqlWindows) optionalFeatures() ([]any, error) {
 	conn := w.MqlRuntime.Connection.(shared.Connection)
 
@@ -319,22 +338,105 @@ func (w *mqlWindows) optionalFeatures() ([]any, error) {
 	}
 
 	// convert features to MQL resource
+	details := &optionalFeatureDetails{}
 	mqlFeatures := make([]any, len(features))
 	for i, feature := range features {
 
 		mqlFeature, err := CreateResource(w.MqlRuntime, "windows.optionalFeature", map[string]*llx.RawData{
-			"name":        llx.StringData(feature.Name),
-			"displayName": llx.StringData(feature.DisplayName),
-			"description": llx.StringData(feature.Description),
-			"enabled":     llx.BoolData(feature.Enabled),
-			"state":       llx.IntData(feature.State),
+			"name":    llx.StringData(feature.Name),
+			"enabled": llx.BoolData(feature.Enabled),
+			"state":   llx.IntData(feature.State),
 		})
 		if err != nil {
 			return nil, err
 		}
 
+		mqlFeature.(*mqlWindowsOptionalFeature).details = details
 		mqlFeatures[i] = mqlFeature
 	}
 
 	return mqlFeatures, nil
+}
+
+func (f *mqlWindowsOptionalFeature) displayName() (string, error) {
+	feature, err := f.fetchDetails()
+	if err != nil {
+		return "", err
+	}
+	return feature.DisplayName, nil
+}
+
+func (f *mqlWindowsOptionalFeature) description() (string, error) {
+	feature, err := f.fetchDetails()
+	if err != nil {
+		return "", err
+	}
+	return feature.Description, nil
+}
+
+// fetchDetails loads the fields that DISM only reports for a named feature. For
+// a feature that came from an enumeration this is one query for all of them,
+// shared with its siblings; for a standalone feature it is a single-feature
+// query.
+func (f *mqlWindowsOptionalFeature) fetchDetails() (windows.WindowsOptionalFeature, error) {
+	var empty windows.WindowsOptionalFeature
+
+	name := f.GetName()
+	if name.Error != nil {
+		return empty, name.Error
+	}
+
+	if f.details == nil {
+		features, err := f.queryFeatures(windows.OptionalFeatureQuery(name.Data))
+		if err != nil {
+			return empty, err
+		}
+		for i := range features {
+			// DISM treats `*`/`?` in -FeatureName as wildcards, so require an
+			// exact match
+			if features[i].Name == name.Data {
+				return features[i], nil
+			}
+		}
+		return empty, errors.New("could not find feature " + name.Data)
+	}
+
+	f.details.lock.Lock()
+	defer f.details.lock.Unlock()
+
+	if !f.details.loaded {
+		features, err := f.queryFeatures(windows.QUERY_OPTIONAL_FEATURE_DETAILS)
+		if err != nil {
+			return empty, err
+		}
+		f.details.byName = make(map[string]windows.WindowsOptionalFeature, len(features))
+		for i := range features {
+			f.details.byName[features[i].Name] = features[i]
+		}
+		f.details.loaded = true
+	}
+
+	feature, ok := f.details.byName[name.Data]
+	if !ok {
+		return empty, errors.New("could not find feature " + name.Data)
+	}
+	return feature, nil
+}
+
+func (f *mqlWindowsOptionalFeature) queryFeatures(query string) ([]windows.WindowsOptionalFeature, error) {
+	conn := f.MqlRuntime.Connection.(shared.Connection)
+
+	executedCmd, err := conn.RunCommand(powershell.Encode(query))
+	if err != nil {
+		return nil, err
+	}
+	if executedCmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(executedCmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("failed to retrieve optional feature details: " + string(stderr))
+	}
+
+	return windows.ParseWindowsOptionalFeatures(executedCmd.Stdout)
 }

--- a/providers/os/resources/windows/optionalfeatures.go
+++ b/providers/os/resources/windows/optionalfeatures.go
@@ -10,7 +10,16 @@ import (
 	"strings"
 )
 
-const QUERY_OPTIONAL_FEATURES = "Get-WindowsOptionalFeature -Online -FeatureName * | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
+// QUERY_OPTIONAL_FEATURES lists every optional feature with its state. Without
+// -FeatureName, DISM answers from the feature list alone; the display name and
+// description are not part of that list, they require a per-feature image query
+// (see QUERY_OPTIONAL_FEATURE_DETAILS).
+const QUERY_OPTIONAL_FEATURES = "Get-WindowsOptionalFeature -Online | Select-Object -Property FeatureName,State | ConvertTo-Json"
+
+// QUERY_OPTIONAL_FEATURE_DETAILS is the expensive form: -FeatureName makes DISM
+// look up detailed information for every feature it matches, which is why it is
+// only used to back the lazily loaded display name and description fields.
+const QUERY_OPTIONAL_FEATURE_DETAILS = "Get-WindowsOptionalFeature -Online -FeatureName * | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json"
 
 // OptionalFeatureQuery builds a PowerShell command that retrieves a single
 // optional feature by name, which is much cheaper than enumerating the whole

--- a/providers/os/resources/windows/optionalfeatures_test.go
+++ b/providers/os/resources/windows/optionalfeatures_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// the detailed form (-FeatureName *) carries display name and description
 func TestWindowsOptionalFeatures(t *testing.T) {
 	r, err := os.Open("./testdata/optionalfeatures.json")
 	require.NoError(t, err)
@@ -24,6 +25,34 @@ func TestWindowsOptionalFeatures(t *testing.T) {
 	assert.True(t, items[9].Enabled)
 	assert.Equal(t, int64(2), items[9].State)
 	assert.Equal(t, "Adds or Removes Windows PowerShell 2.0 Engine", items[9].Description)
+}
+
+// The plain listing has no display name or description — that is the whole point
+// of it — but it still carries the state every check keys on.
+func TestWindowsOptionalFeatures_Listing(t *testing.T) {
+	input := `[
+    {
+        "FeatureName": "SMB1Protocol",
+        "State": 2
+    },
+    {
+        "FeatureName": "TelnetClient",
+        "State": 0
+    }
+]`
+
+	items, err := ParseWindowsOptionalFeatures(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "SMB1Protocol", items[0].Name)
+	assert.Equal(t, int64(2), items[0].State)
+	assert.True(t, items[0].Enabled)
+	assert.Empty(t, items[0].DisplayName)
+	assert.Empty(t, items[0].Description)
+
+	assert.Equal(t, "TelnetClient", items[1].Name)
+	assert.False(t, items[1].Enabled)
 }
 
 // a single-feature lookup makes ConvertTo-Json emit a bare object, not an array
@@ -60,4 +89,16 @@ func TestOptionalFeatureQuery(t *testing.T) {
 	assert.Equal(t,
 		"Get-WindowsOptionalFeature -Online -FeatureName 'O''Brien' | Select-Object -Property FeatureName,DisplayName,Description,State | ConvertTo-Json",
 		OptionalFeatureQuery("O'Brien"))
+}
+
+// The enumeration must not ask for a feature name: -FeatureName makes DISM look
+// up detailed information for every feature it matches, which is what makes the
+// call cost tens of seconds on a Windows client.
+func TestOptionalFeatureQueries(t *testing.T) {
+	assert.NotContains(t, QUERY_OPTIONAL_FEATURES, "-FeatureName")
+	assert.NotContains(t, QUERY_OPTIONAL_FEATURES, "Description")
+	assert.Contains(t, QUERY_OPTIONAL_FEATURES, "FeatureName,State")
+
+	assert.Contains(t, QUERY_OPTIONAL_FEATURE_DETAILS, "-FeatureName *")
+	assert.Contains(t, QUERY_OPTIONAL_FEATURE_DETAILS, "FeatureName,DisplayName,Description,State")
 }

--- a/providers/os/resources/windows_optionalfeatures_internal_test.go
+++ b/providers/os/resources/windows_optionalfeatures_internal_test.go
@@ -1,0 +1,125 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/os/connection/mock"
+	"go.mondoo.com/mql/v13/providers/os/connection/shared"
+	"go.mondoo.com/mql/v13/providers/os/resources/powershell"
+	"go.mondoo.com/mql/v13/providers/os/resources/windows"
+	"go.mondoo.com/mql/v13/utils/syncx"
+)
+
+type optionalFeatureRecordingConnection struct {
+	*mock.Connection
+	commands []string
+}
+
+func (c *optionalFeatureRecordingConnection) RunCommand(command string) (*shared.Command, error) {
+	c.commands = append(c.commands, command)
+	return c.Connection.RunCommand(command)
+}
+
+// The enumeration must not pay for DISM's detailed per-feature lookup: every
+// check that filters on a feature state runs it, and it costs tens of seconds on
+// a Windows client. Display name and description are loaded on demand instead,
+// once for the whole enumeration.
+func TestOptionalFeaturesDefersDetailQuery(t *testing.T) {
+	listCmd := powershell.Encode(windows.QUERY_OPTIONAL_FEATURES)
+	detailCmd := powershell.Encode(windows.QUERY_OPTIONAL_FEATURE_DETAILS)
+
+	mockConn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "windows",
+			Family: []string{"windows"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			listCmd: {Stdout: `[
+				{"FeatureName": "SMB1Protocol", "State": 2},
+				{"FeatureName": "TelnetClient", "State": 0}
+			]`},
+			detailCmd: {Stdout: `[
+				{"FeatureName": "SMB1Protocol", "DisplayName": "SMB 1.0/CIFS File Sharing Support", "Description": "Support for the SMB 1.0/CIFS file sharing protocol", "State": 2},
+				{"FeatureName": "TelnetClient", "DisplayName": "Telnet Client", "Description": "Telnet Client uses the Telnet protocol", "State": 0}
+			]`},
+		},
+	}))
+	require.NoError(t, err)
+
+	conn := &optionalFeatureRecordingConnection{Connection: mockConn}
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	features, err := (&mqlWindows{MqlRuntime: runtime}).optionalFeatures()
+	require.NoError(t, err)
+	require.Len(t, features, 2)
+	assert.Equal(t, []string{listCmd}, conn.commands, "the enumeration only lists features")
+
+	smb := features[0].(*mqlWindowsOptionalFeature)
+	assert.Equal(t, "SMB1Protocol", smb.GetName().Data)
+	assert.Equal(t, int64(2), smb.GetState().Data)
+	assert.True(t, smb.GetEnabled().Data)
+
+	telnet := features[1].(*mqlWindowsOptionalFeature)
+	assert.Equal(t, "TelnetClient", telnet.GetName().Data)
+	assert.False(t, telnet.GetEnabled().Data)
+
+	displayName := smb.GetDisplayName()
+	require.NoError(t, displayName.Error)
+	assert.Equal(t, "SMB 1.0/CIFS File Sharing Support", displayName.Data)
+
+	description := telnet.GetDescription()
+	require.NoError(t, description.Error)
+	assert.Equal(t, "Telnet Client uses the Telnet protocol", description.Data)
+
+	assert.Equal(t, []string{listCmd, detailCmd}, conn.commands,
+		"details are loaded once for the whole enumeration")
+}
+
+// A feature looked up by name never enumerates the image.
+func TestInitOptionalFeatureUsesTargetedLookup(t *testing.T) {
+	lookupCmd := powershell.Encode(windows.OptionalFeatureQuery("SMB1Protocol"))
+
+	mockConn, err := mock.New(0, &inventory.Asset{
+		Platform: &inventory.Platform{
+			Name:   "windows",
+			Family: []string{"windows"},
+		},
+	}, mock.WithData(&mock.TomlData{
+		Commands: map[string]*mock.Command{
+			lookupCmd: {Stdout: `{
+				"FeatureName": "SMB1Protocol",
+				"DisplayName": "SMB 1.0/CIFS File Sharing Support",
+				"Description": "Support for the SMB 1.0/CIFS file sharing protocol",
+				"State": 2
+			}`},
+		},
+	}))
+	require.NoError(t, err)
+
+	conn := &optionalFeatureRecordingConnection{Connection: mockConn}
+	runtime := &plugin.Runtime{
+		Connection: conn,
+		Resources:  &syncx.Map[plugin.Resource]{},
+	}
+
+	args, _, err := initWindowsOptionalFeature(runtime, map[string]*llx.RawData{
+		"name": llx.StringData("SMB1Protocol"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{lookupCmd}, conn.commands)
+	assert.Equal(t, "SMB 1.0/CIFS File Sharing Support", args["displayName"].Value)
+	assert.Equal(t, int64(2), args["state"].Value)
+	assert.Equal(t, true, args["enabled"].Value)
+}

--- a/providers/running_provider.go
+++ b/providers/running_provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog/log"
 	pp "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/resources"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -431,7 +432,15 @@ func SupervisedRunningProvider(name string, id string, plugin pp.ProviderPlugin,
 
 // initialize the heartbeat with the provider
 func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.CancelFunc) error {
-	if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
+	// The first beat is synchronous: a provider we cannot reach at all is a
+	// startup failure. Lateness is not — retry it just like the loop below does.
+	err := p.doOneHeartbeat(p.interval + p.gracePeriod)
+	for late := 1; errors.Is(err, errHeartbeatLate) && late <= maxLateHeartbeats; late++ {
+		log.Warn().Str("plugin", p.Name).Int("consecutive", late).
+			Msg("plugin heartbeat is late, provider is not answering in time")
+		err = p.doOneHeartbeat(p.interval + p.gracePeriod)
+	}
+	if err != nil {
 		log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
 		p.shutdownLock.Lock()
 		p.heartbeatFailed = true
@@ -445,8 +454,20 @@ func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.Canc
 	go func() {
 		ticker := time.NewTicker(p.interval)
 		defer ticker.Stop()
+		late := 0
 		for !p.isCloseOrShutdown() {
-			if err := p.doOneHeartbeat(p.interval + p.gracePeriod); err != nil {
+			err := p.doOneHeartbeat(p.interval + p.gracePeriod)
+			switch {
+			case err == nil:
+				late = 0
+			case errors.Is(err, errHeartbeatLate) && late < maxLateHeartbeats:
+				// The provider is alive but did not answer in time. That is a
+				// loaded host, not a dead plugin: killing it here would throw
+				// away the whole scan's work and report it as a crash.
+				late++
+				log.Warn().Str("plugin", p.Name).Int("consecutive", late).
+					Msg("plugin heartbeat is late, provider is not answering in time")
+			default:
 				log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
 				p.shutdownLock.Lock()
 				p.heartbeatFailed = true
@@ -454,7 +475,7 @@ func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.Canc
 				if err := p.Shutdown(); err != nil {
 					log.Error().Err(err).Str("plugin", p.Name).Msg("error in plugin shutdown")
 				}
-				break
+				return
 			}
 
 			select {
@@ -470,17 +491,29 @@ func (p *RunningProvider) heartbeat(ctx context.Context, cancelFunc context.Canc
 	return nil
 }
 
+// maxLateHeartbeats is how many consecutive heartbeats may time out before we
+// treat the provider as dead. The provider's own watchdog holds out for several
+// windows while it is serving requests, and we have to be at least as patient:
+// both sides exiting on the first missed beat is what turns a momentarily
+// starved host into a crash report.
+const maxLateHeartbeats = 6
+
+// errHeartbeatLate marks a heartbeat that did not complete within its window.
+// Unlike a transport error it does not imply the provider is gone.
+var errHeartbeatLate = errors.New("heartbeat did not complete in time")
+
 func (p *RunningProvider) doOneHeartbeat(t time.Duration) error {
 	_, err := p.Plugin.Heartbeat(&pp.HeartbeatReq{
 		Interval: uint64(t),
 	})
 	if err != nil {
-		log.Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
-		if status, ok := status.FromError(err); ok {
-			if status.Code() == 12 {
-				return errors.New("please update the provider plugin for " + p.Name)
-			}
+		switch status.Code(err) {
+		case codes.DeadlineExceeded:
+			return fmt.Errorf("%w for %s after %s", errHeartbeatLate, p.Name, t)
+		case codes.Unimplemented:
+			return errors.New("please update the provider plugin for " + p.Name)
 		}
+		log.Err(err).Str("plugin", p.Name).Msg("error in plugin heartbeat")
 		return errors.New("cannot establish heartbeat with the provider plugin for " + p.Name)
 	}
 	return nil

--- a/providers/running_provider_test.go
+++ b/providers/running_provider_test.go
@@ -4,14 +4,18 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	pp "go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestConnectionGraph(t *testing.T) {
@@ -360,4 +364,114 @@ func TestRestartableProvider_MultiNamespaceMultiBatch(t *testing.T) {
 	for ns := range numNamespaces {
 		assert.False(t, mock.alive(nsID(ns)), "namespace %d should be GC'd after scan", ns)
 	}
+}
+
+// heartbeatPlugin answers heartbeats according to a script keyed on the call
+// number, so a test can describe a provider that is late, recovering, or gone.
+type heartbeatPlugin struct {
+	*mockPlugin
+	mu     sync.Mutex
+	calls  int
+	script func(call int) error
+}
+
+func (h *heartbeatPlugin) Heartbeat(*pp.HeartbeatReq) (*pp.HeartbeatRes, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls++
+	if err := h.script(h.calls); err != nil {
+		return nil, err
+	}
+	return &pp.HeartbeatRes{}, nil
+}
+
+func (h *heartbeatPlugin) callCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls
+}
+
+func newHeartbeatProvider(plugin pp.ProviderPlugin) *RunningProvider {
+	return &RunningProvider{
+		Name:        "test",
+		Plugin:      plugin,
+		startedAt:   time.Now(),
+		interval:    10 * time.Millisecond,
+		gracePeriod: 10 * time.Millisecond,
+	}
+}
+
+// A provider that answers late is slow, not dead. Shutting it down on the first
+// late beat is what turns a momentarily starved host into a crash report, so we
+// hold out for maxLateHeartbeats before giving up.
+func TestHeartbeat_ToleratesLateBeats(t *testing.T) {
+	lateBeat := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	mock := &heartbeatPlugin{
+		mockPlugin: newMockPlugin(),
+		script: func(call int) error {
+			if call == 1 {
+				return nil
+			}
+			return lateBeat
+		},
+	}
+	rp := newHeartbeatProvider(mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, rp.heartbeat(ctx, cancel))
+
+	// still alive while it is merely late
+	require.Eventually(t, func() bool { return mock.callCount() >= 1+maxLateHeartbeats }, 5*time.Second, 5*time.Millisecond)
+	// and gone once the whole budget is used up
+	require.Eventually(t, rp.isCloseOrShutdown, 5*time.Second, 5*time.Millisecond)
+	assert.True(t, rp.hadHeartbeatFailure())
+	assert.GreaterOrEqual(t, mock.callCount(), 1+maxLateHeartbeats+1)
+}
+
+// Intermittent lateness must not accumulate into a shutdown: every answered beat
+// proves the provider is there.
+func TestHeartbeat_RecoveryResetsLateBudget(t *testing.T) {
+	lateBeat := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+	mock := &heartbeatPlugin{
+		mockPlugin: newMockPlugin(),
+		script: func(call int) error {
+			if call%2 == 0 {
+				return lateBeat
+			}
+			return nil
+		},
+	}
+	rp := newHeartbeatProvider(mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, rp.heartbeat(ctx, cancel))
+
+	require.Eventually(t, func() bool { return mock.callCount() > 4*maxLateHeartbeats }, 5*time.Second, 5*time.Millisecond)
+	assert.False(t, rp.isCloseOrShutdown())
+	assert.False(t, rp.hadHeartbeatFailure())
+}
+
+// A broken connection is different: the provider is gone, so there is nothing to
+// wait for and we report it right away.
+func TestHeartbeat_DeadProviderFailsImmediately(t *testing.T) {
+	mock := &heartbeatPlugin{
+		mockPlugin: newMockPlugin(),
+		script: func(call int) error {
+			if call == 1 {
+				return nil
+			}
+			return status.Error(codes.Unavailable, "connection refused")
+		},
+	}
+	rp := newHeartbeatProvider(mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, rp.heartbeat(ctx, cancel))
+
+	require.Eventually(t, rp.isCloseOrShutdown, 5*time.Second, 5*time.Millisecond)
+	assert.True(t, rp.hadHeartbeatFailure())
+	assert.Equal(t, 2, mock.callCount(), "a dead provider is not retried")
 }


### PR DESCRIPTION
Fixes #9545

## The defect

The provider's dead-man's switch exits the process as soon as **one** heartbeat window (`interval + gracePeriod` = 5s) passes without a beat, and the client tears the provider down as soon as **one** heartbeat call fails. Neither condition means the provider is dead — on a loaded host, GC, paging and plain CPU starvation routinely delay either side by seconds — but the consequence is expensive: every field in flight at teardown is reported as a separate provider crash, the scan's work is discarded, and the error-valued data is quarantined downstream. In telemetry this appears as `code = Unavailable` + `exit=code:4` + `trigger=heartbeat-timeout`, attributed to whichever field happened to be in flight, which is why the reported "crash" moves around between slow resolvers (`port.*`, `package.*`, `windows.optionalFeatures`, `windows.computerInfo`).

The watchdog's actual job is reaping an *abandoned* provider: when the parent dies without shutting us down, nothing else stops the process. Detecting a slow or wedged provider is the client's job — it has the context to decide. So the budget can be far more generous than one window, and generosity costs nothing in the abandoned case, because a dead parent sends nothing ever again.

## The change

**Provider (`providers-sdk/v1/plugin`)**
- The per-beat goroutine + exact-timestamp comparison is replaced by one watchdog loop: it exits after `heartbeatMissesBeforeExit` (3) missed windows, or `heartbeatBusyMissesBeforeExit` (6) while requests are in flight — a request in flight proves the parent was there to send it.
- Requests are counted centrally in `GRPCServer` (`Heartbeat` and `Shutdown` excluded) through `Service.TrackRequest`, so every provider gets it without a per-provider change.
- The near miss — exactly where the process used to exit — is now logged, and the reason is written to stderr before exiting. `stderrSnapshot` puts that line in the crash report, so this exit is no longer indistinguishable from a hard kill.
- The watchdog is retired on `Shutdown`, so a teardown slower than one window can no longer be reported as a crash.

**Client (`providers/running_provider.go`, `GRPCClient.Heartbeat`)**
- Each beat gets a deadline equal to the window it is holding the provider to. Before, `context.Background()` meant one wedged call stopped the beat stream permanently — which then guaranteed the provider self-exited.
- A late beat (`DeadlineExceeded`) is tolerated up to `maxLateHeartbeats`, so the client is at least as patient as the provider; any other error still fails immediately, because a broken connection means the provider really is gone.

**`windows.optionalFeatures` (the resolver that stalls past the window most often)**
- `Get-WindowsOptionalFeature -Online` lists features with their state; `-FeatureName` is what makes DISM look up *detailed* information for every feature it matches. Checks and filters only key on the state, so the enumeration now uses the plain listing and `displayName`/`description` load on demand — once for the whole enumeration, shared between its features. Values are unchanged; a query that asks for descriptions pays exactly what it paid before.

## Verification

The starvation is reproducible without a Windows host: freeze the client for longer than one window while the provider is serving a request.

```
mql run local -c 'command("sleep 12").exitcode' &
sleep 3; kill -STOP $!; sleep 8; kill -CONT $!
```

`main`:

```
the 'os' provider crashed (resource=command, field=exitcode): rpc error: code = Unavailable desc = error reading from server: EOF
[uptime=10.94s subprocess=exited exit=code:4 max_rss=53620736 trigger=heartbeat-timeout]
command.exitcode: no data available
```

this branch:

```
! no heartbeat from the parent process, still working inflight=1 silence=5.500850379s window=5s
command.exitcode: 0
```

Same binary, same 8s freeze: the near miss is logged instead of ending the scan.

Abandonment still reaps: with this branch installed, `kill -9` on the parent mid-query left no provider process behind (gone within 5s, i.e. well inside the watchdog's budget — the plugin connection loss tears it down independently).

Tests: watchdog tolerance and the idle/busy split, the exit path via an injectable exit, retirement on shutdown, client tolerance for late vs. dead providers, and the `optionalFeatures` split (the enumeration issues only the listing; details are fetched once for all features, and a lookup by name still issues a single targeted query).

## Notes for reviewers

- Wire format is unchanged: the client still sends `interval + gracePeriod` and old clients keep working — the tolerance multiplier is applied provider-side.
- Worst case for reaping an abandoned provider grows from 5s to 15s (30s if a request is stuck in flight). That only delays cleanup of a process whose parent is already gone.
- `displayName`/`description` on `windows.optionalFeature` become computed fields. Recordings made before this change still carry them; new recordings only carry them if a query asked.
- The remaining latency of the DISM enumeration itself is a property of the cmdlet, not of the payload; measuring it on a Windows 11 vs Windows 10 pair is still worth doing separately.