### PR TITLE
✨ azure: resolve RBAC principals, model management groups and resource locks

### DIFF
--- a/providers-sdk/v1/util/permissions/permissions.go
+++ b/providers-sdk/v1/util/permissions/permissions.go
@@ -1832,6 +1832,10 @@ var azureServiceToARMMap = map[string]string{
 	"appcontainers":         "Microsoft.App",
 	"containerinstance":     "Microsoft.ContainerInstance",
 	"machinelearning":       "Microsoft.MachineLearningServices",
+	// The SDK package is armmanagementgroups but the ARM namespace is
+	// Microsoft.Management; without this the default branch would emit
+	// "Microsoft.Managementgroups", which is not a real provider.
+	"managementgroups": "Microsoft.Management",
 }
 
 func azureServiceToARM(service string) string {
@@ -1871,6 +1875,17 @@ var azureMethodPermissionOverrides = map[string]string{
 	"TableResources.NewListTableRoleDefinitionsPager":         "Microsoft.DocumentDB/databaseAccounts/tableRoleDefinitions/read",
 	"MongoMIResources.NewListMongoMIRoleAssignmentsPager":     "Microsoft.DocumentDB/databaseAccounts/mongoMIRoleAssignments/read",
 	"MongoMIResources.NewListMongoMIRoleDefinitionsPager":     "Microsoft.DocumentDB/databaseAccounts/mongoMIRoleDefinitions/read",
+
+	// armlocks lives under the resourcemanager/resources directory, so the
+	// service derives to Microsoft.Resources; locks are actually governed by
+	// Microsoft.Authorization. The service key cannot be remapped because
+	// armresources, armdeployments, armsubscriptions and armpolicy legitimately
+	// share it.
+	"ManagementLocks.NewListAtSubscriptionLevelPager": "Microsoft.Authorization/locks/read",
+
+	// The entities listing walks the management group hierarchy; the governing
+	// permission is on managementGroups, not on an "entities" resource type.
+	"Entities.NewListPager": "Microsoft.Management/managementGroups/read",
 }
 
 // azurePermissionOverrides maps generated permission strings to the correct

--- a/providers/azure/go.mod
+++ b/providers/azure/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/logic/armlogic v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
@@ -54,6 +55,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup/v4 v4.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments/v2 v2.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v4 v4.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions/v2 v2.0.0

--- a/providers/azure/go.sum
+++ b/providers/azure/go.sum
@@ -122,6 +122,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachine
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/machinelearning/armmachinelearning/v4 v4.0.0/go.mod h1:nivJvZio5SHpEASAk8LKIueqs7zEHU+iRLKWbx3Xi10=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0 h1:dwmV8G0tLD17J+LcTirpFmNKvZBLLuErtGR0h6h8n2c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managedservices/armmanagedservices v0.7.0/go.mod h1:UmV8UnyCQ+05EvopWqF6CQsFWI5FWcp/AXGVkJguv9E=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0/go.mod h1:8wzvopPfyZYPaQUoKW87Zfdul7jmJMDfp/k7YY3oJyA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0 h1:CRwl8O5YMdbQQ1MJ2ojHtTxaqesztdoBfFFcYVfv+Nc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mongocluster/armmongocluster v1.2.0/go.mod h1:3AVoXQskcMH6BK+RamT0WKc6x3HJxvm05J3N61hOySs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.13.0 h1:c7r8eBbYWf2JbQFinuEbHsqq+ukY1tVIgAxt0uND2Fo=
@@ -156,6 +158,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments/v2 v2.0.0 h1:beUtRjpgxW6I8oyB/8bZ98+NojDTgcokBj+EiXdDqjg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments/v2 v2.0.0/go.mod h1:q9iTxbauRZ9g68KsZ2NpPh/7aC7m7f91AI3gHSTCgr4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks v1.2.0 h1:CMp8GwmUfS/Stg5KBgduD8rPIk9GNj1HMaID/gUAJYg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks v1.2.0/go.mod h1:GE1wqa9Ny9eZ8wHtHqbCE7mMsFfVbdEY0itmzYV8JEg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy v1.0.0 h1:FKYUd0TZfjjWtdk7LR+6rI64yNY1gMe9rNV40Y2Fh4o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armpolicy v1.0.0/go.mod h1:w987ZDGBg74HZu5sAqaBEhDTlvlJlxPggIhBiDviYhE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=

--- a/providers/azure/resources/azure.go
+++ b/providers/azure/resources/azure.go
@@ -3,6 +3,12 @@
 
 package resources
 
+import (
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+)
+
 // TODO: we should look into restructuring resources for v11.
 // we should be able to define the subscription as a property on the azure one, i.e.
 //
@@ -14,4 +20,12 @@ package resources
 // or create azure and then do azure.subscription()
 type mqlAzureInternal struct {
 	sub *mqlAzureSubscription
+
+	// The tenant's management group hierarchy, fetched at most once per scan.
+	// It lives here rather than on a subscription because it spans every
+	// subscription in the tenant, and one entities listing answers parentage,
+	// children, and subtree counts for the whole tree.
+	mgOnce     sync.Once
+	mgEntities []*armmanagementgroups.EntityInfo
+	mgErr      error
 }

--- a/providers/azure/resources/azure.lr
+++ b/providers/azure/resources/azure.lr
@@ -10,9 +10,136 @@ option go_package = "go.mondoo.com/mql/v13/providers/azure/resources"
 // subscription is exposed as `azure.subscription`, and every Azure
 // service-specific accessor (Compute, Storage, Network, Key Vault,
 // Cosmos DB, Monitor, Defender for Cloud, AKS, and so on) is reached
-// through that subscription.
+// through that subscription. Tenant-wide structures that sit above any
+// single subscription are reached here instead: managementGroups walks
+// the governance hierarchy the tenant's subscriptions hang from.
 azure {
+  // Management groups in the tenant
+  //
+  // Every management group the credential can read, in no particular
+  // order, including the tenant root group. Management groups are the
+  // governance containers above subscriptions, so this is where a role
+  // assignment or policy assignment made at a management group scope
+  // gets a name, a position in the hierarchy, and a measurable blast
+  // radius. Empty when the credential has no Microsoft.Management read
+  // access, which is common for service principals scoped to a single
+  // subscription.
+  managementGroups() []azure.managementGroup
 }
+
+// Azure management group
+//
+// Governance container that groups subscriptions and other management
+// groups, and the scope at which tenant-wide role assignments, policy
+// assignments, and deny assignments are made. The `name` field is the
+// group's identifier as it appears in scope paths (a GUID or a chosen
+// short name), and selects the group, for example
+// `azure.managementGroup(name: "mg-production")`. Role assignments and
+// policy assignments made at this exact scope are reachable here, along
+// with the child groups and subscriptions that inherit them, so a grant
+// high in the hierarchy can be attributed to the group that carries it
+// and weighed against everything underneath.
+azure.managementGroup @defaults("name displayName subscriptionCount") {
+  // Full resource ID of the management group
+  id string
+  // Management group identifier used in scope paths
+  name string
+  // Human-readable display name
+  displayName string
+  // Tenant that owns the management group
+  tenantId string
+  // Whether this is the tenant root group
+  //
+  // The root group's name equals the tenant ID and it has no parent.
+  // Every subscription in the tenant sits underneath it, so an
+  // assignment here is the widest possible grant.
+  isRoot bool
+  // Parent management group, or null for the tenant root group
+  parent() azure.managementGroup
+  // Direct child management groups
+  children() []azure.managementGroup
+  // Subscription IDs that are direct children of this management group
+  //
+  // Direct children only. Subscriptions nested under a child management
+  // group are reached through children.
+  subscriptionIds []string
+  // Total number of subscriptions at or below this management group
+  //
+  // Counts subscriptions underneath the whole subtree, not only direct
+  // children, which is the blast radius of a role or policy assignment
+  // made at this scope.
+  subscriptionCount int
+  // Role assignments made at this management group scope
+  //
+  // Assignments whose scope is exactly this group, not ones it inherits
+  // from a parent or ones made further down. Because a grant here is
+  // inherited by every subscription in the subtree, pair this with
+  // subscriptionCount to weigh its reach.
+  roleAssignments() []azure.subscription.authorizationService.roleAssignment
+  // Policy assignments made at this management group scope
+  //
+  // Assignments whose scope is exactly this group. Resolved from the
+  // connected subscription's assignment list, so only assignments that
+  // the subscription inherits are visible here; a sibling branch of the
+  // hierarchy the subscription does not sit under will report none.
+  policyAssignments() []azure.subscription.policy.assignment
+}
+
+// Microsoft Entra principal
+//
+// Directory object behind a role assignment: the user, group, service
+// principal, application, or device that a grant was made to. Carries
+// the display name and type that an object ID alone does not, plus the
+// application identity behind a service principal (appId, the home
+// tenant in appOwnerTenantId, and whether it is a managed identity or a
+// registered application), and whether the account is still enabled.
+// This is what turns "some object ID holds Owner" into an attributable
+// finding, and it distinguishes a grant to a managed identity from one
+// to a human or to an application owned by an outside tenant.
+private azure.entraPrincipal @defaults("displayName principalType") {
+  // Object ID of the directory object
+  id string
+  // Display name
+  displayName string
+  // Kind of directory object
+  //
+  // One of "user", "group", "servicePrincipal", "application",
+  // "device", or "" when Microsoft Graph returned a type this provider
+  // does not model.
+  principalType string
+  // User principal name, for users
+  userPrincipalName string
+  // Application (client) ID, for service principals and applications
+  appId string
+  // Tenant that owns the application behind a service principal
+  //
+  // Differs from the subscription's tenant for a multi-tenant
+  // application or a Microsoft first-party service, so a grant to a
+  // principal whose home tenant is not yours is a cross-tenant grant.
+  // Empty for users, groups, and devices.
+  appOwnerTenantId string
+  // Service principal subtype
+  //
+  // One of "Application" (a registered app), "ManagedIdentity" (an
+  // Azure resource identity), or "Legacy". Empty for object types other
+  // than service principals. Distinguishes a workload identity from a
+  // human-facing application registration.
+  servicePrincipalType string
+  // Whether the account is enabled
+  //
+  // Null for object types that carry no enabled state, such as groups.
+  // A disabled account holding a privileged role is a dormant grant
+  // that re-arms the moment the account is re-enabled.
+  accountEnabled bool
+  // Whether the group can be assigned Microsoft Entra roles
+  //
+  // Only meaningful for groups. A role-assignable group is a privilege
+  // escalation path, because whoever can add members to it can grant
+  // themselves the group's roles.
+  isAssignableToRole bool
+}
+
+
 
 // Azure subscription
 //
@@ -58,6 +185,22 @@ azure.subscription @defaults ("name") {
   resourceGroups() []azure.subscription.resourcegroup
   // Subscription-scoped Azure Resource Manager deployments
   deployments() []azure.subscription.deployment
+  // Management group ancestry of the subscription
+  //
+  // The chain of management groups the subscription sits under, nearest
+  // parent first and the tenant root group last. This is the set of
+  // scopes whose role and policy assignments the subscription inherits.
+  // Empty when the credential has no Microsoft.Management read access.
+  managementGroups() []azure.managementGroup
+  // Resource locks in the subscription
+  //
+  // Every management lock at or below the subscription scope, including
+  // locks on resource groups and on individual resources. A lock is the
+  // control that stops a resource being deleted or modified regardless
+  // of RBAC, so this is how you confirm that vaults, backup vaults, and
+  // storage holding retained data cannot be removed by an operator or an
+  // attacker who has gained write access.
+  locks() []azure.subscription.lock
   // Compute resources in the subscription
   compute() azure.subscription.computeService
   // Batch resources in the subscription
@@ -197,6 +340,49 @@ private azure.subscription.resourcegroup @defaults("name location") {
   provisioningState string
   // Azure Resource Manager deployments in the resource group
   deployments() []azure.subscription.deployment
+  // Resource locks at or below this resource group
+  //
+  // Includes locks on the group itself and on the resources inside it.
+  // Resolved from the subscription's lock list, so this costs no
+  // additional API call.
+  locks() []azure.subscription.lock
+}
+
+// Azure resource lock
+//
+// Management lock that blocks deletion, or all modification, of the
+// scope it is applied to. Locks sit outside RBAC: they apply to every
+// principal including subscription owners, which makes them the last
+// line of defense for data that must survive a compromised or mistaken
+// operator. The `level` field says which operations are blocked and
+// `scope` says what the lock protects, so an audit can check that
+// backup vaults, recovery services vaults, key vaults, and storage
+// holding retained data all carry one.
+private azure.subscription.lock @defaults("name level scope") {
+  // Full resource ID of the lock
+  id string
+  // Lock name
+  name string
+  // Lock resource type
+  type string
+  // Operations the lock blocks
+  //
+  // One of "CanNotDelete" (the scope can be read and modified but not
+  // deleted), "ReadOnly" (the scope can only be read, which also blocks
+  // deletion), or "NotSpecified". ReadOnly is the stronger of the two
+  // and can break operations that write resource state.
+  level string
+  // Notes recorded on the lock explaining why it exists
+  notes string
+  // Application IDs of the lock owners
+  owners []string
+  // Resource ID the lock applies to
+  //
+  // The subscription, resource group, or resource the lock protects,
+  // derived by stripping the lock's own provider path from its ID. A
+  // subscription-level lock reports the subscription ID, so a lock's
+  // reach is read from how deep this path goes.
+  scope string
 }
 
 // Azure resource
@@ -10024,6 +10210,34 @@ private azure.subscription.authorizationService.roleDefinition @defaults ("name 
   scopes []string
   // Permissions that are attached to the role definition
   permissions() []azure.subscription.authorizationService.roleDefinition.permission
+  // Whether the role can grant roles, and so escalate its own privileges
+  //
+  // True when the role's allowed actions cover
+  // `Microsoft.Authorization/roleAssignments/write`,
+  // `Microsoft.Authorization/roleDefinitions/write`, or
+  // `Microsoft.Authorization/elevateAccess/action` (directly or via a
+  // wildcard) and no notActions entry takes that action back. A
+  // principal holding such a role can assign itself any other role at
+  // the same scope, so its effective privilege is Owner no matter what
+  // the role is called. Built-in Owner and User Access Administrator
+  // both report true, as does any custom role that reaches those
+  // actions.
+  isPrivilegeEscalating() bool
+  // Whether the role grants wildcard control-plane actions
+  //
+  // True when any allowed action contains a `*`. A bare `*` is full
+  // control at the assigned scope. A narrower pattern such as
+  // `Microsoft.Compute/*` still grants every action in that namespace,
+  // including actions Azure adds after the role was written, so the
+  // role's privilege grows over time without anyone editing it.
+  hasWildcardActions() bool
+  // Whether the role grants data-plane access
+  //
+  // True when the role allows any dataActions. Control-plane actions
+  // govern a resource's configuration; data actions reach its contents
+  // (blob bytes, queue messages, key material), so a role granting them
+  // exposes stored data rather than only settings.
+  grantsDataAccess() bool
 }
 
 // Azure role definition permission
@@ -10058,6 +10272,17 @@ private azure.subscription.authorizationService.roleAssignment  @defaults("princ
   createdAt time
   updatedAt time
   role() azure.subscription.authorizationService.roleDefinition
+  // Microsoft Entra principal the role was assigned to
+  //
+  // Resolves principalId against the directory, giving the grant a name,
+  // an object type, and (for service principals) the application and
+  // home tenant behind it. Null when the object no longer exists, which
+  // marks the assignment as an orphaned grant to a deleted principal.
+  // Requires the credential to hold Microsoft Graph directory read
+  // access; without it this reports an error rather than reporting no
+  // principal, since the latter would silently understate who holds
+  // access.
+  principal() azure.entraPrincipal
 }
 
 // Azure managed identity

--- a/providers/azure/resources/azure.lr.go
+++ b/providers/azure/resources/azure.lr.go
@@ -17,9 +17,12 @@ import (
 // The MQL type names exposed as public consts for ease of reference.
 const (
 	ResourceAzure                                                                                     string = "azure"
+	ResourceAzureManagementGroup                                                                      string = "azure.managementGroup"
+	ResourceAzureEntraPrincipal                                                                       string = "azure.entraPrincipal"
 	ResourceAzureSubscription                                                                         string = "azure.subscription"
 	ResourceAzureSubscriptionWebServiceFunction                                                       string = "azure.subscription.webService.function"
 	ResourceAzureSubscriptionResourcegroup                                                            string = "azure.subscription.resourcegroup"
+	ResourceAzureSubscriptionLock                                                                     string = "azure.subscription.lock"
 	ResourceAzureSubscriptionResource                                                                 string = "azure.subscription.resource"
 	ResourceAzureSubscriptionSystemData                                                               string = "azure.subscription.systemData"
 	ResourceAzureSubscriptionDeployment                                                               string = "azure.subscription.deployment"
@@ -512,6 +515,14 @@ func init() {
 			// to override args, implement: initAzure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzure,
 		},
+		"azure.managementGroup": {
+			Init:   initAzureManagementGroup,
+			Create: createAzureManagementGroup,
+		},
+		"azure.entraPrincipal": {
+			// to override args, implement: initAzureEntraPrincipal(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureEntraPrincipal,
+		},
 		"azure.subscription": {
 			Init:   initAzureSubscription,
 			Create: createAzureSubscription,
@@ -523,6 +534,10 @@ func init() {
 		"azure.subscription.resourcegroup": {
 			// to override args, implement: initAzureSubscriptionResourcegroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAzureSubscriptionResourcegroup,
+		},
+		"azure.subscription.lock": {
+			// to override args, implement: initAzureSubscriptionLock(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAzureSubscriptionLock,
 		},
 		"azure.subscription.resource": {
 			// to override args, implement: initAzureSubscriptionResource(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -2523,6 +2538,69 @@ func CreateResource(runtime *plugin.Runtime, name string, args map[string]*llx.R
 }
 
 var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
+	"azure.managementGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzure).GetManagementGroups()).ToDataRes(types.Array(types.Resource("azure.managementGroup")))
+	},
+	"azure.managementGroup.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetId()).ToDataRes(types.String)
+	},
+	"azure.managementGroup.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetName()).ToDataRes(types.String)
+	},
+	"azure.managementGroup.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetDisplayName()).ToDataRes(types.String)
+	},
+	"azure.managementGroup.tenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetTenantId()).ToDataRes(types.String)
+	},
+	"azure.managementGroup.isRoot": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetIsRoot()).ToDataRes(types.Bool)
+	},
+	"azure.managementGroup.parent": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetParent()).ToDataRes(types.Resource("azure.managementGroup"))
+	},
+	"azure.managementGroup.children": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetChildren()).ToDataRes(types.Array(types.Resource("azure.managementGroup")))
+	},
+	"azure.managementGroup.subscriptionIds": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetSubscriptionIds()).ToDataRes(types.Array(types.String))
+	},
+	"azure.managementGroup.subscriptionCount": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetSubscriptionCount()).ToDataRes(types.Int)
+	},
+	"azure.managementGroup.roleAssignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetRoleAssignments()).ToDataRes(types.Array(types.Resource("azure.subscription.authorizationService.roleAssignment")))
+	},
+	"azure.managementGroup.policyAssignments": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureManagementGroup).GetPolicyAssignments()).ToDataRes(types.Array(types.Resource("azure.subscription.policy.assignment")))
+	},
+	"azure.entraPrincipal.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetId()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.displayName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetDisplayName()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.principalType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetPrincipalType()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.userPrincipalName": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetUserPrincipalName()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.appId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetAppId()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.appOwnerTenantId": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetAppOwnerTenantId()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.servicePrincipalType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetServicePrincipalType()).ToDataRes(types.String)
+	},
+	"azure.entraPrincipal.accountEnabled": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetAccountEnabled()).ToDataRes(types.Bool)
+	},
+	"azure.entraPrincipal.isAssignableToRole": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureEntraPrincipal).GetIsAssignableToRole()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscription).GetId()).ToDataRes(types.String)
 	},
