### PR TITLE
✨ aws: evaluate effective inbound reachability across security groups and network ACLs

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -6689,6 +6689,49 @@ private aws.network.exposure @defaults("internetReachable publiclyAccessible") {
   openIngressRules []aws.ec2.securitygroup.ippermission
 }
 
+// Inbound reachability of a network interface after security group and network ACL evaluation
+//
+// One security group ingress rule, narrowed to a single source range, paired
+// with the subnet network ACL's decision on that traffic. A security group can
+// permit traffic that the network ACL then drops, so neither resource alone
+// answers whether a port is reachable. The `reachable` field combines both, and
+// `networkAclVerdict` explains the network ACL half of the decision.
+private aws.network.effectiveIngress @defaults("reachable protocol fromPort toPort source") {
+  // Source range the security group rule permits
+  source string
+  // IP protocol the rule covers: tcp, udp, icmp, icmpv6, a protocol number, or -1 for all protocols
+  protocol string
+  // Start of the port range, -1 when the protocol carries no port concept
+  fromPort int
+  // End of the port range, -1 when the protocol carries no port concept
+  toPort int
+  // Security group whose ingress rule permits this traffic
+  securityGroup aws.ec2.securitygroup
+  // Security group ingress rule that permits this traffic
+  securityGroupRule aws.ec2.securitygroup.ippermission
+  // Network ACL decision on this traffic
+  //
+  // One of `allow` (the first matching inbound entry permits the whole range),
+  // `deny` (the first matching entry denies the whole range, or nothing matches
+  // and the implicit final deny applies), `partial` (the first matching entry
+  // covers only part of the range, so the remainder falls through to
+  // later entries and needs reading by hand), or `unknown` (the network ACL
+  // could not be read).
+  networkAclVerdict string
+  // First network ACL inbound entry matching this traffic
+  //
+  // Null when no entry matches, so the implicit final deny applies, and when the
+  // network ACL could not be read.
+  networkAclEntry aws.ec2.networkacl.entry
+  // Whether the traffic can reach the interface
+  //
+  // True when a security group permits the traffic and the network ACL does not
+  // deny all of it. A `partial` verdict counts as reachable, because some of the
+  // range does get through. An `unknown` verdict also counts as reachable, so a
+  // failed network ACL read never reports an interface as protected.
+  reachable bool
+}
+
 // AWS ELB listener
 private aws.elb.listener @defaults("arn port protocol") {
   // ARN for the listener
@@ -17835,6 +17878,14 @@ private aws.ec2.networkacl.entry @defaults("id egress ruleAction cidrBlock portR
   // True when the entry matches every IPv4 address (`0.0.0.0/0`) or every IPv6
   // address (`::/0`).
   isPublic() bool
+  // Whether an earlier entry makes this one unreachable
+  //
+  // True when a lower-numbered entry in the same direction matches every packet
+  // this entry would match, so this entry can never be the first match and has
+  // no effect on traffic. Rule number alone does not establish this: a narrow
+  // deny in front of a broad allow shadows only its own protocol, source range,
+  // and ports, leaving the rest of the allow in force.
+  isShadowed() bool
   // ID for the ACL entry rule
   id string
 }
@@ -19171,6 +19222,15 @@ private aws.ec2.networkinterface @defaults("id privateIpAddress macAddress") {
   availabilityZone string
   // Security groups associated with the network interface
   securityGroups() []aws.ec2.securitygroup
+  // Inbound traffic that reaches the interface after both filters are applied
+  //
+  // Every ingress rule across the attached security groups, expanded to one
+  // entry per source range, with the subnet network ACL's decision on it. This
+  // is what tells a world-open security group rule that a network ACL blocks
+  // apart from one that is genuinely reachable. Rules whose source is a
+  // security group reference or a managed prefix list are not included, since
+  // neither resolves to a source range a network ACL can be evaluated against.
+  effectiveIngress() []aws.network.effectiveIngress
   // Whether this is an IPv6 only network interface
   ipv6Native bool
   // MAC address of the network interface
@@ -19470,6 +19530,14 @@ private aws.ec2.securitygroup @defaults("id name region vpc.id") {
   ownerId string
   // Whether the security group is attached to Amazon Elastic Compute Cloud
   isAttachedToNetworkInterface() bool
+  // Whether nothing depends on the security group
+  //
+  // True when the group is attached to no network interface and no other
+  // security group in the same region references it from a rule. Attachment
+  // alone does not settle this: a group with no interfaces of its own is still
+  // load-bearing when another group's rule allows traffic from it, and deleting
+  // it would change that group's meaning.
+  isUnused() bool
   // Network interfaces this security group is attached to
   networkInterfaces() []aws.ec2.networkinterface
   // EC2 instances this security group is attached to, resolved through their network interfaces

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -148930,7 +148930,7 @@ func (c *mqlAwsSsmInstance) GetSourceLocation() *plugin.TValue[string] {
 type mqlAwsEc2 struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2Internal it will be used here
+	mqlAwsEc2Internal
 	SecurityGroups                   plugin.TValue[[]any]
 	Instances                        plugin.TValue[[]any]
 	EbsEncryptionByDefault           plugin.TValue[map[string]any]

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -237,6 +237,7 @@ const (
 	ResourceAwsElbTargetgroupAttributes                                         string = "aws.elb.targetgroup.attributes"
 	ResourceAwsElbLoadbalancer                                                  string = "aws.elb.loadbalancer"
 	ResourceAwsNetworkExposure                                                  string = "aws.network.exposure"
+	ResourceAwsNetworkEffectiveIngress                                          string = "aws.network.effectiveIngress"
 	ResourceAwsElbListener                                                      string = "aws.elb.listener"
 	ResourceAwsElbListenerRule                                                  string = "aws.elb.listener.rule"
 	ResourceAwsElbLoadbalancerAttribute                                         string = "aws.elb.loadbalancer.attribute"
@@ -1856,6 +1857,10 @@ func init() {
 		"aws.network.exposure": {
 			// to override args, implement: initAwsNetworkExposure(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
 			Create: createAwsNetworkExposure,
+		},
+		"aws.network.effectiveIngress": {
+			// to override args, implement: initAwsNetworkEffectiveIngress(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
+			Create: createAwsNetworkEffectiveIngress,
 		},
 		"aws.elb.listener": {
 			// to override args, implement: initAwsElbListener(runtime *plugin.Runtime, args map[string]*llx.RawData) (map[string]*llx.RawData, plugin.Resource, error)
@@ -11828,6 +11833,33 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.network.exposure.openIngressRules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsNetworkExposure).GetOpenIngressRules()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup.ippermission")))
+	},
+	"aws.network.effectiveIngress.source": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetSource()).ToDataRes(types.String)
+	},
+	"aws.network.effectiveIngress.protocol": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetProtocol()).ToDataRes(types.String)
+	},
+	"aws.network.effectiveIngress.fromPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetFromPort()).ToDataRes(types.Int)
+	},
+	"aws.network.effectiveIngress.toPort": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetToPort()).ToDataRes(types.Int)
+	},
+	"aws.network.effectiveIngress.securityGroup": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetSecurityGroup()).ToDataRes(types.Resource("aws.ec2.securitygroup"))
+	},
+	"aws.network.effectiveIngress.securityGroupRule": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetSecurityGroupRule()).ToDataRes(types.Resource("aws.ec2.securitygroup.ippermission"))
+	},
+	"aws.network.effectiveIngress.networkAclVerdict": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetNetworkAclVerdict()).ToDataRes(types.String)
+	},
+	"aws.network.effectiveIngress.networkAclEntry": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetNetworkAclEntry()).ToDataRes(types.Resource("aws.ec2.networkacl.entry"))
+	},
+	"aws.network.effectiveIngress.reachable": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsNetworkEffectiveIngress).GetReachable()).ToDataRes(types.Bool)
 	},
 	"aws.elb.listener.arn": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsElbListener).GetArn()).ToDataRes(types.String)
@@ -22941,6 +22973,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.networkacl.entry.isPublic": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2NetworkaclEntry).GetIsPublic()).ToDataRes(types.Bool)
 	},
+	"aws.ec2.networkacl.entry.isShadowed": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2NetworkaclEntry).GetIsShadowed()).ToDataRes(types.Bool)
+	},
 	"aws.ec2.networkacl.entry.id": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2NetworkaclEntry).GetId()).ToDataRes(types.String)
 	},
@@ -24435,6 +24470,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.ec2.networkinterface.securityGroups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetSecurityGroups()).ToDataRes(types.Array(types.Resource("aws.ec2.securitygroup")))
 	},
+	"aws.ec2.networkinterface.effectiveIngress": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Networkinterface).GetEffectiveIngress()).ToDataRes(types.Array(types.Resource("aws.network.effectiveIngress")))
+	},
 	"aws.ec2.networkinterface.ipv6Native": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Networkinterface).GetIpv6Native()).ToDataRes(types.Bool)
 	},
