### PR TITLE
✨ aws: expose all AWS Organizations policy types and effective policies

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -112,6 +112,25 @@ aws.account @defaults("id aliases.first organization.id") {
   // Available only when the calling identity is the organization's management
   // account or a delegated administrator.
   joinedTimestamp() time
+
+  // Organization policies attached directly to the account, across every policy type
+  //
+  // Only the policies attached to this account, not the ones it inherits from
+  // the organization root or its organizational units. Available only when the
+  // calling identity is the organization's management account or a delegated
+  // administrator. Otherwise empty.
+  policies() []aws.organization.policy
+
+  // Organization policies that resolve for the account, merged across the organization
+  //
+  // The value each control settles on for this account once inherited and
+  // directly attached policies are combined. Covers the management policy
+  // types only, since AWS computes no effective policy for service control or
+  // resource control policies. A type with no policy applying to the account
+  // contributes no entry. Available only when the calling identity is the
+  // organization's management account or a delegated administrator. Otherwise
+  // empty.
+  effectivePolicies() []aws.organization.effectivePolicy
 }
 
 // AWS Account alternate contact
@@ -239,6 +258,17 @@ aws.organization @defaults("id masterAccountEmail") {
   organizationalUnits() []aws.organization.organizationalUnit
   // Service control policies defined in the organization, if available to the caller
   serviceControlPolicies() []aws.organization.serviceControlPolicy
+  // Policies defined in the organization, across every policy type
+  //
+  // Covers all policy types AWS Organizations supports, not only service
+  // control policies: resource control policies, which bound what external
+  // principals may do to resources in the organization, declarative policies,
+  // which pin account settings such as EC2 instance metadata defaults, and the
+  // tag, backup, and AI-services opt-out policies. Select a type with a filter,
+  // for example
+  // `policies.where(type == "RESOURCE_CONTROL_POLICY")`. A policy type that is
+  // not enabled for the organization contributes nothing.
+  policies() []aws.organization.policy
 }
 
 // AWS Organizations service control policy
@@ -264,6 +294,72 @@ private aws.organization.serviceControlPolicy @defaults("name id") {
   content() string
   // Parsed statements from the policy content
   statements() []aws.iam.policyStatement
+}
+
+// AWS Organizations policy
+//
+// Policy of any type defined in an organization, and the guardrail it applies
+// to the accounts, organizational units, and roots it is attached to. The type
+// field says which control the policy carries: SERVICE_CONTROL_POLICY bounds
+// what principals in the organization may do, RESOURCE_CONTROL_POLICY bounds
+// what may be done to the organization's resources by principals outside it,
+// DECLARATIVE_POLICY_EC2 pins account settings such as instance metadata
+// defaults and EBS encryption, and the remaining types cover tagging, backup,
+// AI-services opt-out, and per-service configuration. Other values include
+// TAG_POLICY, BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY, CHATBOT_POLICY,
+// SECURITYHUB_POLICY, INSPECTOR_POLICY, UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY,
+// S3_POLICY, and NETWORK_SECURITY_DIRECTOR_POLICY.
+private aws.organization.policy @defaults("name type id") {
+  // Unique identifier of the policy
+  id string
+  // ARN of the policy
+  arn string
+  // Friendly name of the policy
+  name string
+  // Description of the policy
+  description string
+  // Type of control the policy carries
+  //
+  // One of SERVICE_CONTROL_POLICY, RESOURCE_CONTROL_POLICY, TAG_POLICY,
+  // BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY, CHATBOT_POLICY,
+  // DECLARATIVE_POLICY_EC2, SECURITYHUB_POLICY, INSPECTOR_POLICY,
+  // UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY, S3_POLICY, or
+  // NETWORK_SECURITY_DIRECTOR_POLICY.
+  type string
+  // Whether the policy is managed by AWS rather than the customer
+  awsManaged bool
+  // Raw policy content document (JSON)
+  content() string
+  // Parsed statements from the policy content
+  //
+  // Resolved for the policy types written in the IAM policy grammar, which are
+  // the service control and resource control policies. Empty for the tag,
+  // backup, declarative, AI-services opt-out, and per-service policy types,
+  // which use their own document formats: read content for those.
+  statements() []aws.iam.policyStatement
+}
+
+// AWS Organizations effective policy
+//
+// Merged policy that actually applies to one account, combining the policies
+// it inherits from the organization root and its organizational units with any
+// policy attached directly to it. This is the value to audit when the question
+// is what a control resolves to for an account rather than which documents
+// were attached where. AWS computes an effective policy for the management
+// policy types only, so there is no entry for service control or resource
+// control policies, whose combined effect AWS does not expose.
+private aws.organization.effectivePolicy @defaults("type lastUpdatedAt") {
+  // Type of the effective policy
+  //
+  // One of TAG_POLICY, BACKUP_POLICY, AISERVICES_OPT_OUT_POLICY,
+  // CHATBOT_POLICY, DECLARATIVE_POLICY_EC2, SECURITYHUB_POLICY,
+  // INSPECTOR_POLICY, UPGRADE_ROLLOUT_POLICY, BEDROCK_POLICY, S3_POLICY, or
+  // NETWORK_SECURITY_DIRECTOR_POLICY.
+  type string
+  // Merged policy content document (JSON)
+  content string
+  // When the effective policy was last updated
+  lastUpdatedAt time
 }
 
 // AWS Organization delegated administrator
