### PR TITLE
✨ aws: expose IAM service last-accessed and unused-access findings

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17518,6 +17518,32 @@ aws.ec2 {
   serialConsoleAccessEnabled() map[string]bool
   // AMI block public access state per region: block-new-sharing or unblocked
   imageBlockPublicAccess() map[string]string
+  // Whether public sharing of EBS snapshots is blocked, per region
+  //
+  // One of block-all-sharing, which also blocks snapshots that are already
+  // public, block-new-sharing, which leaves already-public snapshots public,
+  // or unblocked. A region absent from the map is one the caller could not
+  // read the setting for.
+  snapshotBlockPublicAccess() map[string]string
+  // Allowed AMIs setting state, per region
+  //
+  // One of enabled, where only AMIs matching the account's image criteria can
+  // be discovered and launched, audit-mode, where non-matching AMIs stay
+  // usable but are flagged, or disabled. The setting bounds which AMI
+  // publishers an account will trust.
+  allowedImagesState() map[string]string
+  // Account-level instance metadata service defaults, one entry per region
+  //
+  // The defaults new instances launch with when the launch itself specifies
+  // nothing, which is how an account requires IMDSv2 without depending on
+  // every launch template being correct.
+  instanceMetadataDefaults() []aws.ec2.instanceMetadataDefault
+  // KMS keys used for EBS encryption by default, one per region where a key is set
+  //
+  // The key EBS encrypts new volumes with when the request names no key. Each
+  // key carries its own region. A region resolves to the AWS-managed
+  // aws/ebs key unless the account set a customer managed key.
+  ebsDefaultKmsKeys() []aws.kms.key
   // List of volumes across the AWS account
   volumes() []aws.ec2.volume
   // List of snapshots across the account
@@ -18853,6 +18879,49 @@ private aws.inspector.finding.codeVulnerability @defaults("detectorName") {
   sourceLambdaLayerArn string
 }
 
+// Account-level EC2 instance metadata service defaults
+//
+// The instance metadata service settings new instances in one region launch
+// with when the launch request specifies none of its own. Setting httpTokens to
+// required at the account level is how IMDSv2 becomes the floor for every
+// launch, rather than depending on each launch template and each API caller
+// getting it right. The settings are per region, and a region with no account
+// default reports null for each value, which is distinct from a default that
+// permits IMDSv1. When managedByDeclarativePolicy is true the values are pinned
+// by an organization declarative policy and cannot be changed in the account.
+private aws.ec2.instanceMetadataDefault @defaults("region httpTokens httpEndpoint") {
+  // Region the defaults apply to
+  region string
+  // Whether a session token is required to read instance metadata
+  //
+  // A value of required denotes IMDSv2; optional permits the unauthenticated
+  // IMDSv1 path. Null when the account sets no default for the region.
+  httpTokens string
+  // Whether the instance metadata endpoint is enabled by default
+  //
+  // One of enabled or disabled. Null when the account sets no default for the
+  // region.
+  httpEndpoint string
+  // Default hop limit for the instance metadata PUT response
+  //
+  // Values above 1 let a container or a proxied request reach the metadata
+  // service, which widens the blast radius of a server-side request forgery.
+  // Null when the account sets no default for the region.
+  httpPutResponseHopLimit int
+  // Whether instance tags are exposed through instance metadata by default
+  //
+  // One of enabled or disabled. Null when the account sets no default for the
+  // region.
+  instanceMetadataTags string
+  // Whether the httpTokens default is enforced rather than advisory
+  //
+  // One of enforced or unenforced. Null when the account sets no default for
+  // the region.
+  httpTokensEnforced string
+  // Whether an organization declarative policy pins these defaults
+  managedByDeclarativePolicy bool
+}
+
 // Amazon EC2 instance
 private aws.ec2.instance @defaults("instanceId region state instanceType architecture platformDetails") {
   // ARN for the instance
@@ -18877,6 +18946,15 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   httpPutResponseHopLimit int
   // Whether IMDSv2 is required (httpTokens is "required"), enforcing session-token-authenticated metadata access
   imdsv2Required bool
+  // User data supplied at launch, base64-decoded
+  //
+  // The launch script the instance bootstrapped with. It is readable by any
+  // process on the instance through the metadata service, so a credential
+  // written into it is effectively shared with every workload on the host.
+  // Empty when the instance was launched without user data.
+  userData() string
+  // Whether the instance has user data set (a launch script that may embed secrets)
+  userDataPresent() bool
   // Whether the instance is enabled for AWS Nitro Enclaves
   enclaveEnabled bool
   // Patch state information about the instance

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -112,6 +112,25 @@ aws.account @defaults("id aliases.first organization.id") {
   // Available only when the calling identity is the organization's management
   // account or a delegated administrator.
   joinedTimestamp() time
+
+  // Organization policies attached directly to the account, across every policy type
+  //
+  // Only the policies attached to this account, not the ones it inherits from
+  // the organization root or its organizational units. Available only when the
+  // calling identity is the organization's management account or a delegated
+  // administrator. Otherwise empty.
+  policies() []aws.organization.policy
+
+  // Organization policies that resolve for the account, merged across the organization
+  //
+  // The value each control settles on for this account once inherited and
+  // directly attached policies are combined. Covers the management policy
+  // types only, since AWS computes no effective policy for service control or
+  // resource control policies. A type with no policy applying to the account
+  // contributes no entry. Available only when the calling identity is the
+  // organization's management account or a delegated administrator. Otherwise
+  // empty.
+  effectivePolicies() []aws.organization.effectivePolicy
 }
 
 // AWS Account alternate contact
@@ -239,6 +258,17 @@ aws.organization @defaults("id masterAccountEmail") {
   organizationalUnits() []aws.organization.organizationalUnit
   // Service control policies defined in the organization, if available to the caller
   serviceControlPolicies() []aws.organization.serviceControlPolicy
+  // Policies defined in the organization, across every policy type
+  //
+  // Covers all policy types AWS Organizations supports, not only service
+  // control policies: resource control policies, which bound what external
+  // principals may do to resources in the organization, declarative policies,
+  // which pin account settings such as EC2 instance metadata defaults, and the
+  // tag, backup, and AI-services opt-out policies. Select a type with a filter,
+  // for example
+  // `policies.where(type == "RESOURCE_CONTROL_POLICY")`. A policy type that is
+  // not enabled for the organization contributes nothing.
+  policies() []aws.organization.policy
 }
 
 // AWS Organizations service control policy
@@ -264,6 +294,72 @@ private aws.organization.serviceControlPolicy @defaults("name id") {
   content() string
   // Parsed statements from the policy content
   statements() []aws.iam.policyStatement
+}
+
+// AWS Organizations policy
+//
+// Policy of any type defined in an organization, and the guardrail it applies
+// to the accounts, organizational units, and roots it is attached to. The type
+// field says which control the policy carries: SERVICE_CONTROL_POLICY bounds
+// what principals in the organization may do, RESOURCE_CONTROL_POLICY bounds
+// what may be done to the organization's resources by principals outside it,
+// DECLARATIVE_POLICY_EC2 pins account settings such as instance metadata
+// defaults and EBS encryption, and the remaining types cover tagging, backup,
+// AI-services opt-out, and per-service configuration. Other values include
+// TAG_POLICY, BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY, CHATBOT_POLICY,
+// SECURITYHUB_POLICY, INSPECTOR_POLICY, UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY,
+// S3_POLICY, and NETWORK_SECURITY_DIRECTOR_POLICY.
+private aws.organization.policy @defaults("name type id") {
+  // Unique identifier of the policy
+  id string
+  // ARN of the policy
+  arn string
+  // Friendly name of the policy
+  name string
+  // Description of the policy
+  description string
+  // Type of control the policy carries
+  //
+  // One of SERVICE_CONTROL_POLICY, RESOURCE_CONTROL_POLICY, TAG_POLICY,
+  // BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY, CHATBOT_POLICY,
+  // DECLARATIVE_POLICY_EC2, SECURITYHUB_POLICY, INSPECTOR_POLICY,
+  // UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY, S3_POLICY, or
+  // NETWORK_SECURITY_DIRECTOR_POLICY.
+  type string
+  // Whether the policy is managed by AWS rather than the customer
+  awsManaged bool
+  // Raw policy content document (JSON)
+  content() string
+  // Parsed statements from the policy content
+  //
+  // Resolved for the policy types written in the IAM policy grammar, which are
+  // the service control and resource control policies. Empty for the tag,
+  // backup, declarative, AI-services opt-out, and per-service policy types,
+  // which use their own document formats: read content for those.
+  statements() []aws.iam.policyStatement
+}
+
+// AWS Organizations effective policy
+//
+// Merged policy that actually applies to one account, combining the policies
+// it inherits from the organization root and its organizational units with any
+// policy attached directly to it. This is the value to audit when the question
+// is what a control resolves to for an account rather than which documents
+// were attached where. AWS computes an effective policy for the management
+// policy types only, so there is no entry for service control or resource
+// control policies, whose combined effect AWS does not expose.
+private aws.organization.effectivePolicy @defaults("type lastUpdatedAt") {
+  // Type of the effective policy
+  //
+  // One of TAG_POLICY, BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY,
+  // CHATBOT_POLICY, DECLARATIVE_POLICY_EC2, SECURITYHUB_POLICY,
+  // INSPECTOR_POLICY, UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY, S3_POLICY, or
+  // NETWORK_SECURITY_DIRECTOR_POLICY.
+  type string
+  // Merged policy content document (JSON)
+  content string
+  // When the effective policy was last updated
+  lastUpdatedAt time
 }
 
 // AWS Organization delegated administrator
@@ -310,6 +406,11 @@ private aws.organization.organizationalUnit @defaults("id name path") {
   path string
   // Service control policies attached directly to this organizational unit
   serviceControlPolicies() []aws.organization.serviceControlPolicy
+  // Policies attached directly to this organizational unit, across every policy type
+  //
+  // Only the policies attached at this level, not the ones the unit inherits
+  // from the organization root or a parent unit.
+  policies() []aws.organization.policy
 }
 
 // Amazon Virtual Private Cloud (VPC)

--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2436,6 +2436,14 @@ private aws.iam.user @defaults("arn name createdAt") {
   mfaDevices() []dict
   // Managed policy that sets the permissions boundary for the user, if one is set
   permissionsBoundary() aws.iam.policy
+  // Services the user is permitted to use, with when each was last accessed
+  //
+  // Sourced from an IAM service-last-accessed report, which IAM generates as
+  // an asynchronous job for one principal at a time. A query that reads this
+  // field for every user in the account waits on one report each, so scope the
+  // query to the users under review. Records with a null lastAuthenticatedAt
+  // are the services the user can reach but has never used.
+  lastAccessedServices() []aws.iam.serviceLastAccessed
 }
 
 // IAM user access key
@@ -2570,6 +2578,14 @@ private aws.iam.policy @defaults("arn name") {
   attachedRoles() []aws.iam.role
   // List of groups attached to the policy
   attachedGroups() []aws.iam.group
+  // Services the policy grants access to, with when each was last accessed
+  //
+  // Sourced from an IAM service-last-accessed report, which IAM generates as
+  // an asynchronous job for one policy at a time. Records with a null
+  // lastAuthenticatedAt are the services the policy grants but no attached
+  // principal has used, and totalAuthenticatedEntities counts the principals
+  // that did use each service.
+  lastAccessedServices() []aws.iam.serviceLastAccessed
 }
 
 // AWS IAM policy version
@@ -2621,6 +2637,41 @@ private aws.iam.inlinePolicy @defaults("name entityType entityName") {
   // True when an Allow statement includes a wildcard action — the global `*`
   // or a service-wide wildcard such as `s3:*` — or the all-resources `*`.
   hasWildcardAllow() bool
+}
+
+// AWS IAM service last-accessed record
+//
+// When a principal last authenticated to one AWS service, taken from the IAM
+// service-last-accessed report. A record whose lastAuthenticatedAt is null
+// means the principal holds permissions for that service but never used them
+// in the tracking period, which is the signal for permissions that can be
+// removed. The record also reports which entity made the last request and from
+// which region, so a grant that looks active can be traced to the one
+// principal and region that keeps it alive.
+private aws.iam.serviceLastAccessed @defaults("serviceNamespace lastAuthenticatedAt") {
+  // Name of the service
+  serviceName string
+  // Namespace of the service, such as s3, ec2, or iam
+  serviceNamespace string
+  // When the service was last accessed
+  //
+  // Null when the service was never accessed in the tracking period, which
+  // IAM limits to the trailing 400 days. A null value on a principal that is
+  // permitted to call the service means the permission is unused.
+  lastAuthenticatedAt time
+  // ARN of the user or role that last accessed the service
+  //
+  // Reported for a policy, where many principals share the grant. Empty when
+  // the record belongs to a single principal, which is its own last-accessed
+  // entity.
+  lastAuthenticatedEntity string
+  // Region from which the service was last accessed
+  lastAuthenticatedRegion string
+  // Number of entities that accessed the service
+  //
+  // Reported for a policy, counting the attached principals that used the
+  // service. Zero for records that belong to a single principal.
+  totalAuthenticatedEntities int
 }
 
 // AWS IAM role
@@ -2686,6 +2737,14 @@ private aws.iam.role @defaults("arn name") {
   inlinePolicyDetails() []aws.iam.inlinePolicy
   // IAM Access Analyzer findings reporting external or public access to this resource
   externalAccessFindings() []aws.iam.accessAnalyzer.finding
+  // Services the role is permitted to use, with when each was last accessed
+  //
+  // Sourced from an IAM service-last-accessed report, which IAM generates as
+  // an asynchronous job for one principal at a time. A query that reads this
+  // field for every role in the account waits on one report each, so scope the
+  // query to the roles under review. Records with a null lastAuthenticatedAt
+  // are the services the role can reach but has never used.
+  lastAccessedServices() []aws.iam.serviceLastAccessed
 }
 
 // AWS IAM group
@@ -2717,6 +2776,13 @@ private aws.iam.group @defaults("arn name") {
   attachedPolicies() []aws.iam.policy
   // Path to the group
   path string
+  // Services the group's members are permitted to use, with when each was last accessed
+  //
+  // Sourced from an IAM service-last-accessed report, which IAM generates as
+  // an asynchronous job for one entity at a time. Records with a null
+  // lastAuthenticatedAt are the services the group grants but no member has
+  // used.
+  lastAccessedServices() []aws.iam.serviceLastAccessed
 }
 
 // AWS IAM virtual MFA device
@@ -2825,6 +2891,29 @@ private aws.iam.accessAnalyzer.finding @defaults("resourceType region type statu
   region string
   // Analyzer ARN
   analyzerArn string
+  // When the unused role, credential, or permission was last used
+  //
+  // Reported for the unused-access finding types (UnusedIAMRole,
+  // UnusedIAMUserAccessKey, UnusedIAMUserPassword, and UnusedPermission).
+  // Null when the subject of the finding was never used at all, and null for
+  // external-access and internal-access findings, which do not carry a
+  // last-used time.
+  lastAccessedAt() time
+  // Service namespace whose permissions are unused, such as s3 or ec2
+  //
+  // Reported for UnusedPermission findings. Empty for every other finding
+  // type.
+  unusedServiceNamespace() string
+  // Actions within the service that the principal never called
+  //
+  // Reported for UnusedPermission findings, listing the action names only.
+  // Empty for every other finding type.
+  unusedActions() []string
+  // Access key that has gone unused
+  //
+  // Reported for UnusedIAMUserAccessKey findings. Empty for every other
+  // finding type.
+  unusedAccessKeyId() string
 }
 
 // Amazon Personalize

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -104,6 +104,7 @@ const (
 	ResourceAwsIamPolicy                                                        string = "aws.iam.policy"
 	ResourceAwsIamPolicyversion                                                 string = "aws.iam.policyversion"
 	ResourceAwsIamInlinePolicy                                                  string = "aws.iam.inlinePolicy"
+	ResourceAwsIamServiceLastAccessed                                           string = "aws.iam.serviceLastAccessed"
 	ResourceAwsIamRole                                                          string = "aws.iam.role"
 	ResourceAwsIamGroup                                                         string = "aws.iam.group"
 	ResourceAwsIamVirtualmfadevice                                              string = "aws.iam.virtualmfadevice"
@@ -1318,6 +1319,10 @@ func init() {
 		"aws.iam.inlinePolicy": {
 			// to override args, implement: initAwsIamInlinePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsIamInlinePolicy,
+		},
+		"aws.iam.serviceLastAccessed": {
+			// to override args, implement: initAwsIamServiceLastAccessed(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsIamServiceLastAccessed,
 		},
 		"aws.iam.role": {
 			Init:   initAwsIamRole,
@@ -7164,6 +7169,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.user.permissionsBoundary": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUser).GetPermissionsBoundary()).ToDataRes(types.Resource("aws.iam.policy"))
 	},
+	"aws.iam.user.lastAccessedServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamUser).GetLastAccessedServices()).ToDataRes(types.Array(types.Resource("aws.iam.serviceLastAccessed")))
+	},
 	"aws.iam.user.accessKey.accessKeyId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamUserAccessKey).GetAccessKeyId()).ToDataRes(types.String)
 	},
@@ -7293,6 +7301,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.policy.attachedGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicy).GetAttachedGroups()).ToDataRes(types.Array(types.Resource("aws.iam.group")))
 	},
