### PR TITLE
✨ aws: extend exposure() to EKS, ECS services, App Runner, and SageMaker notebooks

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -3386,6 +3386,14 @@ private aws.sagemaker.notebookinstance @defaults("arn name") {
   name string
   // Details about the notebook
   details() aws.sagemaker.notebookinstancedetails
+  // Internet exposure of the notebook instance
+  //
+  // Combines the direct-internet-access setting with the security groups the
+  // instance runs behind. A notebook with direct internet access reaches the
+  // internet through a SageMaker-managed path outside the VPC, which is how a
+  // notebook holding credentials and training data becomes an exfiltration
+  // route.
+  exposure() aws.network.exposure
   // Region where the notebook instance exists
   region string
   // Tags for the notebook instance
@@ -9078,6 +9086,14 @@ private aws.ecs.service @defaults("arn name clusterArn status") {
   deploymentConfiguration() aws.ecs.service.deploymentConfiguration
   // Network configuration for the service
   networkConfiguration() aws.ecs.service.networkConfiguration
+  // Internet exposure of tasks the service runs
+  //
+  // Combines the awsvpc public-IP assignment with the security groups the tasks
+  // launch with. A service that assigns public IPs puts every task it starts
+  // directly on the internet, so the security groups are the only filter left.
+  // Null for a service using host or bridge networking, where the container
+  // instance decides reachability instead.
+  exposure() aws.network.exposure
   // Tags associated with the service
   tags map[string]string
   // Creation timestamp of the service
@@ -20099,6 +20115,13 @@ aws.eks.cluster @defaults("arn version status") {
   endpointPrivateAccess() bool
   // CIDR blocks allowed to access the public Kubernetes API endpoint
   publicAccessCidrs() []string
+  // Internet exposure of the Kubernetes API server endpoint
+  //
+  // Combines the public-endpoint setting with the cluster security groups. Read
+  // it together with `publicAccessCidrs`: that field narrows a public endpoint
+  // to specific source ranges, so a cluster reporting internetReachable may
+  // still answer only a short allow-list rather than the whole internet.
+  exposure() aws.network.exposure
   // List of EKS access entries for RBAC
   accessEntries() []aws.eks.accessEntry
   // List of EKS Fargate profiles
@@ -22296,6 +22319,13 @@ private aws.apprunner.service @defaults("serviceName status region") {
   vpcConnector() aws.apprunner.vpcConnector
   // Whether the service is reachable from the public internet
   isPubliclyAccessible() bool
+  // Internet exposure of the service endpoint
+  //
+  // App Runner services are not gated by security groups on the inbound side, so
+  // this reduces to the public-accessibility setting. It exists so an App Runner
+  // service answers the same exposure query as the rest of the account's
+  // internet-facing resources.
+  exposure() aws.network.exposure
   // IP address type of the service: IPV4 or DUAL_STACK
   ipAddressType() string
   // Observability configuration bound to the service when observability is enabled, null otherwise

--- a/providers/aws/resources/aws.lr.go
+++ b/providers/aws/resources/aws.lr.go
@@ -8032,6 +8032,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.sagemaker.notebookinstance.details": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerNotebookinstance).GetDetails()).ToDataRes(types.Resource("aws.sagemaker.notebookinstancedetails"))
 	},
+	"aws.sagemaker.notebookinstance.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsSagemakerNotebookinstance).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.sagemaker.notebookinstance.region": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsSagemakerNotebookinstance).GetRegion()).ToDataRes(types.String)
 	},
@@ -14127,6 +14130,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.ecs.service.networkConfiguration": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetNetworkConfiguration()).ToDataRes(types.Resource("aws.ecs.service.networkConfiguration"))
+	},
+	"aws.ecs.service.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEcsService).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.ecs.service.tags": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEcsService).GetTags()).ToDataRes(types.Map(types.String, types.String))
@@ -25339,6 +25345,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"aws.eks.cluster.publicAccessCidrs": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetPublicAccessCidrs()).ToDataRes(types.Array(types.String))
 	},
+	"aws.eks.cluster.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsEksCluster).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
+	},
 	"aws.eks.cluster.accessEntries": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsEksCluster).GetAccessEntries()).ToDataRes(types.Array(types.Resource("aws.eks.accessEntry")))
 	},
