### PR TITLE
📄 aws: add InfrastructureHealth to ecs task stopCode values

### DIFF
--- a/providers/aws/resources/aws.lr
+++ b/providers/aws/resources/aws.lr
@@ -8901,7 +8901,7 @@ private aws.ecs.task @defaults("lastStatus platformFamily platformVersion") {
   enableExecuteCommand bool
   // How the task was stopped
   //
-  // One of TaskFailedToStart, EssentialContainerExited, UserInitiated, ServiceSchedulerInitiated, SpotInterruption, or TerminationNotice.
+  // One of TaskFailedToStart, EssentialContainerExited, UserInitiated, ServiceSchedulerInitiated, SpotInterruption, TerminationNotice, or InfrastructureHealth.
   stopCode string
   // Reason the task was stopped
   stoppedReason string


### PR DESCRIPTION
`aws-sdk-go-v2/service/ecs` v1.89.3 → v1.90.0 (part of the dependency sweep in #9560) added a seventh member to the `TaskStopCode` enum:

```
TaskFailedToStart  EssentialContainerExited  UserInitiated
ServiceSchedulerInitiated  SpotInterruption  TerminationNotice
+ InfrastructureHealth
```

The `aws.ecs.task.stopCode` field comment enumerated exactly the six prior members, so anyone reading the rendered resource docs would conclude `InfrastructureHealth` is not a value the field can return. It is: AWS uses it when a task is stopped because the underlying infrastructure was unhealthy, which is precisely the case someone writing an availability or reliability query cares about.

Doc-only change to the enumerated values. No field, type, or behavior change, so `.lr.versions` is untouched (`aws.resources.json` is gitignored and regenerates from the `.lr`).

## How this was found

I diffed the exported API surface of all 142 bumped modules between their old and new versions and cross-referenced every added enum value against the enum lists documented in the `.lr` files. This was the **only** stale enum list in the entire sweep.

Two near-misses that turned out to be correct as written, worth recording so they aren't re-flagged:

- ECS also added `AGENT_CONNECTIVITY`, but to `InstanceHealthCheckType` (the check *type*), not to `InstanceHealthCheckState`. Our `aws.ecs.containerInstance.healthStatus` comment documents the *state* enum (`OK, IMPAIRED, INITIALIZING, INSUFFICIENT_DATA`), which still has exactly those four members.
- ACM PCA added post-quantum signing algorithms (`ML_DSA_44/65/87`) plus `SHA*WITHRSA_PSS` and `SM3WITHSM2`, but `aws.privateca.certificateAuthority.signingAlgorithm` does not enumerate values today, so nothing there is stale. Documenting that set would be a genuine improvement, but it is an addition rather than a correction, so it is not in this PR.