@@ -2558,6 +2636,12 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.deployments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscription).GetDeployments()).ToDataRes(types.Array(types.Resource("azure.subscription.deployment")))
+	},
+	"azure.subscription.managementGroups": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscription).GetManagementGroups()).ToDataRes(types.Array(types.Resource("azure.managementGroup")))
+	},
+	"azure.subscription.locks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscription).GetLocks()).ToDataRes(types.Array(types.Resource("azure.subscription.lock")))
 	},
 	"azure.subscription.compute": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscription).GetCompute()).ToDataRes(types.Resource("azure.subscription.computeService"))
@@ -2735,6 +2819,30 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.resourcegroup.deployments": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionResourcegroup).GetDeployments()).ToDataRes(types.Array(types.Resource("azure.subscription.deployment")))
+	},
+	"azure.subscription.resourcegroup.locks": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionResourcegroup).GetLocks()).ToDataRes(types.Array(types.Resource("azure.subscription.lock")))
+	},
+	"azure.subscription.lock.id": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetId()).ToDataRes(types.String)
+	},
+	"azure.subscription.lock.name": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetName()).ToDataRes(types.String)
+	},
+	"azure.subscription.lock.type": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetType()).ToDataRes(types.String)
+	},
+	"azure.subscription.lock.level": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetLevel()).ToDataRes(types.String)
+	},
+	"azure.subscription.lock.notes": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetNotes()).ToDataRes(types.String)
+	},
+	"azure.subscription.lock.owners": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetOwners()).ToDataRes(types.Array(types.String))
+	},
+	"azure.subscription.lock.scope": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionLock).GetScope()).ToDataRes(types.String)
 	},
 	"azure.subscription.resource.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionResource).GetId()).ToDataRes(types.String)
@@ -13248,6 +13356,15 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"azure.subscription.authorizationService.roleDefinition.permissions": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).GetPermissions()).ToDataRes(types.Array(types.Resource("azure.subscription.authorizationService.roleDefinition.permission")))
 	},
+	"azure.subscription.authorizationService.roleDefinition.isPrivilegeEscalating": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).GetIsPrivilegeEscalating()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.authorizationService.roleDefinition.hasWildcardActions": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).GetHasWildcardActions()).ToDataRes(types.Bool)
+	},
+	"azure.subscription.authorizationService.roleDefinition.grantsDataAccess": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).GetGrantsDataAccess()).ToDataRes(types.Bool)
+	},
 	"azure.subscription.authorizationService.roleDefinition.permission.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinitionPermission).GetId()).ToDataRes(types.String)
 	},
@@ -13292,6 +13409,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"azure.subscription.authorizationService.roleAssignment.role": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).GetRole()).ToDataRes(types.Resource("azure.subscription.authorizationService.roleDefinition"))
+	},
+	"azure.subscription.authorizationService.roleAssignment.principal": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).GetPrincipal()).ToDataRes(types.Resource("azure.entraPrincipal"))
 	},
 	"azure.subscription.managedIdentity.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAzureSubscriptionManagedIdentity).GetName()).ToDataRes(types.String)
@@ -19603,6 +19723,98 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzure).__id, ok = v.Value.(string)
 		return
 	},
+	"azure.managementGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzure).ManagementGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.managementGroup.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.tenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).TenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.isRoot": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).IsRoot, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.parent": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).Parent, ok = plugin.RawToTValue[*mqlAzureManagementGroup](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.children": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).Children, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.subscriptionIds": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).SubscriptionIds, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.subscriptionCount": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).SubscriptionCount, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.roleAssignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).RoleAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.managementGroup.policyAssignments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureManagementGroup).PolicyAssignments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.entraPrincipal.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.displayName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).DisplayName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.principalType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).PrincipalType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.userPrincipalName": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).UserPrincipalName, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.appId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).AppId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.appOwnerTenantId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).AppOwnerTenantId, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.servicePrincipalType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).ServicePrincipalType, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.accountEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).AccountEnabled, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.entraPrincipal.isAssignableToRole": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureEntraPrincipal).IsAssignableToRole, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscription).__id, ok = v.Value.(string)
 		return
@@ -19653,6 +19865,14 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.deployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscription).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.managementGroups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscription).ManagementGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.locks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscription).Locks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.compute": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -19897,6 +20117,42 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.resourcegroup.deployments": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionResourcegroup).Deployments, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.resourcegroup.locks": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionResourcegroup).Locks, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).__id, ok = v.Value.(string)
+		return
+	},
+	"azure.subscription.lock.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Type, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.level": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Level, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.notes": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Notes, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.owners": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Owners, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.lock.scope": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionLock).Scope, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.resource.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -35075,6 +35331,18 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).Permissions, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"azure.subscription.authorizationService.roleDefinition.isPrivilegeEscalating": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).IsPrivilegeEscalating, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.authorizationService.roleDefinition.hasWildcardActions": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).HasWildcardActions, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.authorizationService.roleDefinition.grantsDataAccess": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinition).GrantsDataAccess, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"azure.subscription.authorizationService.roleDefinition.permission.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAuthorizationServiceRoleDefinitionPermission).__id, ok = v.Value.(string)
 		return
@@ -35141,6 +35409,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"azure.subscription.authorizationService.roleAssignment.role": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).Role, ok = plugin.RawToTValue[*mqlAzureSubscriptionAuthorizationServiceRoleDefinition](v.Value, v.Error)
+		return
+	},
+	"azure.subscription.authorizationService.roleAssignment.principal": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment).Principal, ok = plugin.RawToTValue[*mqlAzureEntraPrincipal](v.Value, v.Error)
 		return
 	},
 	"azure.subscription.managedIdentity.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -44324,6 +44596,7 @@ type mqlAzure struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureInternal
+	ManagementGroups plugin.TValue[[]any]
 }
 
 // createAzure creates a new instance of this resource
@@ -44358,6 +44631,248 @@ func (c *mqlAzure) MqlID() string {
 	return c.__id
 }
 