@@ -27669,6 +27678,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"aws.apprunner.service.isPubliclyAccessible": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApprunnerService).GetIsPubliclyAccessible()).ToDataRes(types.Bool)
+	},
+	"aws.apprunner.service.exposure": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlAwsApprunnerService).GetExposure()).ToDataRes(types.Resource("aws.network.exposure"))
 	},
 	"aws.apprunner.service.ipAddressType": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlAwsApprunnerService).GetIpAddressType()).ToDataRes(types.String)
@@ -40625,6 +40637,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsSagemakerNotebookinstance).Details, ok = plugin.RawToTValue[*mqlAwsSagemakerNotebookinstancedetails](v.Value, v.Error)
 		return
 	},
+	"aws.sagemaker.notebookinstance.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsSagemakerNotebookinstance).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.sagemaker.notebookinstance.region": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsSagemakerNotebookinstance).Region, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -49487,6 +49503,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.ecs.service.networkConfiguration": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEcsService).NetworkConfiguration, ok = plugin.RawToTValue[*mqlAwsEcsServiceNetworkConfiguration](v.Value, v.Error)
+		return
+	},
+	"aws.ecs.service.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEcsService).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.ecs.service.tags": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -65817,6 +65837,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlAwsEksCluster).PublicAccessCidrs, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
 	},
+	"aws.eks.cluster.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsEksCluster).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
+		return
+	},
 	"aws.eks.cluster.accessEntries": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsEksCluster).AccessEntries, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
 		return
@@ -69143,6 +69167,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"aws.apprunner.service.isPubliclyAccessible": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlAwsApprunnerService).IsPubliclyAccessible, ok = plugin.RawToTValue[bool](v.Value, v.Error)
+		return
+	},
+	"aws.apprunner.service.exposure": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlAwsApprunnerService).Exposure, ok = plugin.RawToTValue[*mqlAwsNetworkExposure](v.Value, v.Error)
 		return
 	},
 	"aws.apprunner.service.ipAddressType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -94271,6 +94299,7 @@ type mqlAwsSagemakerNotebookinstance struct {
 	Arn                        plugin.TValue[string]
 	Name                       plugin.TValue[string]
 	Details                    plugin.TValue[*mqlAwsSagemakerNotebookinstancedetails]
+	Exposure                   plugin.TValue[*mqlAwsNetworkExposure]
 	Region                     plugin.TValue[string]
 	Tags                       plugin.TValue[map[string]any]
 	CloudformationStack        plugin.TValue[*mqlAwsCloudformationStack]
@@ -94343,6 +94372,22 @@ func (c *mqlAwsSagemakerNotebookinstance) GetDetails() *plugin.TValue[*mqlAwsSag
 		}
 
 		return c.details()
+	})
+}
+
+func (c *mqlAwsSagemakerNotebookinstance) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.sagemaker.notebookinstance", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -116991,6 +117036,7 @@ type mqlAwsEcsService struct {
 	LaunchType                    plugin.TValue[string]
 	DeploymentConfiguration       plugin.TValue[*mqlAwsEcsServiceDeploymentConfiguration]
 	NetworkConfiguration          plugin.TValue[*mqlAwsEcsServiceNetworkConfiguration]
+	Exposure                      plugin.TValue[*mqlAwsNetworkExposure]
 	Tags                          plugin.TValue[map[string]any]
 	CreatedAt                     plugin.TValue[*time.Time]
 	CreatedBy                     plugin.TValue[string]
@@ -117142,6 +117188,22 @@ func (c *mqlAwsEcsService) GetNetworkConfiguration() *plugin.TValue[*mqlAwsEcsSe
 		}
 
 		return c.networkConfiguration()
+	})
+}
+
+func (c *mqlAwsEcsService) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.ecs.service", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -158570,6 +158632,7 @@ type mqlAwsEksCluster struct {
 	EndpointPublicAccess    plugin.TValue[bool]
 	EndpointPrivateAccess   plugin.TValue[bool]
 	PublicAccessCidrs       plugin.TValue[[]any]
+	Exposure                plugin.TValue[*mqlAwsNetworkExposure]
 	AccessEntries           plugin.TValue[[]any]
 	FargateProfiles         plugin.TValue[[]any]
 	PodIdentityAssociations plugin.TValue[[]any]
