### PR TITLE
🐛 aws: correct serviceLastAccessed entity field docs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -2762,16 +2762,19 @@ private aws.iam.serviceLastAccessed @defaults("serviceNamespace lastAuthenticate
   lastAuthenticatedAt time
   // ARN of the user or role that last accessed the service
   //
-  // Reported for a policy, where many principals share the grant. Empty when
-  // the record belongs to a single principal, which is its own last-accessed
-  // entity.
+  // Names the entity behind the most recent request: the attached principal
+  // that used a policy, or the principal itself for a user or role record.
+  // Null when the service was never accessed, the same condition that leaves
+  // lastAuthenticatedAt null. Compare with `!= empty` rather than `!= ""`,
+  // since an unused service leaves this null rather than an empty string.
   lastAuthenticatedEntity string
   // Region from which the service was last accessed
   lastAuthenticatedRegion string
   // Number of entities that accessed the service
   //
-  // Reported for a policy, counting the attached principals that used the
-  // service. Zero for records that belong to a single principal.
+  // Counts the distinct entities that reached the service, so it is 1 for a
+  // single user or role that used it and higher for a policy several attached
+  // principals used. Zero when the service was never accessed.
   totalAuthenticatedEntities int
 }
 


### PR DESCRIPTION
Found by live verification of #9551 against a real AWS account (`provider-verification` run `mql-verify-20260805-205729`).

## The bug

Two field docs on `aws.iam.serviceLastAccessed` describe behavior the API does not have. I wrote them from the AWS API reference's framing of *policy* last-accessed reports and inferred the single-principal case, rather than observing it.

**Documented:**

| field | claim |
|---|---|
| `lastAuthenticatedEntity` | "Reported for a policy… **Empty when the record belongs to a single principal**, which is its own last-accessed entity." |
| `totalAuthenticatedEntities` | "Reported for a policy… **Zero for records that belong to a single principal**." |

**Observed** — `aws.iam.users.where(name == "tim") { lastAccessedServices.where(serviceNamespace == "sts") { … } }`:

```
lastAuthenticatedEntity: "arn:aws:iam::…:user/tim"
totalAuthenticatedEntities: 1
serviceNamespace: "sts"
lastAuthenticatedAt: 2026-08-05 23:17:21
```

A *user* record — a single principal — has both fields **populated**, not empty and zero.

Cross-checked against an unused customer managed policy, where both are null and zero:

```
serviceNamespace: "s3"  lastAuthenticatedAt: null
lastAuthenticatedEntity: null  totalAuthenticatedEntities: 0
```

So the real rule is **accessed vs never accessed**, not *policy vs single principal*. The distinction I documented does not exist.

## Why it matters

`.lr` doc comments are machine-parsed into the published resource docs, so this ships user-facing misinformation on a field whose whole purpose is answering "who actually used this permission". Someone reading it would skip the field for user and role records — exactly where it does work.

The fix also records that `lastAuthenticatedEntity` is **null**, not `""`, when unused. That matters for query authors: in MQL `!= ""` does not filter nulls, so the doc now points at `!= empty`.

## Scope

Doc comments only — no code, no schema shape change. `.lr.versions` entries stay at `13.52.2` (a doc change does not bump), `aws.lr.go` and `aws.permissions.json` are unchanged, and `mqlr generate` re-parses the two-part doc-comment structure cleanly.

Nothing runtime to re-verify for a comment change; the *facts* now in the comments are the observed values quoted above.