+func (c *mqlAzure) GetManagementGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ManagementGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure", c.__id, "managementGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.managementGroups()
+	})
+}
+
+// mqlAzureManagementGroup for the azure.managementGroup resource
+type mqlAzureManagementGroup struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	mqlAzureManagementGroupInternal
+	Id                plugin.TValue[string]
+	Name              plugin.TValue[string]
+	DisplayName       plugin.TValue[string]
+	TenantId          plugin.TValue[string]
+	IsRoot            plugin.TValue[bool]
+	Parent            plugin.TValue[*mqlAzureManagementGroup]
+	Children          plugin.TValue[[]any]
+	SubscriptionIds   plugin.TValue[[]any]
+	SubscriptionCount plugin.TValue[int64]
+	RoleAssignments   plugin.TValue[[]any]
+	PolicyAssignments plugin.TValue[[]any]
+}
+
+// createAzureManagementGroup creates a new instance of this resource
+func createAzureManagementGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureManagementGroup{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.managementGroup", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureManagementGroup) MqlName() string {
+	return "azure.managementGroup"
+}
+
+func (c *mqlAzureManagementGroup) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureManagementGroup) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureManagementGroup) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureManagementGroup) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlAzureManagementGroup) GetTenantId() *plugin.TValue[string] {
+	return &c.TenantId
+}
+
+func (c *mqlAzureManagementGroup) GetIsRoot() *plugin.TValue[bool] {
+	return &c.IsRoot
+}
+
+func (c *mqlAzureManagementGroup) GetParent() *plugin.TValue[*mqlAzureManagementGroup] {
+	return plugin.GetOrCompute[*mqlAzureManagementGroup](&c.Parent, func() (*mqlAzureManagementGroup, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.managementGroup", c.__id, "parent")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureManagementGroup), nil
+			}
+		}
+
+		return c.parent()
+	})
+}
+
+func (c *mqlAzureManagementGroup) GetChildren() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Children, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.managementGroup", c.__id, "children")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.children()
+	})
+}
+
+func (c *mqlAzureManagementGroup) GetSubscriptionIds() *plugin.TValue[[]any] {
+	return &c.SubscriptionIds
+}
+
+func (c *mqlAzureManagementGroup) GetSubscriptionCount() *plugin.TValue[int64] {
+	return &c.SubscriptionCount
+}
+
+func (c *mqlAzureManagementGroup) GetRoleAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.RoleAssignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.managementGroup", c.__id, "roleAssignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.roleAssignments()
+	})
+}
+
+func (c *mqlAzureManagementGroup) GetPolicyAssignments() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.PolicyAssignments, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.managementGroup", c.__id, "policyAssignments")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.policyAssignments()
+	})
+}
+
+// mqlAzureEntraPrincipal for the azure.entraPrincipal resource
+type mqlAzureEntraPrincipal struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureEntraPrincipalInternal it will be used here
+	Id                   plugin.TValue[string]
+	DisplayName          plugin.TValue[string]
+	PrincipalType        plugin.TValue[string]
+	UserPrincipalName    plugin.TValue[string]
+	AppId                plugin.TValue[string]
+	AppOwnerTenantId     plugin.TValue[string]
+	ServicePrincipalType plugin.TValue[string]
+	AccountEnabled       plugin.TValue[bool]
+	IsAssignableToRole   plugin.TValue[bool]
+}
+
+// createAzureEntraPrincipal creates a new instance of this resource
+func createAzureEntraPrincipal(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureEntraPrincipal{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.entraPrincipal", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureEntraPrincipal) MqlName() string {
+	return "azure.entraPrincipal"
+}
+
+func (c *mqlAzureEntraPrincipal) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureEntraPrincipal) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureEntraPrincipal) GetDisplayName() *plugin.TValue[string] {
+	return &c.DisplayName
+}
+
+func (c *mqlAzureEntraPrincipal) GetPrincipalType() *plugin.TValue[string] {
+	return &c.PrincipalType
+}
+
+func (c *mqlAzureEntraPrincipal) GetUserPrincipalName() *plugin.TValue[string] {
+	return &c.UserPrincipalName
+}
+
+func (c *mqlAzureEntraPrincipal) GetAppId() *plugin.TValue[string] {
+	return &c.AppId
+}
+
+func (c *mqlAzureEntraPrincipal) GetAppOwnerTenantId() *plugin.TValue[string] {
+	return &c.AppOwnerTenantId
+}
+
+func (c *mqlAzureEntraPrincipal) GetServicePrincipalType() *plugin.TValue[string] {
+	return &c.ServicePrincipalType
+}
+
+func (c *mqlAzureEntraPrincipal) GetAccountEnabled() *plugin.TValue[bool] {
+	return &c.AccountEnabled
+}
+
+func (c *mqlAzureEntraPrincipal) GetIsAssignableToRole() *plugin.TValue[bool] {
+	return &c.IsAssignableToRole
+}
+
 // mqlAzureSubscription for the azure.subscription resource
 type mqlAzureSubscription struct {
 	MqlRuntime *plugin.Runtime
@@ -44375,6 +44890,8 @@ type mqlAzureSubscription struct {
 	Resources             plugin.TValue[[]any]
 	ResourceGroups        plugin.TValue[[]any]
 	Deployments           plugin.TValue[[]any]
+	ManagementGroups      plugin.TValue[[]any]
+	Locks                 plugin.TValue[[]any]
 	Compute               plugin.TValue[*mqlAzureSubscriptionComputeService]
 	Batch                 plugin.TValue[*mqlAzureSubscriptionBatchService]
 	Databricks            plugin.TValue[*mqlAzureSubscriptionDatabricksService]
@@ -44540,6 +45057,38 @@ func (c *mqlAzureSubscription) GetDeployments() *plugin.TValue[[]any] {
 		}
 
 		return c.deployments()
+	})
+}
+
+func (c *mqlAzureSubscription) GetManagementGroups() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.ManagementGroups, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription", c.__id, "managementGroups")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.managementGroups()
+	})
+}
+
+func (c *mqlAzureSubscription) GetLocks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Locks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription", c.__id, "locks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.locks()
 	})
 }
 
@@ -45362,6 +45911,7 @@ type mqlAzureSubscriptionResourcegroup struct {
 	ManagedBy         plugin.TValue[string]
 	ProvisioningState plugin.TValue[string]
 	Deployments       plugin.TValue[[]any]
+	Locks             plugin.TValue[[]any]
 }
 
 // createAzureSubscriptionResourcegroup creates a new instance of this resource
@@ -45443,6 +45993,96 @@ func (c *mqlAzureSubscriptionResourcegroup) GetDeployments() *plugin.TValue[[]an
 
 		return c.deployments()
 	})
+}
+
+func (c *mqlAzureSubscriptionResourcegroup) GetLocks() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.Locks, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.resourcegroup", c.__id, "locks")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.locks()
+	})
+}
+
+// mqlAzureSubscriptionLock for the azure.subscription.lock resource
+type mqlAzureSubscriptionLock struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAzureSubscriptionLockInternal it will be used here
+	Id     plugin.TValue[string]
+	Name   plugin.TValue[string]
+	Type   plugin.TValue[string]
+	Level  plugin.TValue[string]
+	Notes  plugin.TValue[string]
+	Owners plugin.TValue[[]any]
+	Scope  plugin.TValue[string]
+}
+
+// createAzureSubscriptionLock creates a new instance of this resource
+func createAzureSubscriptionLock(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAzureSubscriptionLock{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("azure.subscription.lock", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAzureSubscriptionLock) MqlName() string {
+	return "azure.subscription.lock"
+}
+
+func (c *mqlAzureSubscriptionLock) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAzureSubscriptionLock) GetId() *plugin.TValue[string] {
+	return &c.Id
+}
+
+func (c *mqlAzureSubscriptionLock) GetName() *plugin.TValue[string] {
+	return &c.Name
+}
+
+func (c *mqlAzureSubscriptionLock) GetType() *plugin.TValue[string] {
+	return &c.Type
+}
+
+func (c *mqlAzureSubscriptionLock) GetLevel() *plugin.TValue[string] {
+	return &c.Level
+}
+
+func (c *mqlAzureSubscriptionLock) GetNotes() *plugin.TValue[string] {
+	return &c.Notes
+}
+
+func (c *mqlAzureSubscriptionLock) GetOwners() *plugin.TValue[[]any] {
+	return &c.Owners
+}
+
+func (c *mqlAzureSubscriptionLock) GetScope() *plugin.TValue[string] {
+	return &c.Scope
 }
 
 // mqlAzureSubscriptionResource for the azure.subscription.resource resource
@@ -80897,7 +81537,7 @@ func (c *mqlAzureSubscriptionCloudDefenderServiceSecurityContact) GetSystemMetad
 type mqlAzureSubscriptionAuthorizationService struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAzureSubscriptionAuthorizationServiceInternal it will be used here
+	mqlAzureSubscriptionAuthorizationServiceInternal
 	SubscriptionId           plugin.TValue[string]
 	Roles                    plugin.TValue[[]any]
 	RoleAssignments          plugin.TValue[[]any]
@@ -81708,12 +82348,15 @@ type mqlAzureSubscriptionAuthorizationServiceRoleDefinition struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlAzureSubscriptionAuthorizationServiceRoleDefinitionInternal
-	Id          plugin.TValue[string]
-	Description plugin.TValue[string]
-	Name        plugin.TValue[string]
-	Type        plugin.TValue[string]
-	Scopes      plugin.TValue[[]any]
-	Permissions plugin.TValue[[]any]
+	Id                    plugin.TValue[string]
+	Description           plugin.TValue[string]
+	Name                  plugin.TValue[string]
+	Type                  plugin.TValue[string]
+	Scopes                plugin.TValue[[]any]
+	Permissions           plugin.TValue[[]any]
+	IsPrivilegeEscalating plugin.TValue[bool]
+	HasWildcardActions    plugin.TValue[bool]
+	GrantsDataAccess      plugin.TValue[bool]
 }
 
 // createAzureSubscriptionAuthorizationServiceRoleDefinition creates a new instance of this resource
@@ -81781,6 +82424,24 @@ func (c *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) GetPermissions(
 		}
 
 		return c.permissions()
+	})
+}
+
+func (c *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) GetIsPrivilegeEscalating() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsPrivilegeEscalating, func() (bool, error) {
+		return c.isPrivilegeEscalating()
+	})
+}
+
+func (c *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) GetHasWildcardActions() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardActions, func() (bool, error) {
+		return c.hasWildcardActions()
+	})
+}
+
+func (c *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) GetGrantsDataAccess() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.GrantsDataAccess, func() (bool, error) {
+		return c.grantsDataAccess()
 	})
 }
 
@@ -81863,6 +82524,7 @@ type mqlAzureSubscriptionAuthorizationServiceRoleAssignment struct {
 	CreatedAt     plugin.TValue[*time.Time]
 	UpdatedAt     plugin.TValue[*time.Time]
 	Role          plugin.TValue[*mqlAzureSubscriptionAuthorizationServiceRoleDefinition]
+	Principal     plugin.TValue[*mqlAzureEntraPrincipal]
 }
 
 // createAzureSubscriptionAuthorizationServiceRoleAssignment creates a new instance of this resource
@@ -81946,6 +82608,22 @@ func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetRole() *plug
 		}
 
 		return c.role()
+	})
+}
+
+func (c *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) GetPrincipal() *plugin.TValue[*mqlAzureEntraPrincipal] {
+	return plugin.GetOrCompute[*mqlAzureEntraPrincipal](&c.Principal, func() (*mqlAzureEntraPrincipal, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("azure.subscription.authorizationService.roleAssignment", c.__id, "principal")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAzureEntraPrincipal), nil
+			}
+		}
+
+		return c.principal()
 	})
 }
 

--- a/providers/azure/resources/azure.lr.versions
+++ b/providers/azure/resources/azure.lr.versions
@@ -2,6 +2,29 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 azure 9.0.0
+azure.entraPrincipal 13.33.8
+azure.entraPrincipal.accountEnabled 13.33.8
+azure.entraPrincipal.appId 13.33.8
+azure.entraPrincipal.appOwnerTenantId 13.33.8
+azure.entraPrincipal.displayName 13.33.8
+azure.entraPrincipal.id 13.33.8
+azure.entraPrincipal.isAssignableToRole 13.33.8
+azure.entraPrincipal.principalType 13.33.8
+azure.entraPrincipal.servicePrincipalType 13.33.8
+azure.entraPrincipal.userPrincipalName 13.33.8
+azure.managementGroup 13.33.8
+azure.managementGroup.children 13.33.8
+azure.managementGroup.displayName 13.33.8
+azure.managementGroup.id 13.33.8
+azure.managementGroup.isRoot 13.33.8
+azure.managementGroup.name 13.33.8
+azure.managementGroup.parent 13.33.8
+azure.managementGroup.policyAssignments 13.33.8
+azure.managementGroup.roleAssignments 13.33.8
+azure.managementGroup.subscriptionCount 13.33.8
+azure.managementGroup.subscriptionIds 13.33.8
+azure.managementGroup.tenantId 13.33.8
+azure.managementGroups 13.33.8
 azure.subscription 11.4.28
 azure.subscription.advisor 11.4.28
 azure.subscription.advisorService 9.0.13
