### PR TITLE
✨ aws: expose EC2 account-level guardrails and instance user data

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -17518,6 +17518,32 @@ aws.ec2 {
   serialConsoleAccessEnabled() map[string]bool
   // AMI block public access state per region: block-new-sharing or unblocked
   imageBlockPublicAccess() map[string]string
+  // Whether public sharing of EBS snapshots is blocked, per region
+  //
+  // One of block-all-sharing, which also blocks snapshots that are already
+  // public, block-new-sharing, which leaves already-public snapshots public,
+  // or unblocked. A region absent from the map is one the caller could not
+  // read the setting for.
+  snapshotBlockPublicAccess() map[string]string
+  // Allowed AMIs setting state, per region
+  //
+  // One of enabled, where only AMIs matching the account's image criteria can
+  // be discovered and launched, audit-mode, where non-matching AMIs stay
+  // usable but are flagged, or disabled. The setting bounds which AMI
+  // publishers an account will trust.
+  allowedImagesState() map[string]string
+  // Account-level instance metadata service defaults, one entry per region
+  //
+  // The defaults new instances launch with when the launch itself specifies
+  // nothing, which is how an account requires IMDSv2 without depending on
+  // every launch template being correct.
+  instanceMetadataDefaults() []aws.ec2.instanceMetadataDefault
+  // KMS keys used for EBS encryption by default, one per region where a key is set
+  //
+  // The key EBS encrypts new volumes with when the request names no key. Each
+  // key carries its own region. A region resolves to the AWS-managed
+  // aws/ebs key unless the account set a customer managed key.
+  ebsDefaultKmsKeys() []aws.kms.key
   // List of volumes across the AWS account
   volumes() []aws.ec2.volume
   // List of snapshots across the account
@@ -18853,6 +18879,49 @@ private aws.inspector.finding.codeVulnerability @defaults("detectorName") {
   sourceLambdaLayerArn string
 }
 
+// Account-level EC2 instance metadata service defaults
+//
+// The instance metadata service settings new instances in one region launch
+// with when the launch request specifies none of its own. Setting httpTokens to
+// required at the account level is how IMDSv2 becomes the floor for every
+// launch, rather than depending on each launch template and each API caller
+// getting it right. The settings are per region, and a region with no account
+// default reports null for each value, which is distinct from a default that
+// permits IMDSv1. When managedByDeclarativePolicy is true the values are pinned
+// by an organization declarative policy and cannot be changed in the account.
+private aws.ec2.instanceMetadataDefault @defaults("region httpTokens httpEndpoint") {
+  // Region the defaults apply to
+  region string
+  // Whether a session token is required to read instance metadata
+  //
+  // A value of required denotes IMDSv2; optional permits the unauthenticated
+  // IMDSv1 path. Null when the account sets no default for the region.
+  httpTokens string
+  // Whether the instance metadata endpoint is enabled by default
+  //
+  // One of enabled or disabled. Null when the account sets no default for the
+  // region.
+  httpEndpoint string
+  // Default hop limit for the instance metadata PUT response
+  //
+  // Values above 1 let a container or a proxied request reach the metadata
+  // service, which widens the blast radius of a server-side request forgery.
+  // Null when the account sets no default for the region.
+  httpPutResponseHopLimit int
+  // Whether instance tags are exposed through instance metadata by default
+  //
+  // One of enabled or disabled. Null when the account sets no default for the
+  // region.
+  instanceMetadataTags string
+  // Whether the httpTokens default is enforced rather than advisory
+  //
+  // One of enforced or unenforced. Null when the account sets no default for
+  // the region.
+  httpTokensEnforced string
+  // Whether an organization declarative policy pins these defaults
+  managedByDeclarativePolicy bool
+}
+
 // Amazon EC2 instance
 private aws.ec2.instance @defaults("instanceId region state instanceType architecture platformDetails") {
   // ARN for the instance
@@ -18877,6 +18946,15 @@ private aws.ec2.instance @defaults("instanceId region state instanceType archite
   httpPutResponseHopLimit int
   // Whether IMDSv2 is required (httpTokens is "required"), enforcing session-token-authenticated metadata access
   imdsv2Required bool
+  // User data supplied at launch, base64-decoded
+  //
+  // The launch script the instance bootstrapped with. It is readable by any
+  // process on the instance through the metadata service, so a credential
+  // written into it is effectively shared with every workload on the host.
+  // Empty when the instance was launched without user data.
+  userData() string
+  // Whether the instance has user data set (a launch script that may embed secrets)
+  userDataPresent() bool
   // Whether the instance is enabled for AWS Nitro Enclaves
   enclaveEnabled bool
   // Patch state information about the instance

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -622,6 +622,7 @@ const (
 	ResourceAwsInspectorFindingVulnerablePackage                                string = "aws.inspector.finding.vulnerablePackage"
 	ResourceAwsInspectorFindingNetworkReachability                              string = "aws.inspector.finding.networkReachability"
 	ResourceAwsInspectorFindingCodeVulnerability                                string = "aws.inspector.finding.codeVulnerability"
+	ResourceAwsEc2InstanceMetadataDefault                                       string = "aws.ec2.instanceMetadataDefault"
 	ResourceAwsEc2Instance                                                      string = "aws.ec2.instance"
 	ResourceAwsEc2Networkinterface                                              string = "aws.ec2.networkinterface"
 	ResourceAwsEc2Keypair                                                       string = "aws.ec2.keypair"
@@ -3393,6 +3394,10 @@ func init() {
 		"aws.inspector.finding.codeVulnerability": {
 			// to override args, implement: initAwsInspectorFindingCodeVulnerability(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsInspectorFindingCodeVulnerability,
+		},
+		"aws.ec2.instanceMetadataDefault": {
+			// to override args, implement: initAwsEc2InstanceMetadataDefault(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsEc2InstanceMetadataDefault,
 		},
 		"aws.ec2.instance": {
 			Init:   initAwsEc2Instance,
@@ -22602,6 +22607,18 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.imageBlockPublicAccess": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetImageBlockPublicAccess()).ToDataRes(types.Map(types.String, types.String))
 	},
+	"aws.ec2.snapshotBlockPublicAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetSnapshotBlockPublicAccess()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ec2.allowedImagesState": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetAllowedImagesState()).ToDataRes(types.Map(types.String, types.String))
+	},
+	"aws.ec2.instanceMetadataDefaults": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetInstanceMetadataDefaults()).ToDataRes(types.Array(types.Resource("aws.ec2.instanceMetadataDefault")))
+	},
+	"aws.ec2.ebsDefaultKmsKeys": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2).GetEbsDefaultKmsKeys()).ToDataRes(types.Array(types.Resource("aws.kms.key")))
+	},
 	"aws.ec2.volumes": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2).GetVolumes()).ToDataRes(types.Array(types.Resource("aws.ec2.volume")))
 	},
