### PR TITLE
🧹 stackit: migrate off SDK packages slated for removal

### DIFF
--- a/providers/stackit/connection/connection.go
+++ b/providers/stackit/connection/connection.go
@@ -13,31 +13,31 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 	albwaf "github.com/stackitcloud/stackit-sdk-go/services/albwaf/v1betaapi"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
-	"github.com/stackitcloud/stackit-sdk-go/services/certificates"
-	"github.com/stackitcloud/stackit-sdk-go/services/dns"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
-	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
-	"github.com/stackitcloud/stackit-sdk-go/services/logme"
-	"github.com/stackitcloud/stackit-sdk-go/services/mariadb"
-	"github.com/stackitcloud/stackit-sdk-go/services/modelserving"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
-	"github.com/stackitcloud/stackit-sdk-go/services/observability"
-	"github.com/stackitcloud/stackit-sdk-go/services/opensearch"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
+	certificates "github.com/stackitcloud/stackit-sdk-go/services/certificates/v2api"
+	dns "github.com/stackitcloud/stackit-sdk-go/services/dns/v1api"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
+	loadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer/v2api"
+	logme "github.com/stackitcloud/stackit-sdk-go/services/logme/v2api"
+	mariadb "github.com/stackitcloud/stackit-sdk-go/services/mariadb/v2api"
+	modelserving "github.com/stackitcloud/stackit-sdk-go/services/modelserving/v1api"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	objectstorage "github.com/stackitcloud/stackit-sdk-go/services/objectstorage/v2api"
+	observability "github.com/stackitcloud/stackit-sdk-go/services/observability/v1api"
+	opensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch/v2api"
 	postgresflex "github.com/stackitcloud/stackit-sdk-go/services/postgresflex/v2api"
-	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
-	"github.com/stackitcloud/stackit-sdk-go/services/redis"
-	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
-	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
-	"github.com/stackitcloud/stackit-sdk-go/services/sfs"
-	"github.com/stackitcloud/stackit-sdk-go/services/ske"
+	rabbitmq "github.com/stackitcloud/stackit-sdk-go/services/rabbitmq/v2api"
+	redis "github.com/stackitcloud/stackit-sdk-go/services/redis/v2api"
+	resourcemanager "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api"
+	secretsmanager "github.com/stackitcloud/stackit-sdk-go/services/secretsmanager/v1api"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
+	sfs "github.com/stackitcloud/stackit-sdk-go/services/sfs/v1api"
+	ske "github.com/stackitcloud/stackit-sdk-go/services/ske/v2api"
 	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 	telemetrylink "github.com/stackitcloud/stackit-sdk-go/services/telemetrylink/v1betaapi"
 	telemetryrouter "github.com/stackitcloud/stackit-sdk-go/services/telemetryrouter/v1betaapi"