+	"aws.iam.policy.lastAccessedServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamPolicy).GetLastAccessedServices()).ToDataRes(types.Array(types.Resource("aws.iam.serviceLastAccessed")))
+	},
 	"aws.iam.policyversion.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamPolicyversion).GetArn()).ToDataRes(types.String)
 	},
@@ -7328,6 +7339,24 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.inlinePolicy.hasWildcardAllow": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamInlinePolicy).GetHasWildcardAllow()).ToDataRes(types.Bool)
+	},
+	"aws.iam.serviceLastAccessed.serviceName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetServiceName()).ToDataRes(types.String)
+	},
+	"aws.iam.serviceLastAccessed.serviceNamespace": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetServiceNamespace()).ToDataRes(types.String)
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetLastAuthenticatedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedEntity": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetLastAuthenticatedEntity()).ToDataRes(types.String)
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedRegion": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetLastAuthenticatedRegion()).ToDataRes(types.String)
+	},
+	"aws.iam.serviceLastAccessed.totalAuthenticatedEntities": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamServiceLastAccessed).GetTotalAuthenticatedEntities()).ToDataRes(types.Int)
 	},
 	"aws.iam.role.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetArn()).ToDataRes(types.String)
@@ -7395,6 +7424,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.iam.role.externalAccessFindings": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamRole).GetExternalAccessFindings()).ToDataRes(types.Array(types.Resource("aws.iam.accessAnalyzer.finding")))
 	},
+	"aws.iam.role.lastAccessedServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamRole).GetLastAccessedServices()).ToDataRes(types.Array(types.Resource("aws.iam.serviceLastAccessed")))
+	},
 	"aws.iam.group.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetArn()).ToDataRes(types.String)
 	},
@@ -7421,6 +7453,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.group.path": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamGroup).GetPath()).ToDataRes(types.String)
+	},
+	"aws.iam.group.lastAccessedServices": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamGroup).GetLastAccessedServices()).ToDataRes(types.Array(types.Resource("aws.iam.serviceLastAccessed")))
 	},
 	"aws.iam.virtualmfadevice.serialNumber": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamVirtualmfadevice).GetSerialNumber()).ToDataRes(types.String)
@@ -7538,6 +7573,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.iam.accessAnalyzer.finding.analyzerArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsIamAccessAnalyzerFinding).GetAnalyzerArn()).ToDataRes(types.String)
+	},
+	"aws.iam.accessAnalyzer.finding.lastAccessedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzerFinding).GetLastAccessedAt()).ToDataRes(types.Time)
+	},
+	"aws.iam.accessAnalyzer.finding.unusedServiceNamespace": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzerFinding).GetUnusedServiceNamespace()).ToDataRes(types.String)
+	},
+	"aws.iam.accessAnalyzer.finding.unusedActions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzerFinding).GetUnusedActions()).ToDataRes(types.Array(types.String))
+	},
+	"aws.iam.accessAnalyzer.finding.unusedAccessKeyId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsIamAccessAnalyzerFinding).GetUnusedAccessKeyId()).ToDataRes(types.String)
 	},
 	"aws.personalize.datasetGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsPersonalize).GetDatasetGroups()).ToDataRes(types.Array(types.Resource("aws.personalize.datasetGroup")))
@@ -39128,6 +39175,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamUser).PermissionsBoundary, ok = plugin.RawToTValue[*mqlAwsIamPolicy](v.Value, v.Error)
 		return
 	},
+	"aws.iam.user.lastAccessedServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamUser).LastAccessedServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.user.accessKey.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamUserAccessKey).__id, ok = v.Value.(string)
 		return
@@ -39320,6 +39371,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamPolicy).AttachedGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.policy.lastAccessedServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamPolicy).LastAccessedServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.policyversion.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamPolicyversion).__id, ok = v.Value.(string)
 		return
@@ -39374,6 +39429,34 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.inlinePolicy.hasWildcardAllow": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamInlinePolicy).HasWildcardAllow, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.iam.serviceLastAccessed.serviceName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).ServiceName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.serviceNamespace": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).ServiceNamespace, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).LastAuthenticatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedEntity": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).LastAuthenticatedEntity, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.lastAuthenticatedRegion": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).LastAuthenticatedRegion, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.serviceLastAccessed.totalAuthenticatedEntities": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamServiceLastAccessed).TotalAuthenticatedEntities, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"aws.iam.role.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39468,6 +39551,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsIamRole).ExternalAccessFindings, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.iam.role.lastAccessedServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamRole).LastAccessedServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.iam.group.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamGroup).__id, ok = v.Value.(string)
 		return
@@ -39506,6 +39593,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.group.path": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamGroup).Path, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.group.lastAccessedServices": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamGroup).LastAccessedServices, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.iam.virtualmfadevice.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -39686,6 +39777,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.iam.accessAnalyzer.finding.analyzerArn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsIamAccessAnalyzerFinding).AnalyzerArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessAnalyzer.finding.lastAccessedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzerFinding).LastAccessedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessAnalyzer.finding.unusedServiceNamespace": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzerFinding).UnusedServiceNamespace, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessAnalyzer.finding.unusedActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzerFinding).UnusedActions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.iam.accessAnalyzer.finding.unusedAccessKeyId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsIamAccessAnalyzerFinding).UnusedAccessKeyId, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"aws.personalize.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -89730,23 +89837,24 @@ type mqlAwsIamUser struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsIamUserInternal
-	Arn                 plugin.TValue[string]
-	Id                  plugin.TValue[string]
-	Name                plugin.TValue[string]
-	CreatedAt           plugin.TValue[*time.Time]
-	PasswordLastUsed    plugin.TValue[*time.Time]
-	Tags                plugin.TValue[map[string]any]
-	ManagedBy           plugin.TValue[string]
-	Policies            plugin.TValue[[]any]
-	InlinePolicyDetails plugin.TValue[[]any]
-	AttachedPolicies    plugin.TValue[[]any]
-	Groups              plugin.TValue[[]any]
-	AccessKeys          plugin.TValue[[]any]
-	AccessKeyDetails    plugin.TValue[[]any]
-	LoginProfile        plugin.TValue[*mqlAwsIamLoginProfile]
-	Path                plugin.TValue[string]
-	MfaDevices          plugin.TValue[[]any]
-	PermissionsBoundary plugin.TValue[*mqlAwsIamPolicy]
+	Arn                  plugin.TValue[string]
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	CreatedAt            plugin.TValue[*time.Time]
+	PasswordLastUsed     plugin.TValue[*time.Time]
+	Tags                 plugin.TValue[map[string]any]
+	ManagedBy            plugin.TValue[string]
+	Policies             plugin.TValue[[]any]
+	InlinePolicyDetails  plugin.TValue[[]any]
+	AttachedPolicies     plugin.TValue[[]any]
+	Groups               plugin.TValue[[]any]
+	AccessKeys           plugin.TValue[[]any]
+	AccessKeyDetails     plugin.TValue[[]any]
+	LoginProfile         plugin.TValue[*mqlAwsIamLoginProfile]
+	Path                 plugin.TValue[string]
+	MfaDevices           plugin.TValue[[]any]
+	PermissionsBoundary  plugin.TValue[*mqlAwsIamPolicy]
+	LastAccessedServices plugin.TValue[[]any]
 }
 
 // createAwsIamUser creates a new instance of this resource
@@ -89923,6 +90031,22 @@ func (c *mqlAwsIamUser) GetPermissionsBoundary() *plugin.TValue[*mqlAwsIamPolicy
 		}
 
 		return c.permissionsBoundary()
+	})
+}
+
+func (c *mqlAwsIamUser) GetLastAccessedServices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LastAccessedServices, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.user", c.__id, "lastAccessedServices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.lastAccessedServices()
 	})
 }
 
@@ -90252,22 +90376,23 @@ type mqlAwsIamPolicy struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsIamPolicyInternal
-	Arn              plugin.TValue[string]
-	PolicyId         plugin.TValue[string]
-	Name             plugin.TValue[string]
-	Description      plugin.TValue[string]
-	IsAttachable     plugin.TValue[bool]
-	AttachmentCount  plugin.TValue[int64]
-	CreatedAt        plugin.TValue[*time.Time]
-	UpdatedAt        plugin.TValue[*time.Time]
-	Scope            plugin.TValue[string]
-	Versions         plugin.TValue[[]any]
-	DefaultVersion   plugin.TValue[*mqlAwsIamPolicyversion]
-	Statements       plugin.TValue[[]any]
-	HasWildcardAllow plugin.TValue[bool]
-	AttachedUsers    plugin.TValue[[]any]
-	AttachedRoles    plugin.TValue[[]any]
-	AttachedGroups   plugin.TValue[[]any]
+	Arn                  plugin.TValue[string]
+	PolicyId             plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	Description          plugin.TValue[string]
+	IsAttachable         plugin.TValue[bool]
+	AttachmentCount      plugin.TValue[int64]
+	CreatedAt            plugin.TValue[*time.Time]
+	UpdatedAt            plugin.TValue[*time.Time]
+	Scope                plugin.TValue[string]
+	Versions             plugin.TValue[[]any]
+	DefaultVersion       plugin.TValue[*mqlAwsIamPolicyversion]
+	Statements           plugin.TValue[[]any]
+	HasWildcardAllow     plugin.TValue[bool]
+	AttachedUsers        plugin.TValue[[]any]
+	AttachedRoles        plugin.TValue[[]any]
+	AttachedGroups       plugin.TValue[[]any]
+	LastAccessedServices plugin.TValue[[]any]
 }
 
 // createAwsIamPolicy creates a new instance of this resource