@@ -310,6 +406,11 @@ private aws.organization.organizationalUnit @defaults("id name path") {
   path string
   // Service control policies attached directly to this organizational unit
   serviceControlPolicies() []aws.organization.serviceControlPolicy
+  // Policies attached directly to this organizational unit, across every policy type
+  //
+  // Only the policies attached at this level, not the ones the unit inherits
+  // from the organization root or a parent unit.
+  policies() []aws.organization.policy
 }
 
 // Amazon Virtual Private Cloud (VPC)

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -23,6 +23,8 @@ const (
 	ResourceAwsBillingBudget                                                    string = "aws.billing.budget"
 	ResourceAwsOrganization                                                     string = "aws.organization"
 	ResourceAwsOrganizationServiceControlPolicy                                 string = "aws.organization.serviceControlPolicy"
+	ResourceAwsOrganizationPolicy                                               string = "aws.organization.policy"
+	ResourceAwsOrganizationEffectivePolicy                                      string = "aws.organization.effectivePolicy"
 	ResourceAwsOrganizationDelegatedAdministrator                               string = "aws.organization.delegatedAdministrator"
 	ResourceAwsOrganizationDelegatedService                                     string = "aws.organization.delegatedService"
 	ResourceAwsOrganizationOrganizationalUnit                                   string = "aws.organization.organizationalUnit"
@@ -995,6 +997,14 @@ func init() {
 		"aws.organization.serviceControlPolicy": {
 			// to override args, implement: initAwsOrganizationServiceControlPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsOrganizationServiceControlPolicy,
+		},
+		"aws.organization.policy": {
+			// to override args, implement: initAwsOrganizationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationPolicy,
+		},
+		"aws.organization.effectivePolicy": {
+			// to override args, implement: initAwsOrganizationEffectivePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsOrganizationEffectivePolicy,
 		},
 		"aws.organization.delegatedAdministrator": {
 			// to override args, implement: initAwsOrganizationDelegatedAdministrator(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -4877,6 +4887,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.account.joinedTimestamp": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAccount).GetJoinedTimestamp()).ToDataRes(types.Time)
 	},
+	"aws.account.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAccount).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
+	},
+	"aws.account.effectivePolicies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsAccount).GetEffectivePolicies()).ToDataRes(types.Array(types.Resource("aws.organization.effectivePolicy")))
+	},
 	"aws.account.alternateContact.accountId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsAccountAlternateContact).GetAccountId()).ToDataRes(types.String)
 	},
@@ -4991,6 +5007,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.organization.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganization).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
 	},
+	"aws.organization.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganization).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
+	},
 	"aws.organization.serviceControlPolicy.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetId()).ToDataRes(types.String)
 	},
@@ -5011,6 +5030,39 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationServiceControlPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.organization.policy.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetId()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.arn": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetArn()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetName()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.description": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetDescription()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetType()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.awsManaged": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetAwsManaged()).ToDataRes(types.Bool)
+	},
+	"aws.organization.policy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.policy.statements": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationPolicy).GetStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
+	},
+	"aws.organization.effectivePolicy.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetType()).ToDataRes(types.String)
+	},
+	"aws.organization.effectivePolicy.content": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetContent()).ToDataRes(types.String)
+	},
+	"aws.organization.effectivePolicy.lastUpdatedAt": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationEffectivePolicy).GetLastUpdatedAt()).ToDataRes(types.Time)
 	},
 	"aws.organization.delegatedAdministrator.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationDelegatedAdministrator).GetArn()).ToDataRes(types.String)
@@ -5062,6 +5114,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetServiceControlPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.serviceControlPolicy")))
+	},
+	"aws.organization.organizationalUnit.policies": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsOrganizationOrganizationalUnit).GetPolicies()).ToDataRes(types.Array(types.Resource("aws.organization.policy")))
 	},
 	"aws.vpc.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpc).GetArn()).ToDataRes(types.String)