@@ -24123,6 +24140,27 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.inspector.finding.codeVulnerability.sourceLambdaLayerArn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsInspectorFindingCodeVulnerability).GetSourceLambdaLayerArn()).ToDataRes(types.String)
 	},
+	"aws.ec2.instanceMetadataDefault.region": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetRegion()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokens": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpTokens()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpEndpoint": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpEndpoint()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpPutResponseHopLimit()).ToDataRes(types.Int)
+	},
+	"aws.ec2.instanceMetadataDefault.instanceMetadataTags": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetInstanceMetadataTags()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokensEnforced": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetHttpTokensEnforced()).ToDataRes(types.String)
+	},
+	"aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2InstanceMetadataDefault).GetManagedByDeclarativePolicy()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.instance.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetArn()).ToDataRes(types.String)
 	},
@@ -24155,6 +24193,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetImdsv2Required()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.instance.userData": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetUserData()).ToDataRes(types.String)
+	},
+	"aws.ec2.instance.userDataPresent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Instance).GetUserDataPresent()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Instance).GetEnclaveEnabled()).ToDataRes(types.Bool)
@@ -61694,6 +61738,22 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2).ImageBlockPublicAccess, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.snapshotBlockPublicAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).SnapshotBlockPublicAccess, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.allowedImagesState": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).AllowedImagesState, ok = plugin.RawToTValue[map[string]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefaults": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).InstanceMetadataDefaults, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.ebsDefaultKmsKeys": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2).EbsDefaultKmsKeys, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.volumes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2).Volumes, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -63922,6 +63982,38 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsInspectorFindingCodeVulnerability).SourceLambdaLayerArn, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.instanceMetadataDefault.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokens": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpTokens, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpEndpoint": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpEndpoint, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpPutResponseHopLimit, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.instanceMetadataTags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).InstanceMetadataTags, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.httpTokensEnforced": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).HttpTokensEnforced, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2InstanceMetadataDefault).ManagedByDeclarativePolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.instance.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).__id, ok = v.Value.(string)
 		return