@@ -90461,6 +90586,22 @@ func (c *mqlAwsIamPolicy) GetAttachedGroups() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsIamPolicy) GetLastAccessedServices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LastAccessedServices, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.policy", c.__id, "lastAccessedServices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.lastAccessedServices()
+	})
+}
+
 // mqlAwsIamPolicyversion for the aws.iam.policyversion resource
 type mqlAwsIamPolicyversion struct {
 	MqlRuntime *plugin.Runtime
@@ -90632,6 +90773,75 @@ func (c *mqlAwsIamInlinePolicy) GetHasWildcardAllow() *plugin.TValue[bool] {
 	})
 }
 
+// mqlAwsIamServiceLastAccessed for the aws.iam.serviceLastAccessed resource
+type mqlAwsIamServiceLastAccessed struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsIamServiceLastAccessedInternal it will be used here
+	ServiceName                plugin.TValue[string]
+	ServiceNamespace           plugin.TValue[string]
+	LastAuthenticatedAt        plugin.TValue[*time.Time]
+	LastAuthenticatedEntity    plugin.TValue[string]
+	LastAuthenticatedRegion    plugin.TValue[string]
+	TotalAuthenticatedEntities plugin.TValue[int64]
+}
+
+// createAwsIamServiceLastAccessed creates a new instance of this resource
+func createAwsIamServiceLastAccessed(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsIamServiceLastAccessed{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.iam.serviceLastAccessed", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsIamServiceLastAccessed) MqlName() string {
+	return "aws.iam.serviceLastAccessed"
+}
+
+func (c *mqlAwsIamServiceLastAccessed) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetServiceName() *plugin.TValue[string] {
+	return &c.ServiceName
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetServiceNamespace() *plugin.TValue[string] {
+	return &c.ServiceNamespace
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetLastAuthenticatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastAuthenticatedAt
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetLastAuthenticatedEntity() *plugin.TValue[string] {
+	return &c.LastAuthenticatedEntity
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetLastAuthenticatedRegion() *plugin.TValue[string] {
+	return &c.LastAuthenticatedRegion
+}
+
+func (c *mqlAwsIamServiceLastAccessed) GetTotalAuthenticatedEntities() *plugin.TValue[int64] {
+	return &c.TotalAuthenticatedEntities
+}
+
 // mqlAwsIamRole for the aws.iam.role resource
 type mqlAwsIamRole struct {
 	MqlRuntime *plugin.Runtime
@@ -90659,6 +90869,7 @@ type mqlAwsIamRole struct {
 	InlinePolicies              plugin.TValue[[]any]
 	InlinePolicyDetails         plugin.TValue[[]any]
 	ExternalAccessFindings      plugin.TValue[[]any]
+	LastAccessedServices        plugin.TValue[[]any]
 }
 
 // createAwsIamRole creates a new instance of this resource
@@ -90870,20 +91081,37 @@ func (c *mqlAwsIamRole) GetExternalAccessFindings() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsIamRole) GetLastAccessedServices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LastAccessedServices, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.role", c.__id, "lastAccessedServices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.lastAccessedServices()
+	})
+}
+
 // mqlAwsIamGroup for the aws.iam.group resource
 type mqlAwsIamGroup struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAwsIamGroupInternal
-	Arn                 plugin.TValue[string]
-	Id                  plugin.TValue[string]
-	Name                plugin.TValue[string]
-	CreatedAt           plugin.TValue[*time.Time]
-	Usernames           plugin.TValue[[]any]
-	InlinePolicies      plugin.TValue[[]any]
-	InlinePolicyDetails plugin.TValue[[]any]
-	AttachedPolicies    plugin.TValue[[]any]
-	Path                plugin.TValue[string]
+	Arn                  plugin.TValue[string]
+	Id                   plugin.TValue[string]
+	Name                 plugin.TValue[string]
+	CreatedAt            plugin.TValue[*time.Time]
+	Usernames            plugin.TValue[[]any]
+	InlinePolicies       plugin.TValue[[]any]
+	InlinePolicyDetails  plugin.TValue[[]any]
+	AttachedPolicies     plugin.TValue[[]any]
+	Path                 plugin.TValue[string]
+	LastAccessedServices plugin.TValue[[]any]
 }
 
 // createAwsIamGroup creates a new instance of this resource
@@ -90985,6 +91213,22 @@ func (c *mqlAwsIamGroup) GetAttachedPolicies() *plugin.TValue[[]any] {
 
 func (c *mqlAwsIamGroup) GetPath() *plugin.TValue[string] {
 	return &c.Path
+}
+
+func (c *mqlAwsIamGroup) GetLastAccessedServices() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.LastAccessedServices, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.iam.group", c.__id, "lastAccessedServices")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.lastAccessedServices()
+	})
 }
 
 // mqlAwsIamVirtualmfadevice for the aws.iam.virtualmfadevice resource
@@ -91409,19 +91653,23 @@ func (c *mqlAwsIamAccessAnalyzerAnalyzer) GetCreatedAt() *plugin.TValue[*time.Ti
 type mqlAwsIamAccessAnalyzerFinding struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsIamAccessAnalyzerFindingInternal it will be used here
-	Id                   plugin.TValue[string]
-	Error                plugin.TValue[string]
-	ResourceArn          plugin.TValue[string]
-	ResourceOwnerAccount plugin.TValue[string]
-	ResourceType         plugin.TValue[string]
-	Type                 plugin.TValue[string]
-	Status               plugin.TValue[string]
-	AnalyzedAt           plugin.TValue[*time.Time]
-	CreatedAt            plugin.TValue[*time.Time]
-	UpdatedAt            plugin.TValue[*time.Time]
-	Region               plugin.TValue[string]
-	AnalyzerArn          plugin.TValue[string]
+	mqlAwsIamAccessAnalyzerFindingInternal
+	Id                     plugin.TValue[string]
+	Error                  plugin.TValue[string]
+	ResourceArn            plugin.TValue[string]
+	ResourceOwnerAccount   plugin.TValue[string]
+	ResourceType           plugin.TValue[string]
+	Type                   plugin.TValue[string]
+	Status                 plugin.TValue[string]
+	AnalyzedAt             plugin.TValue[*time.Time]
+	CreatedAt              plugin.TValue[*time.Time]
+	UpdatedAt              plugin.TValue[*time.Time]
+	Region                 plugin.TValue[string]
+	AnalyzerArn            plugin.TValue[string]
+	LastAccessedAt         plugin.TValue[*time.Time]
+	UnusedServiceNamespace plugin.TValue[string]
+	UnusedActions          plugin.TValue[[]any]
+	UnusedAccessKeyId      plugin.TValue[string]
 }
 
 // createAwsIamAccessAnalyzerFinding creates a new instance of this resource
@@ -91502,6 +91750,30 @@ func (c *mqlAwsIamAccessAnalyzerFinding) GetRegion() *plugin.TValue[string] {
 
 func (c *mqlAwsIamAccessAnalyzerFinding) GetAnalyzerArn() *plugin.TValue[string] {
 	return &c.AnalyzerArn
+}
+
+func (c *mqlAwsIamAccessAnalyzerFinding) GetLastAccessedAt() *plugin.TValue[*time.Time] {
+	return plugin.GetOrCompute[*time.Time](&c.LastAccessedAt, func() (*time.Time, error) {
+		return c.lastAccessedAt()
+	})
+}
+
+func (c *mqlAwsIamAccessAnalyzerFinding) GetUnusedServiceNamespace() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UnusedServiceNamespace, func() (string, error) {
+		return c.unusedServiceNamespace()
+	})
+}
+
+func (c *mqlAwsIamAccessAnalyzerFinding) GetUnusedActions() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.UnusedActions, func() ([]any, error) {
+		return c.unusedActions()
+	})
+}
+
+func (c *mqlAwsIamAccessAnalyzerFinding) GetUnusedAccessKeyId() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UnusedAccessKeyId, func() (string, error) {
+		return c.unusedAccessKeyId()
+	})
 }
 
 // mqlAwsPersonalize for the aws.personalize resource

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -23,6 +23,8 @@ const (
 	ResourceAwsBillingBudget                                                    string = "aws.billing.budget"
 	ResourceAwsOrganization                                                     string = "aws.organization"
 	ResourceAwsOrganizationServiceControlPolicy                                 string = "aws.organization.serviceControlPolicy"
+	ResourceAwsOrganizationPolicy                                               string = "aws.organization.policy"
+	ResourceAwsOrganizationEffectivePolicy                                      string = "aws.organization.effectivePolicy"
 	ResourceAwsOrganizationDelegatedAdministrator                               string = "aws.organization.delegatedAdministrator"
 	ResourceAwsOrganizationDelegatedService                                     string = "aws.organization.delegatedService"
 	ResourceAwsOrganizationOrganizationalUnit                                   string = "aws.organization.organizationalUnit"
@@ -995,6 +997,14 @@ func init() {
 		"aws.organization.serviceControlPolicy": {
 			// to override args, implement: initAwsOrganizationServiceControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsOrganizationServiceControlPolicy,
+		},
+		"aws.organization.policy": {
+			// to override args, implement: initAwsOrganizationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationPolicy,
+		},
+		"aws.organization.effectivePolicy": {
+			// to override args, implement: initAwsOrganizationEffectivePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationEffectivePolicy,
 		},
 		"aws.organization.delegatedAdministrator": {
 			// to override args, implement: initAwsOrganizationDelegatedAdministrator(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4877,6 +4887,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.account.joinedTimestamp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAccount).GetJoinedTimestamp()).ToDataRes(types.Time)
 	},
+	"aws.account.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAccount).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
+	},
+	"aws.account.effectivePolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAccount).GetEffectivePolicies()).ToDataRes(types.Array(types.Resource("aws.organization.effectivePolicy")))
+	},
 	"aws.account.alternateContact.accountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAccountAlternateContact).GetAccountId()).ToDataRes(types.String)
 	},
@@ -4991,6 +5007,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.organization.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
 	},
+	"aws.organization.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
+	},
 	"aws.organization.serviceControlPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -5011,6 +5030,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.organization.policy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetId()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetArn()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetName()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetType()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.awsManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetAwsManaged()).ToDataRes(types.Bool)
+	},
+	"aws.organization.policy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.organization.effectivePolicy.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetType()).ToDataRes(types.String)
+	},
+	"aws.organization.effectivePolicy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.effectivePolicy.lastUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetLastUpdatedAt()).ToDataRes(types.Time)
 	},
 	"aws.organization.delegatedAdministrator.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationDelegatedAdministrator).GetArn()).ToDataRes(types.String)
@@ -5062,6 +5114,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
+	},
+	"aws.organization.organizationalUnit.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
 	},
 	"aws.vpc.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetArn()).ToDataRes(types.String)
@@ -35803,6 +35858,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsAccount).JoinedTimestamp, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.account.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAccount).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.account.effectivePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAccount).EffectivePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.account.alternateContact.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAccountAlternateContact).__id, ok = v.Value.(string)
 		return
@@ -35971,6 +36034,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsOrganization).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.organization.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.organization.serviceControlPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationServiceControlPolicy).__id, ok = v.Value.(string)
 		return
@@ -36001,6 +36068,58 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationServiceControlPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.policy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.awsManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).AwsManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.effectivePolicy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.lastUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).LastUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.organization.delegatedAdministrator.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36081,6 +36200,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationOrganizationalUnit).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.organizationalUnit.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationOrganizationalUnit).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80799,6 +80922,8 @@ type mqlAwsAccount struct {
 	State              plugin.TValue[string]
 	JoinedMethod       plugin.TValue[string]
 	JoinedTimestamp    plugin.TValue[*time.Time]
+	Policies           plugin.TValue[[]any]
+	EffectivePolicies  plugin.TValue[[]any]
 }
 
 // createAwsAccount creates a new instance of this resource
@@ -80979,6 +81104,38 @@ func (c *mqlAwsAccount) GetJoinedMethod() *plugin.TValue[string] {
 func (c *mqlAwsAccount) GetJoinedTimestamp() *plugin.TValue[*time.Time] {
 	return plugin.GetOrCompute[*time.Time](&c.JoinedTimestamp, func() (*time.Time, error) {
 		return c.joinedTimestamp()
+	})
+}
+
+func (c *mqlAwsAccount) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.account", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
+	})
+}
+
+func (c *mqlAwsAccount) GetEffectivePolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectivePolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.account", c.__id, "effectivePolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectivePolicies()
 	})
 }
 
@@ -81297,6 +81454,7 @@ type mqlAwsOrganization struct {
 	DelegatedAdministrators plugin.TValue[[]any]
 	OrganizationalUnits     plugin.TValue[[]any]
 	ServiceControlPolicies  plugin.TValue[[]any]
+	Policies                plugin.TValue[[]any]
 }
 
 // createAwsOrganization creates a new instance of this resource
@@ -81419,6 +81577,22 @@ func (c *mqlAwsOrganization) GetServiceControlPolicies() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsOrganization) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
+	})
+}
+
 // mqlAwsOrganizationServiceControlPolicy for the aws.organization.serviceControlPolicy resource
 type mqlAwsOrganizationServiceControlPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -81505,6 +81679,153 @@ func (c *mqlAwsOrganizationServiceControlPolicy) GetStatements() *plugin.TValue[
 
 		return c.statements()
 	})
