### PR TITLE
✨ aws: flag unrestricted VPC endpoint policies, type endpoint subnets

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -737,8 +737,22 @@ private aws.vpc.endpoint @defaults("id type region") {
   policyDocument string
   // Parsed statements from the endpoint policy
   policyStatements() []aws.iam.policyStatement
-  // Subnets for the (interface) endpoint
-  subnets []string
+  // Whether the endpoint policy leaves access unrestricted
+  //
+  // True when an Allow statement grants a wildcard action or a wildcard
+  // resource, which is what the default endpoint policy does. An unrestricted
+  // endpoint lets anything in the VPC that can route to it reach any resource
+  // the service offers, including buckets and tables in other accounts, so the
+  // endpoint stops being a boundary and becomes an egress path. A restrictive
+  // policy naming specific resources and principals is what makes an endpoint
+  // a control.
+  hasWildcardPolicy() bool
+  // Subnet IDs for the (interface) endpoint
+  //
+  // Deprecated in favor of `subnetRefs`.
+  subnets @maturity("deprecated") []string
+  // Subnets the (interface) endpoint places network interfaces in
+  subnetRefs() []aws.vpc.subnet
   // Whether to associate a private hosted zone with the specified VPC
   privateDnsEnabled bool
   // VPC endpoint state

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -5457,8 +5457,14 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.vpc.endpoint.policyStatements": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetPolicyStatements()).ToDataRes(types.Array(types.Resource("aws.iam.policyStatement")))
 	},
+	"aws.vpc.endpoint.hasWildcardPolicy": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcEndpoint).GetHasWildcardPolicy()).ToDataRes(types.Bool)
+	},
 	"aws.vpc.endpoint.subnets": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetSubnets()).ToDataRes(types.Array(types.String))
+	},
+	"aws.vpc.endpoint.subnetRefs": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsVpcEndpoint).GetSubnetRefs()).ToDataRes(types.Array(types.Resource("aws.vpc.subnet")))
 	},
 	"aws.vpc.endpoint.privateDnsEnabled": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsVpcEndpoint).GetPrivateDnsEnabled()).ToDataRes(types.Bool)
@@ -36756,8 +36762,16 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsVpcEndpoint).PolicyStatements, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.vpc.endpoint.hasWildcardPolicy": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcEndpoint).HasWildcardPolicy, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
 	"aws.vpc.endpoint.subnets": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsVpcEndpoint).Subnets, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"aws.vpc.endpoint.subnetRefs": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsVpcEndpoint).SubnetRefs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
 	"aws.vpc.endpoint.privateDnsEnabled": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -83487,7 +83501,9 @@ type mqlAwsVpcEndpoint struct {
 	ServiceName       plugin.TValue[string]
 	PolicyDocument    plugin.TValue[string]
 	PolicyStatements  plugin.TValue[[]any]
+	HasWildcardPolicy plugin.TValue[bool]
 	Subnets           plugin.TValue[[]any]
+	SubnetRefs        plugin.TValue[[]any]
 	PrivateDnsEnabled plugin.TValue[bool]
 	State             plugin.TValue[string]
 	CreatedAt         plugin.TValue[*time.Time]
@@ -83584,8 +83600,30 @@ func (c *mqlAwsVpcEndpoint) GetPolicyStatements() *plugin.TValue[[]any] {
 	})
 }
 