@@ -63968,6 +64060,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.instance.imdsv2Required": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Instance).Imdsv2Required, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.userData": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).UserData, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.instance.userDataPresent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Instance).UserDataPresent, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.instance.enclaveEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -148407,6 +148507,10 @@ type mqlAwsEc2 struct {
 	EbsEncryptionByDefault           plugin.TValue[map[string]any]
 	SerialConsoleAccessEnabled       plugin.TValue[map[string]any]
 	ImageBlockPublicAccess           plugin.TValue[map[string]any]
+	SnapshotBlockPublicAccess        plugin.TValue[map[string]any]
+	AllowedImagesState               plugin.TValue[map[string]any]
+	InstanceMetadataDefaults         plugin.TValue[[]any]
+	EbsDefaultKmsKeys                plugin.TValue[[]any]
 	Volumes                          plugin.TValue[[]any]
 	Snapshots                        plugin.TValue[[]any]
 	InternetGateways                 plugin.TValue[[]any]
@@ -148513,6 +148617,50 @@ func (c *mqlAwsEc2) GetSerialConsoleAccessEnabled() *plugin.TValue[map[string]an
 func (c *mqlAwsEc2) GetImageBlockPublicAccess() *plugin.TValue[map[string]any] {
 	return plugin.GetOrCompute[map[string]any](&c.ImageBlockPublicAccess, func() (map[string]any, error) {
 		return c.imageBlockPublicAccess()
+	})
+}
+
+func (c *mqlAwsEc2) GetSnapshotBlockPublicAccess() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.SnapshotBlockPublicAccess, func() (map[string]any, error) {
+		return c.snapshotBlockPublicAccess()
+	})
+}
+
+func (c *mqlAwsEc2) GetAllowedImagesState() *plugin.TValue[map[string]any] {
+	return plugin.GetOrCompute[map[string]any](&c.AllowedImagesState, func() (map[string]any, error) {
+		return c.allowedImagesState()
+	})
+}
+
+func (c *mqlAwsEc2) GetInstanceMetadataDefaults() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.InstanceMetadataDefaults, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2", c.__id, "instanceMetadataDefaults")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.instanceMetadataDefaults()
+	})
+}
+
+func (c *mqlAwsEc2) GetEbsDefaultKmsKeys() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EbsDefaultKmsKeys, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2", c.__id, "ebsDefaultKmsKeys")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.ebsDefaultKmsKeys()
 	})
 }
 
@@ -154148,6 +154296,80 @@ func (c *mqlAwsInspectorFindingCodeVulnerability) GetSourceLambdaLayerArn() *plu
 	return &c.SourceLambdaLayerArn
 }
 