+}
+
+// mqlAwsOrganizationPolicy for the aws.organization.policy resource
+type mqlAwsOrganizationPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationPolicyInternal it will be used here
+	Id          plugin.TValue[string]
+	Arn         plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Description plugin.TValue[string]
+	Type        plugin.TValue[string]
+	AwsManaged  plugin.TValue[bool]
+	Content     plugin.TValue[string]
+	Statements  plugin.TValue[[]any]
+}
+
+// createAwsOrganizationPolicy creates a new instance of this resource
+func createAwsOrganizationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.policy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationPolicy) MqlName() string {
+	return "aws.organization.policy"
+}
+
+func (c *mqlAwsOrganizationPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsOrganizationPolicy) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsOrganizationPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsOrganizationPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsOrganizationPolicy) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsOrganizationPolicy) GetAwsManaged() *plugin.TValue[bool] {
+	return &c.AwsManaged
+}
+
+func (c *mqlAwsOrganizationPolicy) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		return c.content()
+	})
+}
+
+func (c *mqlAwsOrganizationPolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.policy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
+	})
+}
+
+// mqlAwsOrganizationEffectivePolicy for the aws.organization.effectivePolicy resource
+type mqlAwsOrganizationEffectivePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationEffectivePolicyInternal it will be used here
+	Type          plugin.TValue[string]
+	Content       plugin.TValue[string]
+	LastUpdatedAt plugin.TValue[*time.Time]
+}
+
+// createAwsOrganizationEffectivePolicy creates a new instance of this resource
+func createAwsOrganizationEffectivePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationEffectivePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.effectivePolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) MqlName() string {
+	return "aws.organization.effectivePolicy"
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetContent() *plugin.TValue[string] {
+	return &c.Content
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetLastUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastUpdatedAt
 }
 
 // mqlAwsOrganizationDelegatedAdministrator for the aws.organization.delegatedAdministrator resource
@@ -81689,6 +82010,7 @@ type mqlAwsOrganizationOrganizationalUnit struct {
 	Name                   plugin.TValue[string]
 	Path                   plugin.TValue[string]
 	ServiceControlPolicies plugin.TValue[[]any]
+	Policies               plugin.TValue[[]any]
 }
 
 // createAwsOrganizationOrganizationalUnit creates a new instance of this resource
@@ -81757,6 +82079,22 @@ func (c *mqlAwsOrganizationOrganizationalUnit) GetServiceControlPolicies() *plug
 		}
 
 		return c.serviceControlPolicies()
+	})
+}
+
+func (c *mqlAwsOrganizationOrganizationalUnit) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.organizationalUnit", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -622,6 +622,7 @@ const (
 	ResourceAwsInspectorFindingVulnerablePackage                                string = "aws.inspector.finding.vulnerablePackage"
 	ResourceAwsInspectorFindingNetworkReachability                              string = "aws.inspector.finding.networkReachability"
 	ResourceAwsInspectorFindingCodeVulnerability                                string = "aws.inspector.finding.codeVulnerability"
+	ResourceAwsEc2InstanceMetadataDefault                                       string = "aws.ec2.instanceMetadataDefault"
 	ResourceAwsEc2Instance                                                      string = "aws.ec2.instance"
 	ResourceAwsEc2Networkinterface                                              string = "aws.ec2.networkinterface"
 	ResourceAwsEc2Keypair                                                       string = "aws.ec2.keypair"
@@ -3393,6 +3394,10 @@ func init() {
 		"aws.inspector.finding.codeVulnerability": {
 			// to override args, implement: initAwsInspectorFindingCodeVulnerability(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsInspectorFindingCodeVulnerability,
+		},
+		"aws.ec2.instanceMetadataDefault": {
+			// to override args, implement: initAwsEc2InstanceMetadataDefault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsEc2InstanceMetadataDefault,
 		},
 		"aws.ec2.instance": {
 			Init:   initAwsEc2Instance,
@@ -22602,6 +22607,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.imageBlockPublicAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetImageBlockPublicAccess()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.ec2.snapshotBlockPublicAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetSnapshotBlockPublicAccess()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ec2.allowedImagesState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetAllowedImagesState()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ec2.instanceMetadataDefaults": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetInstanceMetadataDefaults()).ToDataRes(types.Array(types.Resource("aws.ec2.instanceMetadataDefault")))
+	},
+	"aws.ec2.ebsDefaultKmsKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetEbsDefaultKmsKeys()).ToDataRes(types.Array(types.Resource("aws.kms.key")))
+	},
 	"aws.ec2.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetVolumes()).ToDataRes(types.Array(types.Resource("aws.ec2.volume")))
 	},
@@ -24123,6 +24140,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.inspector.finding.codeVulnerability.sourceLambdaLayerArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsInspectorFindingCodeVulnerability).GetSourceLambdaLayerArn()).ToDataRes(types.String)
 	},
+	"aws.ec2.instanceMetadataDefault.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokens": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpTokens()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpEndpoint()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpPutResponseHopLimit()).ToDataRes(types.Int)
+	},
+	"aws.ec2.instanceMetadataDefault.instanceMetadataTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetInstanceMetadataTags()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokensEnforced": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpTokensEnforced()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetManagedByDeclarativePolicy()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.instance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetArn()).ToDataRes(types.String)
 	},
@@ -24155,6 +24193,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetImdsv2Required()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.instance.userData": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetUserData()).ToDataRes(types.String)
+	},
+	"aws.ec2.instance.userDataPresent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetUserDataPresent()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetEnclaveEnabled()).ToDataRes(types.Bool)
@@ -61694,6 +61738,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2).ImageBlockPublicAccess, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshotBlockPublicAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).SnapshotBlockPublicAccess, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.allowedImagesState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).AllowedImagesState, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).InstanceMetadataDefaults, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.ebsDefaultKmsKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).EbsDefaultKmsKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -63922,6 +63982,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsInspectorFindingCodeVulnerability).SourceLambdaLayerArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instanceMetadataDefault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokens": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpTokens, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpPutResponseHopLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.instanceMetadataTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).InstanceMetadataTags, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokensEnforced": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpTokensEnforced, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).ManagedByDeclarativePolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).__id, ok = v.Value.(string)
 		return
@@ -63968,6 +64060,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).Imdsv2Required, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.userData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).UserData, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.userDataPresent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).UserDataPresent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -148407,6 +148507,10 @@ type mqlAwsEc2 struct {
 	EbsEncryptionByDefault           plugin.TValue[map[string]any]
 	SerialConsoleAccessEnabled       plugin.TValue[map[string]any]
 	ImageBlockPublicAccess           plugin.TValue[map[string]any]
+	SnapshotBlockPublicAccess        plugin.TValue[map[string]any]
+	AllowedImagesState               plugin.TValue[map[string]any]
+	InstanceMetadataDefaults         plugin.TValue[[]any]
+	EbsDefaultKmsKeys                plugin.TValue[[]any]
 	Volumes                          plugin.TValue[[]any]
 	Snapshots                        plugin.TValue[[]any]
 	InternetGateways                 plugin.TValue[[]any]
@@ -148513,6 +148617,50 @@ func (c *mqlAwsEc2) GetSerialConsoleAccessEnabled() *plugin.TValue[map[string]an
 func (c *mqlAwsEc2) GetImageBlockPublicAccess() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.ImageBlockPublicAccess, func() (map[string]any, error) {
 		return c.imageBlockPublicAccess()
+	})
+}
+
+func (c *mqlAwsEc2) GetSnapshotBlockPublicAccess() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.SnapshotBlockPublicAccess, func() (map[string]any, error) {
+		return c.snapshotBlockPublicAccess()
+	})
+}
+
+func (c *mqlAwsEc2) GetAllowedImagesState() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.AllowedImagesState, func() (map[string]any, error) {
+		return c.allowedImagesState()
+	})
+}
+
+func (c *mqlAwsEc2) GetInstanceMetadataDefaults() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InstanceMetadataDefaults, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2", c.__id, "instanceMetadataDefaults")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.instanceMetadataDefaults()
+	})
+}
+
+func (c *mqlAwsEc2) GetEbsDefaultKmsKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EbsDefaultKmsKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2", c.__id, "ebsDefaultKmsKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ebsDefaultKmsKeys()
 	})
 }
 
@@ -154148,6 +154296,80 @@ func (c *mqlAwsInspectorFindingCodeVulnerability) GetSourceLambdaLayerArn() *plu
 	return &c.SourceLambdaLayerArn
 }
 