+func (c *mqlAwsVpcEndpoint) GetHasWildcardPolicy() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.HasWildcardPolicy, func() (bool, error) {
+		return c.hasWildcardPolicy()
+	})
+}
+
 func (c *mqlAwsVpcEndpoint) GetSubnets() *plugin.TValue[[]any] {
 	return &c.Subnets
+}
+
+func (c *mqlAwsVpcEndpoint) GetSubnetRefs() *plugin.TValue[[]any] {
+	return plugin.GetOrCompute[[]any](&c.SubnetRefs, func() ([]any, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.vpc.endpoint", c.__id, "subnetRefs")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.([]any), nil
+			}
+		}
+
+		return c.subnetRefs()
+	})
 }
 
 func (c *mqlAwsVpcEndpoint) GetPrivateDnsEnabled() *plugin.TValue[bool] {

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -10573,6 +10573,7 @@ aws.vpc.endpoint 11.15.2
 aws.vpc.endpoint.arn 13.44.1
 aws.vpc.endpoint.createdAt 11.15.2
 aws.vpc.endpoint.dnsEntries 13.6.3
+aws.vpc.endpoint.hasWildcardPolicy 13.52.2
 aws.vpc.endpoint.id 11.15.2
 aws.vpc.endpoint.ipAddressType 13.6.3
 aws.vpc.endpoint.networkInterfaces 13.6.3
@@ -10586,6 +10587,7 @@ aws.vpc.endpoint.routeTables 13.6.3
 aws.vpc.endpoint.securityGroups 13.6.3
 aws.vpc.endpoint.serviceName 11.15.2
 aws.vpc.endpoint.state 11.15.2
+aws.vpc.endpoint.subnetRefs 13.52.2
 aws.vpc.endpoint.subnets 11.15.2
 aws.vpc.endpoint.tags 13.6.3
 aws.vpc.endpoint.type 11.15.2

--- a/providers/aws/resources/aws_vpc.go
+++ b/providers/aws/resources/aws_vpc.go
@@ -430,6 +430,7 @@ type mqlAwsVpcEndpointInternal struct {
 	securityGroupIdHandler
 	cacheRouteTableIds       []string
 	cacheNetworkInterfaceIds []string
+	cacheSubnetIds           []string
 	cacheEndpointId          string
 	region                   string
 	accountID                string
@@ -499,6 +500,9 @@ func (a *mqlAwsVpc) endpoints() ([]any, error) {
 			ep.region = a.Region.Data
 			ep.accountID = conn.AccountId()
 			ep.cacheEndpointId = convert.ToValue(endpoint.VpcEndpointId)
+			// Cached separately from the deprecated subnets field so subnetRefs
+			// does not depend on a field that is due for removal.
+			ep.cacheSubnetIds = endpoint.SubnetIds
 
 			// Cache security group ARNs
 			sgArns := make([]string, len(endpoint.Groups))
@@ -1418,6 +1422,20 @@ func initAwsVpcSubnet(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	}
 
 	conn := runtime.Connection.(*connection.AwsConnection)
+
+	// Reuse a subnet already listed before spending a DescribeSubnets call. The
+	// subnet ARN is its cache key, so resolving several references to subnets in
+	// one VPC costs one API call rather than one per reference.
+	cacheArn := arnValue
+	if cacheArn == "" && region != "" {
+		cacheArn = fmt.Sprintf(subnetArnPattern, region, conn.AccountId(), subnetId)
+	}
+	if cacheArn != "" {
+		if cached, ok := runtime.Resources.Get(ResourceAwsVpcSubnet + "\x00" + cacheArn); ok {
+			return args, cached, nil
+		}
+	}
+
 	svc := conn.Ec2(region)
 	ctx := context.Background()
 	subnets, err := svc.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{Filters: []vpctypes.Filter{{Name: aws.String("subnet-id"), Values: []string{subnetId}}}})
@@ -2071,6 +2089,36 @@ func (a *mqlAwsVpcEndpoint) routeTables() ([]any, error) {
 		rts = append(rts, mqlRt)
 	}
 	return rts, nil
+}
+
+// subnetRefs resolves the endpoint's subnet IDs to typed subnet resources.
+func (a *mqlAwsVpcEndpoint) subnetRefs() ([]any, error) {
+	conn := a.MqlRuntime.Connection.(*connection.AwsConnection)
+	subnets := []any{}
+	for _, subnetId := range a.cacheSubnetIds {
+		if subnetId == "" {
+			continue
+		}
+		mqlSubnet, err := NewResource(a.MqlRuntime, ResourceAwsVpcSubnet,
+			map[string]*llx.RawData{
+				"arn": llx.StringData(fmt.Sprintf(subnetArnPattern, a.region, conn.AccountId(), subnetId)),
+			})
+		if err != nil {
+			return nil, err
+		}
+		subnets = append(subnets, mqlSubnet)
+	}
+	return subnets, nil
+}
+
+// hasWildcardPolicy reports whether the endpoint policy leaves access
+// unrestricted, which is what the default policy AWS attaches does.
+func (a *mqlAwsVpcEndpoint) hasWildcardPolicy() (bool, error) {
+	statements := a.GetPolicyStatements()
+	if statements.Error != nil {
+		return false, statements.Error
+	}
+	return statementsAllowWildcard(statements.Data)
 }
 
 func (a *mqlAwsVpcEndpoint) networkInterfaces() ([]any, error) {


### PR DESCRIPTION
## What

### `aws.vpc.endpoint.hasWildcardPolicy()`

The endpoint already exposed `policyDocument` and `policyStatements()`, but nothing derived a verdict from them. True when an Allow statement grants a wildcard action or a wildcard resource — which is exactly what the default policy AWS attaches to a new endpoint does.

Worth being precise about why this matters, because the risk is **not** internet exposure: a VPC endpoint is only reachable from inside the VPC. An unrestricted endpoint policy means anything in the VPC that can route to the endpoint can reach *any* resource the service offers, including buckets and tables in other accounts. That makes the endpoint an egress path rather than a boundary. A policy naming specific resources and principals is what turns it into a control.

Reuses the existing `statementsAllowWildcard` helper, so it decides the same question the same way `aws.iam.policy.hasWildcardAllow` does.

> I originally scoped this as `hasWildcardPolicy()` **and** `isPublic()`. Dropped `isPublic()` — the ~20 other resources carrying it mean "reachable from the internet", and a VPC endpoint never is. Reusing the name here would have made a fleet-wide `isPublic` query silently wrong.

### `aws.vpc.endpoint.subnetRefs()`

Typed `[]aws.vpc.subnet`, so an endpoint can be walked to the subnets it places interfaces in — and from there, with #9562, to what actually reaches those interfaces.

The raw `subnets []string` becomes `@maturity("deprecated")` rather than changing type in place, which would break consumers. `subnetRefs` follows the existing `sslPolicyRef` / `taskDefinitionRef` convention for a typed ref whose clean name is already occupied by the shipped raw field.

## Implementation notes

- **The subnet IDs are cached on the Internal struct**, not read back out of the deprecated field. A typed accessor that feeds off the raw field it deprecates is what makes the eventual removal load-bearing; caching separately means deleting `subnets` in a future major is a one-line change.
- **`initAwsVpcSubnet` is now cache-aware.** It checks the runtime cache for the subnet ARN before calling `DescribeSubnets`, matching the convention the typed route next-hops established. Resolving several references to subnets in one VPC is now one API call instead of one per reference. This also speeds up the pre-existing `natGateway()` / route-association paths that resolve subnets by ID.

## Testing

- `go build ./...`, `go vet`, full `go test ./resources/` pass; `gofmt` clean.
- No new unit tests: `hasWildcardPolicy` delegates to the already-tested `statementsAllowWildcard`, and `subnetRefs` is a thin resolver. There is no new pure-Go logic in this change.
- `.lr.versions`: 2 new entries at 13.52.2. `aws.vpc.endpoint.subnets` correctly **stays** at 11.15.2 — deprecating a field does not bump its version.
- **No new IAM permissions** — manifest unchanged at 990.

**Not yet live-verified.** Queued for the next batched live-verification run.