+// mqlAwsEc2InstanceMetadataDefault for the aws.ec2.instanceMetadataDefault resource
+type mqlAwsEc2InstanceMetadataDefault struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsEc2InstanceMetadataDefaultInternal it will be used here
+	Region                     plugin.TValue[string]
+	HttpTokens                 plugin.TValue[string]
+	HttpEndpoint               plugin.TValue[string]
+	HttpPutResponseHopLimit    plugin.TValue[int64]
+	InstanceMetadataTags       plugin.TValue[string]
+	HttpTokensEnforced         plugin.TValue[string]
+	ManagedByDeclarativePolicy plugin.TValue[bool]
+}
+
+// createAwsEc2InstanceMetadataDefault creates a new instance of this resource
+func createAwsEc2InstanceMetadataDefault(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsEc2InstanceMetadataDefault{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.ec2.instanceMetadataDefault", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) MqlName() string {
+	return "aws.ec2.instanceMetadataDefault"
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetRegion() *plugin.TValue[string] {
+	return &c.Region
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpTokens() *plugin.TValue[string] {
+	return &c.HttpTokens
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpEndpoint() *plugin.TValue[string] {
+	return &c.HttpEndpoint
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
+	return &c.HttpPutResponseHopLimit
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetInstanceMetadataTags() *plugin.TValue[string] {
+	return &c.InstanceMetadataTags
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetHttpTokensEnforced() *plugin.TValue[string] {
+	return &c.HttpTokensEnforced
+}
+
+func (c *mqlAwsEc2InstanceMetadataDefault) GetManagedByDeclarativePolicy() *plugin.TValue[bool] {
+	return &c.ManagedByDeclarativePolicy
+}
+
 // mqlAwsEc2Instance for the aws.ec2.instance resource
 type mqlAwsEc2Instance struct {
 	MqlRuntime *plugin.Runtime
@@ -154164,6 +154386,8 @@ type mqlAwsEc2Instance struct {
 	HttpEndpoint            plugin.TValue[string]
 	HttpPutResponseHopLimit plugin.TValue[int64]
 	Imdsv2Required          plugin.TValue[bool]
+	UserData                plugin.TValue[string]
+	UserDataPresent         plugin.TValue[bool]
 	EnclaveEnabled          plugin.TValue[bool]
 	PatchState              plugin.TValue[any]
 	State                   plugin.TValue[string]
@@ -154311,6 +154535,18 @@ func (c *mqlAwsEc2Instance) GetHttpPutResponseHopLimit() *plugin.TValue[int64] {
 
 func (c *mqlAwsEc2Instance) GetImdsv2Required() *plugin.TValue[bool] {
 	return &c.Imdsv2Required
+}
+
+func (c *mqlAwsEc2Instance) GetUserData() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.UserData, func() (string, error) {
+		return c.userData()
+	})
+}
+
+func (c *mqlAwsEc2Instance) GetUserDataPresent() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.UserDataPresent, func() (bool, error) {
+		return c.userDataPresent()
+	})
 }
 
 func (c *mqlAwsEc2Instance) GetEnclaveEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3188,6 +3188,7 @@ aws.dynamodb.table.tags 11.15.2
 aws.dynamodb.table.ttlDescription 13.6.3
 aws.dynamodb.tables 11.15.2
 aws.ec2 11.15.2
+aws.ec2.allowedImagesState 13.52.2
 aws.ec2.capacityReservation 13.6.3
 aws.ec2.capacityReservation.arn 13.6.3
 aws.ec2.capacityReservation.availabilityZone 13.6.3
@@ -3252,6 +3253,7 @@ aws.ec2.dhcpOptions.configurations 13.6.3
 aws.ec2.dhcpOptions.id 13.6.3
 aws.ec2.dhcpOptions.region 13.6.3
 aws.ec2.dhcpOptions.tags 13.6.3
+aws.ec2.ebsDefaultKmsKeys 13.52.2
 aws.ec2.ebsEncryptionByDefault 11.15.2
 aws.ec2.egressOnlyInternetGateway 13.6.3
 aws.ec2.egressOnlyInternetGateway.arn 13.6.3
@@ -3422,6 +3424,8 @@ aws.ec2.instance.stateTransitionTime 11.15.2
 aws.ec2.instance.subnet 13.37.1
 aws.ec2.instance.tags 11.15.2
 aws.ec2.instance.tpmSupport 11.15.2
+aws.ec2.instance.userData 13.52.2
+aws.ec2.instance.userDataPresent 13.52.2
 aws.ec2.instance.virtualizationType 11.15.3
 aws.ec2.instance.vpc 11.15.2
 aws.ec2.instance.vpcArn 11.15.2
@@ -3442,6 +3446,15 @@ aws.ec2.instanceConnectEndpoint.tags 13.6.3
 aws.ec2.instanceConnectEndpoint.vpc 13.12.1
 aws.ec2.instanceConnectEndpoint.vpcId 13.6.3
 aws.ec2.instanceConnectEndpoints 13.6.3
+aws.ec2.instanceMetadataDefault 13.52.2
+aws.ec2.instanceMetadataDefault.httpEndpoint 13.52.2
+aws.ec2.instanceMetadataDefault.httpPutResponseHopLimit 13.52.2
+aws.ec2.instanceMetadataDefault.httpTokens 13.52.2
+aws.ec2.instanceMetadataDefault.httpTokensEnforced 13.52.2
+aws.ec2.instanceMetadataDefault.instanceMetadataTags 13.52.2
+aws.ec2.instanceMetadataDefault.managedByDeclarativePolicy 13.52.2
+aws.ec2.instanceMetadataDefault.region 13.52.2
+aws.ec2.instanceMetadataDefaults 13.52.2
 aws.ec2.instances 11.15.2
 aws.ec2.internetGateways 11.15.2
 aws.ec2.internetgateway 11.15.2
@@ -3724,6 +3737,7 @@ aws.ec2.snapshot.tags 11.15.2
 aws.ec2.snapshot.transferType 13.39.2
 aws.ec2.snapshot.volumeId 11.15.2
 aws.ec2.snapshot.volumeSize 11.15.2
+aws.ec2.snapshotBlockPublicAccess 13.52.2
 aws.ec2.snapshots 11.15.2
 aws.ec2.transitGateways 11.15.2
 aws.ec2.transitgateway 11.15.2

--- a/providers/aws/resources/aws.permissions.json
+++ b/providers/aws/resources/aws.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "aws",
   "version": "13.52.1",
-  "generated_at": "2026-08-05T19:39:25+02:00",
+  "generated_at": "2026-08-05T19:49:05+02:00",
   "permissions": [
     "access-analyzer:GetFindingV2",
     "access-analyzer:ListAnalyzers",
@@ -322,11 +322,15 @@
     "ec2:DescribeVpcs",
     "ec2:DescribeVpnConnections",
     "ec2:DescribeVpnGateways",
+    "ec2:GetAllowedImagesSettings",
+    "ec2:GetEbsDefaultKmsKeyId",
     "ec2:GetEbsEncryptionByDefault",
     "ec2:GetImageBlockPublicAccessState",
+    "ec2:GetInstanceMetadataDefaults",
     "ec2:GetIpamPoolAllocations",
     "ec2:GetManagedPrefixListEntries",
     "ec2:GetSerialConsoleAccessStatus",
+    "ec2:GetSnapshotBlockPublicAccessState",
     "ecr-public:DescribeImages",
     "ecr-public:DescribeRepositories",
     "ecr-public:GetRepositoryCatalogData",
@@ -2672,6 +2676,12 @@
       "source_file": "aws_ec2.go"
     },
     {
+      "permission": "ec2:DescribeInstanceAttribute",
+      "service": "ec2",
+      "action": "DescribeInstanceAttribute",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
       "permission": "ec2:DescribeInstanceConnectEndpoints",
       "service": "ec2",
       "action": "DescribeInstanceConnectEndpoints",
@@ -2984,6 +2994,18 @@
       "source_file": "aws_vpc.go"
     },
     {
+      "permission": "ec2:GetAllowedImagesSettings",
+      "service": "ec2",
+      "action": "GetAllowedImagesSettings",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
+      "permission": "ec2:GetEbsDefaultKmsKeyId",
+      "service": "ec2",
+      "action": "GetEbsDefaultKmsKeyId",
+      "source_file": "aws_ec2_account_settings.go"
+    },
+    {
       "permission": "ec2:GetEbsEncryptionByDefault",
       "service": "ec2",
       "action": "GetEbsEncryptionByDefault",
@@ -2994,6 +3016,12 @@
       "service": "ec2",
       "action": "GetImageBlockPublicAccessState",
       "source_file": "aws_ec2.go"
+    },
+    {
+      "permission": "ec2:GetInstanceMetadataDefaults",
+      "service": "ec2",
+      "action": "GetInstanceMetadataDefaults",
+      "source_file": "aws_ec2_account_settings.go"
     },
     {
       "permission": "ec2:GetIpamPoolAllocations",
@@ -3012,6 +3040,12 @@
       "service": "ec2",
       "action": "GetSerialConsoleAccessStatus",
       "source_file": "aws_ec2.go"
+    },
+    {
+      "permission": "ec2:GetSnapshotBlockPublicAccessState",
+      "service": "ec2",
+      "action": "GetSnapshotBlockPublicAccessState",
+      "source_file": "aws_ec2_account_settings.go"
     },
     {
       "permission": "ecr-public:DescribeImages",

--- a/providers/aws/resources/aws_ec2_account_settings.go
+++ b/providers/aws/resources/aws_ec2_account_settings.go
@@ -1,0 +1,265 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/jobpool"
+	"go.mondoo.com/mql/v13/providers/aws/connection"
+)
+
+// regionSetting pairs an account-level setting value with the region it was read
+// from, so a per-region job can report both.
+type regionSetting struct {
+	region string
+	value  string
+}
+
+// collectRegionSettings runs read per region and returns the values keyed by
+// region. A region the caller cannot read is left out of the map rather than
+// reported with an empty value, which would read as a setting that is switched
+// off. read takes the region rather than a client so that each caller's
+// conn.Ec2 call sits in the same function as its API call, which is what the
+// IAM permission extractor traces.
+func collectRegionSettings(conn *connection.AwsConnection, read func(region string) (string, error)) (map[string]any, error) {
+	regions, err := conn.Regions()
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]*jobpool.Job, 0, len(regions))
+	for _, region := range regions {
+		f := func() (jobpool.JobResult, error) {
+			value, err := read(region)
+			if err != nil {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+					return nil, nil
+				}
+				return nil, err
+			}
+			return jobpool.JobResult(regionSetting{region: region, value: value}), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+
+	poolOfJobs := jobpool.CreatePool(tasks, 5)
+	poolOfJobs.Run()
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+
+	res := map[string]any{}
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
+		setting := poolOfJobs.Jobs[i].Result.(regionSetting)
+		res[setting.region] = setting.value
+	}
+	return res, nil
+}
+
+func (a *mqlAwsEc2) snapshotBlockPublicAccess() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetSnapshotBlockPublicAccessState(context.Background(),
+			&ec2.GetSnapshotBlockPublicAccessStateInput{})
+		if err != nil {
+			return "", err
+		}
+		return string(resp.State), nil
+	})
+}
+
+func (a *mqlAwsEc2) allowedImagesState() (map[string]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	return collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetAllowedImagesSettings(context.Background(),
+			&ec2.GetAllowedImagesSettingsInput{})
+		if err != nil {
+			return "", err
+		}
+		return convert.ToValue(resp.State), nil
+	})
+}
+
+// instanceMetadataDefaultsResult carries one region's account-level IMDS
+// defaults. AccountLevel is nil for a region with no defaults set.
+type instanceMetadataDefaultsResult struct {
+	region   string
+	defaults *ec2types.InstanceMetadataDefaultsResponse
+}
+
+func (a *mqlAwsEc2) instanceMetadataDefaults() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	regions, err := conn.Regions()
+	if err != nil {
+		return nil, err
+	}
+
+	tasks := make([]*jobpool.Job, 0, len(regions))
+	for _, region := range regions {
+		f := func() (jobpool.JobResult, error) {
+			svc := conn.Ec2(region)
+			resp, err := svc.GetInstanceMetadataDefaults(context.Background(),
+				&ec2.GetInstanceMetadataDefaultsInput{})
+			if err != nil {
+				if Is400AccessDeniedError(err) || IsServiceNotAvailableInRegionError(err) {
+					return nil, nil
+				}
+				return nil, err
+			}
+			return jobpool.JobResult(instanceMetadataDefaultsResult{
+				region:   region,
+				defaults: resp.AccountLevel,
+			}), nil
+		}
+		tasks = append(tasks, jobpool.NewJob(f))
+	}
+
+	poolOfJobs := jobpool.CreatePool(tasks, 5)
+	poolOfJobs.Run()
+	if poolOfJobs.HasErrors() {
+		return nil, poolOfJobs.GetErrors()
+	}
+
+	res := []any{}
+	for i := range poolOfJobs.Jobs {
+		if poolOfJobs.Jobs[i].Result == nil {
+			continue
+		}
+		result := poolOfJobs.Jobs[i].Result.(instanceMetadataDefaultsResult)
+		mqlDefaults, err := CreateResource(a.MqlRuntime, ResourceAwsEc2InstanceMetadataDefault,
+			instanceMetadataDefaultArgs(result))
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlDefaults)
+	}
+	return res, nil
+}
+
+// instanceMetadataDefaultArgs builds the fields of the per-region defaults
+// resource. A region with no account-level defaults still gets an entry, with
+// every setting null, so that "no default is set" stays distinguishable from a
+// default that permits IMDSv1.
+func instanceMetadataDefaultArgs(result instanceMetadataDefaultsResult) map[string]*llx.RawData {
+	args := map[string]*llx.RawData{
+		"__id":                       llx.StringData("aws.ec2.instanceMetadataDefault/" + result.region),
+		"region":                     llx.StringData(result.region),
+		"managedByDeclarativePolicy": llx.BoolData(false),
+		"httpTokens":                 llx.NilData,
+		"httpEndpoint":               llx.NilData,
+		"httpPutResponseHopLimit":    llx.NilData,
+		"instanceMetadataTags":       llx.NilData,
+		"httpTokensEnforced":         llx.NilData,
+	}
+
+	defaults := result.defaults
+	if defaults == nil {
+		return args
+	}
+
+	args["httpTokens"] = emptyStringToNil(string(defaults.HttpTokens))
+	args["httpEndpoint"] = emptyStringToNil(string(defaults.HttpEndpoint))
+	args["instanceMetadataTags"] = emptyStringToNil(string(defaults.InstanceMetadataTags))
+	args["httpTokensEnforced"] = emptyStringToNil(string(defaults.HttpTokensEnforced))
+	if defaults.HttpPutResponseHopLimit != nil {
+		args["httpPutResponseHopLimit"] = llx.IntDataPtr(defaults.HttpPutResponseHopLimit)
+	}
+	args["managedByDeclarativePolicy"] = llx.BoolData(defaults.ManagedBy == ec2types.ManagedByDeclarativePolicy)
+
+	return args
+}
+
+// emptyStringToNil keeps an unset account default null instead of reporting it
+// as an empty string, which would compare equal to neither "required" nor
+// "optional" but would still look like a value that was read.
+func emptyStringToNil(value string) *llx.RawData {
+	if value == "" {
+		return llx.NilData
+	}
+	return llx.StringData(value)
+}
+
+func (a *mqlAwsEc2) ebsDefaultKmsKeys() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	keyArns, err := collectRegionSettings(conn, func(region string) (string, error) {
+		svc := conn.Ec2(region)
+		resp, err := svc.GetEbsDefaultKmsKeyId(context.Background(),
+			&ec2.GetEbsDefaultKmsKeyIdInput{})
+		if err != nil {
+			return "", err
+		}
+		return convert.ToValue(resp.KmsKeyId), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for region, raw := range keyArns {
+		keyArn, ok := raw.(string)
+		if !ok || keyArn == "" {
+			continue
+		}
+		mqlKey, err := NewResource(a.MqlRuntime, ResourceAwsKmsKey,
+			map[string]*llx.RawData{
+				"arn":    llx.StringData(keyArn),
+				"region": llx.StringData(region),
+			})
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlKey)
+	}
+	return res, nil
+}
+
+// userData returns the launch script the instance was created with. EC2 keeps it
+// in an instance attribute rather than in the describe output, so it costs one
+// call per instance and is only fetched when the field is read.
+func (a *mqlAwsEc2Instance) userData() (string, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	svc := conn.Ec2(a.Region.Data)
+
+	instanceId := a.InstanceId.Data
+	attribute, err := svc.DescribeInstanceAttribute(context.Background(),
+		&ec2.DescribeInstanceAttributeInput{
+			InstanceId: &instanceId,
+			Attribute:  ec2types.InstanceAttributeNameUserData,
+		})
+	if err != nil {
+		if Is400AccessDeniedError(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if attribute.UserData == nil || attribute.UserData.Value == nil {
+		return "", nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(*attribute.UserData.Value)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+func (a *mqlAwsEc2Instance) userDataPresent() (bool, error) {
+	userData := a.GetUserData()
+	if userData.Error != nil {
+		return false, userData.Error
+	}
+	return strings.TrimSpace(userData.Data) != "", nil
+}

--- a/providers/aws/resources/aws_ec2_account_settings_test.go
+++ b/providers/aws/resources/aws_ec2_account_settings_test.go
@@ -1,0 +1,92 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mondoo.com/mql/v13/llx"
+)
+
+func TestEmptyStringToNil(t *testing.T) {
+	assert.Equal(t, llx.NilData, emptyStringToNil(""))
+	assert.Equal(t, llx.StringData("required"), emptyStringToNil("required"))
+}
+
+// A region with no account-level defaults must report null for every setting. An
+// empty string would compare equal to neither "required" nor "optional" while
+// still looking like a value that was read, which is how a missing guardrail
+// gets mistaken for a permissive one.
+func TestInstanceMetadataDefaultArgsWithoutDefaults(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{region: "us-east-1"})
+
+	assert.Equal(t, llx.StringData("us-east-1"), args["region"])
+	assert.Equal(t, llx.BoolData(false), args["managedByDeclarativePolicy"])
+	for _, field := range []string{
+		"httpTokens", "httpEndpoint", "httpPutResponseHopLimit",
+		"instanceMetadataTags", "httpTokensEnforced",
+	} {
+		assert.Equal(t, llx.NilData, args[field], "expected %s to be null", field)
+	}
+}
+
+func TestInstanceMetadataDefaultArgs(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{
+		region: "eu-central-1",
+		defaults: &ec2types.InstanceMetadataDefaultsResponse{
+			HttpTokens:              ec2types.HttpTokensStateRequired,
+			HttpEndpoint:            ec2types.InstanceMetadataEndpointStateEnabled,
+			HttpPutResponseHopLimit: aws.Int32(2),
+			InstanceMetadataTags:    ec2types.InstanceMetadataTagsStateDisabled,
+			ManagedBy:               ec2types.ManagedByDeclarativePolicy,
+		},
+	})
+
+	assert.Equal(t, llx.StringData("required"), args["httpTokens"])
+	assert.Equal(t, llx.StringData("enabled"), args["httpEndpoint"])
+	assert.Equal(t, llx.StringData("disabled"), args["instanceMetadataTags"])
+	assert.Equal(t, int64(2), args["httpPutResponseHopLimit"].Value)
+	assert.Equal(t, llx.BoolData(true), args["managedByDeclarativePolicy"])
+	// The API left HttpTokensEnforced unset, which must stay null.
+	assert.Equal(t, llx.NilData, args["httpTokensEnforced"])
+}
+
+// An account-level default that is not pinned by an organization declarative
+// policy reports managedByDeclarativePolicy false rather than null.
+func TestInstanceMetadataDefaultArgsAccountManaged(t *testing.T) {
+	args := instanceMetadataDefaultArgs(instanceMetadataDefaultsResult{
+		region: "us-west-2",
+		defaults: &ec2types.InstanceMetadataDefaultsResponse{
+			HttpTokens: ec2types.HttpTokensStateOptional,
+			ManagedBy:  ec2types.ManagedByAccount,
+		},
+	})
+
+	assert.Equal(t, llx.StringData("optional"), args["httpTokens"])
+	assert.Equal(t, llx.BoolData(false), args["managedByDeclarativePolicy"])
+}
+
+func TestInstanceUserDataPresent(t *testing.T) {
+	tests := []struct {
+		name     string
+		userData string
+		want     bool
+	}{
+		{"script", "#!/bin/bash\necho hello", true},
+		{"empty", "", false},
+		{"whitespace only", "  \n\t ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &mqlAwsEc2Instance{UserData: setString(tt.userData)}
+			got, err := instance.userDataPresent()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
> Stacked on #9552 → #9551 → #9550. Review those first.

## What

`aws.ec2` already reported three account-level guardrails — `ebsEncryptionByDefault`, `serialConsoleAccessEnabled`, `imageBlockPublicAccess` — and none of the rest of the same family. This adds the missing ones, plus the instance field that the launch template already had.

| new field | question it answers |
|---|---|
| `snapshotBlockPublicAccess()` | can EBS snapshots be shared publicly in this region? |
| `allowedImagesState()` | is Allowed AMIs enforcing, auditing, or off? (which AMI publishers the account trusts) |
| `instanceMetadataDefaults()` | is IMDSv2 the floor for *new* launches, regardless of launch template? |
| `ebsDefaultKmsKeys()` | which key does EBS encrypt new volumes with when none is named? |
| `aws.ec2.instance.userData()` / `userDataPresent()` | what bootstrap script is on this instance? |

## New resource

```
private aws.ec2.instanceMetadataDefault {
  region string
  httpTokens string                    // required = IMDSv2, optional = IMDSv1 permitted
  httpEndpoint string
  httpPutResponseHopLimit int
  instanceMetadataTags string
  httpTokensEnforced string
  managedByDeclarativePolicy bool
}
```

**Null matters here.** A region with no account-level default reports **null** for every setting, not an empty string. An empty string compares equal to neither `"required"` nor `"optional"` while still looking like a value that was read — that's how "no guardrail is set" gets mistaken for "a permissive guardrail is set". Regions the caller can't read are omitted from the map-valued fields for the same reason.

`managedByDeclarativePolicy` ties into #9552: when true, the defaults are pinned by an organization declarative policy and cannot be changed in the account. Named for what it means rather than reusing `managedBy`, which elsewhere in the provider means IaC provenance derived from tags.

## Typed key, not an ARN

`ebsDefaultKmsKeys()` returns `[]aws.kms.key`, not a map of key ARNs. Each key carries its own `region`, so nothing is lost by returning a list, and the key's rotation, policy and `isPublic` fields become reachable from the EBS default. `initAwsKmsKey` already resolves alias ARNs, so the AWS-managed `alias/aws/ebs` case works without special handling.

## Example queries

```coffee
# regions where a public snapshot is still possible
aws.ec2.snapshotBlockPublicAccess.where(value == "unblocked")

# regions that do not require IMDSv2 for new launches
aws.ec2.instanceMetadataDefaults.where(httpTokens != "required") { region httpTokens }

# defaults set in the account rather than pinned by the organization
aws.ec2.instanceMetadataDefaults.where(!managedByDeclarativePolicy) { region }

# EBS default keys that are AWS-managed rather than customer managed
aws.ec2.ebsDefaultKmsKeys.where(keyManager == "AWS") { region arn }

# running instances carrying a launch script
aws.ec2.instances.where(state == "running" && userDataPresent) { instanceId }
```

## A gotcha worth flagging for reviewers

The first version of `collectRegionSettings` took an already-constructed `*ec2.Client`:

```go
func collectRegionSettings(conn, read func(svc *ec2.Client) (string, error))   // don't
```

That builds and the queries work — but it **silently dropped three permissions from `aws.permissions.json`**. The extractor traces `conn.Ec2(...)` → client variable → method calls *within a single function*; hand the client across a function boundary and the API calls become invisible to it. Only `ec2:GetInstanceMetadataDefaults` and `ec2:DescribeInstanceAttribute` were emitted, because those two call sites happened to construct their own client.

Fixed by passing the **region** instead, so each callback does its own `conn.Ec2(region)` next to its API call. Permission count went 987 → 990. Worth knowing for any future per-region helper.

## Permissions

`ec2:GetSnapshotBlockPublicAccessState`, `ec2:GetAllowedImagesSettings`, `ec2:GetEbsDefaultKmsKeyId`, `ec2:GetInstanceMetadataDefaults`, `ec2:DescribeInstanceAttribute`. All region loops guard on `IsServiceNotAvailableInRegionError` as well as access-denied.

## Scope note

`GetAllowedImagesSettings` also returns `ImageCriteria` (allowed image providers, name patterns, marketplace product codes, watermark filters, date conditions). That's a nested list that doesn't meet the sub-resource bar as-is, so this PR exposes the enforcement **state** only and leaves the criteria detail for a follow-up rather than forcing it into a `[]dict`.

## Test

Unit tests cover the null semantics directly: a region with no defaults must yield `llx.NilData` for all five settings; a populated response must map each enum through and leave an absent `HttpTokensEnforced` null; `ManagedByAccount` must give `false` rather than null; and `userDataPresent` across script / empty / whitespace-only input.