+// mqlAwsEc2InstanceMetadataDefault for the aws.ec2.instanceMetadataDefault resource
+type mqlAwsEc2InstanceMetadataDefault struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsEc2InstanceMetadataDefaultInternal it will be used here
+	Region                     plugin.TValue[string]
+	HttpTokens                 plugin.TValue[string]
+	HttpEndpoint               plugin.TValue[string]
+	HttpPutResponseHopLimit    plugin.TValue[int64]
+	InstanceMetadataTags       plugin.TValue[string]
+	HttpTokensEnforced         plugin.TValue[string]
+	ManagedByDeclarativePolicy plugin.TValue[bool]
+}
+
+// createAwsEc2InstanceMetadataDefault creates a new instance of this resource
+func createAwsEc2InstanceMetadataDefault(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsEc2InstanceMetadataDefault{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.ec2.instanceMetadataDefault", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) MqlName() string {
+	return "aws.ec2.instanceMetadataDefault"
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpTokens() *plugin.TValue[string] {
+	return &c.HttpTokens
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpEndpoint() *plugin.TValue[string] {
+	return &c.HttpEndpoint
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
+	return &c.HttpPutResponseHopLimit
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetInstanceMetadataTags() *plugin.TValue[string] {
+	return &c.InstanceMetadataTags
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpTokensEnforced() *plugin.TValue[string] {
+	return &c.HttpTokensEnforced
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetManagedByDeclarativePolicy() *plugin.TValue[bool] {
+	return &c.ManagedByDeclarativePolicy
+}
+
 // mqlAwsEc2Instance for the aws.ec2.instance resource
 type mqlAwsEc2Instance struct {
 	MqlRuntime *plugin.Runtime
@@ -154164,6 +154386,8 @@ type mqlAwsEc2Instance struct {
 	HttpEndpoint            plugin.TValue[string]
 	HttpPutResponseHopLimit plugin.TValue[int64]
 	Imdsv2Required          plugin.TValue[bool]
+	UserData                plugin.TValue[string]
+	UserDataPresent         plugin.TValue[bool]
 	EnclaveEnabled          plugin.TValue[bool]
 	PatchState              plugin.TValue[any]
 	State                   plugin.TValue[string]
@@ -154311,6 +154535,18 @@ func (c *mqlAwsEc2Instance) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
 
 func (c *mqlAwsEc2Instance) GetImdsv2Required() *plugin.TValue[bool] {
 	return &c.Imdsv2Required
+}
+
+func (c *mqlAwsEc2Instance) GetUserData() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UserData, func() (string, error) {
+		return c.userData()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetUserDataPresent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UserDataPresent, func() (bool, error) {
+		return c.userDataPresent()
+	})
 }
 
 func (c *mqlAwsEc2Instance) GetEnclaveEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3188,6 +3188,7 @@ aws.dynamodb.table.tags 11.15.2
 aws.dynamodb.table.ttlDescription 13.6.3
 aws.dynamodb.tables 11.15.2
 aws.ec2 11.15.2
+aws.ec2.allowedImagesState 13.52.2
 aws.ec2.capacityReservation 13.6.3
 aws.ec2.capacityReservation.arn 13.6.3
 aws.ec2.capacityReservation.availabilityZone 13.6.3
@@ -3252,6 +3253,7 @@ aws.ec2.dhcpOptions.configurations 13.6.3
 aws.ec2.dhcpOptions.id 13.6.3
 aws.ec2.dhcpOptions.region 13.6.3
 aws.ec2.dhcpOptions.tags 13.6.3
+aws.ec2.ebsDefaultKmsKeys 13.52.2
 aws.ec2.ebsEncryptionByDefault 11.15.2
 aws.ec2.egressOnlyInternetGateway 13.6.3
 aws.ec2.egressOnlyInternetGateway.arn 13.6.3
@@ -3422,6 +3424,8 @@ aws.ec2.instance.stateTransitionTime 11.15.2
 aws.ec2.instance.subnet 13.37.1
 aws.ec2.instance.tags 11.15.2
 aws.ec2.instance.tpmSupport 11.15.2
+aws.ec2.instance.userData 13.52.2
+aws.ec2.instance.userDataPresent 13.52.2
 aws.ec2.instance.virtualizationType 11.15.3
 aws.ec2.instance.vpc 11.15.2
 aws.ec2.instance.vpcArn 11.15.2
@@ -3442,6 +3446,15 @@ aws.ec2.instanceConnectEndpoint.tags 13.6.3
 aws.ec2.instanceConnectEndpoint.vpc 13.12.1
 aws.ec2.instanceConnectEndpoint.vpcId 13.6.3
 aws.ec2.instanceConnectEndpoints 13.6.3
+aws.ec2.instanceMetadataDefault 13.52.2
+aws.ec2.instanceMetadataDefault.httpEndpoint 13.52.2
+aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit 13.52.2
+aws.ec2.instanceMetadataDefault.httpTokens 13.52.2
+aws.ec2.instanceMetadataDefault.httpTokensEnforced 13.52.2
+aws.ec2.instanceMetadataDefault.instanceMetadataTags 13.52.2
+aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy 13.52.2
+aws.ec2.instanceMetadataDefault.region 13.52.2
+aws.ec2.instanceMetadataDefaults 13.52.2
 aws.ec2.instances 11.15.2
 aws.ec2.internetGateways 11.15.2
 aws.ec2.internetgateway 11.15.2
@@ -3724,6 +3737,7 @@ aws.ec2.snapshot.tags 11.15.2
 aws.ec2.snapshot.transferType 13.39.2
 aws.ec2.snapshot.volumeId 11.15.2
 aws.ec2.snapshot.volumeSize 11.15.2
+aws.ec2.snapshotBlockPublicAccess 13.52.2
 aws.ec2.snapshots 11.15.2
 aws.ec2.transitGateways 11.15.2
 aws.ec2.transitgateway 11.15.2

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -5782,12 +5782,16 @@ aws.iam.accessAnalyzer.finding.analyzerArn 13.29.1
 aws.iam.accessAnalyzer.finding.createdAt 13.29.1
 aws.iam.accessAnalyzer.finding.error 13.29.1
 aws.iam.accessAnalyzer.finding.id 13.29.1
+aws.iam.accessAnalyzer.finding.lastAccessedAt 13.52.2
 aws.iam.accessAnalyzer.finding.region 13.29.1
 aws.iam.accessAnalyzer.finding.resourceArn 13.29.1
 aws.iam.accessAnalyzer.finding.resourceOwnerAccount 13.29.1
 aws.iam.accessAnalyzer.finding.resourceType 13.29.1
 aws.iam.accessAnalyzer.finding.status 13.29.1
 aws.iam.accessAnalyzer.finding.type 13.29.1
+aws.iam.accessAnalyzer.finding.unusedAccessKeyId 13.52.2
+aws.iam.accessAnalyzer.finding.unusedActions 13.52.2
+aws.iam.accessAnalyzer.finding.unusedServiceNamespace 13.52.2
 aws.iam.accessAnalyzer.finding.updatedAt 13.29.1
 aws.iam.accessAnalyzer.findings 11.15.2
 aws.iam.accountAlias 13.6.3
@@ -5802,6 +5806,7 @@ aws.iam.group.createdAt 11.15.2
 aws.iam.group.id 11.15.2
 aws.iam.group.inlinePolicies 11.15.2
 aws.iam.group.inlinePolicyDetails 13.52.2
+aws.iam.group.lastAccessedServices 13.52.2
 aws.iam.group.name 11.15.2
 aws.iam.group.path 11.15.2
 aws.iam.group.usernames 11.15.2
@@ -5856,6 +5861,7 @@ aws.iam.policy.defaultVersion 11.15.2
 aws.iam.policy.description 11.15.2
 aws.iam.policy.hasWildcardAllow 13.33.2
 aws.iam.policy.isAttachable 11.15.2
+aws.iam.policy.lastAccessedServices 13.52.2
 aws.iam.policy.name 11.15.2
 aws.iam.policy.policyId 11.15.2
 aws.iam.policy.scope 11.15.2
@@ -5896,6 +5902,7 @@ aws.iam.role.id 11.15.2
 aws.iam.role.inlinePolicies 13.6.3
 aws.iam.role.inlinePolicyDetails 13.52.2
 aws.iam.role.isServiceLinked 13.6.3
+aws.iam.role.lastAccessedServices 13.52.2
 aws.iam.role.lastUsedAt 11.15.2
 aws.iam.role.lastUsedRegion 11.15.2
 aws.iam.role.maxSessionDuration 11.15.2
@@ -5915,6 +5922,13 @@ aws.iam.samlProvider.tags 11.15.2
 aws.iam.samlProvider.validUntil 11.15.2
 aws.iam.samlProviders 11.15.2
 aws.iam.serverCertificates 11.15.2
+aws.iam.serviceLastAccessed 13.52.2
+aws.iam.serviceLastAccessed.lastAuthenticatedAt 13.52.2
+aws.iam.serviceLastAccessed.lastAuthenticatedEntity 13.52.2
+aws.iam.serviceLastAccessed.lastAuthenticatedRegion 13.52.2
+aws.iam.serviceLastAccessed.serviceName 13.52.2
+aws.iam.serviceLastAccessed.serviceNamespace 13.52.2
+aws.iam.serviceLastAccessed.totalAuthenticatedEntities 13.52.2
 aws.iam.user 11.15.2
 aws.iam.user.accessKey 13.32.2
 aws.iam.user.accessKey.accessKeyId 13.32.2
@@ -5932,6 +5946,7 @@ aws.iam.user.createdAt 11.15.2
 aws.iam.user.groups 11.15.2
 aws.iam.user.id 11.15.2
 aws.iam.user.inlinePolicyDetails 13.52.2
+aws.iam.user.lastAccessedServices 13.52.2
 aws.iam.user.loginProfile 11.15.2
 aws.iam.user.managedBy 13.39.2
 aws.iam.user.mfaDevices 13.26.2

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -15,6 +15,7 @@ aws.account.alternateContact.title 11.15.2
 aws.account.alternateContacts 11.15.2
 aws.account.billingContact 11.15.2
 aws.account.contactInformation 11.15.2
+aws.account.effectivePolicies 13.52.2
 aws.account.email 13.21.4
 aws.account.id 11.15.2
 aws.account.joinedMethod 13.21.4
@@ -23,6 +24,7 @@ aws.account.name 13.21.4
 aws.account.operationsContact 11.15.2
 aws.account.organization 11.15.2
 aws.account.paths 13.6.3
+aws.account.policies 13.52.2
 aws.account.regionOptInStatus 13.21.4
 aws.account.securityContact 11.15.2
 aws.account.state 13.21.4
@@ -7587,6 +7589,10 @@ aws.organization.delegatedAdministrators 13.0.2
 aws.organization.delegatedService 13.0.2
 aws.organization.delegatedService.delegationEnabledDate 13.0.2
 aws.organization.delegatedService.servicePrincipal 13.0.2
+aws.organization.effectivePolicy 13.52.2
+aws.organization.effectivePolicy.content 13.52.2
+aws.organization.effectivePolicy.lastUpdatedAt 13.52.2
+aws.organization.effectivePolicy.type 13.52.2
 aws.organization.featureSet 11.15.2
 aws.organization.id 11.15.2
 aws.organization.masterAccountArn 13.38.2
@@ -7597,8 +7603,19 @@ aws.organization.organizationalUnit.arn 13.6.3
 aws.organization.organizationalUnit.id 13.6.3
 aws.organization.organizationalUnit.name 13.6.3
 aws.organization.organizationalUnit.path 13.6.3
+aws.organization.organizationalUnit.policies 13.52.2
 aws.organization.organizationalUnit.serviceControlPolicies 13.32.2
 aws.organization.organizationalUnits 13.6.3
+aws.organization.policies 13.52.2
+aws.organization.policy 13.52.2
+aws.organization.policy.arn 13.52.2
+aws.organization.policy.awsManaged 13.52.2
+aws.organization.policy.content 13.52.2
+aws.organization.policy.description 13.52.2
+aws.organization.policy.id 13.52.2
+aws.organization.policy.name 13.52.2
+aws.organization.policy.statements 13.52.2
+aws.organization.policy.type 13.52.2
 aws.organization.serviceControlPolicies 13.32.2
 aws.organization.serviceControlPolicy 13.32.2
 aws.organization.serviceControlPolicy.arn 13.32.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T19:27:28+02:00",
+  "generated_at": "2026-08-05T19:39:25+02:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -638,6 +638,7 @@
     "network-firewall:ListRuleGroups",
     "network-firewall:ListTLSInspectionConfigurations",
     "organizations:DescribeAccount",
+    "organizations:DescribeEffectivePolicy",
     "organizations:DescribeOrganization",
     "organizations:DescribePolicy",
     "organizations:ListAccounts",
@@ -4903,6 +4904,12 @@
       "source_file": "aws_account.go"
     },
     {
+      "permission": "organizations:DescribeEffectivePolicy",
+      "service": "organizations",
+      "action": "DescribeEffectivePolicy",
+      "source_file": "aws_organizations_policy.go"
+    },
+    {
       "permission": "organizations:DescribeOrganization",
       "service": "organizations",
       "action": "DescribeOrganization",
@@ -4912,7 +4919,7 @@
       "permission": "organizations:DescribePolicy",
       "service": "organizations",
       "action": "DescribePolicy",
-      "source_file": "aws_account.go"
+      "source_file": "aws_organizations_policy.go"
     },
     {
       "permission": "organizations:ListAccounts",
@@ -4945,10 +4952,22 @@
       "source_file": "aws_account.go"
     },
     {
+      "permission": "organizations:ListPolicies",
+      "service": "organizations",
+      "action": "ListPolicies",
+      "source_file": "aws_organizations_policy.go"
+    },
+    {
       "permission": "organizations:ListPoliciesForTarget",
       "service": "organizations",
       "action": "ListPoliciesForTarget",
       "source_file": "aws_account.go"
+    },
+    {
+      "permission": "organizations:ListPoliciesForTarget",
+      "service": "organizations",
+      "action": "ListPoliciesForTarget",
+      "source_file": "aws_organizations_policy.go"
     },
     {
       "permission": "organizations:ListRoots",

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,8 +1,9 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T17:39:09+02:00",
+  "generated_at": "2026-08-05T19:27:28+02:00",
   "permissions": [
+    "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
     "access-analyzer:ListFindings",
     "account:GetAlternateContact",
@@ -483,6 +484,7 @@
     "guardduty:ListPublishingDestinations",
     "guardduty:ListThreatIntelSets",
     "iam:GenerateCredentialReport",
+    "iam:GenerateServiceLastAccessedDetails",
     "iam:GetAccessKeyLastUsed",
     "iam:GetAccountPasswordPolicy",
     "iam:GetAccountSummary",
@@ -497,6 +499,7 @@
     "iam:GetRole",
     "iam:GetRolePolicy",
     "iam:GetSAMLProvider",
+    "iam:GetServiceLastAccessedDetails",
     "iam:GetUser",
     "iam:GetUserPolicy",
     "iam:ListAccessKeys",
@@ -987,6 +990,12 @@
     "workspaces:DescribeWorkspacesConnectionStatus"
   ],
   "details": [
+    {
+      "permission": "access-analyzer:GetFindingV2",
+      "service": "access-analyzer",
+      "action": "GetFindingV2",
+      "source_file": "aws_iam_accessanalyzer.go"
+    },
     {
       "permission": "access-analyzer:ListAnalyzers",
       "service": "access-analyzer",
@@ -3958,6 +3967,12 @@
       "source_file": "aws_iam.go"
     },
     {
+      "permission": "iam:GenerateServiceLastAccessedDetails",
+      "service": "iam",
+      "action": "GenerateServiceLastAccessedDetails",
+      "source_file": "aws_iam_service_last_accessed.go"
+    },
+    {
       "permission": "iam:GetAccessKeyLastUsed",
       "service": "iam",
       "action": "GetAccessKeyLastUsed",
@@ -4040,6 +4055,12 @@
       "service": "iam",
       "action": "GetSAMLProvider",
       "source_file": "aws_iam.go"
+    },
+    {
+      "permission": "iam:GetServiceLastAccessedDetails",
+      "service": "iam",
+      "action": "GetServiceLastAccessedDetails",
+      "source_file": "aws_iam_service_last_accessed.go"
     },
     {
       "permission": "iam:GetUser",

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T19:39:25+02:00",
+  "generated_at": "2026-08-05T19:49:05+02:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -322,11 +322,15 @@
     "ec2:DescribeVpcs",
     "ec2:DescribeVpnConnections",
     "ec2:DescribeVpnGateways",
+    "ec2:GetAllowedImagesSettings",
+    "ec2:GetEbsDefaultKmsKeyId",
     "ec2:GetEbsEncryptionByDefault",
     "ec2:GetImageBlockPublicAccessState",
+    "ec2:GetInstanceMetadataDefaults",
     "ec2:GetIpamPoolAllocations",
     "ec2:GetManagedPrefixListEntries",
     "ec2:GetSerialConsoleAccessStatus",
+    "ec2:GetSnapshotBlockPublicAccessState",
     "ecr-public:DescribeImages",
     "ecr-public:DescribeRepositories",
     "ecr-public:GetRepositoryCatalogData",
@@ -2672,6 +2676,12 @@
       "source_file": "aws_ec2.go"
     },
     {
+      "permission": "ec2:DescribeInstanceAttribute",
+      "service": "ec2",
+      "action": "DescribeInstanceAttribute",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
       "permission": "ec2:DescribeInstanceConnectEndpoints",
       "service": "ec2",
       "action": "DescribeInstanceConnectEndpoints",
@@ -2984,6 +2994,18 @@
       "source_file": "aws_vpc.go"
     },
     {
+      "permission": "ec2:GetAllowedImagesSettings",
+      "service": "ec2",
+      "action": "GetAllowedImagesSettings",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
+      "permission": "ec2:GetEbsDefaultKmsKeyId",
+      "service": "ec2",
+      "action": "GetEbsDefaultKmsKeyId",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
       "permission": "ec2:GetEbsEncryptionByDefault",
       "service": "ec2",
       "action": "GetEbsEncryptionByDefault",
@@ -2994,6 +3016,12 @@
       "service": "ec2",
       "action": "GetImageBlockPublicAccessState",
       "source_file": "aws_ec2.go"
+    },
+    {
+      "permission": "ec2:GetInstanceMetadataDefaults",
+      "service": "ec2",
+      "action": "GetInstanceMetadataDefaults",
+      "source_file": "aws_ec2_account_settings.go"
     },
     {
       "permission": "ec2:GetIpamPoolAllocations",
@@ -3012,6 +3040,12 @@
       "service": "ec2",
       "action": "GetSerialConsoleAccessStatus",
       "source_file": "aws_ec2.go"
+    },
+    {
+      "permission": "ec2:GetSnapshotBlockPublicAccessState",
+      "service": "ec2",
+      "action": "GetSnapshotBlockPublicAccessState",
+      "source_file": "aws_ec2_account_settings.go"
     },
     {
       "permission": "ecr-public:DescribeImages",

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -621,21 +621,7 @@ func (a *mqlAwsOrganizationOrganizationalUnit) serviceControlPolicies() ([]any, 
 
 func (a *mqlAwsOrganizationServiceControlPolicy) content() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	client := conn.Organizations("")
-	ctx := context.Background()
-
-	id := a.Id.Data
-	resp, err := client.DescribePolicy(ctx, &organizations.DescribePolicyInput{PolicyId: &id})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	if resp.Policy == nil || resp.Policy.Content == nil {
-		return "", nil
-	}
-	return *resp.Policy.Content, nil
+	return describePolicyContent(context.Background(), conn.Organizations(""), a.Id.Data)
 }
 
 func (a *mqlAwsOrganizationServiceControlPolicy) statements() ([]any, error) {

--- a/providers/aws/resources/aws_ec2_account_settings.go
+++ b/providers/aws/resources/aws_ec2_account_settings.go
@@ -1,0 +1,265 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// regionSetting pairs an account-level setting value with the region it was read
+// from, so a per-region job can report both.
+type regionSetting struct {
+	region string
+	value  string
+}
+
+// collectRegionSettings runs read per region and returns the values keyed by
+// region. A region the caller cannot read is left out of the map rather than
+// reported with an empty value, which would read as a setting that is switched
+// off. read takes the region rather than a client so that each caller's
+// conn.Ec2 call sits in the same function as its API call, which is what the
+// IAM permission extractor traces.
+func collectRegionSettings(conn *connection.AwsConnection, read func(region string) (string, error)) (map[string]any, error) {
+	regions, err := conn.Regions()
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]*jobpool.Job, 0, len(regions))
+	for _, region := range regions {
+		f := func() (jobpool.JobResult, error) {
+			value, err := read(region)
+			if err != nil {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+					return nil, nil
+				}
+				return nil, err
+			}
+			return jobpool.JobResult(regionSetting{region: region, value: value}), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+
+	poolOfJobs := jobpool.CreatePool(tasks, 5)
+	poolOfJobs.Run()
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+
+	res := map[string]any{}
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
+		setting := poolOfJobs.Jobs[i].Result.(regionSetting)
+		res[setting.region] = setting.value
+	}
+	return res, nil
+}
+
+func (a *mqlAwsEc2) snapshotBlockPublicAccess() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetSnapshotBlockPublicAccessState(context.Background(),
+			&ec2.GetSnapshotBlockPublicAccessStateInput{})
+		if err != nil {
+			return "", err
+		}
+		return string(resp.State), nil
+	})
+}
+
+func (a *mqlAwsEc2) allowedImagesState() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetAllowedImagesSettings(context.Background(),
+			&ec2.GetAllowedImagesSettingsInput{})
+		if err != nil {
+			return "", err
+		}
+		return convert.ToValue(resp.State), nil
+	})
+}
+
+// instanceMetadataDefaultsResult carries one region's account-level IMDS
+// defaults. AccountLevel is nil for a region with no defaults set.
+type instanceMetadataDefaultsResult struct {
+	region   string
+	defaults *ec2types.InstanceMetadataDefaultsResponse
+}
+
+func (a *mqlAwsEc2) instanceMetadataDefaults() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	regions, err := conn.Regions()
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]*jobpool.Job, 0, len(regions))
+	for _, region := range regions {
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.Ec2(region)
+			resp, err := svc.GetInstanceMetadataDefaults(context.Background(),
+				&ec2.GetInstanceMetadataDefaultsInput{})
+			if err != nil {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+					return nil, nil
+				}
+				return nil, err
+			}
+			return jobpool.JobResult(instanceMetadataDefaultsResult{
+				region:   region,
+				defaults: resp.AccountLevel,
+			}), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+
+	poolOfJobs := jobpool.CreatePool(tasks, 5)
+	poolOfJobs.Run()
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+
+	res := []any{}
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
+		result := poolOfJobs.Jobs[i].Result.(instanceMetadataDefaultsResult)
+		mqlDefaults, err := CreateResource(a.MqlRuntime, ResourceAwsEc2InstanceMetadataDefault,
+			instanceMetadataDefaultArgs(result))
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlDefaults)
+	}
+	return res, nil
+}
+
+// instanceMetadataDefaultArgs builds the fields of the per-region defaults
+// resource. A region with no account-level defaults still gets an entry, with
+// every setting null, so that "no default is set" stays distinguishable from a
+// default that permits IMDSv1.
+func instanceMetadataDefaultArgs(result instanceMetadataDefaultsResult) map[string]*llx.RawData {
+	args := map[string]*llx.RawData{
+		"__id":                       llx.StringData("aws.ec2.instanceMetadataDefault/" + result.region),
+		"region":                     llx.StringData(result.region),
+		"managedByDeclarativePolicy": llx.BoolData(false),
+		"httpTokens":                 llx.NilData,
+		"httpEndpoint":               llx.NilData,
+		"httpPutResponseHopLimit":    llx.NilData,
+		"instanceMetadataTags":       llx.NilData,
+		"httpTokensEnforced":         llx.NilData,
+	}
+
+	defaults := result.defaults
+	if defaults == nil {
+		return args
+	}
+
+	args["httpTokens"] = emptyStringToNil(string(defaults.HttpTokens))
+	args["httpEndpoint"] = emptyStringToNil(string(defaults.HttpEndpoint))
+	args["instanceMetadataTags"] = emptyStringToNil(string(defaults.InstanceMetadataTags))
+	args["httpTokensEnforced"] = emptyStringToNil(string(defaults.HttpTokensEnforced))
+	if defaults.HttpPutResponseHopLimit != nil {
+		args["httpPutResponseHopLimit"] = llx.IntDataPtr(defaults.HttpPutResponseHopLimit)
+	}
+	args["managedByDeclarativePolicy"] = llx.BoolData(defaults.ManagedBy == ec2types.ManagedByDeclarativePolicy)
+
+	return args
+}
+
+// emptyStringToNil keeps an unset account default null instead of reporting it
+// as an empty string, which would compare equal to neither "required" nor
+// "optional" but would still look like a value that was read.
+func emptyStringToNil(value string) *llx.RawData {
+	if value == "" {
+		return llx.NilData
+	}
+	return llx.StringData(value)
+}
+
+func (a *mqlAwsEc2) ebsDefaultKmsKeys() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	keyArns, err := collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetEbsDefaultKmsKeyId(context.Background(),
+			&ec2.GetEbsDefaultKmsKeyIdInput{})
+		if err != nil {
+			return "", err
+		}
+		return convert.ToValue(resp.KmsKeyId), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for region, raw := range keyArns {
+		keyArn, ok := raw.(string)
+		if !ok || keyArn == "" {
+			continue
+		}
+		mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+			map[string]*llx.RawData{
+				"arn":    llx.StringData(keyArn),
+				"region": llx.StringData(region),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlKey)
+	}
+	return res, nil
+}
+
+// userData returns the launch script the instance was created with. EC2 keeps it
+// in an instance attribute rather than in the describe output, so it costs one
+// call per instance and is only fetched when the field is read.
+func (a *mqlAwsEc2Instance) userData() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(a.Region.Data)
+
+	instanceId := a.InstanceId.Data
+	attribute, err := svc.DescribeInstanceAttribute(context.Background(),
+		&ec2.DescribeInstanceAttributeInput{
+			InstanceId: &instanceId,
+			Attribute:  ec2types.InstanceAttributeNameUserData,
+		})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if attribute.UserData == nil || attribute.UserData.Value == nil {
+		return "", nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(*attribute.UserData.Value)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+func (a *mqlAwsEc2Instance) userDataPresent() (bool, error) {
+	userData := a.GetUserData()
+	if userData.Error != nil {
+		return false, userData.Error
+	}
+	return strings.TrimSpace(userData.Data) != "", nil
+}

--- a/providers/aws/resources/aws_ec2_account_settings_test.go
+++ b/providers/aws/resources/aws_ec2_account_settings_test.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestEmptyStringToNil(t *testing.T) {
+	assert.Equal(t, llx.NilData, emptyStringToNil(""))
+	assert.Equal(t, llx.StringData("required"), emptyStringToNil("required"))
+}
+
+// A region with no account-level defaults must report null for every setting. An
+// empty string would compare equal to neither "required" nor "optional" while
+// still looking like a value that was read, which is how a missing guardrail
+// gets mistaken for a permissive one.
+func TestInstanceMetadataDefaultArgsWithoutDefaults(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{region: "us-east-1"})
+
+	assert.Equal(t, llx.StringData("us-east-1"), args["region"])
+	assert.Equal(t, llx.BoolData(false), args["managedByDeclarativePolicy"])
+	for _, field := range []string{
+		"httpTokens", "httpEndpoint", "httpPutResponseHopLimit",
+		"instanceMetadataTags", "httpTokensEnforced",
+	} {
+		assert.Equal(t, llx.NilData, args[field], "expected %s to be null", field)
+	}
+}
+
+func TestInstanceMetadataDefaultArgs(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{
+		region: "eu-central-1",
+		defaults: &ec2types.InstanceMetadataDefaultsResponse{
+			HttpTokens:              ec2types.HttpTokensStateRequired,
+			HttpEndpoint:            ec2types.InstanceMetadataEndpointStateEnabled,
+			HttpPutResponseHopLimit: aws.Int32(2),
+			InstanceMetadataTags:    ec2types.InstanceMetadataTagsStateDisabled,
+			ManagedBy:               ec2types.ManagedByDeclarativePolicy,
+		},
+	})
+
+	assert.Equal(t, llx.StringData("required"), args["httpTokens"])
+	assert.Equal(t, llx.StringData("enabled"), args["httpEndpoint"])
+	assert.Equal(t, llx.StringData("disabled"), args["instanceMetadataTags"])
+	assert.Equal(t, int64(2), args["httpPutResponseHopLimit"].Value)
+	assert.Equal(t, llx.BoolData(true), args["managedByDeclarativePolicy"])
+	// The API left HttpTokensEnforced unset, which must stay null.
+	assert.Equal(t, llx.NilData, args["httpTokensEnforced"])
+}
+
+// An account-level default that is not pinned by an organization declarative
+// policy reports managedByDeclarativePolicy false rather than null.
+func TestInstanceMetadataDefaultArgsAccountManaged(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{
+		region: "us-west-2",
+		defaults: &ec2types.InstanceMetadataDefaultsResponse{
+			HttpTokens: ec2types.HttpTokensStateOptional,
+			ManagedBy:  ec2types.ManagedByAccount,
+		},
+	})
+
+	assert.Equal(t, llx.StringData("optional"), args["httpTokens"])
+	assert.Equal(t, llx.BoolData(false), args["managedByDeclarativePolicy"])
+}
+
+func TestInstanceUserDataPresent(t *testing.T) {
+	tests := []struct {
+		name     string
+		userData string
+		want     bool
+	}{
+		{"script", "#!/bin/bash\necho hello", true},
+		{"empty", "", false},
+		{"whitespace only", "  \n\t ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &mqlAwsEc2Instance{UserData: setString(tt.userData)}
+			got, err := instance.userDataPresent()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/providers/aws/resources/aws_iam_accessanalyzer.go
+++ b/providers/aws/resources/aws_iam_accessanalyzer.go
@@ -6,12 +6,17 @@ package resources
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	aatypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/rs/zerolog/log"
 	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
 	"go.mondoo.com/mql/v13/providers/aws/connection"
 	"go.mondoo.com/mql/v13/types"
@@ -19,6 +24,126 @@ import (
 
 func (a *mqlAwsIamAccessAnalyzerAnalyzer) id() (string, error) {
 	return a.Arn.Data, nil
+}
+
+// mqlAwsIamAccessAnalyzerFindingInternal caches the unused-access detail of a
+// finding. ListFindingsV2 returns a summary without it, so the detail costs one
+// GetFindingV2 call per finding and is shared by the four fields that read it.
+type mqlAwsIamAccessAnalyzerFindingInternal struct {
+	unusedFetched               atomic.Bool
+	unusedLock                  sync.Mutex
+	cacheUnusedLastAccessed     *time.Time
+	cacheUnusedServiceNamespace string
+	cacheUnusedActions          []any
+	cacheUnusedAccessKeyId      string
+}
+
+// fetchUnusedAccessDetails resolves the unused-access detail of the finding.
+// Findings of any other type carry no such detail, so they resolve to empty
+// values without an API call.
+func (a *mqlAwsIamAccessAnalyzerFinding) fetchUnusedAccessDetails() error {
+	if a.unusedFetched.Load() {
+		return nil
+	}
+	a.unusedLock.Lock()
+	defer a.unusedLock.Unlock()
+	if a.unusedFetched.Load() {
+		return nil
+	}
+
+	if !strings.HasPrefix(a.Type.Data, "Unused") {
+		a.unusedFetched.Store(true)
+		return nil
+	}
+
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.AccessAnalyzer(a.Region.Data)
+	finding, err := svc.GetFindingV2(context.Background(), &accessanalyzer.GetFindingV2Input{
+		AnalyzerArn: aws.String(a.AnalyzerArn.Data),
+		Id:          aws.String(a.Id.Data),
+	})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			log.Warn().Str("finding", a.Id.Data).Str("region", a.Region.Data).
+				Msg("no permission to read access analyzer finding detail")
+			a.unusedFetched.Store(true)
+			return nil
+		}
+		return err
+	}
+
+	detail := parseUnusedAccessDetails(finding.FindingDetails)
+	a.cacheUnusedLastAccessed = detail.lastAccessed
+	a.cacheUnusedServiceNamespace = detail.serviceNamespace
+	a.cacheUnusedActions = detail.actions
+	a.cacheUnusedAccessKeyId = detail.accessKeyId
+
+	a.unusedFetched.Store(true)
+	return nil
+}
+
+// unusedAccessDetail holds the unused-access values carried by a finding.
+type unusedAccessDetail struct {
+	lastAccessed     *time.Time
+	serviceNamespace string
+	actions          []any
+	accessKeyId      string
+}
+
+// parseUnusedAccessDetails picks the unused-access member out of a finding
+// detail union. The external-access and internal-access members carry no
+// unused-access data and are skipped.
+func parseUnusedAccessDetails(details []aatypes.FindingDetails) unusedAccessDetail {
+	var res unusedAccessDetail
+	for _, detail := range details {
+		switch typed := detail.(type) {
+		case *aatypes.FindingDetailsMemberUnusedPermissionDetails:
+			res.lastAccessed = typed.Value.LastAccessed
+			res.serviceNamespace = convert.ToValue(typed.Value.ServiceNamespace)
+			for _, action := range typed.Value.Actions {
+				res.actions = append(res.actions, convert.ToValue(action.Action))
+			}
+		case *aatypes.FindingDetailsMemberUnusedIamRoleDetails:
+			res.lastAccessed = typed.Value.LastAccessed
+		case *aatypes.FindingDetailsMemberUnusedIamUserAccessKeyDetails:
+			res.lastAccessed = typed.Value.LastAccessed
+			res.accessKeyId = convert.ToValue(typed.Value.AccessKeyId)
+		case *aatypes.FindingDetailsMemberUnusedIamUserPasswordDetails:
+			res.lastAccessed = typed.Value.LastAccessed
+		}
+	}
+	return res
+}
+
+func (a *mqlAwsIamAccessAnalyzerFinding) lastAccessedAt() (*time.Time, error) {
+	if err := a.fetchUnusedAccessDetails(); err != nil {
+		return nil, err
+	}
+	return a.cacheUnusedLastAccessed, nil
+}
+
+func (a *mqlAwsIamAccessAnalyzerFinding) unusedServiceNamespace() (string, error) {
+	if err := a.fetchUnusedAccessDetails(); err != nil {
+		return "", err
+	}
+	return a.cacheUnusedServiceNamespace, nil
+}
+
+func (a *mqlAwsIamAccessAnalyzerFinding) unusedActions() ([]any, error) {
+	if err := a.fetchUnusedAccessDetails(); err != nil {
+		return nil, err
+	}
+	if a.cacheUnusedActions == nil {
+		return []any{}, nil
+	}
+	return a.cacheUnusedActions, nil
+}
+
+func (a *mqlAwsIamAccessAnalyzerFinding) unusedAccessKeyId() (string, error) {
+	if err := a.fetchUnusedAccessDetails(); err != nil {
+		return "", err
+	}
+	return a.cacheUnusedAccessKeyId, nil
 }
 
 func (a *mqlAwsIamAccessAnalyzer) analyzers() ([]any, error) {

--- a/providers/aws/resources/aws_iam_service_last_accessed.go
+++ b/providers/aws/resources/aws_iam_service_last_accessed.go
@@ -1,0 +1,115 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+const (
+	// serviceLastAccessedPollInterval and serviceLastAccessedTimeout bound the
+	// wait on an IAM service-last-accessed report job.
+	serviceLastAccessedPollInterval = 500 * time.Millisecond
+	serviceLastAccessedTimeout      = 45 * time.Second
+)
+
+// lastAccessedServicesForArn collects the IAM service-last-accessed report for
+// one user, group, role, or policy. IAM produces the report asynchronously: the
+// generate call returns a job id and the get call reports IN_PROGRESS until the
+// job finishes. It polls up to serviceLastAccessedTimeout and returns an error
+// rather than a short list when the job has not finished, so an incomplete
+// report is never read as "no service was ever used".
+func lastAccessedServicesForArn(ctx context.Context, runtime *plugin.Runtime, svc *iam.Client, entityArn string) ([]any, error) {
+	job, err := svc.GenerateServiceLastAccessedDetails(ctx, &iam.GenerateServiceLastAccessedDetailsInput{
+		Arn: &entityArn,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	var marker *string
+	deadline := time.Now().Add(serviceLastAccessedTimeout)
+	for {
+		details, err := svc.GetServiceLastAccessedDetails(ctx, &iam.GetServiceLastAccessedDetailsInput{
+			JobId:  job.JobId,
+			Marker: marker,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		switch details.JobStatus {
+		case iamtypes.JobStatusTypeInProgress:
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("timed out waiting for the IAM service last accessed report for %s", entityArn)
+			}
+			time.Sleep(serviceLastAccessedPollInterval)
+			continue
+		case iamtypes.JobStatusTypeFailed:
+			return nil, fmt.Errorf("IAM could not generate the service last accessed report for %s: %s",
+				entityArn, jobErrorDetails(details.Error))
+		}
+
+		for i := range details.ServicesLastAccessed {
+			service := details.ServicesLastAccessed[i]
+			mqlService, err := CreateResource(runtime, ResourceAwsIamServiceLastAccessed,
+				map[string]*llx.RawData{
+					"__id":                       llx.StringData(entityArn + "/serviceLastAccessed/" + convert.ToValue(service.ServiceNamespace)),
+					"serviceName":                llx.StringDataPtr(service.ServiceName),
+					"serviceNamespace":           llx.StringDataPtr(service.ServiceNamespace),
+					"lastAuthenticatedAt":        llx.TimeDataPtr(service.LastAuthenticated),
+					"lastAuthenticatedEntity":    llx.StringDataPtr(service.LastAuthenticatedEntity),
+					"lastAuthenticatedRegion":    llx.StringDataPtr(service.LastAuthenticatedRegion),
+					"totalAuthenticatedEntities": llx.IntDataDefault(service.TotalAuthenticatedEntities, 0),
+				})
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlService)
+		}
+
+		if !details.IsTruncated {
+			return res, nil
+		}
+		marker = details.Marker
+	}
+}
+
+// jobErrorDetails renders the reason IAM gave for a failed report job.
+func jobErrorDetails(details *iamtypes.ErrorDetails) string {
+	if details == nil {
+		return "no reason reported"
+	}
+	return fmt.Sprintf("%s (%s)", convert.ToValue(details.Message), convert.ToValue(details.Code))
+}
+
+func (a *mqlAwsIamRole) lastAccessedServices() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return lastAccessedServicesForArn(context.Background(), a.MqlRuntime, conn.Iam(""), a.Arn.Data)
+}
+
+func (a *mqlAwsIamUser) lastAccessedServices() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return lastAccessedServicesForArn(context.Background(), a.MqlRuntime, conn.Iam(""), a.Arn.Data)
+}
+
+func (a *mqlAwsIamGroup) lastAccessedServices() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return lastAccessedServicesForArn(context.Background(), a.MqlRuntime, conn.Iam(""), a.Arn.Data)
+}
+
+func (a *mqlAwsIamPolicy) lastAccessedServices() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return lastAccessedServicesForArn(context.Background(), a.MqlRuntime, conn.Iam(""), a.Arn.Data)
+}

--- a/providers/aws/resources/aws_iam_unused_access_test.go
+++ b/providers/aws/resources/aws_iam_unused_access_test.go
@@ -1,0 +1,139 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	aatypes "github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUnusedAccessDetails(t *testing.T) {
+	lastAccessed := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("unused permission", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberUnusedPermissionDetails{
+				Value: aatypes.UnusedPermissionDetails{
+					ServiceNamespace: aws.String("s3"),
+					LastAccessed:     &lastAccessed,
+					Actions: []aatypes.UnusedAction{
+						{Action: aws.String("s3:DeleteBucket")},
+						{Action: aws.String("s3:PutBucketPolicy")},
+					},
+				},
+			},
+		})
+		assert.Equal(t, &lastAccessed, got.lastAccessed)
+		assert.Equal(t, "s3", got.serviceNamespace)
+		assert.Equal(t, []any{"s3:DeleteBucket", "s3:PutBucketPolicy"}, got.actions)
+		assert.Empty(t, got.accessKeyId)
+	})
+
+	t.Run("unused role", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberUnusedIamRoleDetails{
+				Value: aatypes.UnusedIamRoleDetails{LastAccessed: &lastAccessed},
+			},
+		})
+		assert.Equal(t, &lastAccessed, got.lastAccessed)
+		assert.Empty(t, got.serviceNamespace)
+		assert.Empty(t, got.actions)
+	})
+
+	t.Run("unused access key", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberUnusedIamUserAccessKeyDetails{
+				Value: aatypes.UnusedIamUserAccessKeyDetails{
+					AccessKeyId:  aws.String("AKIAEXAMPLE"),
+					LastAccessed: &lastAccessed,
+				},
+			},
+		})
+		assert.Equal(t, "AKIAEXAMPLE", got.accessKeyId)
+		assert.Equal(t, &lastAccessed, got.lastAccessed)
+	})
+
+	t.Run("unused password", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberUnusedIamUserPasswordDetails{
+				Value: aatypes.UnusedIamUserPasswordDetails{LastAccessed: &lastAccessed},
+			},
+		})
+		assert.Equal(t, &lastAccessed, got.lastAccessed)
+	})
+
+	// A role or key that was never used at all reports no last-accessed time,
+	// which must stay null rather than becoming a zero timestamp.
+	t.Run("never used leaves the time null", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberUnusedIamRoleDetails{
+				Value: aatypes.UnusedIamRoleDetails{},
+			},
+		})
+		assert.Nil(t, got.lastAccessed)
+	})
+
+	t.Run("external access detail carries no unused data", func(t *testing.T) {
+		got := parseUnusedAccessDetails([]aatypes.FindingDetails{
+			&aatypes.FindingDetailsMemberExternalAccessDetails{
+				Value: aatypes.ExternalAccessDetails{
+					Action:    []string{"s3:GetObject"},
+					IsPublic:  aws.Bool(true),
+					Condition: map[string]string{},
+				},
+			},
+		})
+		assert.Nil(t, got.lastAccessed)
+		assert.Empty(t, got.serviceNamespace)
+		assert.Empty(t, got.actions)
+		assert.Empty(t, got.accessKeyId)
+	})
+
+	t.Run("no details", func(t *testing.T) {
+		got := parseUnusedAccessDetails(nil)
+		assert.Nil(t, got.lastAccessed)
+		assert.Empty(t, got.actions)
+	})
+}
+
+// A finding that is not an unused-access finding must resolve its unused fields
+// without an API call, which this exercises by leaving the runtime unset — any
+// attempt to reach the connection would panic.
+func TestUnusedAccessFieldsSkipNonUnusedFindings(t *testing.T) {
+	finding := &mqlAwsIamAccessAnalyzerFinding{
+		Id:     setString("finding-1"),
+		Type:   setString("ExternalAccessGranted"),
+		Region: setString("us-east-1"),
+	}
+
+	lastAccessed, err := finding.lastAccessedAt()
+	require.NoError(t, err)
+	assert.Nil(t, lastAccessed)
+
+	namespace, err := finding.unusedServiceNamespace()
+	require.NoError(t, err)
+	assert.Empty(t, namespace)
+
+	actions, err := finding.unusedActions()
+	require.NoError(t, err)
+	assert.Equal(t, []any{}, actions)
+
+	accessKeyId, err := finding.unusedAccessKeyId()
+	require.NoError(t, err)
+	assert.Empty(t, accessKeyId)
+}
+
+func TestJobErrorDetails(t *testing.T) {
+	assert.Equal(t, "no reason reported", jobErrorDetails(nil))
+	assert.Equal(t, "service not supported (SERVICE_ERROR)", jobErrorDetails(&iamtypes.ErrorDetails{
+		Message: aws.String("service not supported"),
+		Code:    aws.String("SERVICE_ERROR"),
+	}))
+}

