### PR TITLE
🐛 fix macos.hardware parsing on virtual machines

### DIFF
--- a/providers/os/resources/macos_hardware.go
+++ b/providers/os/resources/macos_hardware.go
@@ -11,6 +11,57 @@ import (
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
 
+// stringOrNumber accepts a JSON string or number and stores it as a string.
+// system_profiler reports number_processors as a string on Apple Silicon
+// (e.g. "proc 16:12:4") but as a plain number on Intel Macs and virtual
+// machines (e.g. 2).
+type stringOrNumber string
+
+func (s *stringOrNumber) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		*s = stringOrNumber(str)
+		return nil
+	}
+	var num json.Number
+	if err := json.Unmarshal(data, &num); err != nil {
+		return err
+	}
+	*s = stringOrNumber(num.String())
+	return nil
+}
+
+type macosHardwareOverview struct {
+	ActivationLockStatus string         `json:"activation_lock_status"`
+	BootRomVersion       string         `json:"boot_rom_version"`
+	ChipType             string         `json:"chip_type"`
+	MachineModel         string         `json:"machine_model"`
+	MachineName          string         `json:"machine_name"`
+	ModelNumber          string         `json:"model_number"`
+	NumberProcessors     stringOrNumber `json:"number_processors"`
+	OsLoaderVersion      string         `json:"os_loader_version"`
+	PhysicalMemory       string         `json:"physical_memory"`
+	PlatformUUID         string         `json:"platform_UUID"`
+	ProvisioningUDID     string         `json:"provisioning_UDID"`
+	SerialNumber         string         `json:"serial_number"`
+}
+
+func parseMacosHardware(jsonData []byte) (*macosHardwareOverview, error) {
+	var resp struct {
+		SPHardwareDataType []macosHardwareOverview `json:"SPHardwareDataType"`
+	}
+	if err := json.Unmarshal(jsonData, &resp); err != nil {
+		return nil, errors.New("could not gather hardware information")
+	}
+	if len(resp.SPHardwareDataType) == 0 {
+		return nil, errors.New("could not gather hardware information")
+	}
+	return &resp.SPHardwareDataType[0], nil
+}
+
 func initMacosHardware(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
 	if args == nil {
 		args = map[string]*llx.RawData{}
@@ -30,46 +81,21 @@ func initMacosHardware(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 		return nil, nil, errors.New("could not run command")
 	}
 
-	jsonData := cmd.GetStdout().Data
-
-	type machineJsonData struct {
-		SPHardwareDataType []struct {
-			ActivationLockStatus string `json:"activation_lock_status"`
-			BootRomVersion       string `json:"boot_rom_version"`
-			ChipType             string `json:"chip_type"`
-			MachineModel         string `json:"machine_model"`
-			MachineName          string `json:"machine_name"`
-			ModelNumber          string `json:"model_number"`
-			NumberProcessors     string `json:"number_processors"`
-			OsLoaderVersion      string `json:"os_loader_version"`
-			PhysicalMemory       string `json:"physical_memory"`
-			PlatformUUID         string `json:"platform_uuid"`
-			ProvisioningUUID     string `json:"provisioning_uuid"`
-			SerialNumber         string `json:"serial_number"`
-		} `json:"SPHardwareDataType"`
-	}
-
-	var resp machineJsonData
-	err = json.Unmarshal([]byte(jsonData), &resp)
+	hardware, err := parseMacosHardware([]byte(cmd.GetStdout().Data))
 	if err != nil {
-		return nil, nil, errors.New("could not gather hardware information")
+		return nil, nil, err
 	}
-	if len(resp.SPHardwareDataType) == 0 {
-		return nil, nil, errors.New("could not gather hardware information")
-	}
-
-	hardware := resp.SPHardwareDataType[0]
 	args["activationLockStatus"] = llx.StringData(hardware.ActivationLockStatus)
 	args["bootRomVersion"] = llx.StringData(hardware.BootRomVersion)
 	args["chipType"] = llx.StringData(hardware.ChipType)
 	args["machineModel"] = llx.StringData(hardware.MachineModel)
 	args["machineName"] = llx.StringData(hardware.MachineName)
 	args["modelNumber"] = llx.StringData(hardware.ModelNumber)
-	args["numberProcessors"] = llx.StringData(hardware.NumberProcessors)
+	args["numberProcessors"] = llx.StringData(string(hardware.NumberProcessors))
 	args["osLoaderVersion"] = llx.StringData(hardware.OsLoaderVersion)
 	args["physicalMemory"] = llx.StringData(hardware.PhysicalMemory)
 	args["platformUUID"] = llx.StringData(hardware.PlatformUUID)
-	args["provisioningUDID"] = llx.StringData(hardware.ProvisioningUUID)
+	args["provisioningUDID"] = llx.StringData(hardware.ProvisioningUDID)
 	args["serialNumber"] = llx.StringData(hardware.SerialNumber)
 
 	return args, nil, nil

--- a/providers/os/resources/macos_hardware.go
+++ b/providers/os/resources/macos_hardware.go
@@ -18,6 +18,10 @@ import (
 type stringOrNumber string
 
 func (s *stringOrNumber) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = ""
+		return nil
+	}
 	if len(data) > 0 && data[0] == '"' {
 		var str string
 		if err := json.Unmarshal(data, &str); err != nil {

--- a/providers/os/resources/macos_hardware_test.go
+++ b/providers/os/resources/macos_hardware_test.go
@@ -78,6 +78,41 @@ func TestParseMacosHardwarePhysicalMac(t *testing.T) {
 	assert.Equal(t, "00008400-001E20D40168401E", hw.ProvisioningUDID)
 }
 
+func TestParseMacosHardwareLowercaseKeys(t *testing.T) {
+	// Go's JSON key matching is case-insensitive, so the platform_UUID and
+	// provisioning_UDID tags must still match fully lowercase keys
+	data := []byte(`{
+  "SPHardwareDataType" : [
+    {
+      "platform_uuid" : "50DCC3EF-6AD8-5EAA-AC56-451AD340113C",
+      "provisioning_udid" : "4db4fb49aa66c799985e792a6573e713ce8eb024",
+      "serial_number" : "ZFQYR4XYHG"
+    }
+  ]
+}`)
+
+	hw, err := parseMacosHardware(data)
+	require.NoError(t, err)
+	assert.Equal(t, "50DCC3EF-6AD8-5EAA-AC56-451AD340113C", hw.PlatformUUID)
+	assert.Equal(t, "4db4fb49aa66c799985e792a6573e713ce8eb024", hw.ProvisioningUDID)
+}
+
+func TestParseMacosHardwareNullNumberProcessors(t *testing.T) {
+	data := []byte(`{
+  "SPHardwareDataType" : [
+    {
+      "number_processors" : null,
+      "serial_number" : "ZFQYR4XYHG"
+    }
+  ]
+}`)
+
+	hw, err := parseMacosHardware(data)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(hw.NumberProcessors))
+	assert.Equal(t, "ZFQYR4XYHG", hw.SerialNumber)
+}
+
 func TestParseMacosHardwareInvalid(t *testing.T) {
 	_, err := parseMacosHardware([]byte("not json"))
 	assert.Error(t, err)

--- a/providers/os/resources/macos_hardware_test.go
+++ b/providers/os/resources/macos_hardware_test.go
@@ -1,0 +1,87 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMacosHardwareVirtualMachine(t *testing.T) {
+	// Apple Virtual Machine: number_processors is a plain number
+	data := []byte(`{
+  "SPHardwareDataType" : [
+    {
+      "_name" : "hardware_overview",
+      "activation_lock_status" : "activation_lock_disabled",
+      "boot_rom_version" : "mBoot-18000.120.36",
+      "chip_type" : "Apple M4 Max (Virtual)",
+      "machine_model" : "VirtualMac2,1",
+      "machine_name" : "Apple Virtual Machine 1",
+      "model_number" : "VM0001LL/A",
+      "number_processors" : 2,
+      "os_loader_version" : "11881.140.96.701.1",
+      "physical_memory" : "4 GB",
+      "platform_UUID" : "50DCC3EF-6AD8-5EAA-AC56-451AD340113C",
+      "provisioning_UDID" : "4db4fb49aa66c799985e792a6573e713ce8eb024",
+      "serial_number" : "ZFQYR4XYHG"
+    }
+  ]
+}`)
+
+	hw, err := parseMacosHardware(data)
+	require.NoError(t, err)
+	assert.Equal(t, "activation_lock_disabled", hw.ActivationLockStatus)
+	assert.Equal(t, "mBoot-18000.120.36", hw.BootRomVersion)
+	assert.Equal(t, "Apple M4 Max (Virtual)", hw.ChipType)
+	assert.Equal(t, "VirtualMac2,1", hw.MachineModel)
+	assert.Equal(t, "Apple Virtual Machine 1", hw.MachineName)
+	assert.Equal(t, "VM0001LL/A", hw.ModelNumber)
+	assert.Equal(t, "2", string(hw.NumberProcessors))
+	assert.Equal(t, "11881.140.96.701.1", hw.OsLoaderVersion)
+	assert.Equal(t, "4 GB", hw.PhysicalMemory)
+	assert.Equal(t, "50DCC3EF-6AD8-5EAA-AC56-451AD340113C", hw.PlatformUUID)
+	assert.Equal(t, "4db4fb49aa66c799985e792a6573e713ce8eb024", hw.ProvisioningUDID)
+	assert.Equal(t, "ZFQYR4XYHG", hw.SerialNumber)
+}
+
+func TestParseMacosHardwarePhysicalMac(t *testing.T) {
+	// Physical Apple Silicon Mac: number_processors is a string like "proc 16:12:4"
+	data := []byte(`{
+  "SPHardwareDataType" : [
+    {
+      "_name" : "hardware_overview",
+      "activation_lock_status" : "activation_lock_enabled",
+      "boot_rom_version" : "11881.140.96",
+      "chip_type" : "Apple M4 Max",
+      "machine_model" : "Mac16,5",
+      "machine_name" : "MacBook Pro",
+      "model_number" : "Z1FS0002ULL/A",
+      "number_processors" : "proc 16:12:4",
+      "os_loader_version" : "11881.140.96",
+      "physical_memory" : "48 GB",
+      "platform_UUID" : "6D9530A4-90A2-5A28-B133-3D6011CC7772",
+      "provisioning_UDID" : "00008400-001E20D40168401E",
+      "serial_number" : "C6XW4X7JX1"
+    }
+  ]
+}`)
+
+	hw, err := parseMacosHardware(data)
+	require.NoError(t, err)
+	assert.Equal(t, "Apple M4 Max", hw.ChipType)
+	assert.Equal(t, "proc 16:12:4", string(hw.NumberProcessors))
+	assert.Equal(t, "6D9530A4-90A2-5A28-B133-3D6011CC7772", hw.PlatformUUID)
+	assert.Equal(t, "00008400-001E20D40168401E", hw.ProvisioningUDID)
+}
+
+func TestParseMacosHardwareInvalid(t *testing.T) {
+	_, err := parseMacosHardware([]byte("not json"))
+	assert.Error(t, err)
+
+	_, err = parseMacosHardware([]byte(`{"SPHardwareDataType": []}`))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

`macos.hardware` failed entirely on Apple Virtual Machines with "could not gather hardware information", and `provisioningUDID` was silently empty on every Mac.

- **`number_processors` type mismatch:** `system_profiler SPHardwareDataType -json` reports `number_processors` as a plain number on Apple Virtual Machines and Intel Macs (e.g. `2`), but as a string on physical Apple Silicon (e.g. `"proc 16:12:4"`). The struct declared it `string`, so `json.Unmarshal` rejected the whole payload on VMs. A small `stringOrNumber` type now accepts both shapes and normalizes to a string, keeping the `.lr` field type unchanged.
- **`provisioning_UDID` tag fix:** the struct tag was `json:"provisioning_uuid"`, but the actual key is `provisioning_UDID`. Go's case-insensitive key matching doesn't cover `udid` vs `uuid`, so the field never populated.
- Extracted the inline parsing into a package-level `parseMacosHardware` helper so it can be unit tested.

## Testing

Added `macos_hardware_test.go` covering real `system_profiler` output from an Apple Virtual Machine (number-typed `number_processors`), a physical Apple Silicon Mac (string-typed), and invalid/empty payloads. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)