### PR TITLE
✨ aws: expose IAM inline policy documents

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2406,8 +2406,14 @@ private aws.iam.user @defaults("arn name createdAt") {
   //
   // Inferred from the provenance tags AWS injects on managed resources (for example cloudformation, elasticbeanstalk, eks). Empty when the user is unmanaged or managed by a tool that leaves no recognizable tag.
   managedBy() string
-  // List of inline policies attached to the user
-  policies() []string
+  // Inline policy names embedded in the user
+  //
+  // Deprecated in favor of inlinePolicyDetails, which resolves each inline
+  // policy to an aws.iam.inlinePolicy carrying the policy document and its
+  // parsed statements.
+  policies() @maturity("deprecated") []string
+  // Inline policies embedded in the user, including their documents
+  inlinePolicyDetails() []aws.iam.inlinePolicy
   // List of managed policies attached to the user
   attachedPolicies() []aws.iam.policy
   // List of group ARNs that the user belongs to
@@ -2585,6 +2591,38 @@ private aws.iam.policyversion @defaults("arn isDefaultVersion createdAt") {
   createdAt time
 }
 
+// AWS IAM inline policy
+//
+// Permission policy embedded directly in a single IAM user, group, or role
+// rather than managed as a standalone policy that many principals share. The
+// document field carries the policy JSON and statements resolves it to
+// individual statements, so inline grants can be audited with the same
+// queries as managed policies. Because an inline policy has no ARN and no
+// attachment count, it is invisible to policy-level reporting, which makes
+// hasWildcardAllow the practical way to find over-broad embedded grants.
+// The entityType and entityName fields identify the principal the policy
+// lives on, which matters when statements from many principals are collected
+// into one list.
+private aws.iam.inlinePolicy @defaults("name entityType entityName") {
+  // Name of the inline policy
+  name string
+  // Type of IAM entity the policy is embedded in: user, group, or role
+  entityType string
+  // Name of the user, group, or role the policy is embedded in
+  entityName string
+  // Policy document
+  //
+  // Parsed policy JSON. See statements for the resolved statement form.
+  document dict
+  // Parsed statements from the policy document
+  statements() []aws.iam.policyStatement
+  // Whether any Allow statement in the policy grants wildcard access
+  //
+  // True when an Allow statement includes a wildcard action — the global `*`
+  // or a service-wide wildcard such as `s3:*` — or the all-resources `*`.
+  hasWildcardAllow() bool
+}
+
 // AWS IAM role
 //
 // IAM role in the account, including its trust policy, attached and inline
@@ -2638,8 +2676,14 @@ private aws.iam.role @defaults("arn name") {
   isServiceLinked bool
   // List of managed policies attached to the role
   attachedPolicies() []aws.iam.policy
-  // List of inline policy names embedded in the role
-  inlinePolicies() []string
+  // Inline policy names embedded in the role
+  //
+  // Deprecated in favor of inlinePolicyDetails, which resolves each inline
+  // policy to an aws.iam.inlinePolicy carrying the policy document and its
+  // parsed statements.
+  inlinePolicies() @maturity("deprecated") []string
+  // Inline policies embedded in the role, including their documents
+  inlinePolicyDetails() []aws.iam.inlinePolicy
   // IAM Access Analyzer findings reporting external or public access to this resource
   externalAccessFindings() []aws.iam.accessAnalyzer.finding
 }
@@ -2661,8 +2705,14 @@ private aws.iam.group @defaults("arn name") {
   createdAt time
   // List of usernames that belong to the group
   usernames() []string
-  // List of inline policy names attached to the group
-  inlinePolicies() []string
+  // Inline policy names embedded in the group
+  //
+  // Deprecated in favor of inlinePolicyDetails, which resolves each inline
+  // policy to an aws.iam.inlinePolicy carrying the policy document and its
+  // parsed statements.
+  inlinePolicies() @maturity("deprecated") []string
+  // Inline policies embedded in the group, including their documents
+  inlinePolicyDetails() []aws.iam.inlinePolicy
   // List of managed policies attached to the group
   attachedPolicies() []aws.iam.policy
   // Path to the group

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -103,6 +103,7 @@ const (
 	ResourceAwsIamPolicyStatement                                               string = "aws.iam.policyStatement"
 	ResourceAwsIamPolicy                                                        string = "aws.iam.policy"
 	ResourceAwsIamPolicyversion                                                 string = "aws.iam.policyversion"
+	ResourceAwsIamInlinePolicy                                                  string = "aws.iam.inlinePolicy"
 	ResourceAwsIamRole                                                          string = "aws.iam.role"
 	ResourceAwsIamGroup                                                         string = "aws.iam.group"
 	ResourceAwsIamVirtualmfadevice                                              string = "aws.iam.virtualmfadevice"
@@ -1313,6 +1314,10 @@ func init() {
 		"aws.iam.policyversion": {
 			// to override args, implement: initAwsIamPolicyversion(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamPolicyversion,
+		},
+		"aws.iam.inlinePolicy": {
+			// to override args, implement: initAwsIamInlinePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamInlinePolicy,
 		},
 		"aws.iam.role": {
 			Init:   initAwsIamRole,
@@ -7132,6 +7137,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.user.policies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetPolicies()).ToDataRes(types.Array(types.String))
 	},
+	"aws.iam.user.inlinePolicyDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetInlinePolicyDetails()).ToDataRes(types.Array(types.Resource("aws.iam.inlinePolicy")))
+	},
 	"aws.iam.user.attachedPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetAttachedPolicies()).ToDataRes(types.Array(types.Resource("aws.iam.policy")))
 	},
@@ -7303,6 +7311,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policyversion.createdAt": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetCreatedAt()).ToDataRes(types.Time)
 	},