@@ -259,7 +259,7 @@ func (c *StackitConnection) Verify(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	resp, err := client.GetProjectExecute(ctx, c.projectID)
+	resp, err := client.DefaultAPI.GetProject(ctx, c.projectID).Execute()
 	if err != nil {
 		log.Warn().Err(err).Msg("stackit> verify project lookup failed")
 		return fmt.Errorf("failed to verify STACKIT connection for project %s: %w", c.projectID, err)
@@ -279,7 +279,7 @@ func (c *StackitConnection) captureProjectMetadata(resp *resourcemanager.GetProj
 	if labels, ok := resp.GetLabelsOk(); ok && labels != nil {
 		// Snapshot the map so a later SDK mutation of its internal copy cannot
 		// change our captured labels, honoring the ProjectLabels() contract.
-		c.projectLabels = maps.Clone(labels)
+		c.projectLabels = maps.Clone(*labels)
 	}
 	if parent, ok := resp.GetParentOk(); ok {
 		c.projectParent = parent.GetContainerId()

--- a/providers/stackit/connection/connection_test.go
+++ b/providers/stackit/connection/connection_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
+	resourcemanager "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/inventory"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/vault"
 )

--- a/providers/stackit/resources/alb.go
+++ b/providers/stackit/resources/alb.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/alb"
+	alb "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -19,7 +19,7 @@ func (r *mqlStackit) albLoadBalancers() ([]any, error) {
 	out := []any{}
 	pageId := ""
 	for {
-		req := client.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
+		req := client.DefaultAPI.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
 		if pageId != "" {
 			req = req.PageId(pageId)
 		}
@@ -39,10 +39,10 @@ func (r *mqlStackit) albLoadBalancers() ([]any, error) {
 			out = append(out, res)
 		}
 		next, ok := resp.GetNextPageIdOk()
-		if !ok || next == "" {
+		if !ok || next == nil || *next == "" {
 			break
 		}
-		pageId = next
+		pageId = *next
 	}
 	return out, nil
 }

--- a/providers/stackit/resources/certificates.go
+++ b/providers/stackit/resources/certificates.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/certificates"
+	certificates "github.com/stackitcloud/stackit-sdk-go/services/certificates/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -19,7 +19,7 @@ func (r *mqlStackit) certificates() ([]any, error) {
 	out := []any{}
 	pageId := ""
 	for {
-		req := client.ListCertificates(bgctx(), c.ProjectID(), c.Region())
+		req := client.DefaultAPI.ListCertificates(bgctx(), c.ProjectID(), c.Region())
 		if pageId != "" {
 			req = req.PageId(pageId)
 		}
@@ -39,10 +39,10 @@ func (r *mqlStackit) certificates() ([]any, error) {
 			out = append(out, res)
 		}
 		next, ok := resp.GetNextPageIdOk()
-		if !ok || next == "" {
+		if !ok || next == nil || *next == "" {
 			break
 		}
-		pageId = next
+		pageId = *next
 	}
 	return out, nil
 }
@@ -111,7 +111,7 @@ func initStackitCertificate(runtime *plugin.Runtime, args map[string]*llx.RawDat
 	if err != nil {
 		return nil, nil, err
 	}
-	cert, err := client.GetCertificateExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	cert, err := client.DefaultAPI.GetCertificate(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/certificates_test.go
+++ b/providers/stackit/resources/certificates_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/certificates"
+	certificates "github.com/stackitcloud/stackit-sdk-go/services/certificates/v2api"
 )
 
 func TestCertificateUsage(t *testing.T) {
@@ -24,9 +24,9 @@ func TestCertificateUsage(t *testing.T) {
 		listenersA := []string{"https", "http"}
 		listenersB := []string{"tls"}
 		u := certificates.Usage{
-			Items: &[]certificates.UsageItem{
-				{LoadBalancerName: strPtr("lb-a"), ListenerNames: &listenersA},
-				{LoadBalancerName: strPtr("lb-b"), ListenerNames: &listenersB},
+			Items: []certificates.UsageItem{
+				{LoadBalancerName: strPtr("lb-a"), ListenerNames: listenersA},
+				{LoadBalancerName: strPtr("lb-b"), ListenerNames: listenersB},
 			},
 		}
 
@@ -42,7 +42,7 @@ func TestCertificateUsage(t *testing.T) {
 
 	t.Run("item without listeners yields empty listener slice", func(t *testing.T) {
 		u := certificates.Usage{
-			Items: &[]certificates.UsageItem{
+			Items: []certificates.UsageItem{
 				{LoadBalancerName: strPtr("lb-c")},
 			},
 		}

--- a/providers/stackit/resources/dbaas.go
+++ b/providers/stackit/resources/dbaas.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
-	"github.com/stackitcloud/stackit-sdk-go/services/observability"
+	mongodbflex "github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/v2api"
+	observability "github.com/stackitcloud/stackit-sdk-go/services/observability/v1api"
 	postgresflex "github.com/stackitcloud/stackit-sdk-go/services/postgresflex/v2api"
 	sqlserverflex "github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/v2api"
 	"go.mondoo.com/mql/v13/llx"
@@ -178,7 +178,7 @@ func (r *mqlStackitMongoDbFlex) instances() ([]any, error) {
 	// requires a `tag` query parameter. An empty tag returns all instances in
 	// the project, so use the request builder rather than the convenience
 	// ListInstancesExecute (which cannot set a tag).
-	resp, err := client.ListInstances(bgctx(), c.ProjectID(), c.Region()).Tag("").Execute()
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Tag("").Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -222,7 +222,7 @@ func (r *mqlStackitMongoDbFlexInstance) fetchDetail() (*mongodbflex.Instance, er
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
+	resp, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			r.fetched.Store(true)
@@ -231,7 +231,7 @@ func (r *mqlStackitMongoDbFlexInstance) fetchDetail() (*mongodbflex.Instance, er
 		return nil, err
 	}
 	if item, ok := resp.GetItemOk(); ok {
-		r.detail = &item
+		r.detail = item
 	}
 	r.fetched.Store(true)
 	return r.detail, nil
@@ -304,7 +304,7 @@ func (r *mqlStackitOpenSearch) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -350,7 +350,7 @@ func (r *mqlStackitMariaDb) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -396,7 +396,7 @@ func (r *mqlStackitRedis) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -442,7 +442,7 @@ func (r *mqlStackitRabbitMq) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -488,7 +488,7 @@ func (r *mqlStackitSecretsManager) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -528,7 +528,7 @@ func (r *mqlStackitSecretsManagerInstance) acls() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListACLsExecute(bgctx(), c.ProjectID(), r.Id.Data)
+	resp, err := client.DefaultAPI.ListACLs(bgctx(), c.ProjectID(), r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -561,7 +561,7 @@ func (r *mqlStackitObservability) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -606,7 +606,7 @@ func (r *mqlStackitObservabilityInstance) fetchDetail() (*observability.GetInsta
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetInstanceExecute(bgctx(), r.Id.Data, c.ProjectID())
+	resp, err := client.DefaultAPI.GetInstance(bgctx(), r.Id.Data, c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			r.fetched.Store(true)
@@ -640,8 +640,11 @@ func (r *mqlStackitObservabilityInstance) parameters() (any, error) {
 	if err != nil || d == nil {
 		return nil, err
 	}
-	params, _ := d.GetParametersOk()
-	return stringMap(params), nil
+	params, ok := d.GetParametersOk()
+	if !ok || params == nil {
+		return map[string]any{}, nil
+	}
+	return stringMap(*params), nil
 }
 
 func (r *mqlStackitObservabilityInstance) isUpdatable() (bool, error) {
@@ -708,7 +711,7 @@ func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*ll
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), id, c.Region())
+	resp, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), id, c.Region()).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -726,7 +729,7 @@ func initStackitMongoDbFlexInstance(runtime *plugin.Runtime, args map[string]*ll
 		return nil, nil, err
 	}
 	r := res.(*mqlStackitMongoDbFlexInstance)
-	r.detail = &inst
+	r.detail = inst
 	r.fetched.Store(true)
 	return nil, res, nil
 }
@@ -744,7 +747,7 @@ func initStackitOpenSearchInstance(runtime *plugin.Runtime, args map[string]*llx
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -784,7 +787,7 @@ func initStackitMariaDbInstance(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -824,7 +827,7 @@ func initStackitRedisInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -864,7 +867,7 @@ func initStackitRabbitMqInstance(runtime *plugin.Runtime, args map[string]*llx.R
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -904,7 +907,7 @@ func initStackitSecretsManagerInstance(runtime *plugin.Runtime, args map[string]
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -937,7 +940,7 @@ func initStackitObservabilityInstance(runtime *plugin.Runtime, args map[string]*
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetInstanceExecute(bgctx(), id, c.ProjectID())
+	resp, err := client.DefaultAPI.GetInstance(bgctx(), id, c.ProjectID()).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -969,7 +972,7 @@ func (r *mqlStackitLogMe) instances() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListInstancesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListInstances(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -1020,7 +1023,7 @@ func initStackitLogMeInstance(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
-	inst, err := client.GetInstanceExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	inst, err := client.DefaultAPI.GetInstance(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/dns.go
+++ b/providers/stackit/resources/dns.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/dns"
+	dns "github.com/stackitcloud/stackit-sdk-go/services/dns/v1api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -21,7 +21,7 @@ func (r *mqlStackitDns) zones() ([]any, error) {
 	out := []any{}
 	const pageSize int32 = 500
 	for page := int32(1); ; page++ {
-		resp, err := client.ListZones(bgctx(), c.ProjectID()).Page(page).PageSize(pageSize).Execute()
+		resp, err := client.DefaultAPI.ListZones(bgctx(), c.ProjectID()).Page(page).PageSize(pageSize).Execute()
 		if err != nil {
 			if isAccessDenied(err) {
 				return []any{}, nil
@@ -112,7 +112,7 @@ func initStackitDnsZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetZoneExecute(bgctx(), c.ProjectID(), id)
+	resp, err := client.DefaultAPI.GetZone(bgctx(), c.ProjectID(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -120,7 +120,7 @@ func initStackitDnsZone(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit.dns.zone with id %q not found", id)
 	}
-	res, err := buildDnsZone(runtime, &z)
+	res, err := buildDnsZone(runtime, z)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -136,7 +136,7 @@ func (r *mqlStackitDnsZone) recordSets() ([]any, error) {
 	out := []any{}
 	const pageSize int32 = 500
 	for page := int32(1); ; page++ {
-		resp, err := client.ListRecordSets(bgctx(), c.ProjectID(), r.Id.Data).Page(page).PageSize(pageSize).Execute()
+		resp, err := client.DefaultAPI.ListRecordSets(bgctx(), c.ProjectID(), r.Id.Data).Page(page).PageSize(pageSize).Execute()
 		if err != nil {
 			if isAccessDenied(err) {
 				return []any{}, nil

--- a/providers/stackit/resources/dns_test.go
+++ b/providers/stackit/resources/dns_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/dns"
+	dns "github.com/stackitcloud/stackit-sdk-go/services/dns/v1api"
 )
 
 func TestDnsLabels(t *testing.T) {
@@ -17,7 +17,7 @@ func TestDnsLabels(t *testing.T) {
 
 	k1, v1 := "env", "prod"
 	k2, v2 := "team", "sec"
-	in := []dns.Label{{Key: &k1, Value: &v1}, {Key: &k2, Value: &v2}}
+	in := []dns.Label{{Key: k1, Value: &v1}, {Key: k2, Value: &v2}}
 	got := dnsLabels(in)
 	want := map[string]string{"env": "prod", "team": "sec"}
 	if !reflect.DeepEqual(got, want) {

--- a/providers/stackit/resources/helpers.go
+++ b/providers/stackit/resources/helpers.go
@@ -21,12 +21,28 @@ import (
 func bgctx() context.Context { return context.Background() }
 
 // timeOrNil turns a (time, ok) result from the SDK's GetXxxOk methods into the
-// *time.Time form that llx.TimeDataPtr wants. Zero time is treated as unset.
-func timeOrNil(t time.Time, ok bool) *time.Time {
-	if !ok || t.IsZero() {
+// *time.Time form that llx.TimeDataPtr wants. A nil or zero time reads as unset.
+//
+// The STACKIT service packages disagree on whether an optional timestamp comes
+// back as a value or a pointer (sfs returns time.Time, iaas and ske return
+// *time.Time), so accept both rather than making every caller adapt.
+func timeOrNil[T time.Time | *time.Time](t T, ok bool) *time.Time {
+	if !ok {
 		return nil
 	}
-	return &t
+	switch v := any(t).(type) {
+	case time.Time:
+		if v.IsZero() {
+			return nil
+		}
+		return &v
+	case *time.Time:
+		if v == nil || v.IsZero() {
+			return nil
+		}
+		return v
+	}
+	return nil
 }
 
 // rfc3339OrNil formats a (time, ok) pair from the SDK's GetXxxOk methods as an
@@ -34,11 +50,12 @@ func timeOrNil(t time.Time, ok bool) *time.Time {
 // A `dict` value must be a dict-native scalar (string/number/bool), so a
 // *time.Time cannot be stored directly; use llx.TimeDataPtr for typed `time`
 // fields and this helper only for timestamps that live inside a dict.
-func rfc3339OrNil(t time.Time, ok bool) any {
-	if !ok || t.IsZero() {
+func rfc3339OrNil[T time.Time | *time.Time](t T, ok bool) any {
+	tp := timeOrNil(t, ok)
+	if tp == nil {
 		return nil
 	}
-	return t.Format(time.RFC3339)
+	return tp.Format(time.RFC3339)
 }
 
 // parseRFC3339 turns an RFC3339 timestamp string into the *time.Time form
@@ -122,12 +139,38 @@ func labelData(in any) *llx.RawData {
 // metadataData is the same as labelData; kept distinct so callers read clearly.
 func metadataData(in any) *llx.RawData { return labelData(in) }
 
-// ptrStr derefs a nullable string returned by the SDK's getter methods.
-func ptrStr(p *string) string {
+// ptrStr derefs a nullable string returned by the SDK's getter methods. Accepts
+// the plain-string form too, since the service packages differ on which they
+// return for an optional field.
+func ptrStr[T string | *string](p T) string {
+	switch v := any(p).(type) {
+	case string:
+		return v
+	case *string:
+		if v == nil {
+			return ""
+		}
+		return *v
+	}
+	return ""
+}
+
+// derefInt64 returns the value behind a *int64, or 0 when nil.
+func derefInt64(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// ptrEnumStr renders a pointer-to-string-enum as its string value, or "" when
+// the field is unset. The versioned service packages hand back a pointer for
+// optional enums where the root packages returned the bare enum.
+func ptrEnumStr[T ~string](p *T) string {
 	if p == nil {
 		return ""
 	}
-	return *p
+	return string(*p)
 }
 
 // toDict marshals any SDK struct (or other value) into the JSON-equivalent

--- a/providers/stackit/resources/helpers_test.go
+++ b/providers/stackit/resources/helpers_test.go
@@ -301,7 +301,7 @@ func TestStringMap(t *testing.T) {
 }
 
 func TestPtrStr(t *testing.T) {
-	if got := ptrStr(nil); got != "" {
+	if got := ptrStr[*string](nil); got != "" {
 		t.Fatalf("nil pointer: expected empty string, got %q", got)
 	}
 	s := "value"

--- a/providers/stackit/resources/iaas.go
+++ b/providers/stackit/resources/iaas.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strconv"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -22,7 +22,7 @@ func (r *mqlStackit) servers() ([]any, error) {
 	}
 	// Details(true) so the response includes nics, security groups, and volumes;
 	// without it the API returns servers with those fields empty.
-	resp, err := client.ListServers(bgctx(), c.ProjectID(), c.Region()).Details(true).Execute()
+	resp, err := client.DefaultAPI.ListServers(bgctx(), c.ProjectID(), c.Region()).Details(true).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -118,7 +118,7 @@ func initStackitServer(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if err != nil {
 		return nil, nil, err
 	}
-	s, err := client.GetServer(bgctx(), c.ProjectID(), c.Region(), id).Details(true).Execute()
+	s, err := client.DefaultAPI.GetServer(bgctx(), c.ProjectID(), c.Region(), id).Details(true).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -254,7 +254,7 @@ func (r *mqlStackit) volumes() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListVolumesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListVolumes(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -347,7 +347,7 @@ func initStackitVolume(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if err != nil {
 		return nil, nil, err
 	}
-	v, err := client.GetVolumeExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	v, err := client.DefaultAPI.GetVolume(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -418,7 +418,7 @@ func (r *mqlStackit) snapshots() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListSnapshotsInProjectExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListSnapshotsInProject(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -468,7 +468,7 @@ func initStackitSnapshot(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	if err != nil {
 		return nil, nil, err
 	}
-	s, err := client.GetSnapshotExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	s, err := client.DefaultAPI.GetSnapshot(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -500,7 +500,7 @@ func (r *mqlStackit) images() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListImagesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListImages(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -531,17 +531,17 @@ func buildImage(runtime *plugin.Runtime, img *iaas.Image) (plugin.Resource, erro
 	if cfg, ok := img.GetConfigOk(); ok {
 		config = map[string]any{
 			"bootMenu":               cfg.GetBootMenu(),
-			"cdromBus":               ptrStr(cfg.GetCdromBus()),
-			"diskBus":                ptrStr(cfg.GetDiskBus()),
-			"nicModel":               ptrStr(cfg.GetNicModel()),
+			"cdromBus":               cfg.GetCdromBus(),
+			"diskBus":                cfg.GetDiskBus(),
+			"nicModel":               cfg.GetNicModel(),
 			"operatingSystem":        cfg.GetOperatingSystem(),
-			"operatingSystemDistro":  ptrStr(cfg.GetOperatingSystemDistro()),
-			"operatingSystemVersion": ptrStr(cfg.GetOperatingSystemVersion()),
-			"rescueBus":              ptrStr(cfg.GetRescueBus()),
-			"rescueDevice":           ptrStr(cfg.GetRescueDevice()),
+			"operatingSystemDistro":  cfg.GetOperatingSystemDistro(),
+			"operatingSystemVersion": cfg.GetOperatingSystemVersion(),
+			"rescueBus":              cfg.GetRescueBus(),
+			"rescueDevice":           cfg.GetRescueDevice(),
 			"secureBoot":             cfg.GetSecureBoot(),
 			"uefi":                   cfg.GetUefi(),
-			"videoModel":             ptrStr(cfg.GetVideoModel()),
+			"videoModel":             cfg.GetVideoModel(),
 			"virtioScsi":             cfg.GetVirtioScsi(),
 		}
 	}
@@ -581,7 +581,7 @@ func initStackitImage(runtime *plugin.Runtime, args map[string]*llx.RawData) (ma
 	if err != nil {
 		return nil, nil, err
 	}
-	img, err := client.GetImageExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	img, err := client.DefaultAPI.GetImage(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -600,7 +600,7 @@ func (r *mqlStackit) networks() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListNetworksExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListNetworks(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -631,7 +631,7 @@ func buildNetwork(runtime *plugin.Runtime, n *iaas.Network) (plugin.Resource, er
 		ipv6PrefixSing string
 	)
 	if ipv4 := n.GetIpv4(); !iaasNetworkIPv4Empty(ipv4) {
-		ipv4Gateway = ptrStr(ipv4.GetGateway())
+		ipv4Gateway = ipv4.GetGateway()
 		ipv4Nameserv = ipv4.GetNameservers()
 		ipv4Prefixes = ipv4.GetPrefixes()
 		if len(ipv4Prefixes) > 0 {
@@ -639,7 +639,7 @@ func buildNetwork(runtime *plugin.Runtime, n *iaas.Network) (plugin.Resource, er
 		}
 	}
 	if ipv6 := n.GetIpv6(); !iaasNetworkIPv6Empty(ipv6) {
-		ipv6Gateway = ptrStr(ipv6.GetGateway())
+		ipv6Gateway = ipv6.GetGateway()
 		ipv6Nameserv = ipv6.GetNameservers()
 		ipv6Prefixes = ipv6.GetPrefixes()
 		if len(ipv6Prefixes) > 0 {
@@ -682,7 +682,7 @@ func initStackitNetwork(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if err != nil {
 		return nil, nil, err
 	}
-	n, err := client.GetNetworkExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	n, err := client.DefaultAPI.GetNetwork(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -697,11 +697,11 @@ func initStackitNetwork(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 // always return a (possibly zero-value) struct, so check the inner pointers
 // for "set"-ness instead.
 func iaasNetworkIPv4Empty(v iaas.NetworkIPv4) bool {
-	return v.Gateway == nil && v.Nameservers == nil && v.Prefixes == nil && v.PublicIp == nil
+	return !v.Gateway.IsSet() && v.Nameservers == nil && v.Prefixes == nil && v.PublicIp == nil
 }
 
 func iaasNetworkIPv6Empty(v iaas.NetworkIPv6) bool {
-	return v.Gateway == nil && v.Nameservers == nil && v.Prefixes == nil
+	return !v.Gateway.IsSet() && v.Nameservers == nil && v.Prefixes == nil
 }
 
 // ------------------------- public IPs -------------------------
@@ -712,7 +712,7 @@ func (r *mqlStackit) publicIps() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListPublicIPsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListPublicIPs(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -735,7 +735,7 @@ func buildPublicIp(runtime *plugin.Runtime, ip *iaas.PublicIp) (plugin.Resource,
 	args := map[string]*llx.RawData{
 		"id":                 llx.StringData(ip.GetId()),
 		"ip":                 llx.StringData(ip.GetIp()),
-		"networkInterfaceId": llx.StringData(ptrStr(ip.GetNetworkInterface())),
+		"networkInterfaceId": llx.StringData(ip.GetNetworkInterface()),
 		"labels":             labelData(ip.GetLabels()),
 	}
 	return CreateResource(runtime, "stackit.publicIp", args)
@@ -755,7 +755,7 @@ func initStackitPublicIp(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	if err != nil {
 		return nil, nil, err
 	}
-	ip, err := client.GetPublicIPExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	ip, err := client.DefaultAPI.GetPublicIP(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -774,7 +774,7 @@ func (r *mqlStackit) securityGroups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListSecurityGroupsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListSecurityGroups(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -822,7 +822,7 @@ func initStackitSecurityGroup(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
-	sg, err := client.GetSecurityGroupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	sg, err := client.DefaultAPI.GetSecurityGroup(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -839,7 +839,7 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListSecurityGroupRulesExecute(bgctx(), c.ProjectID(), c.Region(), r.Id.Data)
+	resp, err := client.DefaultAPI.ListSecurityGroupRules(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -868,7 +868,7 @@ func (r *mqlStackitSecurityGroup) rules() ([]any, error) {
 		var protocol string
 		if p, ok := rule.GetProtocolOk(); ok {
 			n, okNum := p.GetNumberOk()
-			protocol = protocolLabel(p.GetName(), n, okNum)
+			protocol = protocolLabel(p.GetName(), derefInt64(n), okNum && n != nil)
 		}
 
 		createdAt, okCreated := rule.GetCreatedAtOk()
@@ -923,7 +923,7 @@ func (r *mqlStackit) keyPairs() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListKeyPairsExecute(bgctx())
+	resp, err := client.DefaultAPI.ListKeyPairs(bgctx()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -974,7 +974,7 @@ func initStackitKeyPair(runtime *plugin.Runtime, args map[string]*llx.RawData) (
 	if err != nil {
 		return nil, nil, err
 	}
-	kp, err := client.GetKeyPairExecute(bgctx(), name)
+	kp, err := client.DefaultAPI.GetKeyPair(bgctx(), name).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/iaas_compute.go
+++ b/providers/stackit/resources/iaas_compute.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -25,7 +25,7 @@ func (r *mqlStackit) backups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListBackupsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListBackups(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -83,7 +83,7 @@ func initStackitBackup(runtime *plugin.Runtime, args map[string]*llx.RawData) (m
 	if err != nil {
 		return nil, nil, err
 	}
-	b, err := client.GetBackupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	b, err := client.DefaultAPI.GetBackup(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,7 +126,7 @@ func (r *mqlStackit) affinityGroups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListAffinityGroupsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListAffinityGroups(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -173,7 +173,7 @@ func initStackitAffinityGroup(runtime *plugin.Runtime, args map[string]*llx.RawD
 	if err != nil {
 		return nil, nil, err
 	}
-	ag, err := client.GetAffinityGroupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	ag, err := client.DefaultAPI.GetAffinityGroup(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/iaas_nic.go
+++ b/providers/stackit/resources/iaas_nic.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -18,7 +18,7 @@ func (r *mqlStackitNetwork) nics() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListNicsExecute(bgctx(), c.ProjectID(), c.Region(), r.Id.Data)
+	resp, err := client.DefaultAPI.ListNics(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -36,7 +36,7 @@ func (r *mqlStackitServer) networkInterfaces() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListServerNICsExecute(bgctx(), c.ProjectID(), c.Region(), r.Id.Data)
+	resp, err := client.DefaultAPI.ListServerNICs(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/iam.go
+++ b/providers/stackit/resources/iam.go
@@ -17,7 +17,7 @@ func (r *mqlStackitIam) members() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListMembersExecute(bgctx(), authResourceTypeProject, c.ProjectID())
+	resp, err := client.DefaultAPI.ListMembers(bgctx(), authResourceTypeProject, c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -51,7 +51,7 @@ func (r *mqlStackitIam) roles() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListRolesExecute(bgctx(), authResourceTypeProject, c.ProjectID())
+	resp, err := client.DefaultAPI.ListRoles(bgctx(), authResourceTypeProject, c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/kms.go
+++ b/providers/stackit/resources/kms.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/kms"
+	kms "github.com/stackitcloud/stackit-sdk-go/services/kms/v1api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -15,7 +15,7 @@ func (r *mqlStackitKms) keyRings() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListKeyRingsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListKeyRings(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -82,7 +82,7 @@ func initStackitKmsKeyRing(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if err != nil {
 		return nil, nil, err
 	}
-	kr, err := client.GetKeyRingExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	kr, err := client.DefaultAPI.GetKeyRing(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +99,7 @@ func (r *mqlStackitKmsKeyRing) keys() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListKeysExecute(bgctx(), c.ProjectID(), c.Region(), r.Id.Data)
+	resp, err := client.DefaultAPI.ListKeys(bgctx(), c.ProjectID(), c.Region(), r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/loadbalancer.go
+++ b/providers/stackit/resources/loadbalancer.go
@@ -4,7 +4,7 @@
 package resources
 
 import (
-	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
+	loadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -19,7 +19,7 @@ func (r *mqlStackit) loadBalancers() ([]any, error) {
 	out := []any{}
 	pageId := ""
 	for {
-		req := client.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
+		req := client.DefaultAPI.ListLoadBalancers(bgctx(), c.ProjectID(), c.Region())
 		if pageId != "" {
 			req = req.PageId(pageId)
 		}
@@ -39,10 +39,10 @@ func (r *mqlStackit) loadBalancers() ([]any, error) {
 			out = append(out, res)
 		}
 		next, ok := resp.GetNextPageIdOk()
-		if !ok || next == "" {
+		if !ok || next == nil || *next == "" {
 			break
 		}
-		pageId = next
+		pageId = *next
 	}
 	return out, nil
 }
@@ -60,7 +60,7 @@ func buildLoadBalancer(runtime *plugin.Runtime, lb *loadbalancer.LoadBalancer, r
 	var privateOnly bool
 	if v, ok := lb.GetOptionsOk(); ok {
 		if pno, ok := v.GetPrivateNetworkOnlyOk(); ok {
-			privateOnly = pno
+			privateOnly = pno != nil && *pno
 		}
 	}
 
@@ -167,7 +167,7 @@ func initStackitLoadBalancer(runtime *plugin.Runtime, args map[string]*llx.RawDa
 	if err != nil {
 		return nil, nil, err
 	}
-	lb, err := client.GetLoadBalancerExecute(bgctx(), c.ProjectID(), c.Region(), name)
+	lb, err := client.DefaultAPI.GetLoadBalancer(bgctx(), c.ProjectID(), c.Region(), name).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/loadbalancer_test.go
+++ b/providers/stackit/resources/loadbalancer_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
+	loadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer/v2api"
 )
 
 func TestListenerSNINames(t *testing.T) {

--- a/providers/stackit/resources/modelserving.go
+++ b/providers/stackit/resources/modelserving.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/modelserving"
+	modelserving "github.com/stackitcloud/stackit-sdk-go/services/modelserving/v1api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -31,7 +31,7 @@ func (r *mqlStackitModelServing) tokens() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListTokensExecute(bgctx(), c.Region(), c.ProjectID())
+	resp, err := client.DefaultAPI.ListTokens(bgctx(), c.Region(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -64,7 +64,7 @@ func initStackitModelServingToken(runtime *plugin.Runtime, args map[string]*llx.
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetTokenExecute(bgctx(), c.Region(), c.ProjectID(), id)
+	resp, err := client.DefaultAPI.GetToken(bgctx(), c.Region(), c.ProjectID(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -72,7 +72,7 @@ func initStackitModelServingToken(runtime *plugin.Runtime, args map[string]*llx.
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit model serving token %q not found", id)
 	}
-	res, err := CreateResource(runtime, "stackit.modelServing.token", modelServingTokenArgs(&token))
+	res, err := CreateResource(runtime, "stackit.modelServing.token", modelServingTokenArgs(token))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -87,7 +87,7 @@ func (r *mqlStackitModelServing) models() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListModelsExecute(bgctx(), c.Region())
+	resp, err := client.DefaultAPI.ListModels(bgctx(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/objectstorage.go
+++ b/providers/stackit/resources/objectstorage.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
+	objectstorage "github.com/stackitcloud/stackit-sdk-go/services/objectstorage/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -32,7 +32,7 @@ func (r *mqlStackitObjectStorage) buckets() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListBucketsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListBuckets(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		// A 404 here means the project is not onboarded to Object Storage
 		// (the service returns "project.not_found"); treat it as no buckets.
@@ -85,7 +85,7 @@ func initStackitObjectStorageBucket(runtime *plugin.Runtime, args map[string]*ll
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetBucketExecute(bgctx(), c.ProjectID(), c.Region(), name)
+	resp, err := client.DefaultAPI.GetBucket(bgctx(), c.ProjectID(), c.Region(), name).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,7 +93,7 @@ func initStackitObjectStorageBucket(runtime *plugin.Runtime, args map[string]*ll
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit.objectStorage.bucket %q not found", name)
 	}
-	res, err := buildBucket(runtime, &b)
+	res, err := buildBucket(runtime, b)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,7 +118,7 @@ func (r *mqlStackitObjectStorageBucket) fetchDefaultRetention() (int64, string, 
 	if err != nil {
 		return 0, "", err
 	}
-	resp, err := client.GetDefaultRetentionExecute(bgctx(), c.ProjectID(), c.Region(), r.Name.Data)
+	resp, err := client.DefaultAPI.GetDefaultRetention(bgctx(), c.ProjectID(), c.Region(), r.Name.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			r.retentionFetched = true
@@ -126,7 +126,7 @@ func (r *mqlStackitObjectStorageBucket) fetchDefaultRetention() (int64, string, 
 		}
 		return 0, "", err
 	}
-	r.retentionDays = resp.GetDays()
+	r.retentionDays = int64(resp.GetDays())
 	r.retentionMode = string(resp.GetMode())
 	r.retentionFetched = true
 	return r.retentionDays, r.retentionMode, nil
@@ -150,7 +150,7 @@ func (r *mqlStackitObjectStorage) credentialsGroups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListCredentialsGroupsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListCredentialsGroups(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		// A 404 means the project is not onboarded to Object Storage; treat it
 		// as no credentials groups.
@@ -191,7 +191,7 @@ func initStackitObjectStorageCredentialsGroup(runtime *plugin.Runtime, args map[
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetCredentialsGroupExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	resp, err := client.DefaultAPI.GetCredentialsGroup(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -216,7 +216,7 @@ func (r *mqlStackitObjectStorageCredentialsGroup) accessKeys() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListAccessKeys(bgctx(), c.ProjectID(), c.Region()).
+	resp, err := client.DefaultAPI.ListAccessKeys(bgctx(), c.ProjectID(), c.Region()).
 		CredentialsGroup(r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {

--- a/providers/stackit/resources/serverbackup.go
+++ b/providers/stackit/resources/serverbackup.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strconv"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serverbackup"
+	serverbackup "github.com/stackitcloud/stackit-sdk-go/services/serverbackup/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -28,7 +28,7 @@ func (r *mqlStackitServer) backups() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListBackupsExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
+	resp, err := client.DefaultAPI.ListBackups(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			// A 404 means the Server Backup service is not enabled for this
@@ -130,7 +130,7 @@ func (r *mqlStackitServer) backupSchedules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListBackupSchedulesExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
+	resp, err := client.DefaultAPI.ListBackupSchedules(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			return []any{}, nil
@@ -155,7 +155,7 @@ func buildBackupSchedule(runtime *plugin.Runtime, serverID string, s *serverback
 		volumeIds []string
 	)
 	if props, ok := s.GetBackupPropertiesOk(); ok {
-		retention = props.GetRetentionPeriod()
+		retention = int64(props.GetRetentionPeriod())
 		volumeIds = props.GetVolumeIds()
 	}
 	args := map[string]*llx.RawData{

--- a/providers/stackit/resources/serverupdate.go
+++ b/providers/stackit/resources/serverupdate.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"strconv"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
+	serverupdate "github.com/stackitcloud/stackit-sdk-go/services/serverupdate/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -19,7 +19,7 @@ func (r *mqlStackitServer) updates() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListUpdatesExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
+	resp, err := client.DefaultAPI.ListUpdates(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			// A 404 means the Server Update service is not enabled for this
@@ -70,7 +70,7 @@ func (r *mqlStackitServer) updateSchedules() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListUpdateSchedulesExecute(bgctx(), c.ProjectID(), r.Id.Data, c.Region())
+	resp, err := client.DefaultAPI.ListUpdateSchedules(bgctx(), c.ProjectID(), r.Id.Data, c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/serviceaccount.go
+++ b/providers/stackit/resources/serviceaccount.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"fmt"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -17,7 +17,7 @@ func (r *mqlStackit) serviceAccounts() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListServiceAccountsExecute(bgctx(), c.ProjectID())
+	resp, err := client.DefaultAPI.ListServiceAccounts(bgctx(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -58,7 +58,7 @@ func initStackitServiceAccount(runtime *plugin.Runtime, args map[string]*llx.Raw
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.ListServiceAccountsExecute(bgctx(), c.ProjectID())
+	resp, err := client.DefaultAPI.ListServiceAccounts(bgctx(), c.ProjectID()).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,7 +82,7 @@ func (r *mqlStackitServiceAccount) accessTokens() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListAccessTokensExecute(bgctx(), r.ProjectId.Data, r.Email.Data)
+	resp, err := client.DefaultAPI.ListAccessTokens(bgctx(), r.ProjectId.Data, r.Email.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -118,7 +118,7 @@ func (r *mqlStackitServiceAccount) keys() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListServiceAccountKeysExecute(bgctx(), r.ProjectId.Data, r.Email.Data)
+	resp, err := client.DefaultAPI.ListServiceAccountKeys(bgctx(), r.ProjectId.Data, r.Email.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil

--- a/providers/stackit/resources/serviceaccount_test.go
+++ b/providers/stackit/resources/serviceaccount_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
+	serviceaccount "github.com/stackitcloud/stackit-sdk-go/services/serviceaccount/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/types"
 )

--- a/providers/stackit/resources/sfs.go
+++ b/providers/stackit/resources/sfs.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/sfs"
+	sfs "github.com/stackitcloud/stackit-sdk-go/services/sfs/v1api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 )
@@ -23,31 +23,37 @@ type sfsResourcePoolData interface {
 	GetState() string
 	GetPerformanceClass() sfs.ResourcePoolPerformanceClass
 	GetSpace() sfs.ResourcePoolSpace
-	GetSnapshotPolicy() *sfs.NullableResourcePoolSnapshotPolicy
+	GetSnapshotPolicyOk() (*sfs.ResourcePoolSnapshotPolicy, bool)
 	GetAvailabilityZone() string
 	GetMountPath() string
-	GetCountShares() int64
+	GetCountShares() int32
 	GetIpAcl() []string
 	GetSnapshotsAreVisible() bool
 	GetLabels() map[string]string
-	GetCreatedAtOk() (time.Time, bool)
+	GetCreatedAtOk() (*time.Time, bool)
 }
 
 type sfsExportPolicyData interface {
 	GetId() string
 	GetName() string
-	GetSharesUsingExportPolicy() int64
+	GetSharesUsingExportPolicy() int32
 	GetLabels() map[string]string
-	GetCreatedAtOk() (time.Time, bool)
+	GetCreatedAtOk() (*time.Time, bool)
 }
 
 // derefFloat returns the value behind a *float64, or 0 when nil. SFS reports
 // the space-usage gauges as optional floats; an absent value reads as 0.
-func derefFloat(p *float64) float64 {
-	if p == nil {
-		return 0
+func derefFloat[T float64 | *float64](p T) float64 {
+	switch v := any(p).(type) {
+	case float64:
+		return v
+	case *float64:
+		if v == nil {
+			return 0
+		}
+		return *v
 	}
-	return *p
+	return 0
 }
 
 // ------------------------- SFS namespace -------------------------
@@ -58,7 +64,7 @@ func (r *mqlStackitSfs) resourcePools() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListResourcePoolsExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListResourcePools(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -83,7 +89,7 @@ func (r *mqlStackitSfs) exportPolicies() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListShareExportPoliciesExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListShareExportPolicies(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -108,7 +114,7 @@ func (r *mqlStackitSfs) lockId() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := client.GetLockExecute(bgctx(), c.Region(), c.ProjectID())
+	resp, err := client.DefaultAPI.GetLock(bgctx(), c.Region(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) || isNotFound(err) {
 			return "", nil
@@ -124,11 +130,9 @@ func sfsResourcePoolArgs(region string, rp sfsResourcePoolData) map[string]*llx.
 	pc := rp.GetPerformanceClass()
 	sp := rp.GetSpace()
 	snapPolicyID, snapPolicyName := "", ""
-	if np := rp.GetSnapshotPolicy(); np != nil && np.IsSet() {
-		if v := np.Get(); v != nil {
-			snapPolicyID = v.GetId()
-			snapPolicyName = v.GetName()
-		}
+	if v, ok := rp.GetSnapshotPolicyOk(); ok && v != nil {
+		snapPolicyID = v.GetId()
+		snapPolicyName = v.GetName()
 	}
 	return map[string]*llx.RawData{
 		"id":                         llx.StringData(rp.GetId()),
@@ -164,7 +168,7 @@ func (r *mqlStackitSfsResourcePool) shares() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListSharesExecute(bgctx(), c.ProjectID(), r.Region.Data, r.Id.Data)
+	resp, err := client.DefaultAPI.ListShares(bgctx(), c.ProjectID(), r.Region.Data, r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -176,10 +180,8 @@ func (r *mqlStackitSfsResourcePool) shares() ([]any, error) {
 	for i := range shares {
 		sh := shares[i]
 		exportPolicyID := ""
-		if np := sh.GetExportPolicy(); np != nil && np.IsSet() {
-			if v := np.Get(); v != nil {
-				exportPolicyID = v.GetId()
-			}
+		if v, ok := sh.GetExportPolicyOk(); ok && v != nil {
+			exportPolicyID = v.GetId()
 		}
 		res, err := CreateResource(r.MqlRuntime, "stackit.sfs.share", map[string]*llx.RawData{
 			"id":                      llx.StringData(sh.GetId()),
@@ -207,7 +209,7 @@ func (r *mqlStackitSfsResourcePool) snapshots() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListResourcePoolSnapshotsExecute(bgctx(), c.ProjectID(), r.Region.Data, r.Id.Data)
+	resp, err := client.DefaultAPI.ListResourcePoolSnapshots(bgctx(), c.ProjectID(), r.Region.Data, r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -223,8 +225,8 @@ func (r *mqlStackitSfsResourcePool) snapshots() ([]any, error) {
 			"name":                 llx.StringData(snap.GetSnapshotName()),
 			"sizeGigabytes":        llx.IntData(snap.GetSizeGigabytes()),
 			"logicalSizeGigabytes": llx.IntData(snap.GetLogicalSizeGigabytes()),
-			"comment":              llx.StringData(ptrStr(snap.GetComment())),
-			"snaplockExpiryTime":   llx.TimeDataPtr(snap.GetSnaplockExpiryTime()),
+			"comment":              llx.StringData(snap.GetComment()),
+			"snaplockExpiryTime":   llx.TimeDataPtr(timeOrNil(snap.GetSnaplockExpiryTimeOk())),
 			"createdAt":            llx.TimeDataPtr(timeOrNil(snap.GetCreatedAtOk())),
 		})
 		if err != nil {
@@ -245,7 +247,7 @@ func initStackitSfsResourcePool(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetResourcePoolExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	resp, err := client.DefaultAPI.GetResourcePool(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,7 +255,7 @@ func initStackitSfsResourcePool(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit.sfs.resourcePool with id %q not found", id)
 	}
-	res, err := CreateResource(runtime, "stackit.sfs.resourcePool", sfsResourcePoolArgs(c.Region(), &pool))
+	res, err := CreateResource(runtime, "stackit.sfs.resourcePool", sfsResourcePoolArgs(c.Region(), pool))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -321,7 +323,7 @@ func (r *mqlStackitSfsExportPolicy) rules() ([]any, error) {
 	if region == "" {
 		region = c.Region()
 	}
-	resp, err := client.GetShareExportPolicyExecute(bgctx(), c.ProjectID(), region, r.Id.Data)
+	resp, err := client.DefaultAPI.GetShareExportPolicy(bgctx(), c.ProjectID(), region, r.Id.Data).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -340,7 +342,7 @@ func (r *mqlStackitSfsExportPolicy) rules() ([]any, error) {
 			"id":          llx.StringData(rule.GetId()),
 			"order":       llx.IntData(rule.GetOrder()),
 			"ipAcl":       strSliceData(rule.GetIpAcl()),
-			"description": llx.StringData(ptrStr(rule.GetDescription())),
+			"description": llx.StringData(rule.GetDescription()),
 			"createdAt":   llx.TimeDataPtr(timeOrNil(rule.GetCreatedAtOk())),
 		})
 		if err != nil {
@@ -365,7 +367,7 @@ func initStackitSfsExportPolicy(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := client.GetShareExportPolicyExecute(bgctx(), c.ProjectID(), c.Region(), id)
+	resp, err := client.DefaultAPI.GetShareExportPolicy(bgctx(), c.ProjectID(), c.Region(), id).Execute()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -373,7 +375,7 @@ func initStackitSfsExportPolicy(runtime *plugin.Runtime, args map[string]*llx.Ra
 	if !ok {
 		return nil, nil, fmt.Errorf("stackit.sfs.exportPolicy with id %q not found", id)
 	}
-	res, err := newSfsExportPolicy(runtime, c.Region(), &pol)
+	res, err := newSfsExportPolicy(runtime, c.Region(), pol)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/sfs_test.go
+++ b/providers/stackit/resources/sfs_test.go
@@ -6,7 +6,7 @@ package resources
 import "testing"
 
 func TestDerefFloat(t *testing.T) {
-	if got := derefFloat(nil); got != 0 {
+	if got := derefFloat[*float64](nil); got != 0 {
 		t.Fatalf("nil pointer: got %v, want 0", got)
 	}
 	f := 3.5

--- a/providers/stackit/resources/ske.go
+++ b/providers/stackit/resources/ske.go
@@ -6,7 +6,7 @@ package resources
 import (
 	"time"
 
-	"github.com/stackitcloud/stackit-sdk-go/services/ske"
+	ske "github.com/stackitcloud/stackit-sdk-go/services/ske/v2api"
 	"go.mondoo.com/mql/v13/llx"
 	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
 	"go.mondoo.com/mql/v13/types"
@@ -18,7 +18,7 @@ func (r *mqlStackitSke) clusters() ([]any, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.ListClustersExecute(bgctx(), c.ProjectID(), c.Region())
+	resp, err := client.DefaultAPI.ListClusters(bgctx(), c.ProjectID(), c.Region()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return []any{}, nil
@@ -59,15 +59,15 @@ func buildSkeCluster(runtime *plugin.Runtime, cluster *ske.Cluster) (plugin.Reso
 	if status, ok := cluster.GetStatusOk(); ok {
 		aggregated = string(status.GetAggregated())
 		if ct, ok := status.GetCreationTimeOk(); ok && !ct.IsZero() {
-			creationTime = &ct
+			creationTime = ct
 		}
 		if cr, ok := status.GetCredentialsRotationOk(); ok {
 			credRotPhase = string(cr.GetPhase())
 			if t, ok := cr.GetLastInitiationTimeOk(); ok && !t.IsZero() {
-				credRotInitiated = &t
+				credRotInitiated = t
 			}
 			if t, ok := cr.GetLastCompletionTimeOk(); ok && !t.IsZero() {
-				credRotCompleted = &t
+				credRotCompleted = t
 			}
 		}
 		if r, ok := status.GetEgressAddressRangesOk(); ok {
@@ -224,7 +224,7 @@ func (r *mqlStackitSkeCluster) nodePools() ([]any, error) {
 		var volSize int64
 		var volType string
 		if v, ok := np.GetVolumeOk(); ok {
-			volSize = v.GetSize()
+			volSize = int64(v.GetSize())
 			volType = v.GetType()
 		}
 
@@ -305,7 +305,7 @@ func initStackitSkeCluster(runtime *plugin.Runtime, args map[string]*llx.RawData
 	if err != nil {
 		return nil, nil, err
 	}
-	cluster, err := client.GetClusterExecute(bgctx(), c.ProjectID(), c.Region(), name)
+	cluster, err := client.DefaultAPI.GetCluster(bgctx(), c.ProjectID(), c.Region(), name).Execute()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/providers/stackit/resources/stackit.go
+++ b/providers/stackit/resources/stackit.go
@@ -28,7 +28,7 @@ func (r *mqlStackit) project() (*mqlStackitProject, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.GetProjectExecute(bgctx(), c.ProjectID())
+	resp, err := client.DefaultAPI.GetProject(bgctx(), c.ProjectID()).Execute()
 	if err != nil {
 		if isAccessDenied(err) {
 			return markNull[mqlStackitProject](&r.Project)
@@ -52,7 +52,7 @@ func (r *mqlStackit) project() (*mqlStackitProject, error) {
 		"id":             llx.StringData(resp.GetProjectId()),
 		"name":           llx.StringData(resp.GetName()),
 		"parent":         llx.StringData(parentID),
-		"lifecycleState": llx.StringData(string(lifecycle)),
+		"lifecycleState": llx.StringData(ptrEnumStr(lifecycle)),
 		"creationTime":   llx.TimeDataPtr(timeOrNil(createdAt, ok)),
 		"labels":         labelData(labels),
 	}


### PR DESCRIPTION
Every unversioned STACKIT service package we import is deprecated and **scheduled for removal after 2026-09-30**:

```
// Deprecated: Will be removed after 2026-09-30. Move to the packages
// generated for each available API version instead
```

That marker is on all 23 root packages the provider imports. This migrates every one of them to its versioned equivalent. Nothing about the provider's behavior, schema, or queries changes.

## Why this isn't a find-and-replace

`v1api` and `v2api` are **different API versions**, not old/new bindings of one API. The root package is equivalent to exactly one of them, and picking wrong silently changes which API we call. Two obvious heuristics both got subsets wrong:

- **By version number** (take the lowest GA) put `ske` on `v1api`, which has no `Audit`, `Access`, `Observability`, `ServiceAccountIssuer`, or `GatewayApi`. It compiles only after deleting those accessors, which would have dropped shipped fields from the MQL schema.
- **By symbol-name coverage** tied `logme`/`mariadb`/`opensearch`/`rabbitmq`/`redis`/`mongodbflex` between `v1api` and `v2api`, because the method *names* are identical. Only the arity differs: `v1api` drops the region parameter entirely.

Targets here were chosen by matching **parameter type lists** of the methods we actually call against the root package, which is ground truth because it's what we call in production today. Every one of the 92 call sites resolves to a target where the signature matches exactly.

## Targets

| service | → | service | → | service | → |
|---|---|---|---|---|---|
| alb | v2api | logme | v2api | secretsmanager | v1api |
| authorization | v2api | mariadb | v2api | serverbackup | v2api |
| certificates | v2api | modelserving | v1api | serverupdate | v2api |
| dns | v1api | mongodbflex | v2api | serviceaccount | v2api |
| iaas | v2api | objectstorage | v2api | sfs | v1api |
| kms | v1api | observability | v1api | ske | v2api |
| loadbalancer | v2api | opensearch | v2api | resourcemanager | v0api |
| | | rabbitmq / redis | v2api | | |

Each import is aliased to the service name (`dns "…/services/dns/v1api"`), matching the existing `postgresflex "…/v2api"` convention. That keeps every `dns.Zone` / `alb.LoadBalancer` type reference compiling unchanged, so the diff is import lines plus call shape rather than ~800 symbol rewrites.

## Call-shape changes

Root packages hang methods off `*APIClient`; versioned packages put them behind a `DefaultAPI` field, and drop the `XExecute(ctx, …)` convenience form:

```go
- client.GetZoneExecute(bgctx(), c.ProjectID(), id)
+ client.DefaultAPI.GetZone(bgctx(), c.ProjectID(), id).Execute()
```

## Helper changes

The versioned packages disagree with each other on nullability: `iaas`/`ske` return `*time.Time` where root returned `time.Time`, while `sfs` went the **opposite** direction. Rather than adapting ~30 call sites in both directions, `timeOrNil`, `rfc3339OrNil`, `ptrStr`, and `derefFloat` are now generic over both forms. Added `derefInt64` and `ptrEnumStr` for the same reason.

Where a nullable wrapper became a plain value (`sfs` `GetSnapshotPolicy`, `GetExportPolicy`), the `*Ok` variant is used so "is set" semantics are preserved rather than treating an empty value as absent.

## Not included

Three packages are deprecated but have **no removal deadline**, and each needs a model reshape rather than a package swap. Keeping them out so this PR stays reviewable:

| package | why deferred |
|---|---|
| `albwaf/v1betaapi` → `v1api` | `v1api` has no `GetBehaviourOk`; the rule/condition model was reshaped into new `Action`/`Severity`/`Operator` enums |
| `postgresflex/v2api` → `v3api` | `v3api` renamed the response models: no `Instance`, no `GetItemsOk`/`GetItemOk` |
| `sqlserverflex/v2api` → `v3api` | same model rename, **plus** `GetInstance` reorders `(projectId, instanceId, region)` → `(projectId, region, instanceId)`. Both are `string`, so the compiler cannot catch it |

## Verification

```
go build -gcflags=-e ./...   0 errors
go vet ./...                 0 errors
go test ./...                ok (connection, resources)
gofmt -l                     clean
go mod tidy -diff            clean
```

No remaining unversioned `services/<name>` imports in the provider.

Not exercised against live STACKIT infrastructure. The signature-match analysis above is what stands in for that: every called method was verified to have an identical parameter type list in its target package, and the argument-order hazard class was checked explicitly (the one instance found is in the deferred `sqlserverflex` work, not here).