@@ -35803,6 +35858,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsAccount).JoinedTimestamp, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
+	"aws.account.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAccount).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.account.effectivePolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsAccount).EffectivePolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.account.alternateContact.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsAccountAlternateContact).__id, ok = v.Value.(string)
 		return
@@ -35971,6 +36034,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsOrganization).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.organization.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganization).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.organization.serviceControlPolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationServiceControlPolicy).__id, ok = v.Value.(string)
 		return
@@ -36001,6 +36068,58 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.serviceControlPolicy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationServiceControlPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.policy.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.arn": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Arn, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.description": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Description, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.awsManaged": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).AwsManaged, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.policy.statements": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationPolicy).Statements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.organization.effectivePolicy.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.content": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).Content, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.organization.effectivePolicy.lastUpdatedAt": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationEffectivePolicy).LastUpdatedAt, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
 		return
 	},
 	"aws.organization.delegatedAdministrator.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -36081,6 +36200,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.organization.organizationalUnit.serviceControlPolicies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsOrganizationOrganizationalUnit).ServiceControlPolicies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.organization.organizationalUnit.policies": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsOrganizationOrganizationalUnit).Policies, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -80799,6 +80922,8 @@ type mqlAwsAccount struct {
 	State              plugin.TValue[string]
 	JoinedMethod       plugin.TValue[string]
 	JoinedTimestamp    plugin.TValue[*time.Time]
+	Policies           plugin.TValue[[]any]
+	EffectivePolicies  plugin.TValue[[]any]
 }
 
 // createAwsAccount creates a new instance of this resource
@@ -80979,6 +81104,38 @@ func (c *mqlAwsAccount) GetJoinedMethod() *plugin.TValue[string] {
 func (c *mqlAwsAccount) GetJoinedTimestamp() *plugin.TValue[*time.Time] {
 	return plugin.GetOrCompute[*time.Time](&c.JoinedTimestamp, func() (*time.Time, error) {
 		return c.joinedTimestamp()
+	})
+}
+
+func (c *mqlAwsAccount) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.account", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
+	})
+}
+
+func (c *mqlAwsAccount) GetEffectivePolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectivePolicies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.account", c.__id, "effectivePolicies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectivePolicies()
 	})
 }
 
@@ -81297,6 +81454,7 @@ type mqlAwsOrganization struct {
 	DelegatedAdministrators plugin.TValue[[]any]
 	OrganizationalUnits     plugin.TValue[[]any]
 	ServiceControlPolicies  plugin.TValue[[]any]
+	Policies                plugin.TValue[[]any]
 }
 
 // createAwsOrganization creates a new instance of this resource
@@ -81419,6 +81577,22 @@ func (c *mqlAwsOrganization) GetServiceControlPolicies() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsOrganization) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
+	})
+}
+
 // mqlAwsOrganizationServiceControlPolicy for the aws.organization.serviceControlPolicy resource
 type mqlAwsOrganizationServiceControlPolicy struct {
 	MqlRuntime *plugin.Runtime
@@ -81505,6 +81679,153 @@ func (c *mqlAwsOrganizationServiceControlPolicy) GetStatements() *plugin.TValue[
 
 		return c.statements()
 	})