+	"aws.iam.inlinePolicy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetName()).ToDataRes(types.String)
+	},
+	"aws.iam.inlinePolicy.entityType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetEntityType()).ToDataRes(types.String)
+	},
+	"aws.iam.inlinePolicy.entityName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetEntityName()).ToDataRes(types.String)
+	},
+	"aws.iam.inlinePolicy.document": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetDocument()).ToDataRes(types.Dict)
+	},
+	"aws.iam.inlinePolicy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.iam.inlinePolicy.hasWildcardAllow": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamInlinePolicy).GetHasWildcardAllow()).ToDataRes(types.Bool)
+	},
 	"aws.iam.role.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetArn()).ToDataRes(types.String)
 	},
@@ -7363,6 +7389,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.role.inlinePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetInlinePolicies()).ToDataRes(types.Array(types.String))
 	},
+	"aws.iam.role.inlinePolicyDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetInlinePolicyDetails()).ToDataRes(types.Array(types.Resource("aws.iam.inlinePolicy")))
+	},
 	"aws.iam.role.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
 	},
@@ -7383,6 +7412,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.group.inlinePolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetInlinePolicies()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.group.inlinePolicyDetails": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamGroup).GetInlinePolicyDetails()).ToDataRes(types.Array(types.Resource("aws.iam.inlinePolicy")))
 	},
 	"aws.iam.group.attachedPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetAttachedPolicies()).ToDataRes(types.Array(types.Resource("aws.iam.policy")))
@@ -39060,6 +39092,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamUser).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.user.inlinePolicyDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).InlinePolicyDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.user.attachedPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUser).AttachedPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -39312,6 +39348,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamPolicyversion).CreatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.iam.inlinePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.iam.inlinePolicy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.inlinePolicy.entityType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).EntityType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.inlinePolicy.entityName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).EntityName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.inlinePolicy.document": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).Document, ok = plugin.RawToTValue[any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.inlinePolicy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.inlinePolicy.hasWildcardAllow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamInlinePolicy).HasWildcardAllow, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.iam.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).__id, ok = v.Value.(string)
 		return
@@ -39396,6 +39460,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamRole).InlinePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.role.inlinePolicyDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).InlinePolicyDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.role.externalAccessFindings": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamRole).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -39426,6 +39494,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.group.inlinePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamGroup).InlinePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.group.inlinePolicyDetails": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamGroup).InlinePolicyDetails, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.group.attachedPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -89666,6 +89738,7 @@ type mqlAwsIamUser struct {
 	Tags                plugin.TValue[map[string]any]
 	ManagedBy           plugin.TValue[string]
 	Policies            plugin.TValue[[]any]
+	InlinePolicyDetails plugin.TValue[[]any]
 	AttachedPolicies    plugin.TValue[[]any]
 	Groups              plugin.TValue[[]any]
 	AccessKeys          plugin.TValue[[]any]
@@ -89748,6 +89821,22 @@ func (c *mqlAwsIamUser) GetManagedBy() *plugin.TValue[string] {
 func (c *mqlAwsIamUser) GetPolicies() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
 		return c.policies()
+	})
+}
+
+func (c *mqlAwsIamUser) GetInlinePolicyDetails() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InlinePolicyDetails, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.user", c.__id, "inlinePolicyDetails")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.inlinePolicyDetails()
 	})
 }
 
@@ -90460,6 +90549,89 @@ func (c *mqlAwsIamPolicyversion) GetCreatedAt() *plugin.TValue[*time.Time] {
 	return &c.CreatedAt
 }
 