@@ -276,6 +299,7 @@ azure.subscription.authorizationService.roleAssignment.condition 11.2.1
 azure.subscription.authorizationService.roleAssignment.createdAt 11.2.1
 azure.subscription.authorizationService.roleAssignment.description 11.2.1
 azure.subscription.authorizationService.roleAssignment.id 11.2.1
+azure.subscription.authorizationService.roleAssignment.principal 13.33.8
 azure.subscription.authorizationService.roleAssignment.principalId 11.2.1
 azure.subscription.authorizationService.roleAssignment.principalType 13.16.2
 azure.subscription.authorizationService.roleAssignment.role 11.2.1
@@ -301,7 +325,10 @@ azure.subscription.authorizationService.roleAssignmentSchedules 13.25.1
 azure.subscription.authorizationService.roleAssignments 11.2.1
 azure.subscription.authorizationService.roleDefinition 11.4.28
 azure.subscription.authorizationService.roleDefinition.description 11.4.28
+azure.subscription.authorizationService.roleDefinition.grantsDataAccess 13.33.8
+azure.subscription.authorizationService.roleDefinition.hasWildcardActions 13.33.8
 azure.subscription.authorizationService.roleDefinition.id 11.4.28
+azure.subscription.authorizationService.roleDefinition.isPrivilegeEscalating 13.33.8
 azure.subscription.authorizationService.roleDefinition.name 11.4.28
 azure.subscription.authorizationService.roleDefinition.permission 11.4.28
 azure.subscription.authorizationService.roleDefinition.permission.allowedActions 11.4.28
@@ -2833,6 +2860,15 @@ azure.subscription.lighthouseService.registrationDefinition.provisioningState 13
 azure.subscription.lighthouseService.registrationDefinition.systemMetadata 13.24.1
 azure.subscription.lighthouseService.registrationDefinitions 13.24.1
 azure.subscription.lighthouseService.subscriptionId 13.24.1
+azure.subscription.lock 13.33.8
+azure.subscription.lock.id 13.33.8
+azure.subscription.lock.level 13.33.8
+azure.subscription.lock.name 13.33.8
+azure.subscription.lock.notes 13.33.8
+azure.subscription.lock.owners 13.33.8
+azure.subscription.lock.scope 13.33.8
+azure.subscription.lock.type 13.33.8
+azure.subscription.locks 13.33.8
 azure.subscription.logic 13.10.2
 azure.subscription.logicService 13.10.2
 azure.subscription.logicService.subscriptionId 13.10.2
@@ -3072,6 +3108,7 @@ azure.subscription.managedIdentity.principalId 11.2.1
 azure.subscription.managedIdentity.roleAssignments 11.2.1
 azure.subscription.managedIdentity.systemMetadata 13.22.1
 azure.subscription.managedIdentity.tenantId 11.2.1
+azure.subscription.managementGroups 13.33.8
 azure.subscription.monitor 9.0.0
 azure.subscription.monitorService 9.0.1
 azure.subscription.monitorService.actionGroup 13.32.1
@@ -4965,6 +5002,7 @@ azure.subscription.resourcegroup 9.0.0
 azure.subscription.resourcegroup.deployments 13.19.2
 azure.subscription.resourcegroup.id 9.0.0
 azure.subscription.resourcegroup.location 9.0.0
+azure.subscription.resourcegroup.locks 13.33.8
 azure.subscription.resourcegroup.managedBy 9.0.0
 azure.subscription.resourcegroup.name 9.0.0
 azure.subscription.resourcegroup.provisioningState 9.0.0