+}
+
+// mqlAwsOrganizationPolicy for the aws.organization.policy resource
+type mqlAwsOrganizationPolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationPolicyInternal it will be used here
+	Id          plugin.TValue[string]
+	Arn         plugin.TValue[string]
+	Name        plugin.TValue[string]
+	Description plugin.TValue[string]
+	Type        plugin.TValue[string]
+	AwsManaged  plugin.TValue[bool]
+	Content     plugin.TValue[string]
+	Statements  plugin.TValue[[]any]
+}
+
+// createAwsOrganizationPolicy creates a new instance of this resource
+func createAwsOrganizationPolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationPolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.policy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationPolicy) MqlName() string {
+	return "aws.organization.policy"
+}
+
+func (c *mqlAwsOrganizationPolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationPolicy) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAwsOrganizationPolicy) GetArn() *plugin.TValue[string] {
+	return &c.Arn
+}
+
+func (c *mqlAwsOrganizationPolicy) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAwsOrganizationPolicy) GetDescription() *plugin.TValue[string] {
+	return &c.Description
+}
+
+func (c *mqlAwsOrganizationPolicy) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsOrganizationPolicy) GetAwsManaged() *plugin.TValue[bool] {
+	return &c.AwsManaged
+}
+
+func (c *mqlAwsOrganizationPolicy) GetContent() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.Content, func() (string, error) {
+		return c.content()
+	})
+}
+
+func (c *mqlAwsOrganizationPolicy) GetStatements() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Statements, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.policy", c.__id, "statements")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.statements()
+	})
+}
+
+// mqlAwsOrganizationEffectivePolicy for the aws.organization.effectivePolicy resource
+type mqlAwsOrganizationEffectivePolicy struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsOrganizationEffectivePolicyInternal it will be used here
+	Type          plugin.TValue[string]
+	Content       plugin.TValue[string]
+	LastUpdatedAt plugin.TValue[*time.Time]
+}
+
+// createAwsOrganizationEffectivePolicy creates a new instance of this resource
+func createAwsOrganizationEffectivePolicy(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsOrganizationEffectivePolicy{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.organization.effectivePolicy", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) MqlName() string {
+	return "aws.organization.effectivePolicy"
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetContent() *plugin.TValue[string] {
+	return &c.Content
+}
+
+func (c *mqlAwsOrganizationEffectivePolicy) GetLastUpdatedAt() *plugin.TValue[*time.Time] {
+	return &c.LastUpdatedAt
 }
 
 // mqlAwsOrganizationDelegatedAdministrator for the aws.organization.delegatedAdministrator resource
@@ -81689,6 +82010,7 @@ type mqlAwsOrganizationOrganizationalUnit struct {
 	Name                   plugin.TValue[string]
 	Path                   plugin.TValue[string]
 	ServiceControlPolicies plugin.TValue[[]any]
+	Policies               plugin.TValue[[]any]
 }
 
 // createAwsOrganizationOrganizationalUnit creates a new instance of this resource
@@ -81757,6 +82079,22 @@ func (c *mqlAwsOrganizationOrganizationalUnit) GetServiceControlPolicies() *plug
 		}
 
 		return c.serviceControlPolicies()
+	})
+}
+
+func (c *mqlAwsOrganizationOrganizationalUnit) GetPolicies() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Policies, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.organization.organizationalUnit", c.__id, "policies")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policies()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -15,6 +15,7 @@ aws.account.alternateContact.title 11.15.2
 aws.account.alternateContacts 11.15.2
 aws.account.billingContact 11.15.2
 aws.account.contactInformation 11.15.2
+aws.account.effectivePolicies 13.52.2
 aws.account.email 13.21.4
 aws.account.id 11.15.2
 aws.account.joinedMethod 13.21.4
@@ -23,6 +24,7 @@ aws.account.name 13.21.4
 aws.account.operationsContact 11.15.2
 aws.account.organization 11.15.2
 aws.account.paths 13.6.3
+aws.account.policies 13.52.2
 aws.account.regionOptInStatus 13.21.4
 aws.account.securityContact 11.15.2
 aws.account.state 13.21.4
@@ -7587,6 +7589,10 @@ aws.organization.delegatedAdministrators 13.0.2
 aws.organization.delegatedService 13.0.2
 aws.organization.delegatedService.delegationEnabledDate 13.0.2
 aws.organization.delegatedService.servicePrincipal 13.0.2
+aws.organization.effectivePolicy 13.52.2
+aws.organization.effectivePolicy.content 13.52.2
+aws.organization.effectivePolicy.lastUpdatedAt 13.52.2
+aws.organization.effectivePolicy.type 13.52.2
 aws.organization.featureSet 11.15.2
 aws.organization.id 11.15.2
 aws.organization.masterAccountArn 13.38.2
@@ -7597,8 +7603,19 @@ aws.organization.organizationalUnit.arn 13.6.3
 aws.organization.organizationalUnit.id 13.6.3
 aws.organization.organizationalUnit.name 13.6.3
 aws.organization.organizationalUnit.path 13.6.3
+aws.organization.organizationalUnit.policies 13.52.2
 aws.organization.organizationalUnit.serviceControlPolicies 13.32.2
 aws.organization.organizationalUnits 13.6.3
+aws.organization.policies 13.52.2
+aws.organization.policy 13.52.2
+aws.organization.policy.arn 13.52.2
+aws.organization.policy.awsManaged 13.52.2
+aws.organization.policy.content 13.52.2
+aws.organization.policy.description 13.52.2
+aws.organization.policy.id 13.52.2
+aws.organization.policy.name 13.52.2
+aws.organization.policy.statements 13.52.2
+aws.organization.policy.type 13.52.2
 aws.organization.serviceControlPolicies 13.32.2
 aws.organization.serviceControlPolicy 13.32.2
 aws.organization.serviceControlPolicy.arn 13.32.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T19:27:28+02:00",