+// mqlAwsIamInlinePolicy for the aws.iam.inlinePolicy resource
+type mqlAwsIamInlinePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsIamInlinePolicyInternal it will be used here
+	Name             plugin.TValue[string]
+	EntityType       plugin.TValue[string]
+	EntityName       plugin.TValue[string]
+	Document         plugin.TValue[any]
+	Statements       plugin.TValue[[]any]
+	HasWildcardAllow plugin.TValue[bool]
+}
+
+// createAwsIamInlinePolicy creates a new instance of this resource
+func createAwsIamInlinePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamInlinePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.inlinePolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamInlinePolicy) MqlName() string {
+	return "aws.iam.inlinePolicy"
+}
+
+func (c *mqlAwsIamInlinePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamInlinePolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsIamInlinePolicy) GetEntityType() *plugin.TValue[string] {
+	return &c.EntityType
+}
+
+func (c *mqlAwsIamInlinePolicy) GetEntityName() *plugin.TValue[string] {
+	return &c.EntityName
+}
+
+func (c *mqlAwsIamInlinePolicy) GetDocument() *plugin.TValue[any] {
+	return &c.Document
+}
+
+func (c *mqlAwsIamInlinePolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.inlinePolicy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
+	})
+}
+
+func (c *mqlAwsIamInlinePolicy) GetHasWildcardAllow() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardAllow, func() (bool, error) {
+		return c.hasWildcardAllow()
+	})
+}
+
 // mqlAwsIamRole for the aws.iam.role resource
 type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
@@ -90485,6 +90657,7 @@ type mqlAwsIamRole struct {
 	IsServiceLinked             plugin.TValue[bool]
 	AttachedPolicies            plugin.TValue[[]any]
 	InlinePolicies              plugin.TValue[[]any]
+	InlinePolicyDetails         plugin.TValue[[]any]
 	ExternalAccessFindings      plugin.TValue[[]any]
 }
 
@@ -90665,6 +90838,22 @@ func (c *mqlAwsIamRole) GetInlinePolicies() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsIamRole) GetInlinePolicyDetails() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InlinePolicyDetails, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.role", c.__id, "inlinePolicyDetails")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.inlinePolicyDetails()
+	})
+}
+
 func (c *mqlAwsIamRole) GetExternalAccessFindings() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.ExternalAccessFindings, func() ([]any, error) {
 		if c.MqlRuntime.HasRecording {
@@ -90686,14 +90875,15 @@ type mqlAwsIamGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsIamGroupInternal
-	Arn              plugin.TValue[string]
-	Id               plugin.TValue[string]
-	Name             plugin.TValue[string]
-	CreatedAt        plugin.TValue[*time.Time]
-	Usernames        plugin.TValue[[]any]
-	InlinePolicies   plugin.TValue[[]any]
-	AttachedPolicies plugin.TValue[[]any]
-	Path             plugin.TValue[string]
+	Arn                 plugin.TValue[string]
+	Id                  plugin.TValue[string]
+	Name                plugin.TValue[string]
+	CreatedAt           plugin.TValue[*time.Time]
+	Usernames           plugin.TValue[[]any]
+	InlinePolicies      plugin.TValue[[]any]
+	InlinePolicyDetails plugin.TValue[[]any]
+	AttachedPolicies    plugin.TValue[[]any]
+	Path                plugin.TValue[string]
 }
 
 // createAwsIamGroup creates a new instance of this resource
@@ -90758,6 +90948,22 @@ func (c *mqlAwsIamGroup) GetUsernames() *plugin.TValue[[]any] {
 func (c *mqlAwsIamGroup) GetInlinePolicies() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.InlinePolicies, func() ([]any, error) {
 		return c.inlinePolicies()
+	})
+}
+
+func (c *mqlAwsIamGroup) GetInlinePolicyDetails() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InlinePolicyDetails, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.group", c.__id, "inlinePolicyDetails")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.inlinePolicyDetails()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5801,10 +5801,18 @@ aws.iam.group.attachedPolicies 13.6.3
 aws.iam.group.createdAt 11.15.2
 aws.iam.group.id 11.15.2
 aws.iam.group.inlinePolicies 11.15.2
+aws.iam.group.inlinePolicyDetails 13.52.2
 aws.iam.group.name 11.15.2
 aws.iam.group.path 11.15.2
 aws.iam.group.usernames 11.15.2
 aws.iam.groups 11.15.2