--- a/providers/aws/resources/aws_organizations_policy.go
+++ b/providers/aws/resources/aws_organizations_policy.go
@@ -1,0 +1,211 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// isPolicyTypeUnavailable reports whether the error means the policy type is
+// simply not in play for this organization, rather than a failure. Organizations
+// rejects a list or describe call for a policy type that has not been enabled,
+// and every type has to be enabled explicitly, so this is the common case rather
+// than an edge case.
+func isPolicyTypeUnavailable(err error) bool {
+	var notEnabled *orgtypes.PolicyTypeNotEnabledException
+	var notAvailable *orgtypes.PolicyTypeNotAvailableForOrganizationException
+	var notInUse *orgtypes.AWSOrganizationsNotInUseException
+	return errors.As(err, &notEnabled) || errors.As(err, &notAvailable) || errors.As(err, &notInUse)
+}
+
+func newOrganizationPolicyResource(runtime *plugin.Runtime, policy orgtypes.PolicySummary) (plugin.Resource, error) {
+	return CreateResource(runtime, ResourceAwsOrganizationPolicy,
+		map[string]*llx.RawData{
+			"__id":        llx.StringDataPtr(policy.Id),
+			"id":          llx.StringDataPtr(policy.Id),
+			"arn":         llx.StringDataPtr(policy.Arn),
+			"name":        llx.StringDataPtr(policy.Name),
+			"description": llx.StringDataPtr(policy.Description),
+			"type":        llx.StringData(string(policy.Type)),
+			"awsManaged":  llx.BoolData(policy.AwsManaged),
+		})
+}
+
+// listOrganizationPolicies lists the organization's policies of every type
+// known to the SDK. Reading the types off the enum rather than a hand-written
+// list means a policy type AWS adds later is picked up with the next SDK bump.
+// An empty targetId lists every policy in the organization; otherwise only the
+// policies attached directly to that root, organizational unit, or account.
+func listOrganizationPolicies(ctx context.Context, runtime *plugin.Runtime, client *organizations.Client, targetId string) ([]any, error) {
+	res := []any{}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		policies, err := listOrganizationPoliciesOfType(ctx, runtime, client, targetId, policyType)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, policies...)
+	}
+	return res, nil
+}
+
+func listOrganizationPoliciesOfType(ctx context.Context, runtime *plugin.Runtime, client *organizations.Client, targetId string, policyType orgtypes.PolicyType) ([]any, error) {
+	var hasMorePages func() bool
+	var nextPage func(context.Context) ([]orgtypes.PolicySummary, error)
+
+	if targetId == "" {
+		paginator := organizations.NewListPoliciesPaginator(client, &organizations.ListPoliciesInput{
+			Filter: policyType,
+		})
+		hasMorePages = paginator.HasMorePages
+		nextPage = func(ctx context.Context) ([]orgtypes.PolicySummary, error) {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return page.Policies, nil
+		}
+	} else {
+		paginator := organizations.NewListPoliciesForTargetPaginator(client, &organizations.ListPoliciesForTargetInput{
+			TargetId: &targetId,
+			Filter:   policyType,
+		})
+		hasMorePages = paginator.HasMorePages
+		nextPage = func(ctx context.Context) ([]orgtypes.PolicySummary, error) {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return page.Policies, nil
+		}
+	}
+
+	res := []any{}
+	for hasMorePages() {
+		policies, err := nextPage(ctx)
+		if err != nil {
+			if isPolicyTypeUnavailable(err) || Is400AccessDeniedError(err) {
+				return res, nil
+			}
+			return nil, err
+		}
+		for i := range policies {
+			mqlPolicy, err := newOrganizationPolicyResource(runtime, policies[i])
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlPolicy)
+		}
+	}
+	return res, nil
+}
+
+// describePolicyContent returns the raw content document of one policy.
+func describePolicyContent(ctx context.Context, client *organizations.Client, policyId string) (string, error) {
+	resp, err := client.DescribePolicy(ctx, &organizations.DescribePolicyInput{PolicyId: &policyId})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if resp.Policy == nil || resp.Policy.Content == nil {
+		return "", nil
+	}
+	return *resp.Policy.Content, nil
+}
+
+func (a *mqlAwsOrganization) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), "")
+}
+
+func (a *mqlAwsOrganizationOrganizationalUnit) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), a.Id.Data)
+}
+
+func (a *mqlAwsAccount) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), a.Id.Data)
+}
+
+func (a *mqlAwsOrganizationPolicy) content() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return describePolicyContent(context.Background(), conn.Organizations(""), a.Id.Data)
+}
+
+// statements parses the policy content for the types written in the IAM policy
+// grammar. The remaining types carry their own document formats, which the IAM
+// statement parser would silently misread, so they resolve to no statements.
+func (a *mqlAwsOrganizationPolicy) statements() ([]any, error) {
+	if !policyTypeUsesIamGrammar(orgtypes.PolicyType(a.Type.Data)) {
+		return []any{}, nil
+	}
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetContent())
+}
+
+// policyTypeUsesIamGrammar reports whether an organization policy type is
+// written in the IAM policy grammar of Statement/Effect/Action/Resource.
+func policyTypeUsesIamGrammar(policyType orgtypes.PolicyType) bool {
+	switch policyType {
+	case orgtypes.PolicyTypeServiceControlPolicy, orgtypes.PolicyTypeResourceControlPolicy:
+		return true
+	}
+	return false
+}
+
+// isEffectivePolicyAbsent reports whether the error means no effective policy of
+// that type applies to the target, which is an ordinary answer rather than a
+// failure.
+func isEffectivePolicyAbsent(err error) bool {
+	var notFound *orgtypes.EffectivePolicyNotFoundException
+	return errors.As(err, &notFound) || isPolicyTypeUnavailable(err)
+}
+
+func (a *mqlAwsAccount) effectivePolicies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+	accountId := a.Id.Data
+
+	res := []any{}
+	// Organizations computes an effective policy for the management policy types
+	// only; service and resource control policies are absent from this enum
+	// because AWS does not expose their combined effect.
+	for _, policyType := range orgtypes.EffectivePolicyType("").Values() {
+		resp, err := client.DescribeEffectivePolicy(ctx, &organizations.DescribeEffectivePolicyInput{
+			PolicyType: policyType,
+			TargetId:   &accountId,
+		})
+		if err != nil {
+			if isEffectivePolicyAbsent(err) || Is400AccessDeniedError(err) {
+				continue
+			}
+			return nil, err
+		}
+		if resp.EffectivePolicy == nil {
+			continue
+		}
+
+		mqlPolicy, err := CreateResource(a.MqlRuntime, ResourceAwsOrganizationEffectivePolicy,
+			map[string]*llx.RawData{
+				"__id":          llx.StringData(accountId + "/effectivePolicy/" + string(policyType)),
+				"type":          llx.StringData(string(policyType)),
+				"content":       llx.StringDataPtr(resp.EffectivePolicy.PolicyContent),
+				"lastUpdatedAt": llx.TimeDataPtr(resp.EffectivePolicy.LastUpdatedTimestamp),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlPolicy)
+	}
+	return res, nil
+}