+  "generated_at": "2026-08-05T19:39:25+02:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -638,6 +638,7 @@
     "network-firewall:ListRuleGroups",
     "network-firewall:ListTLSInspectionConfigurations",
     "organizations:DescribeAccount",
+    "organizations:DescribeEffectivePolicy",
     "organizations:DescribeOrganization",
     "organizations:DescribePolicy",
     "organizations:ListAccounts",
@@ -4903,6 +4904,12 @@
       "source_file": "aws_account.go"
     },
     {
+      "permission": "organizations:DescribeEffectivePolicy",
+      "service": "organizations",
+      "action": "DescribeEffectivePolicy",
+      "source_file": "aws_organizations_policy.go"
+    },
+    {
       "permission": "organizations:DescribeOrganization",
       "service": "organizations",
       "action": "DescribeOrganization",
@@ -4912,7 +4919,7 @@
       "permission": "organizations:DescribePolicy",
       "service": "organizations",
       "action": "DescribePolicy",
-      "source_file": "aws_account.go"
+      "source_file": "aws_organizations_policy.go"
     },
     {
       "permission": "organizations:ListAccounts",
@@ -4945,10 +4952,22 @@
       "source_file": "aws_account.go"
     },
     {
+      "permission": "organizations:ListPolicies",
+      "service": "organizations",
+      "action": "ListPolicies",
+      "source_file": "aws_organizations_policy.go"
+    },
+    {
       "permission": "organizations:ListPoliciesForTarget",
       "service": "organizations",
       "action": "ListPoliciesForTarget",
       "source_file": "aws_account.go"
+    },
+    {
+      "permission": "organizations:ListPoliciesForTarget",
+      "service": "organizations",
+      "action": "ListPoliciesForTarget",
+      "source_file": "aws_organizations_policy.go"
     },
     {
       "permission": "organizations:ListRoots",

--- a/providers/aws/resources/aws_account.go
+++ b/providers/aws/resources/aws_account.go
@@ -621,21 +621,7 @@ func (a *mqlAwsOrganizationOrganizationalUnit) serviceControlPolicies() ([]any, 
 
 func (a *mqlAwsOrganizationServiceControlPolicy) content() (string, error) {
 	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
-	client := conn.Organizations("")
-	ctx := context.Background()
-
-	id := a.Id.Data
-	resp, err := client.DescribePolicy(ctx, &organizations.DescribePolicyInput{PolicyId: &id})
-	if err != nil {
-		if Is400AccessDeniedError(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	if resp.Policy == nil || resp.Policy.Content == nil {
-		return "", nil
-	}
-	return *resp.Policy.Content, nil
+	return describePolicyContent(context.Background(), conn.Organizations(""), a.Id.Data)
 }
 
 func (a *mqlAwsOrganizationServiceControlPolicy) statements() ([]any, error) {

--- a/providers/aws/resources/aws_organizations_policy.go
+++ b/providers/aws/resources/aws_organizations_policy.go
@@ -1,0 +1,211 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// isPolicyTypeUnavailable reports whether the error means the policy type is
+// simply not in play for this organization, rather than a failure. Organizations
+// rejects a list or describe call for a policy type that has not been enabled,
+// and every type has to be enabled explicitly, so this is the common case rather
+// than an edge case.
+func isPolicyTypeUnavailable(err error) bool {
+	var notEnabled *orgtypes.PolicyTypeNotEnabledException
+	var notAvailable *orgtypes.PolicyTypeNotAvailableForOrganizationException
+	var notInUse *orgtypes.AWSOrganizationsNotInUseException
+	return errors.As(err, &notEnabled) || errors.As(err, &notAvailable) || errors.As(err, &notInUse)
+}
+
+func newOrganizationPolicyResource(runtime *plugin.Runtime, policy orgtypes.PolicySummary) (plugin.Resource, error) {
+	return CreateResource(runtime, ResourceAwsOrganizationPolicy,
+		map[string]*llx.RawData{
+			"__id":        llx.StringDataPtr(policy.Id),
+			"id":          llx.StringDataPtr(policy.Id),
+			"arn":         llx.StringDataPtr(policy.Arn),
+			"name":        llx.StringDataPtr(policy.Name),
+			"description": llx.StringDataPtr(policy.Description),
+			"type":        llx.StringData(string(policy.Type)),
+			"awsManaged":  llx.BoolData(policy.AwsManaged),
+		})
+}
+
+// listOrganizationPolicies lists the organization's policies of every type
+// known to the SDK. Reading the types off the enum rather than a hand-written
+// list means a policy type AWS adds later is picked up with the next SDK bump.
+// An empty targetId lists every policy in the organization; otherwise only the
+// policies attached directly to that root, organizational unit, or account.
+func listOrganizationPolicies(ctx context.Context, runtime *plugin.Runtime, client *organizations.Client, targetId string) ([]any, error) {
+	res := []any{}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		policies, err := listOrganizationPoliciesOfType(ctx, runtime, client, targetId, policyType)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, policies...)
+	}
+	return res, nil
+}
+
+func listOrganizationPoliciesOfType(ctx context.Context, runtime *plugin.Runtime, client *organizations.Client, targetId string, policyType orgtypes.PolicyType) ([]any, error) {
+	var hasMorePages func() bool
+	var nextPage func(context.Context) ([]orgtypes.PolicySummary, error)
+
+	if targetId == "" {
+		paginator := organizations.NewListPoliciesPaginator(client, &organizations.ListPoliciesInput{
+			Filter: policyType,
+		})
+		hasMorePages = paginator.HasMorePages
+		nextPage = func(ctx context.Context) ([]orgtypes.PolicySummary, error) {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return page.Policies, nil
+		}
+	} else {
+		paginator := organizations.NewListPoliciesForTargetPaginator(client, &organizations.ListPoliciesForTargetInput{
+			TargetId: &targetId,
+			Filter:   policyType,
+		})
+		hasMorePages = paginator.HasMorePages
+		nextPage = func(ctx context.Context) ([]orgtypes.PolicySummary, error) {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return page.Policies, nil
+		}
+	}
+
+	res := []any{}
+	for hasMorePages() {
+		policies, err := nextPage(ctx)
+		if err != nil {
+			if isPolicyTypeUnavailable(err) || Is400AccessDeniedError(err) {
+				return res, nil
+			}
+			return nil, err
+		}
+		for i := range policies {
+			mqlPolicy, err := newOrganizationPolicyResource(runtime, policies[i])
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlPolicy)
+		}
+	}
+	return res, nil
+}
+
+// describePolicyContent returns the raw content document of one policy.
+func describePolicyContent(ctx context.Context, client *organizations.Client, policyId string) (string, error) {
+	resp, err := client.DescribePolicy(ctx, &organizations.DescribePolicyInput{PolicyId: &policyId})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if resp.Policy == nil || resp.Policy.Content == nil {
+		return "", nil
+	}
+	return *resp.Policy.Content, nil
+}
+
+func (a *mqlAwsOrganization) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), "")
+}
+
+func (a *mqlAwsOrganizationOrganizationalUnit) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), a.Id.Data)
+}
+
+func (a *mqlAwsAccount) policies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return listOrganizationPolicies(context.Background(), a.MqlRuntime, conn.Organizations(""), a.Id.Data)
+}
+
+func (a *mqlAwsOrganizationPolicy) content() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return describePolicyContent(context.Background(), conn.Organizations(""), a.Id.Data)
+}
+
+// statements parses the policy content for the types written in the IAM policy
+// grammar. The remaining types carry their own document formats, which the IAM
+// statement parser would silently misread, so they resolve to no statements.
+func (a *mqlAwsOrganizationPolicy) statements() ([]any, error) {
+	if !policyTypeUsesIamGrammar(orgtypes.PolicyType(a.Type.Data)) {
+		return []any{}, nil
+	}
+	return policyStatementsFromString(a.MqlRuntime, a.Arn.Data, a.GetContent())
+}
+
+// policyTypeUsesIamGrammar reports whether an organization policy type is
+// written in the IAM policy grammar of Statement/Effect/Action/Resource.
+func policyTypeUsesIamGrammar(policyType orgtypes.PolicyType) bool {
+	switch policyType {
+	case orgtypes.PolicyTypeServiceControlPolicy, orgtypes.PolicyTypeResourceControlPolicy:
+		return true
+	}
+	return false
+}
+
+// isEffectivePolicyAbsent reports whether the error means no effective policy of
+// that type applies to the target, which is an ordinary answer rather than a
+// failure.
+func isEffectivePolicyAbsent(err error) bool {
+	var notFound *orgtypes.EffectivePolicyNotFoundException
+	return errors.As(err, &notFound) || isPolicyTypeUnavailable(err)
+}
+
+func (a *mqlAwsAccount) effectivePolicies() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	client := conn.Organizations("")
+	ctx := context.Background()
+	accountId := a.Id.Data
+
+	res := []any{}
+	// Organizations computes an effective policy for the management policy types
+	// only; service and resource control policies are absent from this enum
+	// because AWS does not expose their combined effect.
+	for _, policyType := range orgtypes.EffectivePolicyType("").Values() {
+		resp, err := client.DescribeEffectivePolicy(ctx, &organizations.DescribeEffectivePolicyInput{
+			PolicyType: policyType,
+			TargetId:   &accountId,
+		})
+		if err != nil {
+			if isEffectivePolicyAbsent(err) || Is400AccessDeniedError(err) {
+				continue
+			}
+			return nil, err
+		}
+		if resp.EffectivePolicy == nil {
+			continue
+		}
+
+		mqlPolicy, err := CreateResource(a.MqlRuntime, ResourceAwsOrganizationEffectivePolicy,
+			map[string]*llx.RawData{
+				"__id":          llx.StringData(accountId + "/effectivePolicy/" + string(policyType)),
+				"type":          llx.StringData(string(policyType)),
+				"content":       llx.StringDataPtr(resp.EffectivePolicy.PolicyContent),
+				"lastUpdatedAt": llx.TimeDataPtr(resp.EffectivePolicy.LastUpdatedTimestamp),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlPolicy)
+	}
+	return res, nil
+}