+aws.iam.inlinePolicy 13.52.2
+aws.iam.inlinePolicy.document 13.52.2
+aws.iam.inlinePolicy.entityName 13.52.2
+aws.iam.inlinePolicy.entityType 13.52.2
+aws.iam.inlinePolicy.hasWildcardAllow 13.52.2
+aws.iam.inlinePolicy.name 13.52.2
+aws.iam.inlinePolicy.statements 13.52.2
 aws.iam.instanceProfile 11.15.2
 aws.iam.instanceProfile.arn 11.15.2
 aws.iam.instanceProfile.createdAt 11.15.2
@@ -5886,6 +5894,7 @@ aws.iam.role.description 11.15.2
 aws.iam.role.externalAccessFindings 13.37.1
 aws.iam.role.id 11.15.2
 aws.iam.role.inlinePolicies 13.6.3
+aws.iam.role.inlinePolicyDetails 13.52.2
 aws.iam.role.isServiceLinked 13.6.3
 aws.iam.role.lastUsedAt 11.15.2
 aws.iam.role.lastUsedRegion 11.15.2
@@ -5922,6 +5931,7 @@ aws.iam.user.attachedPolicies 11.15.2
 aws.iam.user.createdAt 11.15.2
 aws.iam.user.groups 11.15.2
 aws.iam.user.id 11.15.2
+aws.iam.user.inlinePolicyDetails 13.52.2
 aws.iam.user.loginProfile 11.15.2
 aws.iam.user.managedBy 13.39.2
 aws.iam.user.mfaDevices 13.26.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T13:03:59+03:00",