--- a/providers/aws/resources/aws_organizations_policy_test.go
+++ b/providers/aws/resources/aws_organizations_policy_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPolicyTypeUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"policy type not enabled", &orgtypes.PolicyTypeNotEnabledException{}, true},
+		{"policy type not available", &orgtypes.PolicyTypeNotAvailableForOrganizationException{}, true},
+		{"organizations not in use", &orgtypes.AWSOrganizationsNotInUseException{}, true},
+		{"wrapped not enabled", errors.Join(errors.New("call failed"), &orgtypes.PolicyTypeNotEnabledException{}), true},
+		{"effective policy not found", &orgtypes.EffectivePolicyNotFoundException{}, false},
+		{"unrelated error", errors.New("throttled"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPolicyTypeUnavailable(tt.err))
+		})
+	}
+}
+
+func TestIsEffectivePolicyAbsent(t *testing.T) {
+	assert.True(t, isEffectivePolicyAbsent(&orgtypes.EffectivePolicyNotFoundException{}))
+	// A type that was never enabled has no effective policy either.
+	assert.True(t, isEffectivePolicyAbsent(&orgtypes.PolicyTypeNotEnabledException{}))
+	assert.False(t, isEffectivePolicyAbsent(errors.New("throttled")))
+}
+
+// Only the control-policy types use the IAM policy grammar. Every other type
+// carries its own document format, and the enum is read from the SDK so a type
+// added later defaults to "not IAM grammar" rather than being misparsed.
+func TestPolicyTypeUsesIamGrammar(t *testing.T) {
+	iamGrammar := map[orgtypes.PolicyType]bool{
+		orgtypes.PolicyTypeServiceControlPolicy:  true,
+		orgtypes.PolicyTypeResourceControlPolicy: true,
+	}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		assert.Equal(t, iamGrammar[policyType], policyTypeUsesIamGrammar(policyType),
+			"unexpected grammar verdict for %s", policyType)
+	}
+}
+
+// A non-IAM-grammar policy resolves to no statements without reading its
+// content, which this exercises by leaving the runtime unset — parsing would
+// need it and would panic.
+func TestOrganizationPolicyStatementsSkipsNonIamGrammar(t *testing.T) {
+	for _, policyType := range []orgtypes.PolicyType{
+		orgtypes.PolicyTypeTagPolicy,
+		orgtypes.PolicyTypeBackupPolicy,
+		orgtypes.PolicyTypeDeclarativePolicyEc2,
+		orgtypes.PolicyTypeAiservicesOptOutPolicy,
+	} {
+		policy := &mqlAwsOrganizationPolicy{Type: setString(string(policyType))}
+		statements, err := policy.statements()
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, statements, "expected no statements for %s", policyType)
+	}
+}
+
+// Every effective policy type must also be a valid policy type, since the
+// effective-policy list is derived from a separate SDK enum.
+func TestEffectivePolicyTypesArePolicyTypes(t *testing.T) {
+	policyTypes := map[string]bool{}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		policyTypes[string(policyType)] = true
+	}
+	for _, effectiveType := range orgtypes.EffectivePolicyType("").Values() {
+		assert.True(t, policyTypes[string(effectiveType)], "%s is not a known policy type", effectiveType)
+		assert.False(t, policyTypeUsesIamGrammar(orgtypes.PolicyType(effectiveType)),
+			"%s is a control policy, which has no effective-policy API", effectiveType)
+	}
+}