--- a/providers/azure/resources/azure.permissions.json
+++ b/providers/azure/resources/azure.permissions.json
@@ -1,7 +1,7 @@
 {
   "provider": "azure",
   "version": "13.33.7",
-  "generated_at": "2026-08-05T17:39:09+02:00",
+  "generated_at": "2026-08-06T15:48:20+02:00",
   "permissions": [
     "Microsoft.Advisor/recommendations/read",
     "Microsoft.Apimanagement/service/read",
@@ -18,6 +18,7 @@
     "Microsoft.Appconfiguration/configurationStores/read",
     "Microsoft.Authorization/classicAdministrators/read",
     "Microsoft.Authorization/denyAssignments/read",
+    "Microsoft.Authorization/locks/read",
     "Microsoft.Authorization/roleAssignmentSchedules/read",
     "Microsoft.Authorization/roleAssignments/read",
     "Microsoft.Authorization/roleDefinitions/read",
@@ -155,6 +156,7 @@
     "Microsoft.ManagedIdentity/userAssignedIdentities/read",
     "Microsoft.Managedservices/registrationAssignments/read",
     "Microsoft.Managedservices/registrationDefinitions/read",
+    "Microsoft.Management/managementGroups/read",
     "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",
     "Microsoft.Network/adminRuleCollections/read",
     "Microsoft.Network/adminRules/read",
@@ -408,6 +410,12 @@
       "source_file": "iam.go"
     },
     {
+      "permission": "Microsoft.Authorization/locks/read",
+      "service": "Microsoft.Resources",
+      "action": "NewListAtSubscriptionLevelPager",
+      "source_file": "locks.go"
+    },
+    {
       "permission": "Microsoft.Authorization/roleAssignmentSchedules/read",
       "service": "Microsoft.Authorization",
       "action": "NewListForScopePager",
@@ -424,6 +432,12 @@
       "service": "Microsoft.Authorization",
       "action": "NewListForSubscriptionPager",
       "source_file": "iam.go"
+    },
+    {
+      "permission": "Microsoft.Authorization/roleAssignments/read",
+      "service": "Microsoft.Authorization",
+      "action": "NewListForScopePager",
+      "source_file": "managementgroups.go"
     },
     {
       "permission": "Microsoft.Authorization/roleDefinitions/read",
@@ -1240,6 +1254,12 @@
       "service": "Microsoft.Managedservices",
       "action": "NewListPager",
       "source_file": "lighthouse.go"
+    },
+    {
+      "permission": "Microsoft.Management/managementGroups/read",
+      "service": "Microsoft.Management",
+      "action": "NewListPager",
+      "source_file": "managementgroups.go"
     },
     {
       "permission": "Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/read",

--- a/providers/azure/resources/iam_principals.go
+++ b/providers/azure/resources/iam_principals.go
@@ -1,0 +1,332 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+)
+
+const (
+	// graphScope is the OAuth scope a Microsoft Graph call needs. The same
+	// credential the ARM clients use can request it, provided the app (or the
+	// signed-in user) has been granted directory read access.
+	graphScope = "https://graph.microsoft.com/.default"
+
+	// graphEndpoint is the Graph v1.0 base URL for the public cloud. The
+	// provider targets the public cloud throughout (see getArmSecurityConnection,
+	// which pins cloud.AzurePublic the same way).
+	graphEndpoint = "https://graph.microsoft.com/v1.0"
+
+	// graphGetByIdsBatchSize is the maximum number of object IDs Graph accepts
+	// in a single directoryObjects/getByIds request.
+	graphGetByIdsBatchSize = 1000
+)
+
+// graphPrincipalTypes are the directory object types worth requesting. Naming
+// them explicitly (rather than letting Graph default to directoryObject) is
+// what makes the type-specific properties below come back populated.
+var graphPrincipalTypes = []string{"user", "group", "servicePrincipal", "application", "device"}
+
+// graphPrincipal is the subset of a Microsoft Graph directory object this
+// provider models. Graph returns a union of the requested types, so most
+// fields are populated for only some of them.
+type graphPrincipal struct {
+	ODataType              string `json:"@odata.type"`
+	ID                     string `json:"id"`
+	DisplayName            string `json:"displayName"`
+	UserPrincipalName      string `json:"userPrincipalName"`
+	AppID                  string `json:"appId"`
+	AppOwnerOrganizationID string `json:"appOwnerOrganizationId"`
+	ServicePrincipalType   string `json:"servicePrincipalType"`
+	AccountEnabled         *bool  `json:"accountEnabled"`
+	IsAssignableToRole     *bool  `json:"isAssignableToRole"`
+}
+
+type graphGetByIdsRequest struct {
+	IDs   []string `json:"ids"`
+	Types []string `json:"types"`
+}
+
+type graphGetByIdsResponse struct {
+	Value []graphPrincipal `json:"value"`
+}
+
+// principalTypeFromODataType turns a Graph type annotation
+// ("#microsoft.graph.servicePrincipal") into the bare type name
+// ("servicePrincipal"), or "" for a type this provider does not model.
+func principalTypeFromODataType(odataType string) string {
+	name := strings.TrimPrefix(strings.TrimPrefix(odataType, "#"), "microsoft.graph.")
+	for _, t := range graphPrincipalTypes {
+		if strings.EqualFold(name, t) {
+			return t
+		}
+	}
+	return ""
+}
+
+// graphDirectoryReadDenied marks the case where the credential reached Graph
+// but is not allowed to read the directory. It is reported as an error rather
+// than as an absent principal: a privilege audit that silently rendered every
+// grant as "no principal" would understate who holds access, which is the most
+// dangerous way for this to fail.
+var graphDirectoryReadDenied = errors.New(
+	"cannot resolve Microsoft Entra principals: the credential is not authorized to read the directory. " +
+		"Grant it Microsoft Graph Directory.Read.All (application permission, admin-consented) to resolve role assignment principals")
+
+// fetchGraphPrincipals resolves directory object IDs to principals via
+// directoryObjects/getByIds, in batches of graphGetByIdsBatchSize. The returned
+// map is keyed by object ID and omits IDs Graph did not resolve: getByIds
+// silently drops unknown IDs, which is how a role assignment naming a deleted
+// principal is detected.
+func fetchGraphPrincipals(ctx context.Context, conn *connection.AzureConnection, ids []string) (map[string]*graphPrincipal, error) {
+	res := map[string]*graphPrincipal{}
+	if len(ids) == 0 {
+		return res, nil
+	}
+
+	client := http.Client{}
+	url := graphEndpoint + "/directoryObjects/getByIds"
+
+	for start := 0; start < len(ids); start += graphGetByIdsBatchSize {
+		end := start + graphGetByIdsBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		body, err := json.Marshal(graphGetByIdsRequest{IDs: ids[start:end], Types: graphPrincipalTypes})
+		if err != nil {
+			return nil, err
+		}
+
+		// Fetch the token per batch so resolving a large tenant doesn't fail on
+		// an expired bearer token; the credential caches and only refreshes when
+		// the token is near expiry (mirrors getPolicyAssignments).
+		token, err := conn.Token().GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{graphScope}})
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token.Token)
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+			resp.Body.Close()
+			return nil, graphDirectoryReadDenied
+		}
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("failed to resolve Entra principals: %s: %s", resp.Status, strings.TrimSpace(string(raw)))
+		}
+
+		raw, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		page := graphGetByIdsResponse{}
+		if err := json.Unmarshal(raw, &page); err != nil {
+			return nil, err
+		}
+		for i := range page.Value {
+			p := page.Value[i]
+			if p.ID != "" {
+				res[strings.ToLower(p.ID)] = &p
+			}
+		}
+	}
+	return res, nil
+}
+
+type mqlAzureSubscriptionAuthorizationServiceInternal struct {
+	// principalsMu guards the memo below and is deliberately held across the
+	// Graph call, so concurrent block evaluation resolves principals in one
+	// batched request instead of racing to issue one request per assignment.
+	principalsMu   sync.Mutex
+	principals     map[string]*graphPrincipal
+	principalsMiss map[string]struct{}
+	principalsSeed bool
+}
+
+// assignmentPrincipalIDs returns the principal IDs named by the subscription's
+// role assignments, so the first resolution can seed the memo for the whole
+// subscription in one request. A failure to list assignments is not fatal here:
+// the caller still resolves the single ID it was asked about.
+func (a *mqlAzureSubscriptionAuthorizationService) assignmentPrincipalIDs() []string {
+	assignments := a.GetRoleAssignments()
+	if assignments.Error != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(assignments.Data))
+	for _, item := range assignments.Data {
+		assignment, ok := item.(*mqlAzureSubscriptionAuthorizationServiceRoleAssignment)
+		if !ok {
+			continue
+		}
+		if assignment.PrincipalId.Data != "" {
+			ids = append(ids, assignment.PrincipalId.Data)
+		}
+	}
+	return ids
+}
+
+// resolvePrincipal resolves one principal ID against the directory. The first
+// call also pulls in every principal the subscription's role assignments name,
+// so auditing a whole subscription costs a single Graph round trip; later calls
+// are served from the memo. IDs that arrive from another scope (a management
+// group's assignment listing, say) are not in that seed, so they are fetched on
+// demand rather than being mistaken for deleted principals.
+//
+// Returns (nil, nil) when Graph does not know the ID, which means the principal
+// was deleted and the assignment is an orphaned grant.
+func (a *mqlAzureSubscriptionAuthorizationService) resolvePrincipal(principalID string) (*graphPrincipal, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	key := strings.ToLower(principalID)
+
+	a.principalsMu.Lock()
+	defer a.principalsMu.Unlock()
+
+	if a.principals == nil {
+		a.principals = map[string]*graphPrincipal{}
+		a.principalsMiss = map[string]struct{}{}
+	}
+	if p, ok := a.principals[key]; ok {
+		return p, nil
+	}
+	if _, ok := a.principalsMiss[key]; ok {
+		return nil, nil
+	}
+
+	wanted := []string{principalID}
+	if !a.principalsSeed {
+		wanted = append(wanted, a.assignmentPrincipalIDs()...)
+		a.principalsSeed = true
+	}
+
+	// Deduplicate while preserving the requested ID first, and skip anything
+	// already memoized from an earlier batch.
+	seen := map[string]struct{}{}
+	ids := make([]string, 0, len(wanted))
+	for _, id := range wanted {
+		k := strings.ToLower(id)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		if _, done := a.principals[k]; done {
+			continue
+		}
+		if _, done := a.principalsMiss[k]; done {
+			continue
+		}
+		ids = append(ids, id)
+	}
+
+	found, err := fetchGraphPrincipals(context.Background(), conn, ids)
+	if err != nil {
+		return nil, err
+	}
+	for k, p := range found {
+		a.principals[k] = p
+	}
+	// Every ID we asked about and did not get back is a principal Graph cannot
+	// resolve; record it so a repeat query doesn't re-request it.
+	for _, id := range ids {
+		k := strings.ToLower(id)
+		if _, ok := a.principals[k]; !ok {
+			a.principalsMiss[k] = struct{}{}
+		}
+	}
+
+	if p, ok := a.principals[key]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+
+func (a *mqlAzureSubscriptionAuthorizationServiceRoleAssignment) principal() (*mqlAzureEntraPrincipal, error) {
+	if a.PrincipalId.Data == "" {
+		a.Principal.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	// Route through the subscription's authorization service so every assignment
+	// shares one memo and one batched Graph fetch.
+	r, err := CreateResource(a.MqlRuntime, ResourceAzureSubscription, map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + conn.SubId()),
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	iamVal := r.(*mqlAzureSubscription).GetIam()
+	if iamVal.Error != nil {
+		return nil, iamVal.Error
+	}
+	if iamVal.Data == nil {
+		return nil, errors.New("cannot resolve the authorization service for the subscription")
+	}
+
+	p, err := iamVal.Data.resolvePrincipal(a.PrincipalId.Data)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		// Graph does not know this object: the principal was deleted and this is
+		// an orphaned grant.
+		a.Principal.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	res, err := CreateResource(a.MqlRuntime, ResourceAzureEntraPrincipal,
+		map[string]*llx.RawData{
+			"__id":                 llx.StringData(p.ID),
+			"id":                   llx.StringData(p.ID),
+			"displayName":          llx.StringData(p.DisplayName),
+			"principalType":        llx.StringData(principalTypeFromODataType(p.ODataType)),
+			"userPrincipalName":    llx.StringData(p.UserPrincipalName),
+			"appId":                llx.StringData(p.AppID),
+			"appOwnerTenantId":     llx.StringData(p.AppOwnerOrganizationID),
+			"servicePrincipalType": llx.StringData(p.ServicePrincipalType),
+			"accountEnabled":       llx.BoolDataPtr(p.AccountEnabled),
+			"isAssignableToRole":   llx.BoolDataPtr(p.IsAssignableToRole),
+		})
+	if err != nil {
+		return nil, err
+	}
+	return res.(*mqlAzureEntraPrincipal), nil
+}

--- a/providers/azure/resources/iam_principals.go
+++ b/providers/azure/resources/iam_principals.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"go.mondoo.com/mql/v13/llx"
@@ -34,6 +35,15 @@ const (
 	// graphGetByIdsBatchSize is the maximum number of object IDs Graph accepts
 	// in a single directoryObjects/getByIds request.
 	graphGetByIdsBatchSize = 1000
+
+	// graphRequestTimeout bounds a single getByIds round trip. Without it an
+	// unresponsive Graph endpoint would hang the request forever, and because
+	// resolvePrincipal deliberately holds its memo lock across the fetch to
+	// coalesce concurrent resolves, that hang would stall every other
+	// principal() accessor for the rest of the scan. A full 1000-ID batch
+	// normally returns in a few seconds, so this bounds the failure without
+	// cutting off legitimate work.
+	graphRequestTimeout = 30 * time.Second
 )
 
 // graphPrincipalTypes are the directory object types worth requesting. Naming
@@ -98,7 +108,7 @@ func fetchGraphPrincipals(ctx context.Context, conn *connection.AzureConnection,
 		return res, nil
 	}
 
-	client := http.Client{}
+	client := http.Client{Timeout: graphRequestTimeout}
 	url := graphEndpoint + "/directoryObjects/getByIds"
 
 	for start := 0; start < len(ids); start += graphGetByIdsBatchSize {
@@ -166,7 +176,17 @@ func fetchGraphPrincipals(ctx context.Context, conn *connection.AzureConnection,
 type mqlAzureSubscriptionAuthorizationServiceInternal struct {
 	// principalsMu guards the memo below and is deliberately held across the
 	// Graph call, so concurrent block evaluation resolves principals in one
-	// batched request instead of racing to issue one request per assignment.
+	// batched request instead of racing to issue one per assignment.
+	//
+	// Releasing it before the fetch and re-checking afterwards (ordinary
+	// double-check locking) would keep the memo correct but lose the
+	// coalescing: the executor evaluates block fields in goroutines, so every
+	// role assignment whose principal() runs before the first fetch returns
+	// would see an unseeded memo and issue its own single-ID request. On a
+	// subscription with a few hundred assignments that is a few hundred Graph
+	// round trips in place of one, which invites the 429 throttling that
+	// batching exists to avoid. The stall this risks instead is bounded by
+	// graphRequestTimeout.
 	principalsMu   sync.Mutex
 	principals     map[string]*graphPrincipal
 	principalsMiss map[string]struct{}

--- a/providers/azure/resources/iam_privesc.go
+++ b/providers/azure/resources/iam_privesc.go
@@ -1,0 +1,164 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"strings"
+
+	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+)
+
+// privilegeEscalatingActions are the control-plane actions that let a principal
+// grant itself further access. Holding any of them makes a role's effective
+// privilege equal to Owner at the assigned scope, whatever the role is named:
+// the holder can write a new role assignment (or author a new role definition,
+// then assign it) to obtain any permission it does not already have.
+// elevateAccess is the tenant-root escalation a Global Administrator uses to
+// gain User Access Administrator over every subscription.
+var privilegeEscalatingActions = []string{
+	"Microsoft.Authorization/roleAssignments/write",
+	"Microsoft.Authorization/roleDefinitions/write",
+	"Microsoft.Authorization/elevateAccess/action",
+}
+
+// matchesActionPattern reports whether an Azure RBAC action pattern matches a
+// concrete action. In a pattern, `*` stands for zero or more characters and is
+// not bounded by the `/` separators, so `Microsoft.Authorization/*` matches
+// `Microsoft.Authorization/roleAssignments/write`. Comparison is
+// case-insensitive, matching how Azure evaluates action names.
+func matchesActionPattern(pattern, action string) bool {
+	if pattern == "" {
+		return false
+	}
+	pattern = strings.ToLower(pattern)
+	action = strings.ToLower(action)
+	if !strings.Contains(pattern, "*") {
+		return pattern == action
+	}
+
+	// Split on the wildcards: the first segment is anchored to the start of the
+	// action, the last to its end, and the segments between must appear in
+	// order. Consuming each middle segment at its earliest occurrence is safe
+	// here because the segments are literals.
+	parts := strings.Split(pattern, "*")
+	if !strings.HasPrefix(action, parts[0]) {
+		return false
+	}
+	rest := action[len(parts[0]):]
+	for _, mid := range parts[1 : len(parts)-1] {
+		if mid == "" {
+			continue
+		}
+		idx := strings.Index(rest, mid)
+		if idx < 0 {
+			return false
+		}
+		rest = rest[idx+len(mid):]
+	}
+	return strings.HasSuffix(rest, parts[len(parts)-1])
+}
+
+// grantsAction reports whether a role's permission set allows a concrete
+// action. Azure treats NotActions as a subtraction from Actions, evaluated
+// within a single permission block, so an action is granted when some Actions
+// pattern matches it and no NotActions pattern in that same block does.
+func grantsAction(permissions []*authorization.Permission, action string) bool {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+		allowed := false
+		for _, a := range p.Actions {
+			if a != nil && matchesActionPattern(*a, action) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			continue
+		}
+		denied := false
+		for _, na := range p.NotActions {
+			if na != nil && matchesActionPattern(*na, action) {
+				denied = true
+				break
+			}
+		}
+		if !denied {
+			return true
+		}
+	}
+	return false
+}
+
+// roleIsPrivilegeEscalating reports whether any of the role-granting actions
+// survives the role's NotActions.
+func roleIsPrivilegeEscalating(permissions []*authorization.Permission) bool {
+	for _, action := range privilegeEscalatingActions {
+		if grantsAction(permissions, action) {
+			return true
+		}
+	}
+	return false
+}
+
+// roleHasWildcardActions reports whether any allowed control-plane action
+// contains a wildcard. Unlike the checks above this deliberately ignores
+// NotActions: the point is that the role's reach is open-ended and grows as
+// Azure adds actions to the matched namespace, which a fixed NotActions list
+// cannot keep up with.
+func roleHasWildcardActions(permissions []*authorization.Permission) bool {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+		for _, a := range p.Actions {
+			if a != nil && strings.Contains(*a, "*") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// roleGrantsDataAccess reports whether the role allows any data-plane action
+// that its NotDataActions do not take back. A data action pattern counts as
+// negated only when a NotDataActions pattern covers the pattern itself, which
+// catches the total-negation case (DataActions `*` alongside NotDataActions
+// `*`) without trying to reason about partially overlapping wildcards.
+func roleGrantsDataAccess(permissions []*authorization.Permission) bool {
+	for _, p := range permissions {
+		if p == nil {
+			continue
+		}
+		for _, da := range p.DataActions {
+			if da == nil || *da == "" {
+				continue
+			}
+			negated := false
+			for _, nda := range p.NotDataActions {
+				if nda != nil && matchesActionPattern(*nda, *da) {
+					negated = true
+					break
+				}
+			}
+			if !negated {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (a *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) isPrivilegeEscalating() (bool, error) {
+	return roleIsPrivilegeEscalating(a.cachePermissions), nil
+}
+
+func (a *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) hasWildcardActions() (bool, error) {
+	return roleHasWildcardActions(a.cachePermissions), nil
+}
+
+func (a *mqlAzureSubscriptionAuthorizationServiceRoleDefinition) grantsDataAccess() (bool, error) {
+	return roleGrantsDataAccess(a.cachePermissions), nil
+}

--- a/providers/azure/resources/iam_privesc_test.go
+++ b/providers/azure/resources/iam_privesc_test.go
@@ -1,0 +1,211 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchesActionPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		action  string
+		want    bool
+	}{
+		// exact matches, case-insensitive
+		{"Microsoft.Authorization/roleAssignments/write", "Microsoft.Authorization/roleAssignments/write", true},
+		{"microsoft.authorization/roleassignments/write", "Microsoft.Authorization/roleAssignments/write", true},
+		{"Microsoft.Authorization/roleAssignments/read", "Microsoft.Authorization/roleAssignments/write", false},
+
+		// bare wildcard is everything
+		{"*", "Microsoft.Authorization/roleAssignments/write", true},
+
+		// a trailing wildcard spans the remaining segments
+		{"Microsoft.Authorization/*", "Microsoft.Authorization/roleAssignments/write", true},
+		{"Microsoft.Compute/*", "Microsoft.Authorization/roleAssignments/write", false},
+
+		// interior wildcards
+		{"Microsoft.Authorization/*/write", "Microsoft.Authorization/roleAssignments/write", true},
+		{"Microsoft.Authorization/*/read", "Microsoft.Authorization/roleAssignments/write", false},
+		{"*/write", "Microsoft.Authorization/roleAssignments/write", true},
+		{"*roleAssignments*", "Microsoft.Authorization/roleAssignments/write", true},
+
+		// a wildcard matches zero characters
+		{"Microsoft.Authorization/roleAssignments/write*", "Microsoft.Authorization/roleAssignments/write", true},
+		{"*Microsoft.Authorization/roleAssignments/write", "Microsoft.Authorization/roleAssignments/write", true},
+
+		// prefix must anchor
+		{"Authorization/*", "Microsoft.Authorization/roleAssignments/write", false},
+
+		// empty pattern never matches
+		{"", "Microsoft.Authorization/roleAssignments/write", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, matchesActionPattern(c.pattern, c.action),
+			"pattern %q against action %q", c.pattern, c.action)
+	}
+}
+
+func perm(actions, notActions, dataActions, notDataActions []string) *authorization.Permission {
+	p := &authorization.Permission{}
+	for _, a := range actions {
+		p.Actions = append(p.Actions, to.Ptr(a))
+	}
+	for _, a := range notActions {
+		p.NotActions = append(p.NotActions, to.Ptr(a))
+	}
+	for _, a := range dataActions {
+		p.DataActions = append(p.DataActions, to.Ptr(a))
+	}
+	for _, a := range notDataActions {
+		p.NotDataActions = append(p.NotDataActions, to.Ptr(a))
+	}
+	return p
+}
+
+func TestGrantsAction(t *testing.T) {
+	target := "Microsoft.Authorization/roleAssignments/write"
+
+	t.Run("direct grant", func(t *testing.T) {
+		assert.True(t, grantsAction([]*authorization.Permission{perm([]string{target}, nil, nil, nil)}, target))
+	})
+	t.Run("granted via wildcard", func(t *testing.T) {
+		assert.True(t, grantsAction([]*authorization.Permission{perm([]string{"*"}, nil, nil, nil)}, target))
+	})
+	t.Run("notActions takes the wildcard grant back", func(t *testing.T) {
+		// This is the built-in Contributor shape: everything except the ability
+		// to hand out access.
+		p := perm([]string{"*"}, []string{
+			"Microsoft.Authorization/*/Delete",
+			"Microsoft.Authorization/*/Write",
+			"Microsoft.Authorization/elevateAccess/Action",
+		}, nil, nil)
+		assert.False(t, grantsAction([]*authorization.Permission{p}, target))
+	})
+	t.Run("notActions for an unrelated action does not block", func(t *testing.T) {
+		p := perm([]string{"*"}, []string{"Microsoft.Compute/*/write"}, nil, nil)
+		assert.True(t, grantsAction([]*authorization.Permission{p}, target))
+	})
+	t.Run("a second permission block can still grant", func(t *testing.T) {
+		// NotActions only subtracts within its own block.
+		blocked := perm([]string{"*"}, []string{"Microsoft.Authorization/*/write"}, nil, nil)
+		allowed := perm([]string{target}, nil, nil, nil)
+		assert.True(t, grantsAction([]*authorization.Permission{blocked, allowed}, target))
+	})
+	t.Run("no permissions grants nothing", func(t *testing.T) {
+		assert.False(t, grantsAction(nil, target))
+	})
+	t.Run("nil permission entries are skipped", func(t *testing.T) {
+		assert.False(t, grantsAction([]*authorization.Permission{nil}, target))
+	})
+}
+
+func TestRoleIsPrivilegeEscalating(t *testing.T) {
+	t.Run("Owner escalates", func(t *testing.T) {
+		assert.True(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"*"}, nil, nil, nil),
+		}))
+	})
+	t.Run("Contributor does not escalate", func(t *testing.T) {
+		assert.False(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"*"}, []string{
+				"Microsoft.Authorization/*/Delete",
+				"Microsoft.Authorization/*/Write",
+				"Microsoft.Authorization/elevateAccess/Action",
+			}, nil, nil),
+		}))
+	})
+	t.Run("User Access Administrator escalates", func(t *testing.T) {
+		assert.True(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"*/read", "Microsoft.Authorization/*"}, nil, nil, nil),
+		}))
+	})
+	t.Run("Reader does not escalate", func(t *testing.T) {
+		assert.False(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"*/read"}, nil, nil, nil),
+		}))
+	})
+	t.Run("a custom role granting only roleDefinitions/write escalates", func(t *testing.T) {
+		// Authoring a role definition is escalation too: the holder can write a
+		// permissive role and then assign it.
+		assert.True(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"Microsoft.Authorization/roleDefinitions/write"}, nil, nil, nil),
+		}))
+	})
+	t.Run("elevateAccess alone escalates", func(t *testing.T) {
+		assert.True(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"Microsoft.Authorization/elevateAccess/action"}, nil, nil, nil),
+		}))
+	})
+	t.Run("a compute-only custom role does not escalate", func(t *testing.T) {
+		assert.False(t, roleIsPrivilegeEscalating([]*authorization.Permission{
+			perm([]string{"Microsoft.Compute/virtualMachines/*", "Microsoft.Network/*/read"}, nil, nil, nil),
+		}))
+	})
+}
+
+func TestRoleHasWildcardActions(t *testing.T) {
+	t.Run("bare wildcard", func(t *testing.T) {
+		assert.True(t, roleHasWildcardActions([]*authorization.Permission{perm([]string{"*"}, nil, nil, nil)}))
+	})
+	t.Run("namespace wildcard", func(t *testing.T) {
+		assert.True(t, roleHasWildcardActions([]*authorization.Permission{
+			perm([]string{"Microsoft.Storage/storageAccounts/*"}, nil, nil, nil),
+		}))
+	})
+	t.Run("fully enumerated actions have no wildcard", func(t *testing.T) {
+		assert.False(t, roleHasWildcardActions([]*authorization.Permission{
+			perm([]string{
+				"Microsoft.Storage/storageAccounts/read",
+				"Microsoft.Storage/storageAccounts/write",
+			}, nil, nil, nil),
+		}))
+	})
+	t.Run("a wildcard only in notActions does not count", func(t *testing.T) {
+		assert.False(t, roleHasWildcardActions([]*authorization.Permission{
+			perm([]string{"Microsoft.Storage/storageAccounts/read"}, []string{"Microsoft.Authorization/*"}, nil, nil),
+		}))
+	})
+	t.Run("no permissions", func(t *testing.T) {
+		assert.False(t, roleHasWildcardActions(nil))
+	})
+}
+
+func TestRoleGrantsDataAccess(t *testing.T) {
+	t.Run("blob data reader grants data access", func(t *testing.T) {
+		assert.True(t, roleGrantsDataAccess([]*authorization.Permission{
+			perm([]string{"Microsoft.Storage/storageAccounts/blobServices/containers/read"}, nil,
+				[]string{"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"}, nil),
+		}))
+	})
+	t.Run("a control-plane-only role does not", func(t *testing.T) {
+		assert.False(t, roleGrantsDataAccess([]*authorization.Permission{
+			perm([]string{"Microsoft.Storage/storageAccounts/*"}, nil, nil, nil),
+		}))
+	})
+	t.Run("totally negated data actions do not count", func(t *testing.T) {
+		// Owner's shape: DataActions and NotDataActions both wildcard, which
+		// grants no data access at the control plane.
+		assert.False(t, roleGrantsDataAccess([]*authorization.Permission{
+			perm([]string{"*"}, nil, []string{"*"}, []string{"*"}),
+		}))
+	})
+	t.Run("partially negated data actions still grant", func(t *testing.T) {
+		assert.True(t, roleGrantsDataAccess([]*authorization.Permission{
+			perm(nil, nil,
+				[]string{"Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"},
+				[]string{"Microsoft.Storage/storageAccounts/queueServices/*"}),
+		}))
+	})
+	t.Run("empty data action strings are ignored", func(t *testing.T) {
+		assert.False(t, roleGrantsDataAccess([]*authorization.Permission{
+			perm(nil, nil, []string{""}, nil),
+		}))
+	})
+}