@@ -158829,6 +158892,22 @@ func (c *mqlAwsEksCluster) GetEndpointPrivateAccess() *plugin.TValue[bool] {
 func (c *mqlAwsEksCluster) GetPublicAccessCidrs() *plugin.TValue[[]any] {
 	return plugin.GetOrCompute[[]any](&c.PublicAccessCidrs, func() ([]any, error) {
 		return c.publicAccessCidrs()
+	})
+}
+
+func (c *mqlAwsEksCluster) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.eks.cluster", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 
@@ -166714,6 +166793,7 @@ type mqlAwsApprunnerService struct {
 	EgressType                 plugin.TValue[string]
 	VpcConnector               plugin.TValue[*mqlAwsApprunnerVpcConnector]
 	IsPubliclyAccessible       plugin.TValue[bool]
+	Exposure                   plugin.TValue[*mqlAwsNetworkExposure]
 	IpAddressType              plugin.TValue[string]
 	ObservabilityConfiguration plugin.TValue[*mqlAwsApprunnerObservabilityConfiguration]
 	AutoScalingConfiguration   plugin.TValue[*mqlAwsApprunnerAutoScalingConfiguration]
@@ -166861,6 +166941,22 @@ func (c *mqlAwsApprunnerService) GetVpcConnector() *plugin.TValue[*mqlAwsApprunn
 func (c *mqlAwsApprunnerService) GetIsPubliclyAccessible() *plugin.TValue[bool] {
 	return plugin.GetOrCompute[bool](&c.IsPubliclyAccessible, func() (bool, error) {
 		return c.isPubliclyAccessible()
+	})
+}
+
+func (c *mqlAwsApprunnerService) GetExposure() *plugin.TValue[*mqlAwsNetworkExposure] {
+	return plugin.GetOrCompute[*mqlAwsNetworkExposure](&c.Exposure, func() (*mqlAwsNetworkExposure, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("aws.apprunner.service", c.__id, "exposure")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlAwsNetworkExposure), nil
+			}
+		}
+
+		return c.exposure()
 	})
 }
 

--- a/providers/aws/resources/aws.lr.versions
+++ b/providers/aws/resources/aws.lr.versions
@@ -472,6 +472,7 @@ aws.apprunner.service.autoScalingConfiguration 13.26.3
 aws.apprunner.service.createdAt 13.26.3
 aws.apprunner.service.deletedAt 13.26.3
 aws.apprunner.service.egressType 13.26.3
+aws.apprunner.service.exposure 13.52.2
 aws.apprunner.service.healthCheckConfiguration 13.26.3
 aws.apprunner.service.instanceCpu 13.26.3
 aws.apprunner.service.instanceMemory 13.26.3
@@ -4109,6 +4110,7 @@ aws.ecs.service.deploymentController 13.29.1
 aws.ecs.service.desiredCount 11.15.2
 aws.ecs.service.enableEcsManagedTags 11.15.2
 aws.ecs.service.enableExecuteCommand 11.15.2
+aws.ecs.service.exposure 13.52.2
 aws.ecs.service.healthCheckGracePeriodSeconds 11.15.2
 aws.ecs.service.iamRole 13.29.1
 aws.ecs.service.launchType 11.15.2
@@ -4415,6 +4417,7 @@ aws.eks.cluster.encryptionResources 13.12.1
 aws.eks.cluster.endpoint 11.15.2
 aws.eks.cluster.endpointPrivateAccess 11.15.2
 aws.eks.cluster.endpointPublicAccess 11.15.2
+aws.eks.cluster.exposure 13.52.2
 aws.eks.cluster.fargateProfiles 13.6.3
 aws.eks.cluster.health 13.12.1
 aws.eks.cluster.iamRole 11.15.2
@@ -9499,6 +9502,7 @@ aws.sagemaker.notebookinstance.cloudformationStack 13.39.2
 aws.sagemaker.notebookinstance.createdAt 11.16.1
 aws.sagemaker.notebookinstance.defaultCodeRepository 13.12.0
 aws.sagemaker.notebookinstance.details 11.15.2
+aws.sagemaker.notebookinstance.exposure 13.52.2
 aws.sagemaker.notebookinstance.instanceType 13.12.0
 aws.sagemaker.notebookinstance.lastModifiedAt 11.16.1
 aws.sagemaker.notebookinstance.lifecycleConfigName 13.12.0

--- a/providers/aws/resources/aws_network_exposure.go
+++ b/providers/aws/resources/aws_network_exposure.go
@@ -4,6 +4,10 @@
 package resources
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -93,6 +97,15 @@ func buildNetworkExposure(runtime *plugin.Runtime, id string, publiclyAccessible
 		return nil, err
 	}
 	return res.(*mqlAwsNetworkExposure), nil