@@ -24788,6 +24826,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ec2.securitygroup.isAttachedToNetworkInterface": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetIsAttachedToNetworkInterface()).ToDataRes(types.Bool)
+	},
+	"aws.ec2.securitygroup.isUnused": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEc2Securitygroup).GetIsUnused()).ToDataRes(types.Bool)
 	},
 	"aws.ec2.securitygroup.networkInterfaces": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEc2Securitygroup).GetNetworkInterfaces()).ToDataRes(types.Array(types.Resource("aws.ec2.networkinterface")))
@@ -46060,6 +46101,46 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsNetworkExposure).OpenIngressRules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.network.effectiveIngress.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).__id, ok = v.Value.(string)
+		return
+	},
+	"aws.network.effectiveIngress.source": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).Source, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).Protocol, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.fromPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).FromPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.toPort": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).ToPort, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.securityGroup": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).SecurityGroup, ok = plugin.RawToTValue[*mqlAwsEc2Securitygroup](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.securityGroupRule": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).SecurityGroupRule, ok = plugin.RawToTValue[*mqlAwsEc2SecuritygroupIppermission](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.networkAclVerdict": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).NetworkAclVerdict, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.networkAclEntry": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).NetworkAclEntry, ok = plugin.RawToTValue[*mqlAwsEc2NetworkaclEntry](v.Value, v.Error)
+		return
+	},
+	"aws.network.effectiveIngress.reachable": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsNetworkEffectiveIngress).Reachable, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.elb.listener.__id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsElbListener).__id, ok = v.Value.(string)
 		return
@@ -62260,6 +62341,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2NetworkaclEntry).IsPublic, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.networkacl.entry.isShadowed": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2NetworkaclEntry).IsShadowed, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.networkacl.entry.id": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2NetworkaclEntry).Id, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -64428,6 +64513,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEc2Networkinterface).SecurityGroups, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.ec2.networkinterface.effectiveIngress": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Networkinterface).EffectiveIngress, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
 	"aws.ec2.networkinterface.ipv6Native": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Networkinterface).Ipv6Native, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
@@ -64938,6 +65027,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ec2.securitygroup.isAttachedToNetworkInterface": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEc2Securitygroup).IsAttachedToNetworkInterface, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.ec2.securitygroup.isUnused": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEc2Securitygroup).IsUnused, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"aws.ec2.securitygroup.networkInterfaces": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -108395,6 +108488,90 @@ func (c *mqlAwsNetworkExposure) GetOpenIngressRules() *plugin.TValue[[]any] {
 	return &c.OpenIngressRules
 }
 