--- a/providers/azure/resources/locks.go
+++ b/providers/azure/resources/locks.go
@@ -1,0 +1,141 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armlocks"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// lockProviderPath is the segment a lock's resource ID appends to the ID of
+// whatever it protects.
+const lockProviderPath = "/providers/microsoft.authorization/locks/"
+
+// lockScopeFromID recovers the scope a lock applies to from the lock's own
+// resource ID, which is the protected scope with the lock's provider path
+// appended. The search runs from the right and case-insensitively: a resource
+// ID contains its own "/providers/..." segment, and Azure does not guarantee
+// the casing it echoes back. Returns "" when the ID does not carry the lock
+// provider path.
+func lockScopeFromID(id string) string {
+	idx := strings.LastIndex(strings.ToLower(id), lockProviderPath)
+	if idx < 0 {
+		return ""
+	}
+	return id[:idx]
+}
+
+func (a *mqlAzureSubscription) locks() ([]any, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	client, err := armlocks.NewManagementLocksClient(a.SubscriptionId.Data, conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	// The subscription-level listing covers every lock in the subscription,
+	// including locks placed on resource groups and on individual resources, so
+	// resourcegroup.locks() filters this one fetch rather than paging per group.
+	pager := client.NewListAtSubscriptionLevelPager(&armlocks.ManagementLocksClientListAtSubscriptionLevelOptions{})
+	res := []any{}
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, lock := range page.Value {
+			if lock == nil {
+				continue
+			}
+			mqlLock, err := newMqlLock(a.MqlRuntime, lock)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlLock)
+		}
+	}
+	return res, nil
+}
+
+func newMqlLock(runtime *plugin.Runtime, lock *armlocks.ManagementLockObject) (plugin.Resource, error) {
+	// Properties is REQUIRED per the SDK but nullable in Go; normalize so the
+	// args map below can dereference it unconditionally.
+	props := lock.Properties
+	if props == nil {
+		props = &armlocks.ManagementLockProperties{}
+	}
+
+	owners := []any{}
+	for _, o := range props.Owners {
+		if o != nil && o.ApplicationID != nil {
+			owners = append(owners, *o.ApplicationID)
+		}
+	}
+
+	return CreateResource(runtime, "azure.subscription.lock",
+		map[string]*llx.RawData{
+			"__id":   llx.StringDataPtr(lock.ID),
+			"id":     llx.StringDataPtr(lock.ID),
+			"name":   llx.StringDataPtr(lock.Name),
+			"type":   llx.StringDataPtr(lock.Type),
+			"level":  llx.StringData(string(convert.ToValue(props.Level))),
+			"notes":  llx.StringDataPtr(props.Notes),
+			"owners": llx.ArrayData(owners, types.String),
+			"scope":  llx.StringData(lockScopeFromID(convert.ToValue(lock.ID))),
+		})
+}
+
+func (a *mqlAzureSubscriptionResourcegroup) locks() ([]any, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	// Resolve the subscription's lock list and narrow it to this group. Reusing
+	// the cached subscription-wide fetch keeps this free of extra API calls even
+	// when every group in a large subscription is queried.
+	r, err := CreateResource(a.MqlRuntime, ResourceAzureSubscription, map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + conn.SubId()),
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	all := r.(*mqlAzureSubscription).GetLocks()
+	if all.Error != nil {
+		return nil, all.Error
+	}
+
+	// A lock protecting this group has a scope of either the group itself or a
+	// resource inside it, so match on the group ID followed by a separator (or
+	// nothing) to avoid matching a sibling group whose name shares this prefix.
+	groupID := strings.ToLower(a.Id.Data)
+	res := []any{}
+	for _, l := range all.Data {
+		lock, ok := l.(*mqlAzureSubscriptionLock)
+		if !ok {
+			continue
+		}
+		scope := strings.ToLower(lock.Scope.Data)
+		if scope == groupID || strings.HasPrefix(scope, groupID+"/") {
+			res = append(res, lock)
+		}
+	}
+	return res, nil
+}

--- a/providers/azure/resources/locks_test.go
+++ b/providers/azure/resources/locks_test.go
@@ -1,0 +1,59 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockScopeFromID(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{
+			name: "subscription-level lock",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks/no-delete",
+			want: "/subscriptions/00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name: "resource group lock",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Authorization/locks/rg-lock",
+			want: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod",
+		},
+		{
+			name: "resource lock keeps the resource's own provider segment",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/sa1/providers/Microsoft.Authorization/locks/sa-lock",
+			want: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod/providers/Microsoft.Storage/storageAccounts/sa1",
+		},
+		{
+			name: "casing as returned by ARM is tolerated",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-prod/providers/microsoft.authorization/LOCKS/rg-lock",
+			want: "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-prod",
+		},
+		{
+			name: "a lock named like the provider path does not confuse the split",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/locks/locks",
+			want: "/subscriptions/00000000-0000-0000-0000-000000000000",
+		},
+		{
+			name: "id without the lock provider path yields nothing",
+			id:   "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-prod",
+			want: "",
+		},
+		{
+			name: "empty id",
+			id:   "",
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, lockScopeFromID(c.id))
+		})
+	}
+}