+}
+
+// buildNetworkExposureFromGroups is buildNetworkExposure for callers holding
+// already-resolved security groups rather than a lazily-fetched field.
+func buildNetworkExposureFromGroups(runtime *plugin.Runtime, id string, publiclyAccessible bool, sgs []any) (*mqlAwsNetworkExposure, error) {
+	return buildNetworkExposure(runtime, id, publiclyAccessible, &plugin.TValue[[]any]{
+		Data:  sgs,
+		State: plugin.StateIsSet,
+	})
 }
 
 func (a *mqlAwsRdsDbinstance) exposure() (*mqlAwsNetworkExposure, error) {
@@ -208,6 +221,128 @@ func buildVpcOnlyExposure(a interface {
 
 func (a *mqlAwsDocumentdbCluster) exposure() (*mqlAwsNetworkExposure, error) {
 	return buildVpcOnlyExposure(a, a.MqlRuntime)
+}
+
+// exposure reports the internet exposure of the cluster's Kubernetes API server
+// endpoint. publicAccessCidrs can narrow a public endpoint to specific source
+// ranges; it is left on the cluster rather than folded in here, so a caller sees
+// both the verdict and the allow-list.
+func (a *mqlAwsEksCluster) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publicAccess := a.GetEndpointPublicAccess()
+	if publicAccess.Error != nil {
+		return nil, publicAccess.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publicAccess.Data, a.GetClusterSecurityGroups())
+}
+
+// exposure reports the internet exposure of tasks the service runs.
+//
+// Only awsvpc networking carries a public-IP assignment and task-level security
+// groups. A service using host or bridge networking has neither, and its
+// reachability is decided by the container instance, so exposure is null rather
+// than a verdict about the wrong thing.
+func (a *mqlAwsEcsService) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+
+	netConfig := a.GetNetworkConfiguration()
+	if netConfig.Error != nil {
+		return nil, netConfig.Error
+	}
+	if netConfig.Data == nil {
+		a.Exposure.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	vpcConfig := netConfig.Data.GetAwsVpcConfiguration()
+	if vpcConfig.Error != nil {
+		return nil, vpcConfig.Error
+	}
+	if vpcConfig.Data == nil {
+		a.Exposure.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+
+	assignPublicIp := vpcConfig.Data.GetAssignPublicIp()
+	if assignPublicIp.Error != nil {
+		return nil, assignPublicIp.Error
+	}
+	sgIds := vpcConfig.Data.GetSecurityGroups()
+	if sgIds.Error != nil {
+		return nil, sgIds.Error
+	}
+
+	sgs, err := resolveSecurityGroupsByIdInArnScope(a.MqlRuntime, arn.Data, sgIds.Data)
+	if err != nil {
+		return nil, err
+	}
+	return buildNetworkExposureFromGroups(a.MqlRuntime, arn.Data+"/exposure",
+		strings.EqualFold(assignPublicIp.Data, "ENABLED"), sgs)
+}
+
+// resolveSecurityGroupsByIdInArnScope turns bare security group IDs into typed
+// resources, taking the region and account from a sibling ARN. Services that
+// store group IDs rather than ARNs have no other way to name the scope.
+func resolveSecurityGroupsByIdInArnScope(runtime *plugin.Runtime, scopeArn string, sgIds []any) ([]any, error) {
+	parsed, err := arn.Parse(scopeArn)
+	if err != nil {
+		return nil, err
+	}
+	handler := securityGroupIdHandler{}
+	arns := make([]string, 0, len(sgIds))
+	for _, raw := range sgIds {
+		sgId, ok := raw.(string)
+		if !ok || sgId == "" {
+			continue
+		}
+		arns = append(arns, fmt.Sprintf(securityGroupArnPattern, parsed.Region, parsed.AccountID, sgId))
+	}
+	handler.setSecurityGroupArns(arns)
+	return handler.newSecurityGroupResources(runtime)
+}
+
+// exposure reports the internet exposure of the App Runner service endpoint.
+// App Runner does not gate inbound traffic with security groups, so the
+// public-accessibility setting alone decides.
+func (a *mqlAwsApprunnerService) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	publiclyAccessible := a.GetIsPubliclyAccessible()
+	if publiclyAccessible.Error != nil {
+		return nil, publiclyAccessible.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure", publiclyAccessible.Data, nil)
+}
+
+// exposure reports the internet exposure of the notebook instance. Both inputs
+// live on the details sub-resource, which is a separate API call, so this is the
+// one exposure accessor that can cost a fetch.
+func (a *mqlAwsSagemakerNotebookinstance) exposure() (*mqlAwsNetworkExposure, error) {
+	arn := a.GetArn()
+	if arn.Error != nil {
+		return nil, arn.Error
+	}
+	details := a.GetDetails()
+	if details.Error != nil {
+		return nil, details.Error
+	}
+	if details.Data == nil {
+		a.Exposure.State = plugin.StateIsNull | plugin.StateIsSet
+		return nil, nil
+	}
+	directInternetAccess := details.Data.GetDirectInternetAccess()
+	if directInternetAccess.Error != nil {
+		return nil, directInternetAccess.Error
+	}
+	return buildNetworkExposure(a.MqlRuntime, arn.Data+"/exposure",
+		directInternetAccess.Data, details.Data.GetSecurityGroups())
 }
 
 func (a *mqlAwsElasticacheCluster) exposure() (*mqlAwsNetworkExposure, error) {


### PR DESCRIPTION
## What

`aws.network.exposure` was on 14 resources. Four more services now answer the same query, so "what in this account is internet-reachable" stops needing a service-specific check per service.

| resource | public signal | ingress filter |
|---|---|---|
| `aws.eks.cluster` | `endpointPublicAccess` | cluster security groups |
| `aws.ecs.service` | awsvpc `assignPublicIp` | task security groups |
| `aws.apprunner.service` | `isPubliclyAccessible` | none (App Runner has no inbound SGs) |
| `aws.sagemaker.notebookinstance` | `directInternetAccess` | instance security groups |

A couple of these are worth a second look:

- **EKS**: `publicAccessCidrs` stays its own field rather than being folded into the verdict. A cluster can report `internetReachable` and still only answer a short allow-list, so collapsing the two would lose the distinction. Read them together.
- **ECS**: null for host and bridge networking. Only awsvpc carries a public-IP assignment and task-level security groups; for the others the container instance decides reachability, and a service-level verdict would be describing the wrong object.
- **SageMaker**: the only exposure accessor that can cost an API call, since both inputs live on `details()`. A notebook with direct internet access egresses outside the VPC entirely — that's the path by which one holding credentials and training data becomes an exfiltration route.

## Implementation note

ECS stores bare security group **IDs**, not ARNs, so `resolveSecurityGroupsByIdInArnScope` derives the region and account from the service ARN and reuses the shared `securityGroupIdHandler` to build typed resources. `buildNetworkExposureFromGroups` is a thin wrapper on `buildNetworkExposure` for callers holding already-resolved groups rather than a lazily-fetched field.

## Deliberately excluded

I scoped this as seven services and shipped four. The three I dropped, and why:

- **`aws.emr.cluster`** — `MasterPublicDnsName` returns private DNS for VPC clusters, so it isn't a reliable public signal, and EMR retains terminated clusters whose subnet/SG references dangle, which makes `exposure()` error on them. Needs terminated-cluster-safe ref handling and a real public-IP derivation first. (Same blockers that deferred it in the original exposure sweep.)
- **`aws.es.domain` / `aws.opensearch.domain`** — `es.domain` already has a policy-aware `isPublic()` combining VPC placement *and* the access policy. `aws.network.exposure` is documented as a network-layer verdict, so adding it here would put two fields on one resource that disagree — worse than the gap. `opensearch.domain` has no `accessPolicies` field at all yet, so it can't answer the same way; modeling that is the prerequisite.
- **`aws.lambda.function`** — already carries `isPublic`, `allowsPublicAccess`, and `urlConfigAuthType`. A fourth public-access signal with subtly different semantics would confuse rather than clarify.

## Testing

- `go build ./...`, `go vet`, full `go test ./resources/` pass; `gofmt` clean.
- No new unit tests: these are wiring onto the already-tested `buildNetworkExposure`, and the one piece of new logic (`resolveSecurityGroupsByIdInArnScope`) is ARN parsing plus the existing shared handler.
- `.lr.versions`: 4 new entries at 13.52.2, no existing entries modified.
- **No new IAM permissions** — manifest unchanged at 993.

**Not yet live-verified.** Queued for the next batched live-verification run.