--- a/providers/aws/resources/aws_organizations_policy_test.go
+++ b/providers/aws/resources/aws_organizations_policy_test.go
@@ -1,0 +1,85 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"errors"
+	"testing"
+
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPolicyTypeUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"policy type not enabled", &orgtypes.PolicyTypeNotEnabledException{}, true},
+		{"policy type not available", &orgtypes.PolicyTypeNotAvailableForOrganizationException{}, true},
+		{"organizations not in use", &orgtypes.AWSOrganizationsNotInUseException{}, true},
+		{"wrapped not enabled", errors.Join(errors.New("call failed"), &orgtypes.PolicyTypeNotEnabledException{}), true},
+		{"effective policy not found", &orgtypes.EffectivePolicyNotFoundException{}, false},
+		{"unrelated error", errors.New("throttled"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPolicyTypeUnavailable(tt.err))
+		})
+	}
+}
+
+func TestIsEffectivePolicyAbsent(t *testing.T) {
+	assert.True(t, isEffectivePolicyAbsent(&orgtypes.EffectivePolicyNotFoundException{}))
+	// A type that was never enabled has no effective policy either.
+	assert.True(t, isEffectivePolicyAbsent(&orgtypes.PolicyTypeNotEnabledException{}))
+	assert.False(t, isEffectivePolicyAbsent(errors.New("throttled")))
+}
+
+// Only the control-policy types use the IAM policy grammar. Every other type
+// carries its own document format, and the enum is read from the SDK so a type
+// added later defaults to "not IAM grammar" rather than being misparsed.
+func TestPolicyTypeUsesIamGrammar(t *testing.T) {
+	iamGrammar := map[orgtypes.PolicyType]bool{
+		orgtypes.PolicyTypeServiceControlPolicy:  true,
+		orgtypes.PolicyTypeResourceControlPolicy: true,
+	}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		assert.Equal(t, iamGrammar[policyType], policyTypeUsesIamGrammar(policyType),
+			"unexpected grammar verdict for %s", policyType)
+	}
+}
+
+// A non-IAM-grammar policy resolves to no statements without reading its
+// content, which this exercises by leaving the runtime unset — parsing would
+// need it and would panic.
+func TestOrganizationPolicyStatementsSkipsNonIamGrammar(t *testing.T) {
+	for _, policyType := range []orgtypes.PolicyType{
+		orgtypes.PolicyTypeTagPolicy,
+		orgtypes.PolicyTypeBackupPolicy,
+		orgtypes.PolicyTypeDeclarativePolicyEc2,
+		orgtypes.PolicyTypeAiservicesOptOutPolicy,
+	} {
+		policy := &mqlAwsOrganizationPolicy{Type: setString(string(policyType))}
+		statements, err := policy.statements()
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, statements, "expected no statements for %s", policyType)
+	}
+}
+
+// Every effective policy type must also be a valid policy type, since the
+// effective-policy list is derived from a separate SDK enum.
+func TestEffectivePolicyTypesArePolicyTypes(t *testing.T) {
+	policyTypes := map[string]bool{}
+	for _, policyType := range orgtypes.PolicyType("").Values() {
+		policyTypes[string(policyType)] = true
+	}
+	for _, effectiveType := range orgtypes.EffectivePolicyType("").Values() {
+		assert.True(t, policyTypes[string(effectiveType)], "%s is not a known policy type", effectiveType)
+		assert.False(t, policyTypeUsesIamGrammar(orgtypes.PolicyType(effectiveType)),
+			"%s is a control policy, which has no effective-policy API", effectiveType)
+	}
+}