+  "generated_at": "2026-08-05T17:39:09+02:00",
   "permissions": [
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
@@ -488,14 +488,17 @@
     "iam:GetAccountSummary",
     "iam:GetCredentialReport",
     "iam:GetGroup",
+    "iam:GetGroupPolicy",
     "iam:GetInstanceProfile",
     "iam:GetLoginProfile",
     "iam:GetOpenIDConnectProvider",
     "iam:GetPolicy",
     "iam:GetPolicyVersion",
     "iam:GetRole",
+    "iam:GetRolePolicy",
     "iam:GetSAMLProvider",
     "iam:GetUser",
+    "iam:GetUserPolicy",
     "iam:ListAccessKeys",
     "iam:ListAccountAliases",
     "iam:ListAttachedGroupPolicies",
@@ -3985,6 +3988,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:GetGroupPolicy",
+      "service": "iam",
+      "action": "GetGroupPolicy",
+      "source_file": "aws_iam_inline_policy.go"
+    },
+    {
       "permission": "iam:GetInstanceProfile",
       "service": "iam",
       "action": "GetInstanceProfile",
@@ -4021,6 +4030,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:GetRolePolicy",
+      "service": "iam",
+      "action": "GetRolePolicy",
+      "source_file": "aws_iam_inline_policy.go"
+    },
+    {
       "permission": "iam:GetSAMLProvider",
       "service": "iam",
       "action": "GetSAMLProvider",
@@ -4031,6 +4046,12 @@
       "service": "iam",
       "action": "GetUser",
       "source_file": "aws_iam.go"
+    },
+    {
+      "permission": "iam:GetUserPolicy",
+      "service": "iam",
+      "action": "GetUserPolicy",
+      "source_file": "aws_iam_inline_policy.go"
     },
     {
       "permission": "iam:ListAccessKeys",
@@ -4078,7 +4099,7 @@
       "permission": "iam:ListGroupPolicies",
       "service": "iam",
       "action": "ListGroupPolicies",
-      "source_file": "aws_iam.go"
+      "source_file": "aws_iam_inline_policy.go"
     },
     {
       "permission": "iam:ListGroups",
@@ -4132,7 +4153,7 @@
       "permission": "iam:ListRolePolicies",
       "service": "iam",
       "action": "ListRolePolicies",
-      "source_file": "aws_iam.go"
+      "source_file": "aws_iam_inline_policy.go"
     },
     {
       "permission": "iam:ListRoleTags",
@@ -4162,7 +4183,7 @@
       "permission": "iam:ListUserPolicies",
       "service": "iam",
       "action": "ListUserPolicies",
-      "source_file": "aws_iam.go"
+      "source_file": "aws_iam_inline_policy.go"
     },
     {
       "permission": "iam:ListUserTags",

--- a/providers/aws/resources/aws_iam.go
+++ b/providers/aws/resources/aws_iam.go
@@ -722,14 +722,7 @@ func (a *mqlAwsIam) roles() ([]any, error) {
 		}
 
 		for _, role := range rolesResp.Roles {
-			var policyDocumentMap map[string]any
-			if role.AssumeRolePolicyDocument != nil {
-				policyDocument := *role.AssumeRolePolicyDocument
-				if decoded, err := url.QueryUnescape(policyDocument); err == nil {
-					policyDocument = decoded
-				}
-				json.Unmarshal([]byte(policyDocument), &policyDocumentMap)
-			}
+			policyDocumentMap := decodeIamPolicyDocument(role.AssumeRolePolicyDocument)
 
 			var permBoundaryArn string
 			if role.PermissionsBoundary != nil {
@@ -1293,26 +1286,11 @@ func (a *mqlAwsIamUser) policies() ([]any, error) {
 
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.Iam("")
-	ctx := context.Background()
-
-	username := a.Name.Data
-
-	res := []any{}
-	params := &iam.ListUserPoliciesInput{
-		UserName: &username,
+	policyNames, err := listUserInlinePolicyNames(context.Background(), conn.Iam(""), a.Name.Data)
+	if err != nil {
+		return nil, err
 	}
-	paginator := iam.NewListUserPoliciesPaginator(svc, params)
-	for paginator.HasMorePages() {
-		userPolicies, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for i := range userPolicies.PolicyNames {
-			res = append(res, userPolicies.PolicyNames[i])
-		}
-	}
+	res := convert.SliceAnyToInterface(policyNames)
 
 	a.policiesCache = res
 	a.policiesFetched.Store(true)
@@ -1799,12 +1777,8 @@ func initAwsIamRole(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[
 		role := resp.Role
 
 		var policyDocumentMap map[string]any
-		if role != nil && role.AssumeRolePolicyDocument != nil {
-			policyDocument := *role.AssumeRolePolicyDocument
-			decodedPolicyDocument, decodeErr := url.QueryUnescape(policyDocument)
-			if decodeErr == nil {
-				json.Unmarshal([]byte(decodedPolicyDocument), &policyDocumentMap)
-			}
+		if role != nil {
+			policyDocumentMap = decodeIamPolicyDocument(role.AssumeRolePolicyDocument)
 		}
 
 		args["arn"] = llx.StringDataPtr(role.Arn)
@@ -1964,28 +1938,11 @@ func (a *mqlAwsIamRole) attachedPolicies() ([]any, error) {
 func (a *mqlAwsIamRole) inlinePolicies() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.Iam("")
-	ctx := context.Background()
-
-	rolename := a.Name.Data
-
-	res := []any{}
-	params := &iam.ListRolePoliciesInput{
-		RoleName: &rolename,
+	policyNames, err := listRoleInlinePolicyNames(context.Background(), conn.Iam(""), a.Name.Data)
+	if err != nil {
+		return nil, err
 	}
-	paginator := iam.NewListRolePoliciesPaginator(svc, params)
-	for paginator.HasMorePages() {
-		rolePolicies, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for i := range rolePolicies.PolicyNames {
-			res = append(res, rolePolicies.PolicyNames[i])
-		}
-	}
-
-	return res, nil
+	return convert.SliceAnyToInterface(policyNames), nil
 }
 
 // usedByInstances returns the EC2 instances that use this role through an
@@ -2213,28 +2170,11 @@ func (a *mqlAwsIamGroup) attachedPolicies() ([]any, error) {
 func (a *mqlAwsIamGroup) inlinePolicies() ([]any, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
 
-	svc := conn.Iam("")
-	ctx := context.Background()
-
-	groupname := a.Name.Data
-
-	res := []any{}
-	params := &iam.ListGroupPoliciesInput{
-		GroupName: &groupname,
+	policyNames, err := listGroupInlinePolicyNames(context.Background(), conn.Iam(""), a.Name.Data)
+	if err != nil {
+		return nil, err
 	}
-	paginator := iam.NewListGroupPoliciesPaginator(svc, params)
-	for paginator.HasMorePages() {
-		groupPolicies, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for i := range groupPolicies.PolicyNames {
-			res = append(res, groupPolicies.PolicyNames[i])
-		}
-	}
-
-	return res, nil
+	return convert.SliceAnyToInterface(policyNames), nil
 }
 
 func (a *mqlAwsIamUser) groups() ([]any, error) {

--- a/providers/aws/resources/aws_iam_inline_policy.go
+++ b/providers/aws/resources/aws_iam_inline_policy.go
@@ -1,0 +1,215 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+	"go.mondoo.com/mql/v13/types"
+)
+
+const (
+	inlinePolicyEntityUser  = "user"
+	inlinePolicyEntityGroup = "group"
+	inlinePolicyEntityRole  = "role"
+)
+
+// decodeIamPolicyDocument turns an IAM policy document into a parsed map. IAM
+// returns policy and trust documents URL-encoded, so the raw bytes are tried
+// first and a URL-decoded pass follows. A document that parses as neither
+// yields a nil map rather than an error, matching how the API treats a missing
+// document.
+func decodeIamPolicyDocument(document *string) map[string]any {
+	if document == nil {
+		return nil
+	}
+	raw := *document
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		decoded, decodeErr := url.QueryUnescape(raw)
+		if decodeErr != nil {
+			return nil
+		}
+		if err := json.Unmarshal([]byte(decoded), &parsed); err != nil {
+			return nil
+		}
+	}
+	return parsed
+}
+
+// newInlinePolicyResource builds an aws.iam.inlinePolicy for one embedded
+// policy. The entity ARN keys the cache entry, since an inline policy name is
+// only unique within the principal it is embedded in.
+func newInlinePolicyResource(runtime *plugin.Runtime, entityType, entityName, entityArn, policyName string, document *string) (plugin.Resource, error) {
+	return CreateResource(runtime, ResourceAwsIamInlinePolicy,
+		map[string]*llx.RawData{
+			"__id":       llx.StringData(entityArn + "/inlinePolicy/" + policyName),
+			"name":       llx.StringData(policyName),
+			"entityType": llx.StringData(entityType),
+			"entityName": llx.StringData(entityName),
+			"document":   llx.MapData(decodeIamPolicyDocument(document), types.Any),
+		})
+}
+
+// inlinePolicyResources resolves a list of inline policy names to
+// aws.iam.inlinePolicy resources, fetching each document through getDocument.
+// A single policy the caller cannot read is logged and skipped so one denied
+// document does not fail the whole principal, but any other error is returned
+// rather than silently reducing the list.
+func inlinePolicyResources(runtime *plugin.Runtime, entityType, entityName, entityArn string, policyNames []string, getDocument func(policyName string) (*string, error)) ([]any, error) {
+	res := make([]any, 0, len(policyNames))
+	for _, policyName := range policyNames {
+		document, err := getDocument(policyName)
+		if err != nil {
+			if Is400AccessDeniedError(err) {
+				log.Warn().Str(entityType, entityName).Str("policy", policyName).
+					Msg("no permission to read inline policy document")
+				continue
+			}
+			return nil, err
+		}
+		mqlPolicy, err := newInlinePolicyResource(runtime, entityType, entityName, entityArn, policyName, document)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlPolicy)
+	}
+	return res, nil
+}
+
+// listRoleInlinePolicyNames returns the names of the policies embedded in a role.
+func listRoleInlinePolicyNames(ctx context.Context, svc *iam.Client, roleName string) ([]string, error) {
+	res := []string{}
+	paginator := iam.NewListRolePoliciesPaginator(svc, &iam.ListRolePoliciesInput{RoleName: &roleName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, page.PolicyNames...)
+	}
+	return res, nil
+}
+
+// listUserInlinePolicyNames returns the names of the policies embedded in a user.
+func listUserInlinePolicyNames(ctx context.Context, svc *iam.Client, userName string) ([]string, error) {
+	res := []string{}
+	paginator := iam.NewListUserPoliciesPaginator(svc, &iam.ListUserPoliciesInput{UserName: &userName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, page.PolicyNames...)
+	}
+	return res, nil
+}
+
+// listGroupInlinePolicyNames returns the names of the policies embedded in a group.
+func listGroupInlinePolicyNames(ctx context.Context, svc *iam.Client, groupName string) ([]string, error) {
+	res := []string{}
+	paginator := iam.NewListGroupPoliciesPaginator(svc, &iam.ListGroupPoliciesInput{GroupName: &groupName})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, page.PolicyNames...)
+	}
+	return res, nil
+}
+
+func (a *mqlAwsIamRole) inlinePolicyDetails() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	roleName := a.Name.Data
+	policyNames, err := listRoleInlinePolicyNames(ctx, svc, roleName)
+	if err != nil {
+		return nil, err
+	}
+
+	return inlinePolicyResources(a.MqlRuntime, inlinePolicyEntityRole, roleName, a.Arn.Data, policyNames,
+		func(policyName string) (*string, error) {
+			policy, err := svc.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+				RoleName:   &roleName,
+				PolicyName: &policyName,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return policy.PolicyDocument, nil
+		})
+}
+
+func (a *mqlAwsIamUser) inlinePolicyDetails() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	userName := a.Name.Data
+	policyNames, err := listUserInlinePolicyNames(ctx, svc, userName)
+	if err != nil {
+		return nil, err
+	}
+
+	return inlinePolicyResources(a.MqlRuntime, inlinePolicyEntityUser, userName, a.Arn.Data, policyNames,
+		func(policyName string) (*string, error) {
+			policy, err := svc.GetUserPolicy(ctx, &iam.GetUserPolicyInput{
+				UserName:   &userName,
+				PolicyName: &policyName,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return policy.PolicyDocument, nil
+		})
+}
+
+func (a *mqlAwsIamGroup) inlinePolicyDetails() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Iam("")
+	ctx := context.Background()
+
+	groupName := a.Name.Data
+	policyNames, err := listGroupInlinePolicyNames(ctx, svc, groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	return inlinePolicyResources(a.MqlRuntime, inlinePolicyEntityGroup, groupName, a.Arn.Data, policyNames,
+		func(policyName string) (*string, error) {
+			policy, err := svc.GetGroupPolicy(ctx, &iam.GetGroupPolicyInput{
+				GroupName:  &groupName,
+				PolicyName: &policyName,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return policy.PolicyDocument, nil
+		})
+}
+
+// statements parses the inline policy document into individual statements.
+func (a *mqlAwsIamInlinePolicy) statements() ([]any, error) {
+	return policyStatementsFromDict(a.MqlRuntime, a.MqlID(), a.GetDocument())
+}
+
+// hasWildcardAllow reports whether any Allow statement in the inline policy
+// grants wildcard access through its actions or resources.
+func (a *mqlAwsIamInlinePolicy) hasWildcardAllow() (bool, error) {
+	statements := a.GetStatements()
+	if statements.Error != nil {
+		return false, statements.Error
+	}
+	return statementsAllowWildcard(statements.Data)
+}

--- a/providers/aws/resources/aws_iam_inline_policy_test.go
+++ b/providers/aws/resources/aws_iam_inline_policy_test.go
@@ -1,0 +1,118 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+const inlinePolicyDoc = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`
+
+func TestDecodeIamPolicyDocument(t *testing.T) {
+	tests := []struct {
+		name     string
+		document *string
+		wantNil  bool
+	}{
+		{"nil document", nil, true},
+		{"plain json", aws.String(inlinePolicyDoc), false},
+		{"url-encoded json", aws.String(url.QueryEscape(inlinePolicyDoc)), false},
+		{"empty string", aws.String(""), true},
+		{"not a policy", aws.String("this is not json"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodeIamPolicyDocument(tt.document)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, "2012-10-17", got["Version"])
+			assert.NotEmpty(t, got["Statement"])
+		})
+	}
+}
+
+// A plain-JSON document that contains a `+` must not be URL-decoded, since
+// QueryUnescape turns `+` into a space and would corrupt the value.
+func TestDecodeIamPolicyDocumentPreservesPlus(t *testing.T) {
+	doc := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::bucket/a+b"}]}`
+	got := decodeIamPolicyDocument(&doc)
+	require.NotNil(t, got)
+
+	statements, ok := got["Statement"].([]any)
+	require.True(t, ok)
+	statement, ok := statements[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "arn:aws:s3:::bucket/a+b", statement["Resource"])
+}
+
+func TestStatementsAllowWildcard(t *testing.T) {
+	statement := func(effect string, actions, resources []any) *mqlAwsIamPolicyStatement {
+		return &mqlAwsIamPolicyStatement{
+			Effect:    setString(effect),
+			Actions:   plugin.TValue[[]any]{Data: actions, State: plugin.StateIsSet},
+			Resources: plugin.TValue[[]any]{Data: resources, State: plugin.StateIsSet},
+		}
+	}
+	scoped := []any{"s3:GetObject"}
+	scopedRes := []any{"arn:aws:s3:::bucket/*"}
+
+	tests := []struct {
+		name       string
+		statements []any
+		want       bool
+	}{
+		{"no statements", []any{}, false},
+		{"scoped allow", []any{statement("Allow", scoped, scopedRes)}, false},
+		{"wildcard action", []any{statement("Allow", []any{"s3:*"}, scopedRes)}, true},
+		{"global action", []any{statement("Allow", []any{"*"}, scopedRes)}, true},
+		{"wildcard resource", []any{statement("Allow", scoped, []any{"*"})}, true},
+		{"lowercase effect", []any{statement("allow", []any{"*"}, scopedRes)}, true},
+		{"wildcard deny is not a grant", []any{statement("Deny", []any{"*"}, []any{"*"})}, false},
+		{
+			"wildcard in a later statement",
+			[]any{statement("Allow", scoped, scopedRes), statement("Allow", []any{"iam:*"}, scopedRes)},
+			true,
+		},
+		{"non-statement element is skipped", []any{"not a statement"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := statementsAllowWildcard(tt.statements)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInlinePolicyHasWildcardAllow(t *testing.T) {
+	wildcard := &mqlAwsIamPolicyStatement{
+		Effect:    setString("Allow"),
+		Actions:   plugin.TValue[[]any]{Data: []any{"*"}, State: plugin.StateIsSet},
+		Resources: plugin.TValue[[]any]{Data: []any{"*"}, State: plugin.StateIsSet},
+	}
+
+	policy := &mqlAwsIamInlinePolicy{
+		Statements: plugin.TValue[[]any]{Data: []any{wildcard}, State: plugin.StateIsSet},
+	}
+	got, err := policy.hasWildcardAllow()
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	empty := &mqlAwsIamInlinePolicy{
+		Statements: plugin.TValue[[]any]{Data: []any{}, State: plugin.StateIsSet},
+	}
+	got, err = empty.hasWildcardAllow()
+	require.NoError(t, err)
+	assert.False(t, got)
+}

--- a/providers/aws/resources/aws_iam_policy_statement.go
+++ b/providers/aws/resources/aws_iam_policy_statement.go
@@ -170,8 +170,17 @@ func (a *mqlAwsIamPolicy) hasWildcardAllow() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	return statementsAllowWildcard(statements)
+}
+
+// statementsAllowWildcard reports whether any Allow statement in the set grants
+// wildcard access through its actions or resources.
+func statementsAllowWildcard(statements []any) (bool, error) {
 	for _, raw := range statements {
-		stmt := raw.(*mqlAwsIamPolicyStatement)
+		stmt, ok := raw.(*mqlAwsIamPolicyStatement)
+		if !ok {
+			continue
+		}
 		effect := stmt.GetEffect()
 		if effect.Error != nil {
 			return false, effect.Error


### PR DESCRIPTION
## What

Adds `aws.iam.inlinePolicy` so the *contents* of inline policies embedded in an IAM user, group, or role can be audited.

Today `aws.iam.role.inlinePolicies`, `aws.iam.group.inlinePolicies` and `aws.iam.user.policies` return `[]string` — policy **names** only. Managed policies expose `statements` and `hasWildcardAllow`; inline policies had no equivalent, and inline is where hand-written over-broad grants tend to live (they have no ARN and no attachment count, so they're also invisible to policy-level reporting).

## Schema

```
private aws.iam.inlinePolicy {
  name string
  entityType string        // user, group, or role
  entityName string
  document dict
  statements() []aws.iam.policyStatement
  hasWildcardAllow() bool
}
```

Reachable via `inlinePolicyDetails()` on `aws.iam.role`, `aws.iam.user`, and `aws.iam.group`. The name-only fields are kept and marked `@maturity("deprecated")` — their `.lr.versions` entries are unchanged.

`entityType`/`entityName` identify the owning principal, which matters when statements from many principals are collected into one list. The cache key is `<entityArn>/inlinePolicy/<name>` (synthetic, so not exposed as an `id` field) — an inline policy name is only unique within the principal it's embedded in.

## Example queries

```coffee
# every inline policy that grants wildcard access
aws.iam.roles.where(inlinePolicyDetails.any(hasWildcardAllow))  { name inlinePolicyDetails { name } }

# inline grants on any principal, flattened
aws.iam.roles.flatMap(inlinePolicyDetails) { entityName name statements { effect actions resources } }

# inline policies that allow iam:PassRole on all resources
aws.iam.roles.flatMap(inlinePolicyDetails).where(
  statements.any(effect == "Allow" && actions.any(_ == "iam:PassRole") && hasWildcardResource)
)
```

## Drive-by

Extracts `decodeIamPolicyDocument`, shared with the two role trust-policy call sites that had the same URL-decode-then-unmarshal logic inline. The extracted version tries the raw bytes *before* URL-decoding, which fixes a latent bug: `url.QueryUnescape` turns `+` into a space, so a plain-JSON policy document containing a `+` (e.g. an S3 key in a resource ARN) was previously corrupted.

`hasWildcardAllow` on `aws.iam.policy` now delegates to an extracted `statementsAllowWildcard` shared with the new resource; its type assertion is comma-ok guarded.

## Permissions

Adds `iam:GetRolePolicy`, `iam:GetUserPolicy`, `iam:GetGroupPolicy`. A single document the caller can't read is logged and skipped rather than failing the whole principal; any other error propagates.

## Test

Unit tests cover the pure-Go logic: `decodeIamPolicyDocument` across nil/plain-JSON/URL-encoded/malformed inputs plus the `+` regression, and `statementsAllowWildcard` across wildcard action, global action, wildcard resource, lowercase effect, wildcard-in-Deny, later-statement, and non-statement-element cases.

Not yet live-verified — batched with the other AWS PRs pending a `provider-verification` run.