--- a/providers/azure/resources/managementgroups.go
+++ b/providers/azure/resources/managementgroups.go
@@ -1,0 +1,470 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	authorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+	"github.com/rs/zerolog/log"
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/util/convert"
+	"go.mondoo.com/mql/v13/providers/azure/connection"
+	"go.mondoo.com/mql/v13/types"
+)
+
+// managementGroupsUnavailable reports whether an entities-listing error means
+// the credential simply cannot read the management group hierarchy, as opposed
+// to something having gone wrong. Only the two authorization outcomes count.
+//
+// Following pimUnavailable, the status codes are matched individually rather
+// than as a 4xx range: a 429 means Microsoft.Management throttled a tenant-wide
+// scan and says nothing about access, and reporting an empty hierarchy for it
+// would silently drop management groups from the results of a scan that had
+// every right to see them.
+func managementGroupsUnavailable(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	switch respErr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	}
+	return false
+}
+
+// managementGroupIDPrefix is the ARM path every management group ID starts
+// with; it also doubles as the scope prefix used in role and policy
+// assignments made at a management group.
+const managementGroupIDPrefix = "/providers/Microsoft.Management/managementGroups/"
+
+// isManagementGroupEntity reports whether an entity from the entities listing
+// is a management group rather than a subscription. Classifying on the ID
+// prefix rather than the Type string keeps this working regardless of the
+// casing or exact literal ARM returns for the type.
+func isManagementGroupEntity(e *armmanagementgroups.EntityInfo) bool {
+	if e == nil || e.ID == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.ToLower(*e.ID), strings.ToLower(managementGroupIDPrefix))
+}
+
+// isSubscriptionEntity reports whether an entity is a subscription. The
+// entities listing returns both management groups and the subscriptions that
+// hang off them.
+func isSubscriptionEntity(e *armmanagementgroups.EntityInfo) bool {
+	if e == nil || e.ID == nil {
+		return false
+	}
+	if strings.HasPrefix(strings.ToLower(*e.ID), "/subscriptions/") {
+		return true
+	}
+	return e.Type != nil && strings.Contains(strings.ToLower(*e.Type), "subscription")
+}
+
+// entityParentID returns the ARM ID of an entity's parent management group, or
+// "" for the tenant root group (which has no parent).
+func entityParentID(e *armmanagementgroups.EntityInfo) string {
+	if e == nil || e.Properties == nil || e.Properties.Parent == nil {
+		return ""
+	}
+	return convert.ToValue(e.Properties.Parent.ID)
+}
+
+// entityParentNameChain returns the management group names from the tenant root
+// down to the entity's immediate parent.
+func entityParentNameChain(e *armmanagementgroups.EntityInfo) []string {
+	if e == nil || e.Properties == nil {
+		return nil
+	}
+	chain := make([]string, 0, len(e.Properties.ParentNameChain))
+	for _, n := range e.Properties.ParentNameChain {
+		if n != nil {
+			chain = append(chain, *n)
+		}
+	}
+	return chain
+}
+
+// managementGroupEntities fetches the tenant's management group hierarchy once
+// and caches it on the azure singleton. The entities listing returns every
+// management group and subscription the credential can see, each carrying its
+// parent and its ancestor name chain, so a single paged call is enough to
+// answer parentage, children, and subtree counts without further requests.
+//
+// A credential without Microsoft.Management read access gets an authorization
+// failure here. That is reported as an empty hierarchy rather than an error:
+// management group access is frequently not granted to a subscription-scoped
+// service principal, and every caller of this treats "no hierarchy" as a
+// legitimate state. It does not understate anyone's privileges, because the
+// role assignments made at a management group still surface through the
+// subscription's own assignment listing, which includes inherited grants.
+func (a *mqlAzure) managementGroupEntities() ([]*armmanagementgroups.EntityInfo, error) {
+	a.mgOnce.Do(func() {
+		conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+		if !ok {
+			a.mgErr = errors.New("invalid connection provided, it is not an Azure connection")
+			return
+		}
+
+		client, err := armmanagementgroups.NewEntitiesClient(conn.Token(), &arm.ClientOptions{
+			ClientOptions: conn.ClientOptions(),
+		})
+		if err != nil {
+			a.mgErr = err
+			return
+		}
+
+		ctx := context.Background()
+		pager := client.NewListPager(&armmanagementgroups.EntitiesClientListOptions{})
+		entities := []*armmanagementgroups.EntityInfo{}
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				if managementGroupsUnavailable(err) {
+					log.Debug().Err(err).Msg("azure> no management group read access, reporting an empty hierarchy")
+					a.mgEntities = []*armmanagementgroups.EntityInfo{}
+					return
+				}
+				a.mgErr = err
+				return
+			}
+			entities = append(entities, page.Value...)
+		}
+		a.mgEntities = entities
+	})
+	return a.mgEntities, a.mgErr
+}
+
+// azureSingleton resolves the provider's top-level azure resource, which owns
+// the cached management group hierarchy.
+func azureSingleton(runtime *plugin.Runtime) (*mqlAzure, error) {
+	r, err := CreateResource(runtime, "azure", map[string]*llx.RawData{})
+	if err != nil {
+		return nil, err
+	}
+	return r.(*mqlAzure), nil
+}
+
+func (a *mqlAzure) managementGroups() ([]any, error) {
+	entities, err := a.managementGroupEntities()
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for _, e := range entities {
+		if !isManagementGroupEntity(e) {
+			continue
+		}
+		mqlGroup, err := newMqlManagementGroup(a.MqlRuntime, e, entities)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, mqlGroup)
+	}
+	return res, nil
+}
+
+type mqlAzureManagementGroupInternal struct {
+	parentID string
+}
+
+// newMqlManagementGroup builds a management group resource. The subscription
+// membership fields are derived from the full entity list, which the caller
+// already holds, so they cost no extra request: subscriptionIds are the
+// subscriptions parented directly by this group, and subscriptionCount is every
+// subscription anywhere beneath it, found through the ancestor name chains.
+//
+// Both figures cover only what the credential can read. A partially visible
+// hierarchy therefore undercounts rather than overcounts the reach of an
+// assignment made at this scope.
+func newMqlManagementGroup(runtime *plugin.Runtime, e *armmanagementgroups.EntityInfo, all []*armmanagementgroups.EntityInfo) (*mqlAzureManagementGroup, error) {
+	name := convert.ToValue(e.Name)
+	id := convert.ToValue(e.ID)
+
+	var displayName, tenantID string
+	if e.Properties != nil {
+		displayName = convert.ToValue(e.Properties.DisplayName)
+		tenantID = convert.ToValue(e.Properties.TenantID)
+	}
+	parentID := entityParentID(e)
+
+	directSubscriptions := []any{}
+	subtreeCount := 0
+	for _, other := range all {
+		if !isSubscriptionEntity(other) {
+			continue
+		}
+		if strings.EqualFold(entityParentID(other), id) {
+			directSubscriptions = append(directSubscriptions, convert.ToValue(other.Name))
+			subtreeCount++
+			continue
+		}
+		for _, ancestor := range entityParentNameChain(other) {
+			if strings.EqualFold(ancestor, name) {
+				subtreeCount++
+				break
+			}
+		}
+	}
+
+	r, err := CreateResource(runtime, ResourceAzureManagementGroup,
+		map[string]*llx.RawData{
+			"__id":              llx.StringData(id),
+			"id":                llx.StringData(id),
+			"name":              llx.StringData(name),
+			"displayName":       llx.StringData(displayName),
+			"tenantId":          llx.StringData(tenantID),
+			"isRoot":            llx.BoolData(parentID == ""),
+			"subscriptionIds":   llx.ArrayData(directSubscriptions, types.String),
+			"subscriptionCount": llx.IntData(int64(subtreeCount)),
+		})
+	if err != nil {
+		return nil, err
+	}
+	group := r.(*mqlAzureManagementGroup)
+	group.parentID = parentID
+	return group, nil
+}
+
+func initAzureManagementGroup(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error) {
+	if len(args) > 2 {
+		return args, nil, nil
+	}
+	nameRaw := args["name"]
+	if nameRaw == nil {
+		return args, nil, nil
+	}
+	name, ok := nameRaw.Value.(string)
+	if !ok || name == "" {
+		return args, nil, nil
+	}
+
+	az, err := azureSingleton(runtime)
+	if err != nil {
+		return nil, nil, err
+	}
+	entities, err := az.managementGroupEntities()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, e := range entities {
+		if !isManagementGroupEntity(e) {
+			continue
+		}
+		if !strings.EqualFold(convert.ToValue(e.Name), name) {
+			continue
+		}
+		group, err := newMqlManagementGroup(runtime, e, entities)
+		if err != nil {
+			return nil, nil, err
+		}
+		// Returning the built resource is the only way to carry the parentID
+		// cache field onto it; args alone would leave parent() unable to
+		// resolve.
+		return nil, group, nil
+	}
+	return nil, nil, errors.New("azure.managementGroup with name " + name + " not found, or not readable by this credential")
+}
+
+func (a *mqlAzureManagementGroup) parent() (*mqlAzureManagementGroup, error) {
+	if a.parentID == "" {
+		// The tenant root group has no parent.
+		a.Parent.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+
+	az, err := azureSingleton(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	entities, err := az.managementGroupEntities()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range entities {
+		if isManagementGroupEntity(e) && strings.EqualFold(convert.ToValue(e.ID), a.parentID) {
+			return newMqlManagementGroup(a.MqlRuntime, e, entities)
+		}
+	}
+	// The parent exists but sits outside what this credential can read.
+	a.Parent.State = plugin.StateIsSet | plugin.StateIsNull
+	return nil, nil
+}
+
+func (a *mqlAzureManagementGroup) children() ([]any, error) {
+	az, err := azureSingleton(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	entities, err := az.managementGroupEntities()
+	if err != nil {
+		return nil, err
+	}
+
+	res := []any{}
+	for _, e := range entities {
+		if !isManagementGroupEntity(e) {
+			continue
+		}
+		if !strings.EqualFold(entityParentID(e), a.Id.Data) {
+			continue
+		}
+		child, err := newMqlManagementGroup(a.MqlRuntime, e, entities)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, child)
+	}
+	return res, nil
+}
+
+func (a *mqlAzureManagementGroup) roleAssignments() ([]any, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	// The client is constructed with a subscription ID but the scope argument
+	// below overrides it, so the listing is genuinely management-group scoped.
+	client, err := authorization.NewRoleAssignmentsClient(conn.SubId(), conn.Token(), &arm.ClientOptions{
+		ClientOptions: conn.ClientOptions(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	scope := a.Id.Data
+	ctx := context.Background()
+	filter := "atScope()"
+	pager := client.NewListForScopePager(scope, &authorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: &filter,
+	})
+
+	res := []any{}
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, ra := range page.Value {
+			if ra == nil {
+				continue
+			}
+			// atScope() bounds the listing from below, but not reliably from
+			// above: assignments inherited from a parent group can still come
+			// back. Keep only the ones whose scope is exactly this group, which
+			// is what the field promises.
+			if ra.Properties == nil || !strings.EqualFold(convert.ToValue(ra.Properties.Scope), scope) {
+				continue
+			}
+			mqlRoleAssignment, err := newMqlRoleAssignment(a.MqlRuntime, ra)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, mqlRoleAssignment)
+		}
+	}
+	return res, nil
+}
+
+func (a *mqlAzureManagementGroup) policyAssignments() ([]any, error) {
+	conn, ok := a.MqlRuntime.Connection.(*connection.AzureConnection)
+	if !ok {
+		return nil, errors.New("invalid connection provided, it is not an Azure connection")
+	}
+
+	// The subscription's policy assignment listing already includes assignments
+	// inherited from the management groups above it, so this narrows that cached
+	// fetch instead of issuing a management-group query. The consequence, called
+	// out on the field, is that a management group the connected subscription
+	// does not descend from reports no assignments.
+	r, err := CreateResource(a.MqlRuntime, ResourceAzureSubscription, map[string]*llx.RawData{
+		"__id":           llx.StringData("/subscriptions/" + conn.SubId()),
+		"subscriptionId": llx.StringData(conn.SubId()),
+	})
+	if err != nil {
+		return nil, err
+	}
+	policyVal := r.(*mqlAzureSubscription).GetPolicy()
+	if policyVal.Error != nil {
+		return nil, policyVal.Error
+	}
+	if policyVal.Data == nil {
+		return nil, errors.New("cannot resolve the policy service for the subscription")
+	}
+	assignments := policyVal.Data.GetAssignments()
+	if assignments.Error != nil {
+		return nil, assignments.Error
+	}
+
+	scope := strings.ToLower(a.Id.Data)
+	res := []any{}
+	for _, item := range assignments.Data {
+		assignment, ok := item.(*mqlAzureSubscriptionPolicyAssignment)
+		if !ok {
+			continue
+		}
+		if strings.ToLower(assignment.Scope.Data) == scope {
+			res = append(res, assignment)
+		}
+	}
+	return res, nil
+}
+
+// managementGroups returns the management group ancestry of the connected
+// subscription, nearest parent first and the tenant root group last. These are
+// the scopes whose role and policy assignments the subscription inherits.
+func (a *mqlAzureSubscription) managementGroups() ([]any, error) {
+	az, err := azureSingleton(a.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	entities, err := az.managementGroupEntities()
+	if err != nil {
+		return nil, err
+	}
+
+	// Locate the subscription's own entity to read its ancestor chain, which
+	// runs root-first.
+	var chain []string
+	subID := a.SubscriptionId.Data
+	for _, e := range entities {
+		if isSubscriptionEntity(e) && strings.EqualFold(convert.ToValue(e.Name), subID) {
+			chain = entityParentNameChain(e)
+			break
+		}
+	}
+
+	byName := map[string]*armmanagementgroups.EntityInfo{}
+	for _, e := range entities {
+		if isManagementGroupEntity(e) {
+			byName[strings.ToLower(convert.ToValue(e.Name))] = e
+		}
+	}
+
+	res := []any{}
+	// Reverse the root-first chain so the immediate parent comes first.
+	for i := len(chain) - 1; i >= 0; i-- {
+		e, ok := byName[strings.ToLower(chain[i])]
+		if !ok {
+			continue
+		}
+		group, err := newMqlManagementGroup(a.MqlRuntime, e, entities)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, group)
+	}
+	return res, nil
+}

--- a/providers/azure/resources/managementgroups_test.go
+++ b/providers/azure/resources/managementgroups_test.go
@@ -1,0 +1,126 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups"
+	"github.com/stretchr/testify/assert"
+)
+
+func mgEntity(name string, parentID string, chain ...string) *armmanagementgroups.EntityInfo {
+	e := &armmanagementgroups.EntityInfo{
+		ID:   to.Ptr(managementGroupIDPrefix + name),
+		Name: to.Ptr(name),
+		Type: to.Ptr("Microsoft.Management/managementGroups"),
+		Properties: &armmanagementgroups.EntityInfoProperties{
+			DisplayName: to.Ptr(name + " display"),
+			TenantID:    to.Ptr("tenant-1"),
+		},
+	}
+	if parentID != "" {
+		e.Properties.Parent = &armmanagementgroups.EntityParentGroupInfo{ID: to.Ptr(parentID)}
+	}
+	for _, c := range chain {
+		e.Properties.ParentNameChain = append(e.Properties.ParentNameChain, to.Ptr(c))
+	}
+	return e
+}
+
+func subEntity(subID string, parentName string, chain ...string) *armmanagementgroups.EntityInfo {
+	e := &armmanagementgroups.EntityInfo{
+		ID:   to.Ptr("/subscriptions/" + subID),
+		Name: to.Ptr(subID),
+		Type: to.Ptr("/subscriptions"),
+		Properties: &armmanagementgroups.EntityInfoProperties{
+			DisplayName: to.Ptr("sub " + subID),
+			Parent:      &armmanagementgroups.EntityParentGroupInfo{ID: to.Ptr(managementGroupIDPrefix + parentName)},
+		},
+	}
+	for _, c := range chain {
+		e.Properties.ParentNameChain = append(e.Properties.ParentNameChain, to.Ptr(c))
+	}
+	return e
+}
+
+func TestIsManagementGroupEntity(t *testing.T) {
+	assert.True(t, isManagementGroupEntity(mgEntity("root", "")))
+	assert.False(t, isManagementGroupEntity(subEntity("sub-1", "root", "root")))
+	assert.False(t, isManagementGroupEntity(nil))
+	assert.False(t, isManagementGroupEntity(&armmanagementgroups.EntityInfo{}))
+
+	t.Run("casing of the provider path is tolerated", func(t *testing.T) {
+		e := &armmanagementgroups.EntityInfo{
+			ID: to.Ptr("/providers/microsoft.management/managementgroups/root"),
+		}
+		assert.True(t, isManagementGroupEntity(e))
+	})
+}
+
+func TestIsSubscriptionEntity(t *testing.T) {
+	assert.True(t, isSubscriptionEntity(subEntity("sub-1", "root", "root")))
+	assert.False(t, isSubscriptionEntity(mgEntity("root", "")))
+	assert.False(t, isSubscriptionEntity(nil))
+
+	t.Run("classified by type when the id prefix is unexpected", func(t *testing.T) {
+		e := &armmanagementgroups.EntityInfo{
+			ID:   to.Ptr("/Subscriptions/sub-2"),
+			Type: to.Ptr("Microsoft.Management/managementGroups/subscriptions"),
+		}
+		assert.True(t, isSubscriptionEntity(e))
+	})
+}
+
+func TestEntityParentID(t *testing.T) {
+	assert.Equal(t, managementGroupIDPrefix+"root", entityParentID(mgEntity("prod", managementGroupIDPrefix+"root", "root")))
+
+	t.Run("root group has no parent", func(t *testing.T) {
+		assert.Equal(t, "", entityParentID(mgEntity("root", "")))
+	})
+	t.Run("nil-safe", func(t *testing.T) {
+		assert.Equal(t, "", entityParentID(nil))
+		assert.Equal(t, "", entityParentID(&armmanagementgroups.EntityInfo{}))
+	})
+}
+
+func TestEntityParentNameChain(t *testing.T) {
+	assert.Equal(t, []string{"root", "platform"},
+		entityParentNameChain(mgEntity("prod", managementGroupIDPrefix+"platform", "root", "platform")))
+
+	t.Run("nil-safe and empty for the root", func(t *testing.T) {
+		assert.Empty(t, entityParentNameChain(nil))
+		assert.Empty(t, entityParentNameChain(mgEntity("root", "")))
+	})
+
+	t.Run("nil chain entries are dropped", func(t *testing.T) {
+		e := mgEntity("prod", managementGroupIDPrefix+"root")
+		e.Properties.ParentNameChain = []*string{to.Ptr("root"), nil, to.Ptr("platform")}
+		assert.Equal(t, []string{"root", "platform"}, entityParentNameChain(e))
+	})
+}
+
+func TestPrincipalTypeFromODataType(t *testing.T) {
+	cases := []struct {
+		odataType string
+		want      string
+	}{
+		{"#microsoft.graph.servicePrincipal", "servicePrincipal"},
+		{"microsoft.graph.servicePrincipal", "servicePrincipal"},
+		{"#microsoft.graph.user", "user"},
+		{"#microsoft.graph.group", "group"},
+		{"#microsoft.graph.application", "application"},
+		{"#microsoft.graph.device", "device"},
+		// casing differences from Graph are normalized to our spelling
+		{"#microsoft.graph.serviceprincipal", "servicePrincipal"},
+		// types we do not model, and malformed input, yield ""
+		{"#microsoft.graph.orgContact", ""},
+		{"", ""},
+		{"servicePrincipal", "servicePrincipal"},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, principalTypeFromODataType(c.odataType), "odata.type %q", c.odataType)
+	}
+}


