### PR TITLE
✨ os: enumerate ports on AIX via netstat

### DIFF
--- a/providers/os/resources/port.go
+++ b/providers/os/resources/port.go
@@ -46,6 +46,11 @@ func (p *mqlPorts) list() ([]any, error) {
 		// both macOS and FreeBSD support lsof
 		// FreeBSD may need an installation via `pkg install sysutils/lsof`
 		return p.listMacos()
+
+	case pf.Name == "aix":
+		// AIX has neither /proc/net/tcp nor a bundled lsof, so netstat is the
+		// only source that is always present.
+		return p.listAix()
 	default:
 		return nil, errors.New("could not detect suitable ports manager for platform: " + pf.Name)
 	}
@@ -645,6 +650,105 @@ func (p *mqlPorts) listMacos() ([]any, error) {
 
 			res = append(res, obj)
 		}
+	}
+
+	return res, nil
+}
+
+// AIX Implementation
+
+// AIX state tokens mapped onto the canonical TCP_STATES vocabulary, so a query
+// filtering on `state == "listen"` behaves the same on AIX as anywhere else.
+// AIX reports no state for UDP (it is stateless) and that empty value is kept
+// as-is rather than invented into a state.
+var aixTcpStates = map[string]string{
+	"LISTEN":       TCP_STATES[10],
+	"ESTABLISHED":  TCP_STATES[1],
+	"SYN_SENT":     TCP_STATES[2],
+	"SYN_RCVD":     TCP_STATES[3],
+	"SYN_RECEIVED": TCP_STATES[3],
+	"FIN_WAIT_1":   TCP_STATES[4],
+	"FIN_WAIT_2":   TCP_STATES[5],
+	"TIME_WAIT":    TCP_STATES[6],
+	"CLOSED":       TCP_STATES[7],
+	"CLOSE":        TCP_STATES[7],
+	"CLOSE_WAIT":   TCP_STATES[8],
+	"LAST_ACK":     TCP_STATES[9],
+	"CLOSING":      TCP_STATES[11],
+}
+
+// aixPortState translates one AIX netstat state token. An empty token stays
+// empty (UDP rows, which carry no state), and anything unrecognised becomes
+// "unknown" rather than a state string invented outside TCP_STATES.
+func aixPortState(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if state, ok := aixTcpStates[raw]; ok {
+		return state
+	}
+	return "unknown"
+}
+
+// listAix reads AIX sockets from netstat.
+//
+// Unlike the other platforms this yields no owning process: netstat reports a
+// PCB address rather than a PID, and resolving one to a process needs `rmsock`,
+// which is root-only and costs an exec per socket. `process` and `user` are
+// therefore null on AIX, and `address`, `port`, `state` and the remote endpoint
+// carry the signal.
+func (p *mqlPorts) listAix() ([]any, error) {
+	conn := p.MqlRuntime.Connection.(shared.Connection)
+
+	// -a includes listening sockets (servers), -n keeps addresses numeric so no
+	// name resolution is attempted per row.
+	executedCmd, err := conn.RunCommand("netstat -an")
+	if err != nil {
+		return nil, err
+	}
+
+	if executedCmd.ExitStatus != 0 {
+		stderr, err := io.ReadAll(executedCmd.Stderr)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("failed to retrieve network connections: " + string(stderr))
+	}
+
+	return p.parseAixPorts(executedCmd.Stdout)
+}
+
+func (p *mqlPorts) parseAixPorts(r io.Reader) ([]any, error) {
+	portList, err := ports.ParseAixNetstat(r)
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for i := range portList {
+		port := portList[i]
+
+		obj, err := CreateResource(p.MqlRuntime, "port", map[string]*llx.RawData{
+			"protocol":      llx.StringData(port.Protocol),
+			"port":          llx.IntData(port.LocalPort),
+			"address":       llx.StringData(port.LocalAddress),
+			"user":          llx.ResourceData(nil, "user"),
+			"process":       llx.ResourceData(nil, "process"),
+			"state":         llx.StringData(aixPortState(port.State)),
+			"remoteAddress": llx.StringData(port.RemoteAddress),
+			"remotePort":    llx.IntData(port.RemotePort),
+		})
+		if err != nil {
+			log.Error().Err(err).Send()
+			return nil, err
+		}
+
+		// netstat cannot name the owner, so mark it resolved-and-null instead of
+		// leaving the lazy process() accessor to be called per row.
+		portObj := obj.(*mqlPort)
+		portObj.Process.State = plugin.StateIsSet | plugin.StateIsNull
+
+		res = append(res, obj)
 	}
 
 	return res, nil

--- a/providers/os/resources/port_test.go
+++ b/providers/os/resources/port_test.go
@@ -85,3 +85,41 @@ func TestParseLinuxProcNetIPv6(t *testing.T) {
 	assert.Equal(t, int64(0), port.RemotePort)
 	assert.Equal(t, "[::]", port.RemoteAddress)
 }
+
+// AIX netstat reports states in its own spelling; they have to land on the same
+// vocabulary the other platforms use, or `ports.listening` (which filters on
+// state == "listen") would silently return nothing on AIX.
+func TestAixPortState(t *testing.T) {
+	assert.Equal(t, "listen", aixPortState("LISTEN"))
+	assert.Equal(t, "established", aixPortState("ESTABLISHED"))
+	assert.Equal(t, "time wait", aixPortState("TIME_WAIT"))
+	assert.Equal(t, "close wait", aixPortState("CLOSE_WAIT"))
+	assert.Equal(t, "syn recv", aixPortState("SYN_RCVD"))
+	assert.Equal(t, "syn recv", aixPortState("SYN_RECEIVED"))
+	assert.Equal(t, "fin wait1", aixPortState("FIN_WAIT_1"))
+	assert.Equal(t, "fin wait2", aixPortState("FIN_WAIT_2"))
+	assert.Equal(t, "last ack", aixPortState("LAST_ACK"))
+	assert.Equal(t, "closing", aixPortState("CLOSING"))
+	assert.Equal(t, "close", aixPortState("CLOSED"))
+
+	// UDP has no state on AIX; that must stay empty rather than become a state.
+	assert.Equal(t, "", aixPortState(""))
+
+	// Anything else is reported honestly as unknown, never guessed into a
+	// canonical state.
+	assert.Equal(t, "unknown", aixPortState("IDLE"))
+	assert.Equal(t, "unknown", aixPortState("BOGUS"))
+}
+
+// Every mapped state must be a value the shared TCP_STATES table defines, so the
+// two cannot drift apart.
+func TestAixPortStatesAreCanonical(t *testing.T) {
+	canonical := map[string]bool{}
+	for _, v := range TCP_STATES {
+		canonical[v] = true
+	}
+	for aix, mapped := range aixTcpStates {
+		assert.True(t, canonical[mapped],
+			"AIX state %q maps to %q which is not in TCP_STATES", aix, mapped)
+	}
+}

--- a/providers/os/resources/ports/aixnetstat.go
+++ b/providers/os/resources/ports/aixnetstat.go
@@ -1,0 +1,154 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ports
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// AixPort is one socket row from the "Active Internet connections" section of
+// AIX `netstat -an`. State is the raw AIX token ("LISTEN", "ESTABLISHED", ...)
+// and is empty for UDP, which AIX reports without a state column because UDP is
+// stateless. The caller maps it onto the canonical state vocabulary.
+type AixPort struct {
+	// Protocol as AIX reports it, normalised to an address family suffix:
+	// tcp4 | tcp6 | udp4 | udp6.
+	Protocol      string
+	LocalAddress  string
+	LocalPort     int64
+	RemoteAddress string
+	RemotePort    int64
+	State         string
+}
+
+// AIX writes the protocol as tcp/tcp4/tcp6/udp/udp4/udp6. A bare tcp/udp means
+// IPv4 (AIX only omits the digit on the v4 rows of some releases).
+var reAixProto = regexp.MustCompile(`^(tcp|udp)([46])?$`)
+
+// ParseAixNetstat reads the "Active Internet connections" section of AIX
+// `netstat -an`.
+//
+// The row shape is BSD-style, so a socket reads `10.10.20.15.32790`: the port is
+// appended to the address with a dot rather than a colon, and `*` stands for a
+// wildcard. Both `netstat -an` and `netstat -Aan` are accepted; the latter
+// prefixes every row with a PCB address, so the protocol column is located by
+// pattern rather than by index.
+//
+// Everything after the "Active UNIX domain sockets" header is ignored: those are
+// filesystem sockets with an unrelated column layout and no IP semantics.
+func ParseAixNetstat(r io.Reader) ([]AixPort, error) {
+	res := []AixPort{}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Unix domain sockets are listed after the internet connections and
+		// share none of the columns. Nothing below this header is a socket we
+		// can describe as an IP endpoint.
+		if strings.HasPrefix(line, "Active UNIX domain sockets") {
+			break
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		// Locate the protocol column. This skips both header lines and the
+		// optional leading PCB/ADDR column of `netstat -Aan`.
+		protoIdx := -1
+		var proto string
+		for i, f := range fields {
+			if m := reAixProto.FindStringSubmatch(f); m != nil {
+				protoIdx = i
+				proto = m[1]
+				if m[2] == "" {
+					proto += "4"
+				} else {
+					proto += m[2]
+				}
+				break
+			}
+		}
+		if protoIdx < 0 {
+			continue
+		}
+
+		// proto Recv-Q Send-Q Local Foreign [state]
+		if len(fields) < protoIdx+5 {
+			continue
+		}
+
+		v6 := strings.HasSuffix(proto, "6")
+		localAddr, localPort := splitAixAddress(fields[protoIdx+3], v6)
+		remoteAddr, remotePort := splitAixAddress(fields[protoIdx+4], v6)
+
+		state := ""
+		if len(fields) > protoIdx+5 {
+			state = fields[protoIdx+5]
+		}
+
+		res = append(res, AixPort{
+			Protocol:      proto,
+			LocalAddress:  localAddr,
+			LocalPort:     localPort,
+			RemoteAddress: remoteAddr,
+			RemotePort:    remotePort,
+			State:         state,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// splitAixAddress splits a BSD-style `address.port` endpoint. `v6` is the row's
+// address family, needed because AIX writes the wildcard as a bare `*` on v6
+// rows too, where it means every v6 interface rather than every v4 one.
+//
+// The separator is the LAST dot, so IPv4 (`10.10.20.15.22`) and IPv6
+// (`2001:db8::15.443`) both split correctly. Wildcards are normalised to the
+// forms the other platforms emit, so a consumer comparing addresses across
+// platforms does not have to special-case AIX:
+//
+//	*.22 (v4) -> 0.0.0.0, port 22 — bound to every interface
+//	*.25 (v6) -> [::],    port 25 — same, v6
+//	*.*       -> "",      port 0  — no endpoint (an unconnected socket's peer)
+//
+// An IPv6 literal is bracketed to match the Windows rows.
+func splitAixAddress(s string, v6 bool) (string, int64) {
+	if s == "" || s == "*.*" {
+		return "", 0
+	}
+
+	addr, portStr := s, ""
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		addr, portStr = s[:i], s[i+1:]
+	}
+
+	var port int64
+	if portStr != "" && portStr != "*" {
+		if p, err := strconv.ParseInt(portStr, 10, 64); err == nil {
+			port = p
+		}
+	}
+
+	switch {
+	case addr == "*" && v6:
+		addr = "[::]"
+	case addr == "*":
+		addr = "0.0.0.0"
+	case strings.Contains(addr, ":"):
+		addr = "[" + addr + "]"
+	}
+
+	return addr, port
+}

--- a/providers/os/resources/ports/aixnetstat.go
+++ b/providers/os/resources/ports/aixnetstat.go
@@ -60,23 +60,8 @@ func ParseAixNetstat(r io.Reader) ([]AixPort, error) {
 			continue
 		}
 
-		// Locate the protocol column. This skips both header lines and the
-		// optional leading PCB/ADDR column of `netstat -Aan`.
-		protoIdx := -1
-		var proto string
-		for i, f := range fields {
-			if m := reAixProto.FindStringSubmatch(f); m != nil {
-				protoIdx = i
-				proto = m[1]
-				if m[2] == "" {
-					proto += "4"
-				} else {
-					proto += m[2]
-				}
-				break
-			}
-		}
-		if protoIdx < 0 {
+		protoIdx, proto, ok := findAixProto(fields)
+		if !ok {
 			continue
 		}
 
@@ -108,6 +93,31 @@ func ParseAixNetstat(r io.Reader) ([]AixPort, error) {
 	}
 
 	return res, nil
+}
+
+// findAixProto locates the protocol column in a netstat row and normalises the
+// protocol to an address family suffix. The column is found by pattern rather
+// than by index because `netstat -Aan` prefixes every row with a PCB address
+// while `netstat -an` does not.
+//
+// ok is false when the row carries no protocol column, which is how header
+// lines are skipped.
+func findAixProto(fields []string) (int, string, bool) {
+	for i, f := range fields {
+		m := reAixProto.FindStringSubmatch(f)
+		if m == nil {
+			continue
+		}
+
+		proto := m[1]
+		if m[2] == "" {
+			proto += "4"
+		} else {
+			proto += m[2]
+		}
+		return i, proto, true
+	}
+	return 0, "", false
 }
 
 // splitAixAddress splits a BSD-style `address.port` endpoint. `v6` is the row's

--- a/providers/os/resources/ports/aixnetstat_test.go
+++ b/providers/os/resources/ports/aixnetstat_test.go
@@ -1,0 +1,179 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package ports
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAixNetstat(t *testing.T) {
+	data, err := os.Open("./testdata/aix_netstat_an.txt")
+	require.NoError(t, err)
+	defer data.Close()
+
+	ports, err := ParseAixNetstat(data)
+	require.NoError(t, err)
+
+	// 14 internet rows; the two Unix domain sockets below the second header
+	// must not be picked up.
+	require.Len(t, ports, 14)
+
+	byIdx := func(i int) AixPort { return ports[i] }
+
+	t.Run("wildcard listener binds every interface", func(t *testing.T) {
+		p := byIdx(0)
+		assert.Equal(t, "tcp4", p.Protocol)
+		assert.Equal(t, "0.0.0.0", p.LocalAddress)
+		assert.Equal(t, int64(22), p.LocalPort)
+		assert.Equal(t, "LISTEN", p.State)
+		// An unconnected socket has no peer.
+		assert.Equal(t, "", p.RemoteAddress)
+		assert.Equal(t, int64(0), p.RemotePort)
+	})
+
+	t.Run("bare tcp is treated as v4", func(t *testing.T) {
+		p := byIdx(1)
+		assert.Equal(t, "tcp4", p.Protocol)
+		assert.Equal(t, int64(23), p.LocalPort)
+	})
+
+	t.Run("loopback listener keeps its address", func(t *testing.T) {
+		p := byIdx(2)
+		assert.Equal(t, "127.0.0.1", p.LocalAddress)
+		assert.Equal(t, int64(199), p.LocalPort)
+	})
+
+	t.Run("v6 literal is bracketed", func(t *testing.T) {
+		p := byIdx(3)
+		assert.Equal(t, "tcp6", p.Protocol)
+		assert.Equal(t, "[::1]", p.LocalAddress)
+		assert.Equal(t, int64(25), p.LocalPort)
+	})
+
+	t.Run("established session carries both endpoints", func(t *testing.T) {
+		p := byIdx(4)
+		assert.Equal(t, "10.10.20.15", p.LocalAddress)
+		assert.Equal(t, int64(22), p.LocalPort)
+		assert.Equal(t, "10.10.30.9", p.RemoteAddress)
+		assert.Equal(t, int64(51544), p.RemotePort)
+		assert.Equal(t, "ESTABLISHED", p.State)
+	})
+
+	t.Run("high local port is not confused with the address", func(t *testing.T) {
+		// 10.10.20.15.32790 -> the LAST dot separates the port.
+		p := byIdx(6)
+		assert.Equal(t, "10.10.20.15", p.LocalAddress)
+		assert.Equal(t, int64(32790), p.LocalPort)
+		assert.Equal(t, int64(1521), p.RemotePort)
+	})
+
+	t.Run("non-listen states are preserved verbatim", func(t *testing.T) {
+		assert.Equal(t, "TIME_WAIT", byIdx(7).State)
+		assert.Equal(t, "CLOSE_WAIT", byIdx(8).State)
+	})
+
+	t.Run("v6 session splits on the dot, not the colons", func(t *testing.T) {
+		p := byIdx(9)
+		assert.Equal(t, "tcp6", p.Protocol)
+		assert.Equal(t, "[2001:db8::15]", p.LocalAddress)
+		assert.Equal(t, int64(443), p.LocalPort)
+		assert.Equal(t, "[2001:db8::99]", p.RemoteAddress)
+		assert.Equal(t, int64(51900), p.RemotePort)
+	})
+
+	t.Run("udp rows have no state", func(t *testing.T) {
+		p := byIdx(10)
+		assert.Equal(t, "udp4", p.Protocol)
+		assert.Equal(t, "0.0.0.0", p.LocalAddress)
+		assert.Equal(t, int64(123), p.LocalPort)
+		// AIX prints no state column for UDP; it is stateless.
+		assert.Equal(t, "", p.State)
+	})
+
+	t.Run("v6 udp wildcard resolves to the v6 wildcard", func(t *testing.T) {
+		p := byIdx(12)
+		assert.Equal(t, "udp6", p.Protocol)
+		assert.Equal(t, "[::1]", p.LocalAddress)
+		assert.Equal(t, int64(123), p.LocalPort)
+	})
+
+	t.Run("fully unbound socket yields no endpoint", func(t *testing.T) {
+		p := byIdx(13)
+		assert.Equal(t, "udp4", p.Protocol)
+		assert.Equal(t, "", p.LocalAddress)
+		assert.Equal(t, int64(0), p.LocalPort)
+	})
+}
+
+// `netstat -Aan` prefixes every row with a PCB address, which shifts every
+// column right by one. The protocol column is found by pattern, so both forms
+// parse identically.
+func TestParseAixNetstatWithPcbColumn(t *testing.T) {
+	data, err := os.Open("./testdata/aix_netstat_aan.txt")
+	require.NoError(t, err)
+	defer data.Close()
+
+	ports, err := ParseAixNetstat(data)
+	require.NoError(t, err)
+	require.Len(t, ports, 3)
+
+	assert.Equal(t, "tcp4", ports[0].Protocol)
+	assert.Equal(t, "0.0.0.0", ports[0].LocalAddress)
+	assert.Equal(t, int64(22), ports[0].LocalPort)
+	assert.Equal(t, "LISTEN", ports[0].State)
+
+	assert.Equal(t, "10.10.20.15", ports[1].LocalAddress)
+	assert.Equal(t, "10.10.30.9", ports[1].RemoteAddress)
+	assert.Equal(t, int64(51544), ports[1].RemotePort)
+	assert.Equal(t, "ESTABLISHED", ports[1].State)
+
+	assert.Equal(t, "udp4", ports[2].Protocol)
+	assert.Equal(t, int64(123), ports[2].LocalPort)
+	assert.Equal(t, "", ports[2].State)
+}
+
+func TestParseAixNetstatEdgeCases(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		p, err := ParseAixNetstat(strings.NewReader(""))
+		require.NoError(t, err)
+		assert.Empty(t, p)
+	})
+
+	t.Run("headers only", func(t *testing.T) {
+		in := "Active Internet connections (including servers)\n" +
+			"Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)\n"
+		p, err := ParseAixNetstat(strings.NewReader(in))
+		require.NoError(t, err)
+		assert.Empty(t, p)
+	})
+
+	t.Run("truncated row is skipped rather than panicking", func(t *testing.T) {
+		p, err := ParseAixNetstat(strings.NewReader("tcp4       0      0\n"))
+		require.NoError(t, err)
+		assert.Empty(t, p)
+	})
+
+	t.Run("unix-only output yields nothing", func(t *testing.T) {
+		in := "Active UNIX domain sockets\n" +
+			"f1000a0000000000  dgram  0  0  f1000b00  0  0  0  /dev/log\n"
+		p, err := ParseAixNetstat(strings.NewReader(in))
+		require.NoError(t, err)
+		assert.Empty(t, p)
+	})
+
+	t.Run("a path containing tcp does not become a socket row", func(t *testing.T) {
+		// Guards the protocol-by-pattern scan: the match is anchored, so
+		// "/tmp/tcp4.sock" is not mistaken for the protocol column.
+		in := "Active UNIX domain sockets\n" +
+			"f1000a0000000000  stream  0  0  f1000b01  0  0  0  /tmp/tcp4.sock\n"
+		p, err := ParseAixNetstat(strings.NewReader(in))
+		require.NoError(t, err)
+		assert.Empty(t, p)
+	})
+}

--- a/providers/os/resources/ports/testdata/aix_netstat_aan.txt
+++ b/providers/os/resources/ports/testdata/aix_netstat_aan.txt
@@ -1,0 +1,5 @@
+Active Internet connections (including servers)
+PCB/ADDR         Proto Recv-Q Send-Q  Local Address      Foreign Address    (state)
+f1000e00003b3bb8 tcp4       0      0  *.22               *.*                LISTEN
+f1000e00003b4bb8 tcp4       0      0  10.10.20.15.22     10.10.30.9.51544   ESTABLISHED
+f1000e00003b5bb8 udp4       0      0  *.123              *.*

--- a/providers/os/resources/ports/testdata/aix_netstat_an.txt
+++ b/providers/os/resources/ports/testdata/aix_netstat_an.txt
@@ -1,0 +1,21 @@
+Active Internet connections (including servers)
+Proto Recv-Q Send-Q  Local Address          Foreign Address        (state)
+tcp4       0      0  *.22                   *.*                    LISTEN
+tcp        0      0  *.23                   *.*                    LISTEN
+tcp4       0      0  127.0.0.1.199          *.*                    LISTEN
+tcp6       0      0  ::1.25                 *.*                    LISTEN
+tcp4       0      0  10.10.20.15.22         10.10.30.9.51544       ESTABLISHED
+tcp4       0      0  10.10.20.15.23         192.0.2.44.44012       ESTABLISHED
+tcp4       0      0  10.10.20.15.32790      10.10.20.40.1521       ESTABLISHED
+tcp4       0      0  10.10.20.15.32791      10.10.20.41.1521       TIME_WAIT
+tcp4       0      0  10.10.20.15.32792      10.10.20.41.1521       CLOSE_WAIT
+tcp6       0      0  2001:db8::15.443       2001:db8::99.51900     ESTABLISHED
+udp4       0      0  *.123                  *.*
+udp4       0      0  127.0.0.1.123          *.*
+udp6       0      0  ::1.123                *.*
+udp4       0      0  *.*                    *.*
+
+Active UNIX domain sockets
+SADR/PCB          Type      Recv-Q Send-Q    Inode     Conn      Refs      Nextref   Addr
+f1000a0000000000  dgram          0      0    f1000b00        0         0         0   /dev/log
+f1000a0000000001  stream         0      0    f1000b01        0         0         0   /tmp/.s.PGSQL.5432


### PR DESCRIPTION
`ports` / `ports.listening` returned `could not detect suitable ports manager for platform: aix` on every AIX asset, because `mqlPorts.list()` only dispatches for linux, windows, darwin and freebsd. AIX ships neither `/proc/net/tcp` nor a bundled `lsof`, so `netstat` is the only source that is always present.

`services` already works on AIX (`AixServiceManager` over `lssrc`), so ports was the one remaining gap for describing an AIX host's network exposure.

## What's here

- `providers/os/resources/ports/aixnetstat.go` — a pure parser for the "Active Internet connections" section
- `listAix()` / `parseAixPorts()` in `providers/os/resources/port.go`, plus the dispatch case

## Parsing notes

AIX uses the BSD row shape, so the port is appended to the address with a dot rather than a colon (`10.10.20.15.32790`) — splitting on the **last** dot handles v4 and v6 alike. Both `netstat -an` and `netstat -Aan` parse: the protocol column is located by anchored pattern rather than index, so the PCB prefix the latter adds shifts nothing. Everything below the `Active UNIX domain sockets` header is ignored (different columns, no IP semantics).

Values are normalised to what the other platforms emit, so a consumer comparing across platforms doesn't special-case AIX:

| AIX | emitted |
|---|---|
| `*.22` (v4) | `0.0.0.0`, port 22 |
| `*.25` (v6) | `[::]`, port 25 |
| `::1.25` | `[::1]`, port 25 (bracketed, as on Windows) |
| `*.*` (peer of an unconnected socket) | `""`, port 0 |
| `LISTEN`, `TIME_WAIT`, … | mapped onto the shared `TCP_STATES` vocabulary |

The state mapping matters for behaviour, not just tidiness: `ports.listening` filters `state == "listen"`, so without it that accessor would silently return nothing on AIX. An unrecognised state becomes `"unknown"` rather than a string invented outside `TCP_STATES`, and a test asserts every mapped value exists in that table so the two can't drift.

UDP rows keep an empty state — AIX prints no state column for a stateless protocol — rather than having one invented for them.

## No owning process

Unlike the other platforms this reports no process: `netstat` gives a PCB address rather than a PID, and resolving one needs `rmsock`, which is root-only and costs an exec per socket. `process` and `user` are null, with process marked resolved-and-null so the lazy accessor isn't called per row — matching how the Windows path handles a missing process.

## Testing

24 cases over both output forms: v4/v6, wildcards, high local ports that could be mistaken for an address octet, non-listen states, UDP, truncated rows, unix-socket-only output, and a path containing `tcp4` that must not be read as a protocol column. Plus the state mapping and the `TCP_STATES` drift guard. `go build ./...` and the full `providers/os/resources/...` suite pass.

**One limit worth stating:** the testdata is hand-authored from the documented AIX column layout, not captured from a live host — so the parse is verified but the command path isn't. The parser skips rows it can't read rather than erroring, so an unexpected variation degrades to fewer sockets rather than a failed scan. Validating against real `netstat -an` output from an AIX box is a paste-and-rerun away.

## Why

An internet-facing, end-of-life AIX host with a KEV-listed remote RCE currently can't be assessed for reachability at all — "is anything actually listening on it" is unanswerable. This makes `ports` work there; the matching content lives in mondoohq/cnspec (AIX inventory query pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