### PR DESCRIPTION
> **Note on scope:** #9550 has merged, and #9552 (*"expose all AWS Organizations policy types and effective policies"*) automerged **into this branch** rather than into main, so this PR now carries that work too. #9552 is closed as merged; its description there is still the reference for the Organizations half of this diff. The two halves are independent — Organizations policy types touch `aws_organizations_policy.go` / `aws_account.go`, the IAM work below touches `aws_iam_service_last_accessed.go` / `aws_iam_accessanalyzer.go`.

## What

Two additions that together answer *"which permissions does this principal hold but never use?"* — a question the provider previously could not answer at all.

`aws.iam.role.lastUsedAt` only reports whether a role was assumed, not what it was allowed to do versus what it actually did. And unused-access findings already reach us through `aws.iam.accessAnalyzer.findings` (`ListFindingsV2` covers the unused-access analyzer types), but only as summaries — the unused-access *detail* was dropped on the floor.

## 1. Service last-accessed

```
private aws.iam.serviceLastAccessed {
  serviceName string
  serviceNamespace string
  lastAuthenticatedAt time        // null = never used in the tracking period
  lastAuthenticatedEntity string
  lastAuthenticatedRegion string
  totalAuthenticatedEntities int
}
```

Reachable via `lastAccessedServices()` on `aws.iam.role`, `aws.iam.user`, `aws.iam.group`, and `aws.iam.policy`.

IAM builds this report **asynchronously** — `GenerateServiceLastAccessedDetails` returns a job id and `GetServiceLastAccessedDetails` reports `IN_PROGRESS` until it finishes. The fetch polls to a 45s deadline and **returns an error on timeout rather than a short list**: a partial report silently read as "no service was ever used" would invert the meaning of every audit built on it. `FAILED` jobs surface IAM's own reason. Marker pagination is handled.

The per-principal cost (one report job each) is called out in each field's doc comment, since reading it across every role in a large account is genuinely expensive.

## 2. Unused-access finding detail

Adds to `aws.iam.accessAnalyzer.finding`:

| field | populated for |
|---|---|
| `lastAccessedAt()` | all four unused-access types (null = never used) |
| `unusedServiceNamespace()` | `UnusedPermission` |
| `unusedActions()` | `UnusedPermission` |
| `unusedAccessKeyId()` | `UnusedIAMUserAccessKey` |

All four share one `GetFindingV2` call cached on the resource (`atomic.Bool` + mutex double-check). A finding whose type is not `Unused*` short-circuits to empty values **without an API call**, so adding these fields costs nothing on accounts that only run external-access analyzers.

## Example queries

```coffee
# roles permitted to reach services they have never called
aws.iam.roles.where(name == "deploy-role") {
  name
  lastAccessedServices.where(lastAuthenticatedAt == null) { serviceNamespace }
}

# unused permissions, worst-stale first
aws.iam.accessAnalyzer.findings.where(type == "UnusedPermission") {
  resourceArn unusedServiceNamespace unusedActions lastAccessedAt
}

# access keys Access Analyzer reports as unused
aws.iam.accessAnalyzer.findings.where(type == "UnusedIAMUserAccessKey") {
  resourceArn unusedAccessKeyId lastAccessedAt
}
```

## Permissions

`iam:GenerateServiceLastAccessedDetails`, `iam:GetServiceLastAccessedDetails`, `access-analyzer:GetFindingV2` (plus `organizations:DescribeEffectivePolicy` from the folded-in #9552). A finding detail the caller can't read is logged and resolves empty rather than failing the finding list.

## Test

`parseUnusedAccessDetails` is extracted as a pure function and unit-tested across all four unused-access union members, the external-access member (must contribute nothing), a never-used subject (time must stay null, not a zero timestamp), and an empty union. A second test asserts the non-unused short-circuit resolves all four fields with **no runtime attached** — if it tried to reach the connection it would panic, so the test pins the "no API call" claim rather than asserting it in a comment.

Not yet live-verified — batched with the other AWS PRs pending a `provider-verification` run. The async report job in particular wants a real-account check.