+// mqlAwsNetworkEffectiveIngress for the aws.network.effectiveIngress resource
+type mqlAwsNetworkEffectiveIngress struct {
+	MqlRuntime *plugin.Runtime
+	__id       string
+	// optional: if you define mqlAwsNetworkEffectiveIngressInternal it will be used here
+	Source            plugin.TValue[string]
+	Protocol          plugin.TValue[string]
+	FromPort          plugin.TValue[int64]
+	ToPort            plugin.TValue[int64]
+	SecurityGroup     plugin.TValue[*mqlAwsEc2Securitygroup]
+	SecurityGroupRule plugin.TValue[*mqlAwsEc2SecuritygroupIppermission]
+	NetworkAclVerdict plugin.TValue[string]
+	NetworkAclEntry   plugin.TValue[*mqlAwsEc2NetworkaclEntry]
+	Reachable         plugin.TValue[bool]
+}
+
+// createAwsNetworkEffectiveIngress creates a new instance of this resource
+func createAwsNetworkEffectiveIngress(runtime *plugin.Runtime, args map[string]*llx.RawData) (plugin.Resource, error) {
+	res := &mqlAwsNetworkEffectiveIngress{
+		MqlRuntime: runtime,
+	}
+
+	err := SetAllData(res, args)
+	if err != nil {
+		return res, err
+	}
+
+	// to override __id implement: id() (string, error)
+
+	if runtime.HasRecording {
+		args, err = runtime.ResourceFromRecording("aws.network.effectiveIngress", res.__id)
+		if err != nil || args == nil {
+			return res, err
+		}
+		return res, SetAllData(res, args)
+	}
+
+	return res, nil
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) MqlName() string {
+	return "aws.network.effectiveIngress"
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) MqlID() string {
+	return c.__id
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetSource() *plugin.TValue[string] {
+	return &c.Source
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetProtocol() *plugin.TValue[string] {
+	return &c.Protocol
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetFromPort() *plugin.TValue[int64] {
+	return &c.FromPort
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetToPort() *plugin.TValue[int64] {
+	return &c.ToPort
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetSecurityGroup() *plugin.TValue[*mqlAwsEc2Securitygroup] {
+	return &c.SecurityGroup
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetSecurityGroupRule() *plugin.TValue[*mqlAwsEc2SecuritygroupIppermission] {
+	return &c.SecurityGroupRule
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetNetworkAclVerdict() *plugin.TValue[string] {
+	return &c.NetworkAclVerdict
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetNetworkAclEntry() *plugin.TValue[*mqlAwsEc2NetworkaclEntry] {
+	return &c.NetworkAclEntry
+}
+
+func (c *mqlAwsNetworkEffectiveIngress) GetReachable() *plugin.TValue[bool] {
+	return &c.Reachable
+}
+
 // mqlAwsElbListener for the aws.elb.listener resource
 type mqlAwsElbListener struct {
 	MqlRuntime *plugin.Runtime
@@ -150055,7 +150232,7 @@ func (c *mqlAwsEc2NetworkaclAssociation) GetSubnet() *plugin.TValue[*mqlAwsVpcSu
 type mqlAwsEc2NetworkaclEntry struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
-	// optional: if you define mqlAwsEc2NetworkaclEntryInternal it will be used here
+	mqlAwsEc2NetworkaclEntryInternal
 	Egress        plugin.TValue[bool]
 	RuleAction    plugin.TValue[string]
 	RuleNumber    plugin.TValue[int64]
@@ -150064,6 +150241,7 @@ type mqlAwsEc2NetworkaclEntry struct {
 	CidrBlock     plugin.TValue[string]
 	Ipv6CidrBlock plugin.TValue[string]
 	IsPublic      plugin.TValue[bool]
+	IsShadowed    plugin.TValue[bool]
 	Id            plugin.TValue[string]
 }
 
@@ -150147,6 +150325,12 @@ func (c *mqlAwsEc2NetworkaclEntry) GetIpv6CidrBlock() *plugin.TValue[string] {
 func (c *mqlAwsEc2NetworkaclEntry) GetIsPublic() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPublic, func() (bool, error) {
 		return c.isPublic()
+	})
+}
+
+func (c *mqlAwsEc2NetworkaclEntry) GetIsShadowed() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsShadowed, func() (bool, error) {
+		return c.isShadowed()
 	})
 }
 
@@ -155167,6 +155351,7 @@ type mqlAwsEc2Networkinterface struct {
 	Tags                plugin.TValue[map[string]any]
 	AvailabilityZone    plugin.TValue[string]
 	SecurityGroups      plugin.TValue[[]any]
+	EffectiveIngress    plugin.TValue[[]any]
 	Ipv6Native          plugin.TValue[bool]
 	MacAddress          plugin.TValue[string]
 	PrivateDnsName      plugin.TValue[string]
@@ -155298,6 +155483,22 @@ func (c *mqlAwsEc2Networkinterface) GetSecurityGroups() *plugin.TValue[[]any] {
 		}
 
 		return c.securityGroups()
+	})
+}
+
+func (c *mqlAwsEc2Networkinterface) GetEffectiveIngress() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.EffectiveIngress, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ec2.networkinterface", c.__id, "effectiveIngress")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.effectiveIngress()
 	})
 }
 
@@ -156296,6 +156497,7 @@ type mqlAwsEc2Securitygroup struct {
 	Region                       plugin.TValue[string]
 	OwnerId                      plugin.TValue[string]
 	IsAttachedToNetworkInterface plugin.TValue[bool]
+	IsUnused                     plugin.TValue[bool]
 	NetworkInterfaces            plugin.TValue[[]any]
 	Instances                    plugin.TValue[[]any]
 	CloudformationStack          plugin.TValue[*mqlAwsCloudformationStack]
@@ -156424,6 +156626,12 @@ func (c *mqlAwsEc2Securitygroup) GetOwnerId() *plugin.TValue[string] {
 func (c *mqlAwsEc2Securitygroup) GetIsAttachedToNetworkInterface() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsAttachedToNetworkInterface, func() (bool, error) {
 		return c.isAttachedToNetworkInterface()
+	})
+}
+
+func (c *mqlAwsEc2Securitygroup) GetIsUnused() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.IsUnused, func() (bool, error) {
+		return c.isUnused()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -3639,6 +3639,7 @@ aws.ec2.networkacl.entry.egress 11.15.2
 aws.ec2.networkacl.entry.id 11.15.2
 aws.ec2.networkacl.entry.ipv6CidrBlock 11.15.2
 aws.ec2.networkacl.entry.isPublic 13.33.2
+aws.ec2.networkacl.entry.isShadowed 13.52.2
 aws.ec2.networkacl.entry.portRange 11.15.2
 aws.ec2.networkacl.entry.portrange 11.15.2
 aws.ec2.networkacl.entry.portrange.from 11.15.2
@@ -3659,6 +3660,7 @@ aws.ec2.networkinterface.availabilityZone 11.15.2
 aws.ec2.networkinterface.deleteOnTermination 13.15.2
 aws.ec2.networkinterface.description 11.15.2
 aws.ec2.networkinterface.deviceIndex 13.15.2
+aws.ec2.networkinterface.effectiveIngress 13.52.2
 aws.ec2.networkinterface.elasticIp 13.15.2
 aws.ec2.networkinterface.id 11.15.2
 aws.ec2.networkinterface.instance 13.15.2
@@ -3716,6 +3718,7 @@ aws.ec2.securitygroup.ippermission.prefixLists 13.23.2
 aws.ec2.securitygroup.ippermission.toPort 11.15.2
 aws.ec2.securitygroup.ippermission.userIdGroupPairs 11.15.2
 aws.ec2.securitygroup.isAttachedToNetworkInterface 11.15.2
+aws.ec2.securitygroup.isUnused 13.52.2
 aws.ec2.securitygroup.managedBy 13.37.1
 aws.ec2.securitygroup.name 11.15.2
 aws.ec2.securitygroup.networkInterfaces 13.37.1
@@ -7429,6 +7432,16 @@ aws.neptuneAnalytics.graph.statusReason 13.18.1
 aws.neptuneAnalytics.graph.tags 13.18.1
 aws.neptuneAnalytics.graph.vectorSearchDimension 13.18.1
 aws.neptuneAnalytics.graphs 13.18.1
+aws.network.effectiveIngress 13.52.2
+aws.network.effectiveIngress.fromPort 13.52.2
+aws.network.effectiveIngress.networkAclEntry 13.52.2
+aws.network.effectiveIngress.networkAclVerdict 13.52.2
+aws.network.effectiveIngress.protocol 13.52.2
+aws.network.effectiveIngress.reachable 13.52.2
+aws.network.effectiveIngress.securityGroup 13.52.2
+aws.network.effectiveIngress.securityGroupRule 13.52.2
+aws.network.effectiveIngress.source 13.52.2
+aws.network.effectiveIngress.toPort 13.52.2
 aws.network.exposure 13.37.1
 aws.network.exposure.internetReachable 13.37.1
 aws.network.exposure.openIngressRules 13.37.1

--- a/providers/aws/resources/aws_ec2.go
+++ b/providers/aws/resources/aws_ec2.go
@@ -467,6 +467,9 @@ func (a *mqlAwsEc2Networkacl) entries() ([]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Back-reference so an entry can compare itself against its siblings,
+		// which is what shadowing depends on.
+		mqlAclEntry.(*mqlAwsEc2NetworkaclEntry).parentAcl = a
 		res = append(res, mqlAclEntry)
 	}
 
@@ -4514,39 +4517,46 @@ func (i *mqlAwsEc2Instance) exposure() (*mqlAwsEc2InstanceExposure, error) {
 	return res.(*mqlAwsEc2InstanceExposure), nil
 }
 
-// naclAllProtocols is the network ACL protocol number meaning "all protocols".
-const naclAllProtocols = "-1"
-
 // naclIngressRule is the shape of a network ACL inbound rule needed to decide
-// public reachability. Protocol and port range are part of that decision:
-// network ACLs are evaluated per packet, so a rule only shadows a
+// public reachability. Protocol, source range, and port range are all part of
+// that decision: network ACLs are evaluated per packet, so a rule only shadows a
 // higher-numbered rule for the traffic it actually matches.
 type naclIngressRule struct {
 	ruleNumber int
 	allow      bool
 	public     bool   // source is 0.0.0.0/0 or ::/0
 	protocol   string // "-1" means all protocols
-	fromPort   int64
-	toPort     int64
+	// cidr is the rule's source range. An empty value means the source was not
+	// recorded and the rule is treated as matching any source.
+	cidr     string
+	fromPort int64
+	toPort   int64
 	// allPorts is true when the rule carries no port range, which for a network
 	// ACL means every port for the protocol.
 	allPorts bool
 }
 
+// ports returns the rule's port span.
+func (r naclIngressRule) ports() portRange {
+	if r.allPorts {
+		return portRange{all: true}
+	}
+	return newPortRange(r.fromPort, r.toPort)
+}
+
 // covers reports whether r matches every packet that other matches, i.e.
 // whether a lower-numbered r fully shadows other.
+//
+// The source range is part of this: an IPv4 and an IPv6 rule never match the
+// same packet, so a deny on 0.0.0.0/0 does not shadow an allow on ::/0.
 func (r naclIngressRule) covers(other naclIngressRule) bool {
-	if r.protocol != naclAllProtocols && r.protocol != other.protocol {
+	if !protocolCovers(r.protocol, other.protocol) {
 		return false
 	}
-	if r.allPorts {
-		return true
-	}
-	if other.allPorts {
-		// other spans every port; a bounded range cannot shadow it
+	if !cidrCovers(r.cidr, other.cidr) {
 		return false
 	}
-	return r.fromPort <= other.fromPort && r.toPort >= other.toPort
+	return r.ports().covers(other.ports())
 }
 
 // naclAllowsPublicIngress reports whether a network ACL permits inbound traffic
@@ -4606,21 +4616,7 @@ func networkAclAllowsPublicIngress(nacl *mqlAwsEc2Networkacl) (bool, error) {
 		if !ok || entry.Egress.Data {
 			continue
 		}
-		rule := naclIngressRule{
-			ruleNumber: int(entry.RuleNumber.Data),
-			allow:      strings.EqualFold(entry.RuleAction.Data, "allow"),
-			public:     cidrEntryIsPublic(entry.CidrBlock.Data, entry.Ipv6CidrBlock.Data),
-			protocol:   entry.Protocol.Data,
-			allPorts:   true,
-		}
-		// portRange is populated as a creation arg, so this reads cached data
-		// rather than triggering a fetch. Its absence means "all ports".
-		if pr := entry.PortRange.Data; pr != nil {
-			rule.fromPort = pr.From.Data
-			rule.toPort = pr.To.Data
-			rule.allPorts = false
-		}
-		rules = append(rules, rule)
+		rules = append(rules, naclEntryRule(entry))
 	}
 	return naclAllowsPublicIngress(rules), nil
 }

--- a/providers/aws/resources/aws_network_cidr.go
+++ b/providers/aws/resources/aws_network_cidr.go
@@ -1,0 +1,166 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"net"
+	"strings"
+)
+
+// Protocol numbers as they appear in a network ACL entry. Security group rules
+// name the protocol instead ("tcp"), so the two have to be compared on a common
+// form before a rule can be matched against an ACL entry.
+const (
+	protocolAll    = "-1"
+	protocolIcmp   = "1"
+	protocolTcp    = "6"
+	protocolUdp    = "17"
+	protocolIcmpv6 = "58"
+)
+
+// normalizeProtocol converts a protocol as written in either a security group
+// rule or a network ACL entry into its protocol number. Security groups use
+// names ("tcp", "udp", "icmp", "icmpv6") and the wildcard "-1"; network ACLs use
+// the number directly. An unrecognized value is returned unchanged so two
+// entries carrying the same unusual protocol still compare equal.
+func normalizeProtocol(protocol string) string {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "", "-1", "all":
+		return protocolAll
+	case "tcp":
+		return protocolTcp
+	case "udp":
+		return protocolUdp
+	case "icmp":
+		return protocolIcmp
+	case "icmpv6", "58":
+		return protocolIcmpv6
+	default:
+		return protocol
+	}
+}
+
+// protocolCovers reports whether a rule for protocol outer applies to every
+// packet a rule for protocol inner applies to. The all-protocols wildcard covers
+// everything; otherwise the protocols must be the same.
+func protocolCovers(outer, inner string) bool {
+	o, i := normalizeProtocol(outer), normalizeProtocol(inner)
+	return o == protocolAll || o == i
+}
+
+// parseCidr parses an IPv4 or IPv6 CIDR block, returning false for anything
+// unparseable rather than an error: rule evaluation treats a CIDR it cannot read
+// as non-matching, and a malformed value from the API should not fail a query.
+func parseCidr(cidr string) (*net.IPNet, bool) {
+	if cidr == "" {
+		return nil, false
+	}
+	_, network, err := net.ParseCIDR(strings.TrimSpace(cidr))
+	if err != nil {
+		return nil, false
+	}
+	return network, true
+}
+
+// isIPv4Network reports which address family a parsed CIDR belongs to. An IPv4
+// and an IPv6 range never overlap, so the family gates every comparison below.
+func isIPv4Network(network *net.IPNet) bool {
+	return network.IP.To4() != nil
+}
+
+// cidrCovers reports whether outer contains every address in inner.
+//
+// An empty outer means "no source restriction recorded" and covers anything,
+// which keeps callers that do not track a CIDR working unchanged. An empty inner
+// is only covered by an equally unrestricted outer, since an unknown source
+// cannot be shown to fall inside a specific range.
+func cidrCovers(outer, inner string) bool {
+	if outer == "" {
+		return true
+	}
+	if inner == "" {
+		return false
+	}
+
+	outerNet, ok := parseCidr(outer)
+	if !ok {
+		return false
+	}
+	innerNet, ok := parseCidr(inner)
+	if !ok {
+		return false
+	}
+	if isIPv4Network(outerNet) != isIPv4Network(innerNet) {
+		return false
+	}
+
+	outerOnes, _ := outerNet.Mask.Size()
+	innerOnes, _ := innerNet.Mask.Size()
+	if outerOnes > innerOnes {
+		// A longer prefix is a smaller range and cannot contain a shorter one.
+		return false
+	}
+	return outerNet.Contains(innerNet.IP)
+}
+
+// cidrsOverlap reports whether two CIDR blocks share at least one address.
+// Overlap without containment is what makes a network ACL verdict partial: some
+// of the traffic a rule permits is decided by the entry and some falls through
+// to later entries.
+func cidrsOverlap(a, b string) bool {
+	aNet, ok := parseCidr(a)
+	if !ok {
+		return false
+	}
+	bNet, ok := parseCidr(b)
+	if !ok {
+		return false
+	}
+	if isIPv4Network(aNet) != isIPv4Network(bNet) {
+		return false
+	}
+	return aNet.Contains(bNet.IP) || bNet.Contains(aNet.IP)
+}
+
+// portRange is an inclusive TCP/UDP port span. all is true when the rule carries
+// no explicit range, which means every port for the protocol.
+type portRange struct {
+	from int64
+	to   int64
+	all  bool
+}
+
+// newPortRange builds a port range from the from/to pair a security group rule
+// or network ACL entry carries. Both resources use -1 to mean "unset", and a
+// protocol with no port concept (ICMP, or the all-protocols wildcard) spans
+// every port.
+func newPortRange(from, to int64) portRange {
+	if from < 0 || to < 0 {
+		return portRange{all: true}
+	}
+	if from > to {
+		from, to = to, from
+	}
+	return portRange{from: from, to: to}
+}
+
+// covers reports whether every port in other falls inside r.
+func (r portRange) covers(other portRange) bool {
+	if r.all {
+		return true
+	}
+	if other.all {
+		// other spans every port; a bounded range cannot contain it.
+		return false
+	}
+	return r.from <= other.from && r.to >= other.to
+}
+
+// overlaps reports whether r and other share at least one port.
+func (r portRange) overlaps(other portRange) bool {
+	if r.all || other.all {
+		return true
+	}
+	return r.from <= other.to && other.from <= r.to
+}

--- a/providers/aws/resources/aws_network_cidr_test.go
+++ b/providers/aws/resources/aws_network_cidr_test.go
@@ -1,0 +1,123 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeProtocol(t *testing.T) {
+	assert.Equal(t, protocolTcp, normalizeProtocol("tcp"))
+	assert.Equal(t, protocolTcp, normalizeProtocol("TCP"))
+	assert.Equal(t, protocolTcp, normalizeProtocol("6"))
+	assert.Equal(t, protocolUdp, normalizeProtocol("udp"))
+	assert.Equal(t, protocolIcmp, normalizeProtocol("icmp"))
+	assert.Equal(t, protocolIcmpv6, normalizeProtocol("icmpv6"))
+	assert.Equal(t, protocolIcmpv6, normalizeProtocol("58"))
+
+	// All the ways "every protocol" is spelled.
+	assert.Equal(t, protocolAll, normalizeProtocol("-1"))
+	assert.Equal(t, protocolAll, normalizeProtocol("all"))
+	assert.Equal(t, protocolAll, normalizeProtocol(""))
+
+	// An unrecognized protocol is preserved so two of the same still match.
+	assert.Equal(t, "132", normalizeProtocol("132"))
+}
+
+func TestProtocolCovers(t *testing.T) {
+	assert.True(t, protocolCovers("-1", "tcp"))
+	assert.True(t, protocolCovers("tcp", "tcp"))
+	assert.True(t, protocolCovers("tcp", "6"), "name and number are the same protocol")
+	assert.True(t, protocolCovers("6", "tcp"))
+
+	assert.False(t, protocolCovers("tcp", "udp"))
+	assert.False(t, protocolCovers("tcp", "-1"), "a single protocol cannot cover all protocols")
+	assert.False(t, protocolCovers("icmp", "icmpv6"))
+}
+
+func TestCidrCovers(t *testing.T) {
+	assert.True(t, cidrCovers("0.0.0.0/0", "10.0.0.0/8"))
+	assert.True(t, cidrCovers("10.0.0.0/8", "10.1.0.0/16"))
+	assert.True(t, cidrCovers("10.0.0.0/8", "10.0.0.0/8"), "a range covers itself")
+	assert.True(t, cidrCovers("::/0", "2600:1f18::/56"))
+
+	assert.False(t, cidrCovers("10.0.0.0/8", "0.0.0.0/0"), "a smaller range cannot cover a larger one")
+	assert.False(t, cidrCovers("10.1.0.0/16", "10.2.0.0/16"), "sibling ranges do not cover each other")
+	assert.False(t, cidrCovers("192.168.0.0/16", "10.0.0.0/8"))
+
+	// Address families never overlap. This is the case that made an IPv4
+	// deny-all appear to shadow an IPv6 allow-all.
+	assert.False(t, cidrCovers("0.0.0.0/0", "::/0"))
+	assert.False(t, cidrCovers("::/0", "0.0.0.0/0"))
+
+	// An unrecorded outer source covers anything; an unrecorded inner source
+	// cannot be placed inside a specific range.
+	assert.True(t, cidrCovers("", "10.0.0.0/8"))
+	assert.True(t, cidrCovers("", ""))
+	assert.False(t, cidrCovers("10.0.0.0/8", ""))
+
+	// Unparseable input never matches.
+	assert.False(t, cidrCovers("not-a-cidr", "10.0.0.0/8"))
+	assert.False(t, cidrCovers("10.0.0.0/8", "not-a-cidr"))
+	assert.False(t, cidrCovers("10.0.0.0/33", "10.0.0.0/8"))
+}
+
+func TestCidrsOverlap(t *testing.T) {
+	assert.True(t, cidrsOverlap("0.0.0.0/0", "10.0.0.0/8"))
+	assert.True(t, cidrsOverlap("10.0.0.0/8", "0.0.0.0/0"), "overlap is symmetric")
+	assert.True(t, cidrsOverlap("10.0.0.0/8", "10.1.0.0/16"))
+	assert.True(t, cidrsOverlap("10.0.0.0/8", "10.0.0.0/8"))
+
+	assert.False(t, cidrsOverlap("10.1.0.0/16", "10.2.0.0/16"))
+	assert.False(t, cidrsOverlap("0.0.0.0/0", "::/0"), "different families never overlap")
+	assert.False(t, cidrsOverlap("", "10.0.0.0/8"))
+	assert.False(t, cidrsOverlap("bad", "10.0.0.0/8"))
+}
+
+func TestNewPortRange(t *testing.T) {
+	r := newPortRange(80, 443)
+	assert.Equal(t, int64(80), r.from)
+	assert.Equal(t, int64(443), r.to)
+	assert.False(t, r.all)
+
+	// -1 is how both security groups and network ACLs spell "unset", which for
+	// a protocol with no ports means every port.
+	assert.True(t, newPortRange(-1, -1).all)
+	assert.True(t, newPortRange(-1, 443).all)
+
+	// A reversed range is normalized rather than treated as empty.
+	reversed := newPortRange(443, 80)
+	assert.Equal(t, int64(80), reversed.from)
+	assert.Equal(t, int64(443), reversed.to)
+}
+
+func TestPortRangeCovers(t *testing.T) {
+	all := portRange{all: true}
+	assert.True(t, all.covers(newPortRange(443, 443)))
+	assert.True(t, all.covers(all))
+
+	assert.True(t, newPortRange(0, 65535).covers(newPortRange(443, 443)))
+	assert.True(t, newPortRange(443, 443).covers(newPortRange(443, 443)))
+	assert.True(t, newPortRange(80, 8443).covers(newPortRange(443, 443)))
+
+	assert.False(t, newPortRange(443, 443).covers(newPortRange(80, 443)))
+	assert.False(t, newPortRange(400, 500).covers(newPortRange(443, 8443)))
+	assert.False(t, newPortRange(0, 65535).covers(all), "a bounded range cannot cover all ports")
+}
+
+func TestPortRangeOverlaps(t *testing.T) {
+	all := portRange{all: true}
+	assert.True(t, all.overlaps(newPortRange(443, 443)))
+	assert.True(t, newPortRange(443, 443).overlaps(all))
+
+	assert.True(t, newPortRange(80, 500).overlaps(newPortRange(443, 8443)))
+	assert.True(t, newPortRange(443, 443).overlaps(newPortRange(443, 443)))
+	// Touching at a single port still overlaps.
+	assert.True(t, newPortRange(80, 443).overlaps(newPortRange(443, 8443)))
+
+	assert.False(t, newPortRange(80, 442).overlaps(newPortRange(443, 8443)))
+	assert.False(t, newPortRange(8443, 8443).overlaps(newPortRange(80, 443)))
+}

--- a/providers/aws/resources/aws_network_effective_ingress.go
+++ b/providers/aws/resources/aws_network_effective_ingress.go
@@ -1,0 +1,388 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.mondoo.com/mql/v13/llx"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+)
+
+// mqlAwsEc2NetworkaclEntryInternal holds a back-reference to the entry's own
+// network ACL. Shadowing is a property of an entry relative to its siblings, and
+// an entry otherwise has no way to reach them. The parent's entry list is already
+// resolved by the time an entry exists, so reading it costs no API call.
+type mqlAwsEc2NetworkaclEntryInternal struct {
+	parentAcl *mqlAwsEc2Networkacl
+}
+
+// Network ACL verdicts on a security group rule's traffic.
+const (
+	// naclVerdictAllow means the first matching inbound entry permits the whole
+	// range the security group rule covers.
+	naclVerdictAllow = "allow"
+	// naclVerdictDeny means the first matching entry denies the whole range, or
+	// nothing matches and the implicit final deny applies.
+	naclVerdictDeny = "deny"
+	// naclVerdictPartial means the first matching entry covers only part of the
+	// range, so the remainder falls through to later entries.
+	naclVerdictPartial = "partial"
+	// naclVerdictUnknown means the network ACL could not be read.
+	naclVerdictUnknown = "unknown"
+)
+
+// naclEntrySourceCidr returns the source range of a network ACL entry. An entry
+// carries either an IPv4 or an IPv6 block, never both.
+func naclEntrySourceCidr(entry *mqlAwsEc2NetworkaclEntry) string {
+	if cidr := entry.CidrBlock.Data; cidr != "" {
+		return cidr
+	}
+	return entry.Ipv6CidrBlock.Data
+}
+
+// naclEntryRule converts a network ACL entry resource into the rule shape used
+// for matching. Reading PortRange here is a cached read: it is populated as a
+// creation arg, so this triggers no fetch. Its absence means all ports.
+func naclEntryRule(entry *mqlAwsEc2NetworkaclEntry) naclIngressRule {
+	rule := naclIngressRule{
+		ruleNumber: int(entry.RuleNumber.Data),
+		allow:      strings.EqualFold(entry.RuleAction.Data, "allow"),
+		public:     cidrEntryIsPublic(entry.CidrBlock.Data, entry.Ipv6CidrBlock.Data),
+		protocol:   entry.Protocol.Data,
+		cidr:       naclEntrySourceCidr(entry),
+		allPorts:   true,
+	}
+	if pr := entry.PortRange.Data; pr != nil {
+		rule.fromPort = pr.From.Data
+		rule.toPort = pr.To.Data
+		rule.allPorts = false
+	}
+	return rule
+}
+
+// orderedNaclEntries returns a network ACL's entries for one direction, sorted
+// by rule number ascending, which is the order AWS evaluates them in.
+func orderedNaclEntries(nacl *mqlAwsEc2Networkacl, egress bool) ([]*mqlAwsEc2NetworkaclEntry, error) {
+	entries := nacl.GetEntries()
+	if entries.Error != nil {
+		return nil, entries.Error
+	}
+	res := make([]*mqlAwsEc2NetworkaclEntry, 0, len(entries.Data))
+	for _, e := range entries.Data {
+		entry, ok := e.(*mqlAwsEc2NetworkaclEntry)
+		if !ok || entry.Egress.Data != egress {
+			continue
+		}
+		res = append(res, entry)
+	}
+	sort.SliceStable(res, func(i, j int) bool {
+		return res[i].RuleNumber.Data < res[j].RuleNumber.Data
+	})
+	return res, nil
+}
+
+// trafficRule describes the packets one security group rule admits, in the same
+// shape network ACL entries are matched in.
+func trafficRule(protocol, cidr string, ports portRange) naclIngressRule {
+	traffic := naclIngressRule{protocol: protocol, cidr: cidr}
+	if ports.all {
+		traffic.allPorts = true
+	} else {
+		traffic.fromPort, traffic.toPort = ports.from, ports.to
+	}
+	return traffic
+}
+
+// evaluateNaclIngressRules decides what a network ACL does to the given traffic,
+// returning the verdict and the index of the deciding rule (-1 when none
+// matched). rules must already be ordered by rule number ascending.
+//
+// The first rule matching a packet wins. A rule that fully covers the traffic
+// settles it. A rule that only overlaps settles part of the traffic and leaves
+// the rest to later rules, which is reported as partial rather than guessed at --
+// resolving it properly would mean splitting the range and evaluating each piece,
+// and reporting either "allow" or "deny" for the whole would be wrong.
+//
+// When nothing matches, the network ACL's implicit final deny applies.
+func evaluateNaclIngressRules(rules []naclIngressRule, traffic naclIngressRule) (string, int) {
+	for i, rule := range rules {
+		// Skip rules that cannot apply to this traffic at all. A rule applies
+		// when it and the traffic share a protocol, a source address, and a port.
+		if !protocolCovers(rule.protocol, traffic.protocol) && !protocolCovers(traffic.protocol, rule.protocol) {
+			continue
+		}
+		if !cidrsOverlap(rule.cidr, traffic.cidr) {
+			continue
+		}
+		if !rule.ports().overlaps(traffic.ports()) {
+			continue
+		}
+
+		if rule.covers(traffic) {
+			if rule.allow {
+				return naclVerdictAllow, i
+			}
+			return naclVerdictDeny, i
+		}
+		return naclVerdictPartial, i
+	}
+	return naclVerdictDeny, -1
+}
+
+// securityGroupRuleSources expands one security group ingress rule into the
+// individual source ranges it permits. Security group references and managed
+// prefix lists are skipped: neither resolves to a range a network ACL can be
+// evaluated against without further lookups.
+func securityGroupRuleSources(perm *mqlAwsEc2SecuritygroupIppermission) ([]string, error) {
+	ipRanges := perm.GetIpRanges()
+	if ipRanges.Error != nil {
+		return nil, ipRanges.Error
+	}
+	ipv6Ranges := perm.GetIpv6Ranges()
+	if ipv6Ranges.Error != nil {
+		return nil, ipv6Ranges.Error
+	}
+
+	sources := []string{}
+	for _, list := range [][]any{ipRanges.Data, ipv6Ranges.Data} {
+		for _, r := range list {
+			cidr, ok := r.(string)
+			if !ok || cidr == "" {
+				continue
+			}
+			sources = append(sources, cidr)
+		}
+	}
+	return sources, nil
+}
+
+// effectiveIngress pairs every security group ingress rule reaching this
+// interface with the subnet network ACL's decision on it.
+//
+// Security groups are evaluated as a union -- any rule permitting traffic
+// permits it -- so each rule is reported on its own rather than being merged.
+// The network ACL applies at the subnet boundary, so all rules are evaluated
+// against the same entry list.
+func (a *mqlAwsEc2Networkinterface) effectiveIngress() ([]any, error) {
+	sgs := a.GetSecurityGroups()
+	if sgs.Error != nil {
+		return nil, sgs.Error
+	}
+
+	// An unreadable subnet or network ACL yields the unknown verdict rather than
+	// failing the query: the security group half of the answer is still useful,
+	// and reporting nothing would read as "no exposure".
+	var entries []*mqlAwsEc2NetworkaclEntry
+	var naclRules []naclIngressRule
+	naclReadable := false
+	if subnet := a.GetSubnet(); subnet.Error == nil && subnet.Data != nil {
+		if nacl := subnet.Data.GetNetworkAcl(); nacl.Error == nil && nacl.Data != nil {
+			ordered, err := orderedNaclEntries(nacl.Data, false)
+			if err == nil {
+				entries = ordered
+				naclRules = make([]naclIngressRule, 0, len(entries))
+				for _, entry := range entries {
+					naclRules = append(naclRules, naclEntryRule(entry))
+				}
+				naclReadable = true
+			}
+		}
+	}
+
+	res := []any{}
+	for _, s := range sgs.Data {
+		sg, ok := s.(*mqlAwsEc2Securitygroup)
+		if !ok {
+			continue
+		}
+		perms := sg.GetIpPermissions()
+		if perms.Error != nil {
+			return nil, perms.Error
+		}
+		for _, p := range perms.Data {
+			perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+			if !ok {
+				continue
+			}
+			sources, err := securityGroupRuleSources(perm)
+			if err != nil {
+				return nil, err
+			}
+			protocol := perm.GetIpProtocol()
+			if protocol.Error != nil {
+				return nil, protocol.Error
+			}
+			fromPort := perm.GetFromPort()
+			if fromPort.Error != nil {
+				return nil, fromPort.Error
+			}
+			toPort := perm.GetToPort()
+			if toPort.Error != nil {
+				return nil, toPort.Error
+			}
+			ports := newPortRange(fromPort.Data, toPort.Data)
+
+			for _, source := range sources {
+				verdict := naclVerdictUnknown
+				var matched *mqlAwsEc2NetworkaclEntry
+				if naclReadable {
+					v, idx := evaluateNaclIngressRules(naclRules, trafficRule(protocol.Data, source, ports))
+					verdict = v
+					if idx >= 0 {
+						matched = entries[idx]
+					}
+				}
+
+				mqlRule, err := a.newEffectiveIngress(sg, perm, source, protocol.Data, fromPort.Data, toPort.Data, verdict, matched)
+				if err != nil {
+					return nil, err
+				}
+				res = append(res, mqlRule)
+			}
+		}
+	}
+	return res, nil
+}
+
+// verdictIsReachable reports whether a network ACL verdict lets traffic through.
+//
+// Partial counts as reachable because part of the range does get through, and
+// unknown counts as reachable so a failed read never reports an interface as
+// protected when it may not be.
+func verdictIsReachable(verdict string) bool {
+	return verdict != naclVerdictDeny
+}
+
+func (a *mqlAwsEc2Networkinterface) newEffectiveIngress(
+	sg *mqlAwsEc2Securitygroup,
+	perm *mqlAwsEc2SecuritygroupIppermission,
+	source string,
+	protocol string,
+	fromPort int64,
+	toPort int64,
+	verdict string,
+	matched *mqlAwsEc2NetworkaclEntry,
+) (plugin.Resource, error) {
+	args := map[string]*llx.RawData{
+		"__id":              llx.StringData(fmt.Sprintf("%s/%s/%s/%d-%d/%s", a.Id.Data, sg.Id.Data, protocol, fromPort, toPort, source)),
+		"source":            llx.StringData(source),
+		"protocol":          llx.StringData(protocol),
+		"fromPort":          llx.IntData(fromPort),
+		"toPort":            llx.IntData(toPort),
+		"securityGroup":     llx.ResourceData(sg, sg.MqlName()),
+		"securityGroupRule": llx.ResourceData(perm, perm.MqlName()),
+		"networkAclVerdict": llx.StringData(verdict),
+		"reachable":         llx.BoolData(verdictIsReachable(verdict)),
+	}
+	if matched != nil {
+		args["networkAclEntry"] = llx.ResourceData(matched, matched.MqlName())
+	} else {
+		args["networkAclEntry"] = llx.NilData
+	}
+	return CreateResource(a.MqlRuntime, ResourceAwsNetworkEffectiveIngress, args)
+}
+
+// isShadowed reports whether an earlier entry in the same direction makes this
+// entry unreachable.
+func (a *mqlAwsEc2NetworkaclEntry) isShadowed() (bool, error) {
+	if a.parentAcl == nil {
+		// The entry was built outside its parent's entry list, so there are no
+		// siblings to compare against.
+		return false, nil
+	}
+	entries, err := orderedNaclEntries(a.parentAcl, a.Egress.Data)
+	if err != nil {
+		return false, err
+	}
+
+	self := naclEntryRule(a)
+	for _, other := range entries {
+		candidate := naclEntryRule(other)
+		if candidate.ruleNumber >= self.ruleNumber {
+			// Entries are ordered, so nothing from here on is earlier.
+			break
+		}
+		if candidate.covers(self) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// isUnused reports whether nothing depends on the security group: it is attached
+// to no network interface and no other group in the region references it.
+func (a *mqlAwsEc2Securitygroup) isUnused() (bool, error) {
+	attached := a.GetIsAttachedToNetworkInterface()
+	if attached.Error != nil {
+		return false, attached.Error
+	}
+	if attached.Data {
+		return false, nil
+	}
+
+	referenced, err := a.isReferencedByAnotherSecurityGroup()
+	if err != nil {
+		return false, err
+	}
+	return !referenced, nil
+}
+
+// isReferencedByAnotherSecurityGroup reports whether any other security group in
+// the account allows traffic from this one. Such a group is load-bearing even
+// with no network interfaces of its own.
+func (a *mqlAwsEc2Securitygroup) isReferencedByAnotherSecurityGroup() (bool, error) {
+	obj, err := CreateResource(a.MqlRuntime, ResourceAwsEc2, map[string]*llx.RawData{})
+	if err != nil {
+		return false, err
+	}
+	groups := obj.(*mqlAwsEc2).GetSecurityGroups()
+	if groups.Error != nil {
+		return false, groups.Error
+	}
+
+	selfId := a.Id.Data
+	for _, g := range groups.Data {
+		sg, ok := g.(*mqlAwsEc2Securitygroup)
+		if !ok || sg.Id.Data == selfId {
+			continue
+		}
+		for _, perms := range []*plugin.TValue[[]any]{sg.GetIpPermissions(), sg.GetIpPermissionsEgress()} {
+			if perms.Error != nil {
+				return false, perms.Error
+			}
+			for _, p := range perms.Data {
+				perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+				if !ok {
+					continue
+				}
+				pairs := perm.GetUserIdGroupPairs()
+				if pairs.Error != nil {
+					return false, pairs.Error
+				}
+				if userIdGroupPairsReference(pairs.Data, selfId) {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// userIdGroupPairsReference reports whether a rule's security group references
+// include the given group ID.
+func userIdGroupPairsReference(pairs []any, groupId string) bool {
+	for _, raw := range pairs {
+		pair, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if id, ok := pair["GroupId"].(string); ok && id == groupId {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/aws/resources/aws_network_effective_ingress.go
+++ b/providers/aws/resources/aws_network_effective_ingress.go
@@ -4,9 +4,11 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
@@ -168,6 +170,13 @@ func securityGroupRuleSources(perm *mqlAwsEc2SecuritygroupIppermission) ([]strin
 // The network ACL applies at the subnet boundary, so all rules are evaluated
 // against the same entry list.
 func (a *mqlAwsEc2Networkinterface) effectiveIngress() ([]any, error) {
+	// The interface ID is part of every row's cache key. An empty one would make
+	// rows from different interfaces with matching rules collide and silently
+	// replace each other, so fail loudly instead.
+	if a.Id.Data == "" {
+		return nil, errors.New("cannot evaluate effective ingress: network interface has no id")
+	}
+
 	sgs := a.GetSecurityGroups()
 	if sgs.Error != nil {
 		return nil, sgs.Error
@@ -313,8 +322,66 @@ func (a *mqlAwsEc2NetworkaclEntry) isShadowed() (bool, error) {
 	return false, nil
 }
 
+// mqlAwsEc2Internal memoizes which security groups are referenced by other
+// security groups' rules.
+//
+// Answering that for one group means walking every rule in the account, and
+// isUnused asks it once per group, so deriving it per group would be quadratic in
+// the number of groups. Building the whole reference map once and sharing it
+// through the runtime-cached aws.ec2 singleton makes a full
+// `aws.ec2.securityGroups { isUnused }` sweep a single pass instead.
+type mqlAwsEc2Internal struct {
+	securityGroupRefsOnce sync.Once
+	// securityGroupRefs maps a referenced group ID to the IDs of the groups whose
+	// rules reference it. The referencing IDs are kept rather than collapsed to a
+	// boolean so a group that only references itself is not counted as used.
+	securityGroupRefs    map[string][]string
+	securityGroupRefsErr error
+}
+
+// securityGroupReferences returns the map of referenced group ID to referencing
+// group IDs, computing it once per runtime.
+func (a *mqlAwsEc2) securityGroupReferences() (map[string][]string, error) {
+	a.securityGroupRefsOnce.Do(func() {
+		refs := map[string][]string{}
+		groups := a.GetSecurityGroups()
+		if groups.Error != nil {
+			a.securityGroupRefsErr = groups.Error
+			return
+		}
+		for _, g := range groups.Data {
+			sg, ok := g.(*mqlAwsEc2Securitygroup)
+			if !ok {
+				continue
+			}
+			for _, perms := range []*plugin.TValue[[]any]{sg.GetIpPermissions(), sg.GetIpPermissionsEgress()} {
+				if perms.Error != nil {
+					a.securityGroupRefsErr = perms.Error
+					return
+				}
+				for _, p := range perms.Data {
+					perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
+					if !ok {
+						continue
+					}
+					pairs := perm.GetUserIdGroupPairs()
+					if pairs.Error != nil {
+						a.securityGroupRefsErr = pairs.Error
+						return
+					}
+					for _, referenced := range userIdGroupPairIds(pairs.Data) {
+						refs[referenced] = append(refs[referenced], sg.Id.Data)
+					}
+				}
+			}
+		}
+		a.securityGroupRefs = refs
+	})
+	return a.securityGroupRefs, a.securityGroupRefsErr
+}
+
 // isUnused reports whether nothing depends on the security group: it is attached
-// to no network interface and no other group in the region references it.
+// to no network interface and no other group references it.
 func (a *mqlAwsEc2Securitygroup) isUnused() (bool, error) {
 	attached := a.GetIsAttachedToNetworkInterface()
 	if attached.Error != nil {
@@ -324,65 +391,41 @@ func (a *mqlAwsEc2Securitygroup) isUnused() (bool, error) {
 		return false, nil
 	}
 
-	referenced, err := a.isReferencedByAnotherSecurityGroup()
-	if err != nil {
-		return false, err
-	}
-	return !referenced, nil
-}
-
-// isReferencedByAnotherSecurityGroup reports whether any other security group in
-// the account allows traffic from this one. Such a group is load-bearing even
-// with no network interfaces of its own.
-func (a *mqlAwsEc2Securitygroup) isReferencedByAnotherSecurityGroup() (bool, error) {
 	obj, err := CreateResource(a.MqlRuntime, ResourceAwsEc2, map[string]*llx.RawData{})
 	if err != nil {
 		return false, err
 	}
-	groups := obj.(*mqlAwsEc2).GetSecurityGroups()
-	if groups.Error != nil {
-		return false, groups.Error
+	refs, err := obj.(*mqlAwsEc2).securityGroupReferences()
+	if err != nil {
+		return false, err
 	}
 
-	selfId := a.Id.Data
-	for _, g := range groups.Data {
-		sg, ok := g.(*mqlAwsEc2Securitygroup)
-		if !ok || sg.Id.Data == selfId {
-			continue
-		}
-		for _, perms := range []*plugin.TValue[[]any]{sg.GetIpPermissions(), sg.GetIpPermissionsEgress()} {
-			if perms.Error != nil {
-				return false, perms.Error
-			}
-			for _, p := range perms.Data {
-				perm, ok := p.(*mqlAwsEc2SecuritygroupIppermission)
-				if !ok {
-					continue
-				}
-				pairs := perm.GetUserIdGroupPairs()
-				if pairs.Error != nil {
-					return false, pairs.Error
-				}
-				if userIdGroupPairsReference(pairs.Data, selfId) {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
+	return !referencedByOtherGroup(refs, a.Id.Data), nil
 }
 
-// userIdGroupPairsReference reports whether a rule's security group references
-// include the given group ID.
-func userIdGroupPairsReference(pairs []any, groupId string) bool {
+// referencedByOtherGroup reports whether any group other than groupId itself
+// references it. A group referencing only itself is still unused: nothing else
+// depends on it, so deleting it changes no other group's meaning.
+func referencedByOtherGroup(refs map[string][]string, groupId string) bool {
+	for _, referencingId := range refs[groupId] {
+		if referencingId != groupId {
+			return true
+		}
+	}
+	return false
+}
+
+// userIdGroupPairIds returns the security group IDs a rule's references name.
+func userIdGroupPairIds(pairs []any) []string {
+	ids := []string{}
 	for _, raw := range pairs {
 		pair, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
-		if id, ok := pair["GroupId"].(string); ok && id == groupId {
-			return true
+		if id, ok := pair["GroupId"].(string); ok && id != "" {
+			ids = append(ids, id)
 		}
 	}
-	return false
+	return ids
 }

--- a/providers/aws/resources/aws_network_effective_ingress_test.go
+++ b/providers/aws/resources/aws_network_effective_ingress_test.go
@@ -179,16 +179,39 @@ func TestVerdictIsReachable(t *testing.T) {
 	assert.False(t, verdictIsReachable(naclVerdictDeny))
 }
 
-func TestUserIdGroupPairsReference(t *testing.T) {
+func TestUserIdGroupPairIds(t *testing.T) {
 	pairs := []any{
 		map[string]any{"GroupId": "sg-aaa", "UserId": "123456789012"},
 		map[string]any{"GroupId": "sg-bbb"},
 	}
-	assert.True(t, userIdGroupPairsReference(pairs, "sg-aaa"))
-	assert.True(t, userIdGroupPairsReference(pairs, "sg-bbb"))
-	assert.False(t, userIdGroupPairsReference(pairs, "sg-ccc"))
-	assert.False(t, userIdGroupPairsReference([]any{}, "sg-aaa"))
+	assert.Equal(t, []string{"sg-aaa", "sg-bbb"}, userIdGroupPairIds(pairs))
+	assert.Equal(t, []string{}, userIdGroupPairIds([]any{}))
 
-	// Malformed entries are skipped rather than panicking.
-	assert.False(t, userIdGroupPairsReference([]any{"not-a-map", nil, map[string]any{"GroupId": 42}}, "sg-aaa"))
+	// Malformed entries are skipped rather than panicking, and an empty GroupId
+	// is not a reference.
+	assert.Equal(t, []string{}, userIdGroupPairIds([]any{
+		"not-a-map",
+		nil,
+		map[string]any{"GroupId": 42},
+		map[string]any{"GroupId": ""},
+		map[string]any{"UserId": "123456789012"},
+	}))
+}
+
+func TestReferencedByOtherGroup(t *testing.T) {
+	refs := map[string][]string{
+		"sg-self":  {"sg-self"},
+		"sg-used":  {"sg-self", "sg-other"},
+		"sg-mixed": {"sg-mixed", "sg-other"},
+	}
+
+	// The common "allow from myself" group is still unused when nothing else
+	// points at it.
+	assert.False(t, referencedByOtherGroup(refs, "sg-self"))
+	assert.True(t, referencedByOtherGroup(refs, "sg-used"))
+	assert.True(t, referencedByOtherGroup(refs, "sg-mixed"), "a self-reference does not mask a real one")
+
+	assert.False(t, referencedByOtherGroup(refs, "sg-absent"))
+	assert.False(t, referencedByOtherGroup(map[string][]string{}, "sg-any"))
+	assert.False(t, referencedByOtherGroup(nil, "sg-any"))
 }

--- a/providers/aws/resources/aws_network_effective_ingress_test.go
+++ b/providers/aws/resources/aws_network_effective_ingress_test.go
@@ -1,0 +1,194 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// naclRule builds an ordered network ACL rule for the evaluation tests.
+func naclRule(number int, allow bool, protocol, cidr string, from, to int64) naclIngressRule {
+	r := naclIngressRule{
+		ruleNumber: number,
+		allow:      allow,
+		protocol:   protocol,
+		cidr:       cidr,
+		public:     cidrIsPublic(cidr),
+	}
+	if from < 0 || to < 0 {
+		r.allPorts = true
+	} else {
+		r.fromPort, r.toPort = from, to
+	}
+	return r
+}
+
+func TestEvaluateNaclIngressRules(t *testing.T) {
+	allowAllV4 := naclRule(100, true, "-1", "0.0.0.0/0", -1, -1)
+
+	tests := []struct {
+		name    string
+		rules   []naclIngressRule
+		traffic naclIngressRule
+		verdict string
+		matched int
+	}{
+		{
+			name:    "default allow-all permits everything",
+			rules:   []naclIngressRule{allowAllV4},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)),
+			verdict: naclVerdictAllow,
+			matched: 0,
+		},
+		{
+			name: "narrow deny in front of broad allow denies only its own port",
+			rules: []naclIngressRule{
+				naclRule(90, false, "6", "0.0.0.0/0", 3389, 3389),
+				allowAllV4,
+			},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(3389, 3389)),
+			verdict: naclVerdictDeny,
+			matched: 0,
+		},
+		{
+			name: "traffic on another port falls through the narrow deny",
+			rules: []naclIngressRule{
+				naclRule(90, false, "6", "0.0.0.0/0", 3389, 3389),
+				allowAllV4,
+			},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)),
+			verdict: naclVerdictAllow,
+			matched: 1,
+		},
+		{
+			name:    "nothing matches, so the implicit final deny applies",
+			rules:   []naclIngressRule{naclRule(100, true, "6", "10.0.0.0/8", 443, 443)},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(22, 22)),
+			verdict: naclVerdictDeny,
+			matched: -1,
+		},
+		{
+			name:    "empty rule list denies",
+			rules:   []naclIngressRule{},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)),
+			verdict: naclVerdictDeny,
+			matched: -1,
+		},
+		{
+			name:    "deny narrower than the traffic is partial, not a full deny",
+			rules:   []naclIngressRule{naclRule(90, false, "6", "10.0.0.0/8", -1, -1), allowAllV4},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)),
+			verdict: naclVerdictPartial,
+			matched: 0,
+		},
+		{
+			name:    "allow narrower than the traffic is also partial",
+			rules:   []naclIngressRule{naclRule(100, true, "6", "0.0.0.0/0", 400, 500)},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 8443)),
+			verdict: naclVerdictPartial,
+			matched: 0,
+		},
+		{
+			name:    "a different protocol is skipped entirely",
+			rules:   []naclIngressRule{naclRule(90, false, "17", "0.0.0.0/0", -1, -1), allowAllV4},
+			traffic: trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)),
+			verdict: naclVerdictAllow,
+			matched: 1,
+		},
+		{
+			name:    "a non-overlapping source is skipped entirely",
+			rules:   []naclIngressRule{naclRule(90, false, "-1", "192.168.0.0/16", -1, -1), allowAllV4},
+			traffic: trafficRule("tcp", "10.0.0.0/8", newPortRange(443, 443)),
+			verdict: naclVerdictAllow,
+			matched: 1,
+		},
+		{
+			name:    "a wider deny covers narrower traffic",
+			rules:   []naclIngressRule{naclRule(90, false, "-1", "0.0.0.0/0", -1, -1), allowAllV4},
+			traffic: trafficRule("tcp", "10.1.0.0/16", newPortRange(443, 443)),
+			verdict: naclVerdictDeny,
+			matched: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verdict, idx := evaluateNaclIngressRules(tt.rules, tt.traffic)
+			assert.Equal(t, tt.verdict, verdict)
+			assert.Equal(t, tt.matched, idx)
+		})
+	}
+}
+
+// TestEvaluateNaclIngressAddressFamily pins the fix for a rule set where an IPv4
+// deny used to shadow an IPv6 allow. The two never match the same packet, so the
+// IPv6 traffic must reach the allow.
+func TestEvaluateNaclIngressAddressFamily(t *testing.T) {
+	rules := []naclIngressRule{
+		naclRule(90, false, "-1", "0.0.0.0/0", -1, -1),
+		naclRule(100, true, "-1", "::/0", -1, -1),
+	}
+
+	verdict, idx := evaluateNaclIngressRules(rules, trafficRule("tcp", "::/0", newPortRange(443, 443)))
+	assert.Equal(t, naclVerdictAllow, verdict, "an IPv4 deny must not decide IPv6 traffic")
+	assert.Equal(t, 1, idx)
+
+	// The IPv4 side still denies.
+	verdict, idx = evaluateNaclIngressRules(rules, trafficRule("tcp", "0.0.0.0/0", newPortRange(443, 443)))
+	assert.Equal(t, naclVerdictDeny, verdict)
+	assert.Equal(t, 0, idx)
+}
+
+// TestNaclAllowsPublicIngressAddressFamily covers the same fix through the
+// existing public-reachability entry point.
+func TestNaclAllowsPublicIngressAddressFamily(t *testing.T) {
+	assert.True(t, naclAllowsPublicIngress([]naclIngressRule{
+		naclRule(90, false, "-1", "0.0.0.0/0", -1, -1),
+		naclRule(100, true, "-1", "::/0", -1, -1),
+	}), "an IPv4 deny-all does not shadow an IPv6 allow-all")
+
+	// Same family still shadows.
+	assert.False(t, naclAllowsPublicIngress([]naclIngressRule{
+		naclRule(90, false, "-1", "0.0.0.0/0", -1, -1),
+		naclRule(100, true, "-1", "0.0.0.0/0", -1, -1),
+	}))
+}
+
+func TestNaclIngressRuleCovers(t *testing.T) {
+	broad := naclRule(100, true, "-1", "0.0.0.0/0", -1, -1)
+	narrow := naclRule(200, true, "6", "10.0.0.0/8", 443, 443)
+
+	assert.True(t, broad.covers(narrow))
+	assert.False(t, narrow.covers(broad))
+	assert.True(t, narrow.covers(narrow))
+
+	// Same protocol and ports, but a source that does not contain the other.
+	a := naclRule(100, true, "6", "10.1.0.0/16", 443, 443)
+	b := naclRule(200, true, "6", "10.2.0.0/16", 443, 443)
+	assert.False(t, a.covers(b))
+	assert.False(t, b.covers(a))
+}
+
+func TestVerdictIsReachable(t *testing.T) {
+	assert.True(t, verdictIsReachable(naclVerdictAllow))
+	assert.True(t, verdictIsReachable(naclVerdictPartial), "part of the range gets through")
+	assert.True(t, verdictIsReachable(naclVerdictUnknown), "an unread ACL must not read as protected")
+	assert.False(t, verdictIsReachable(naclVerdictDeny))
+}
+
+func TestUserIdGroupPairsReference(t *testing.T) {
+	pairs := []any{
+		map[string]any{"GroupId": "sg-aaa", "UserId": "123456789012"},
+		map[string]any{"GroupId": "sg-bbb"},
+	}
+	assert.True(t, userIdGroupPairsReference(pairs, "sg-aaa"))
+	assert.True(t, userIdGroupPairsReference(pairs, "sg-bbb"))
+	assert.False(t, userIdGroupPairsReference(pairs, "sg-ccc"))
+	assert.False(t, userIdGroupPairsReference([]any{}, "sg-aaa"))
+
+	// Malformed entries are skipped rather than panicking.
+	assert.False(t, userIdGroupPairsReference([]any{"not-a-map", nil, map[string]any{"GroupId": 42}}, "sg-aaa"))
+}


### PR DESCRIPTION
## Why

A security group and a network ACL both have to permit inbound traffic before it reaches an interface, but the provider only ever consults the security group. So a world-open SG rule that a network ACL blocks reads identically to one that is genuinely reachable — a false positive, which erodes trust in a finding faster than a miss does.

## What

### `aws.ec2.networkinterface.effectiveIngress()`

New `aws.network.effectiveIngress` resource, one row per (security group rule × source range), each carrying the network ACL's decision on that traffic:

| verdict | meaning |
|---|---|
| `allow` | the first matching inbound entry permits the whole range |
| `deny` | the first matching entry denies the whole range, or nothing matches and the implicit final deny applies |
| `partial` | the deciding entry covers only part of the range; the remainder falls through to later entries |
| `unknown` | the network ACL could not be read |

Plus typed `securityGroup`, `securityGroupRule`, and the first matching `networkAclEntry`, so a finding can show *why*.

```
aws.ec2.networkinterfaces.where(publicIp != "") {
  id
  effectiveIngress.where(reachable && source == "0.0.0.0/0") { protocol fromPort toPort networkAclVerdict }
}
```

### `aws.ec2.securitygroup.isUnused()`

Attached to no network interface **and** referenced by no other group's rules. Attachment alone isn't the answer — a group with no interfaces of its own is still load-bearing when another group allows traffic from it, and deleting it changes that group's meaning.

### `aws.ec2.networkacl.entry.isShadowed()`

An earlier same-direction entry matches every packet this one would, so it can never be the first match. Rule number alone doesn't establish this: a narrow deny in front of a broad allow shadows only its own protocol, source, and ports.

## Drive-by bug fix

The provider already had a `naclIngressRule` model with first-match-wins ordering, so I extended it rather than adding a second evaluator. Doing so surfaced a latent bug: `covers()` compared protocol and ports but **not the source range**, so in

```
rule  90 DENY  0.0.0.0/0 all
rule 100 ALLOW ::/0      all
```

the IPv4 deny shadowed the IPv6 allow and `naclAllowsPublicIngress` returned `false`. Those rules never match the same packet. Fixed by making `covers()` CIDR- and address-family-aware; regression test in `TestNaclAllowsPublicIngressAddressFamily`.

## Design decisions worth a look

- **`partial` is surfaced, not resolved.** Fully resolving it means splitting the range and evaluating each piece. Reporting `allow` or `deny` for the whole range would be wrong in one direction or the other, so the ambiguity is named instead of guessed at.
- **`unknown` and `partial` both count as `reachable`.** A failed network ACL read must never make an interface look protected. Same safe direction as `buildNetworkExposure`'s existing handling of an unenumerable security group list.
- **SG-reference and prefix-list sources are excluded** from `effectiveIngress`, since neither resolves to a range a network ACL can be evaluated against without further lookups. Stated on the field doc so the omission is visible rather than silent.
- **`isUnused` scans the account's security groups** to find references. That list is a runtime-cached singleton (same pattern as `aws.ec2.instance.loadBalancers()`), so it is one enumeration regardless of how many groups are checked.
- **`evaluateNaclIngressRules` works on rule data, not resources**, so the core matching logic is unit-testable without a runtime.

## Testing

- `go build ./...`, `go vet`, full `go test ./resources/` pass; `gofmt` clean.
- New unit tests: CIDR containment/overlap incl. family separation and unparseable input, port-range covers/overlaps incl. the reversed and unset forms, protocol name↔number normalization, 10 table-driven `evaluateNaclIngressRules` cases (narrow-deny-before-broad-allow both ways, implicit final deny, partial in both directions, protocol and source skips), and the address-family regression.
- **No new IAM permissions** — permissions manifest unchanged at 990. Composes entirely from existing accessors.

**Not yet live-verified.** Queued for the next batched live-verification run.