### PR DESCRIPTION
> Stacked on #9551 (which is stacked on #9550). Review those first.

## What

Only **service control policies** were modeled, so every other organization-wide guardrail was invisible. Most importantly:

- **Resource control policies (RCPs)** — bound what principals *outside* the organization may do to its resources. The data-perimeter primitive, and completely absent until now.
- **Declarative policies** (`DECLARATIVE_POLICY_EC2`) — pin account settings org-wide, including EC2 instance metadata defaults and EBS encryption-by-default. These *enforce* controls that we otherwise only report per-account.

## Schema

```
private aws.organization.policy {
  id string
  arn string
  name string
  description string
  type string          // 13 values, see below
  awsManaged bool
  content() string
  statements() []aws.iam.policyStatement
}

private aws.organization.effectivePolicy {
  type string
  content string
  lastUpdatedAt time
}
```

New accessors:

| accessor | scope |
|---|---|
| `aws.organization.policies()` | every policy in the organization, all types |
| `aws.organization.organizationalUnit.policies()` | attached directly to the OU |
| `aws.account.policies()` | attached directly to the account |
| `aws.account.effectivePolicies()` | merged value for the account |

`aws.organization.serviceControlPolicies` is **unchanged and not deprecated** — it stays the ergonomic path to the most common type, and forcing a `.where(type == ...)` would be worse UX for no gain.