### PR DESCRIPTION
Tier 1 of the Azure security-coverage backlog: the identity and authorization blind spots. Four additions sharing one theme — a privilege finding you cannot attribute is a privilege finding you cannot act on.

## 1. Entra principal resolution

`roleAssignment.principalId` was a dead-end GUID. "Which *service principals* hold Owner?" and "is this grant to an app owned by another tenant?" were unanswerable, because Entra lives in the ms365 provider and you cannot join across providers in one query.

Adds `roleAssignment.principal()` → new `azure.entraPrincipal`:

```
azure.subscription.iam.roleAssignments
  .where(role.name == "Owner") {
    principal.displayName
    principal.principalType
    principal.appId
    principal.appOwnerTenantId
    principal.servicePrincipalType
  }
```

**Graph access.** A minimal client on the credential the ARM clients already use — `POST /v1.0/directoryObjects/getByIds` — following the raw-REST shape `armsecurity.go` established, rather than adding `msgraph-sdk-go` (a Kiota-generated client covering all of Graph) for one endpoint. Requires Microsoft Graph `Directory.Read.All`.

IDs batch 1000 per request, and the first resolution seeds every principal the subscription's assignments name, so a whole-subscription audit is **one** Graph round trip. Principals arriving from another scope (a management group's listing) are fetched on demand rather than being mistaken for deleted ones. The token is re-fetched per batch so a large tenant does not fail on an expired bearer token.

**The two failure modes are split deliberately:**

| Case | Behavior | Why |
|---|---|---|
| No directory access | **error** | Rendering every grant as "no principal" would understate who holds access — the most dangerous way for a privilege audit to fail |
| ID Graph cannot resolve | **null** | The principal was deleted; this *is* the finding |

That makes orphaned grants a first-class query:

```
azure.subscription.iam.roleAssignments.where(principal == null)
```

For reference, `Get-AzRoleAssignment` calls the same endpoint and collapses both cases into `ObjectType: Unknown`.

## 2. Management group hierarchy

`azure` was an empty resource (`azure { }`) and everything hung off a subscription, so a grant whose scope was `/providers/Microsoft.Management/managementGroups/abc123` had a name nobody could look up, a position nobody could see, and a blast radius nobody could measure.

```
azure.managementGroups {
  displayName
  isRoot
  subscriptionCount          // whole subtree = blast radius
  roleAssignments { role.name principal.displayName }
}
```

Adds `azure.managementGroups()`, `azure.managementGroup` (with `parent()`, `children()`, `isRoot`, `subscriptionIds`, `subscriptionCount`, `roleAssignments()`, `policyAssignments()`), and `azure.subscription.managementGroups()` for the ancestry a subscription inherits from.

One entities listing builds the whole tree, cached on the `azure` singleton, so parentage, children and subtree counts cost no further requests.

**Scoping note, to be accurate about what this changes:** management-group role assignments were already *visible* — the subscription listing returns inherited grants, with `scope` carrying the MG path. This makes them **attributable and measurable**, not newly visible. `policyAssignments()` likewise narrows the subscription's already-inherited list, so a management group the connected subscription does not descend from reports none; that limitation is documented on the field.

A credential without `Microsoft.Management` read access reports an empty hierarchy rather than erroring — that is common for subscription-scoped service principals, and it cannot understate anyone's privileges, since the grants themselves still surface through the subscription listing.

## 3. Resource locks

Zero coverage previously. Locks sit *outside* RBAC — they apply to every principal including subscription owners — which makes them the last line of defense for data that must survive a compromised or mistaken operator, and the only way to answer "can this retained data actually be deleted?"

```
azure.subscription.locks { name level scope notes }
azure.subscription.resourceGroups { name locks { level } }
```

Adds `azure.subscription.locks()`, `azure.subscription.resourcegroup.locks()`, and `azure.subscription.lock` (`level`, `notes`, `owners`, and `scope` derived from the lock's own ID). The subscription listing covers every lock in the subscription including those on resource groups and individual resources, so the resource-group accessor narrows that one fetch instead of paging per group.

Management groups deliberately get no `locks()` accessor — Azure does not support locking them.

## 4. Custom-role privilege analysis

`roleDefinition.permissions()` already exposed the raw data, but every consumer had to hand-roll the wildcard analysis. Three derived fields, computed from permissions already fetched — **no new API calls**:

```
azure.subscription.iam.roles
  .where(type == "CustomRole" && isPrivilegeEscalating)
  { name hasWildcardActions grantsDataAccess }
```

- **`isPrivilegeEscalating()`** — the role reaches `Microsoft.Authorization/roleAssignments/write`, `roleDefinitions/write`, or `elevateAccess/action` and survives its own `notActions`. Such a role can assign itself any other role, so it is Owner regardless of what it is called.
- **`hasWildcardActions()`** — any allowed action contains `*`. Deliberately ignores `notActions`: the point is that the role's reach grows as Azure adds actions to the matched namespace, which a fixed `notActions` list cannot keep up with.
- **`grantsDataAccess()`** — allows `dataActions` its `notDataActions` do not take back. Control-plane actions govern a resource; data actions reach blob bytes, queue messages, and key material.

The Azure wildcard matcher and the actions/notActions subtraction are pure functions with table tests over the real built-in shapes — Owner escalates, Contributor (`*` minus `Microsoft.Authorization/*/Write`) does not, User Access Administrator does, Reader does not, and Owner's `dataActions: *` / `notDataActions: *` correctly reports no data access.

## Permissions extractor

Two ARM namespaces were derived wrongly and are now overridden:

- `armmanagementgroups` fell through to `Microsoft.Managementgroups` — not a real provider. Now `Microsoft.Management/managementGroups/read`.
- `armlocks` inherited `Microsoft.Resources` from its parent directory. Now `Microsoft.Authorization/locks/read`. The service key could not simply be remapped, since `armresources`, `armdeployments`, `armsubscriptions` and `armpolicy` legitimately share it.

Manifest changes are adds-only (3 new entries).

**Known gap:** the Graph directory-read permission is absent from the manifest. It is a Graph *app* permission, not an ARM action, so the ARM-oriented manifest cannot express it — the same gap as the existing raw-REST calls (`effectiveSecurityRules`, `armsecurity.go`).

## Verification

- `go build ./...` clean; full azure provider suite passes
- New table tests pass (matcher, actions/notActions subtraction, all three predicates, lock-scope parsing, entity classification, Graph `@odata.type` normalization)
- `gofmt` clean; `go mod tidy` clean; codegen re-run twice (the Internal-struct embed pass)
- 38 new `.lr.versions` entries at `13.33.8`, zero modifications to existing entries
- No `config.go` version bump

**Not yet live-verified** — queued for the next batched live-validation run. The management group and Graph paths in particular want a tenant with a real hierarchy and consented directory read; the dev subscription has neither.