## Two design points worth reviewing

**1. Policy types come from the SDK enum, not a hand-written list.** `orgtypes.PolicyType("").Values()` currently yields 13 types (`SERVICE_CONTROL_POLICY`, `RESOURCE_CONTROL_POLICY`, `TAG_POLICY`, `BACKUP_POLICY`, `AISERVICES_OPT_OUT_POLICY`, `CHATBOT_POLICY`, `DECLARATIVE_POLICY_EC2`, `SECURITYHUB_POLICY`, `INSPECTOR_POLICY`, `UPGRADE_ROLLOUT_POLICY`, `BEDROCK_POLICY`, `S3_POLICY`, `NETWORK_SECURITY_DIRECTOR_POLICY`). A type AWS adds later is picked up with the next SDK bump instead of silently missing. A type that isn't enabled for the org (`PolicyTypeNotEnabledException`) contributes nothing rather than failing the list — every type must be enabled explicitly, so that's the common case, not an edge case.

**2. `statements()` is resolved only for the IAM-grammar types.** SCPs and RCPs use `Statement`/`Effect`/`Action`/`Resource`; tag, backup, declarative and opt-out policies use entirely different document formats. Feeding those to the IAM statement parser would produce plausible-looking garbage, so they resolve to no statements and expose `content` instead. This is stated in the field doc rather than left for the user to discover.

Related: **there is no effective-policy API for control policies.** `EffectivePolicyType` omits `SERVICE_CONTROL_POLICY` and `RESOURCE_CONTROL_POLICY` — AWS does not expose their combined effect. So `effectivePolicies()` covers the management policy types only, and the doc says so explicitly rather than implying an effective-SCP capability we can't deliver.

## Example queries

```coffee
# resource control policies and what they deny
aws.organization.policies.where(type == "RESOURCE_CONTROL_POLICY") {
  name statements { effect actions resources conditions }
}

# is EC2 instance metadata pinned org-wide by a declarative policy?
aws.organization.policies.where(type == "DECLARATIVE_POLICY_EC2") { name content }

# what each account's declarative policy actually resolves to
aws.organization.accounts {
  id
  effectivePolicies.where(type == "DECLARATIVE_POLICY_EC2") { content lastUpdatedAt }
}

# OUs with no service control policy attached at their own level
aws.organization.organizationalUnits.where(
  policies.where(type == "SERVICE_CONTROL_POLICY").length == 0
) { name path }
```

## Permissions

Adds `organizations:DescribeEffectivePolicy`. `ListPolicies`/`ListPoliciesForTarget`/`DescribePolicy` were already required; their manifest entries move to the new source file.

## Drive-by

`aws.organization.serviceControlPolicy.content()` now delegates to the extracted `describePolicyContent` shared with the new resource.

## Test

Unit tests cover the error classification (`isPolicyTypeUnavailable` including a wrapped error, `isEffectivePolicyAbsent`), the grammar predicate **checked against the full SDK enum** so a newly added type defaults to "not IAM grammar" rather than being misparsed, and the non-IAM-grammar short circuit with no runtime attached (parsing would panic if it were reached). A final test asserts every `EffectivePolicyType` is a real `PolicyType` and that none of them is a control policy — pinning the API asymmetry above so an SDK change that breaks the assumption fails a test rather than shipping.

Not yet live-verified — needs a management-account credential; batched with the other AWS PRs pending a `provider-verification` run.
