### PR TITLE
✨ digitalocean: expose droplet automated-backup policy

### DIFF
--- a/providers/digitalocean/resources/digitalocean.lr
+++ b/providers/digitalocean/resources/digitalocean.lr
@@ -212,6 +212,28 @@ digitalocean.droplet @defaults("id name status") {
   nextBackupWindowStart time
   // End of the next scheduled automated-backup window; null when backups are disabled
   nextBackupWindowEnd time
+  // Automated-backup plan
+  //
+  // Cadence the backup schedule runs on, either "daily" or "weekly". Null
+  // when the droplet has no backup policy, which is always the case while
+  // `backupsEnabled` is false.
+  backupPlan() string
+  // Day of the week the backup window opens
+  //
+  // One of SUN, MON, TUE, WED, THU, FRI, or SAT. Null on droplets running
+  // the daily plan, and null when the droplet has no backup policy.
+  backupWeekday() string
+  // Hour of the day, in UTC, at which the backup window opens; null when the droplet has no backup policy
+  backupHour() int
+  // Length of the backup window in hours; null when the droplet has no backup policy
+  backupWindowLengthHours() int
+  // Retention period for automated backups, in days
+  //
+  // How long a backup image is kept before DigitalOcean deletes it. Short
+  // retention caps how far back a restore can reach after data loss or a
+  // compromise that goes undetected. Null when the droplet has no backup
+  // policy.
+  backupRetentionPeriodDays() int
   // Automated backup images retained for this droplet
   backups() []digitalocean.image
   // Snapshots taken of this droplet

--- a/providers/digitalocean/resources/digitalocean.lr.go
+++ b/providers/digitalocean/resources/digitalocean.lr.go
@@ -712,6 +712,21 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"digitalocean.droplet.nextBackupWindowEnd": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetNextBackupWindowEnd()).ToDataRes(types.Time)
 	},
+	"digitalocean.droplet.backupPlan": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetBackupPlan()).ToDataRes(types.String)
+	},
+	"digitalocean.droplet.backupWeekday": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetBackupWeekday()).ToDataRes(types.String)
+	},
+	"digitalocean.droplet.backupHour": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetBackupHour()).ToDataRes(types.Int)
+	},
+	"digitalocean.droplet.backupWindowLengthHours": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetBackupWindowLengthHours()).ToDataRes(types.Int)
+	},
+	"digitalocean.droplet.backupRetentionPeriodDays": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlDigitaloceanDroplet).GetBackupRetentionPeriodDays()).ToDataRes(types.Int)
+	},
 	"digitalocean.droplet.backups": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlDigitaloceanDroplet).GetBackups()).ToDataRes(types.Array(types.Resource("digitalocean.image")))
 	},
@@ -3581,6 +3596,26 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"digitalocean.droplet.nextBackupWindowEnd": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlDigitaloceanDroplet).NextBackupWindowEnd, ok = plugin.RawToTValue[*time.Time](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.backupPlan": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).BackupPlan, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.backupWeekday": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).BackupWeekday, ok = plugin.RawToTValue[string](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.backupHour": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).BackupHour, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.backupWindowLengthHours": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).BackupWindowLengthHours, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"digitalocean.droplet.backupRetentionPeriodDays": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlDigitaloceanDroplet).BackupRetentionPeriodDays, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
 	"digitalocean.droplet.backups": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -8072,38 +8107,43 @@ type mqlDigitaloceanDroplet struct {
 	MqlRuntime *plugin.Runtime
 	__id       string
 	mqlDigitaloceanDropletInternal
-	Id                    plugin.TValue[int64]
-	Name                  plugin.TValue[string]
-	Memory                plugin.TValue[int64]
-	Vcpus                 plugin.TValue[int64]
-	Disk                  plugin.TValue[int64]
-	Region                plugin.TValue[string]
-	Size                  plugin.TValue[string]
-	DropletSize           plugin.TValue[*mqlDigitaloceanSize]
-	GpuPartitionMode      plugin.TValue[string]
-	Status                plugin.TValue[string]
-	Locked                plugin.TValue[bool]
-	CreatedAt             plugin.TValue[*time.Time]
-	PublicIpv4            plugin.TValue[string]
-	PrivateIpv4           plugin.TValue[string]
-	PublicIpv6            plugin.TValue[string]
-	Tags                  plugin.TValue[[]any]
-	VpcUuid               plugin.TValue[string]
-	Vpc                   plugin.TValue[*mqlDigitaloceanVpc]
-	Features              plugin.TValue[[]any]
-	BackupsEnabled        plugin.TValue[bool]
-	MonitoringEnabled     plugin.TValue[bool]
-	Image                 plugin.TValue[any]
-	BaseImage             plugin.TValue[*mqlDigitaloceanImage]
-	Firewalls             plugin.TValue[[]any]
-	MissingFirewall       plugin.TValue[bool]
-	Exposure              plugin.TValue[*mqlDigitaloceanNetworkExposure]
-	Volumes               plugin.TValue[[]any]
-	Kernel                plugin.TValue[any]
-	NextBackupWindowStart plugin.TValue[*time.Time]
-	NextBackupWindowEnd   plugin.TValue[*time.Time]
-	Backups               plugin.TValue[[]any]
-	Snapshots             plugin.TValue[[]any]
+	Id                        plugin.TValue[int64]
+	Name                      plugin.TValue[string]
+	Memory                    plugin.TValue[int64]
+	Vcpus                     plugin.TValue[int64]
+	Disk                      plugin.TValue[int64]
+	Region                    plugin.TValue[string]
+	Size                      plugin.TValue[string]
+	DropletSize               plugin.TValue[*mqlDigitaloceanSize]
+	GpuPartitionMode          plugin.TValue[string]
+	Status                    plugin.TValue[string]
+	Locked                    plugin.TValue[bool]
+	CreatedAt                 plugin.TValue[*time.Time]
+	PublicIpv4                plugin.TValue[string]
+	PrivateIpv4               plugin.TValue[string]
+	PublicIpv6                plugin.TValue[string]
+	Tags                      plugin.TValue[[]any]
+	VpcUuid                   plugin.TValue[string]
+	Vpc                       plugin.TValue[*mqlDigitaloceanVpc]
+	Features                  plugin.TValue[[]any]
+	BackupsEnabled            plugin.TValue[bool]
+	MonitoringEnabled         plugin.TValue[bool]
+	Image                     plugin.TValue[any]
+	BaseImage                 plugin.TValue[*mqlDigitaloceanImage]
+	Firewalls                 plugin.TValue[[]any]
+	MissingFirewall           plugin.TValue[bool]
+	Exposure                  plugin.TValue[*mqlDigitaloceanNetworkExposure]
+	Volumes                   plugin.TValue[[]any]
+	Kernel                    plugin.TValue[any]
+	NextBackupWindowStart     plugin.TValue[*time.Time]
+	NextBackupWindowEnd       plugin.TValue[*time.Time]
+	BackupPlan                plugin.TValue[string]
+	BackupWeekday             plugin.TValue[string]
+	BackupHour                plugin.TValue[int64]
+	BackupWindowLengthHours   plugin.TValue[int64]
+	BackupRetentionPeriodDays plugin.TValue[int64]
+	Backups                   plugin.TValue[[]any]
+	Snapshots                 plugin.TValue[[]any]
 }
 
 // createDigitaloceanDroplet creates a new instance of this resource
@@ -8335,6 +8375,36 @@ func (c *mqlDigitaloceanDroplet) GetNextBackupWindowStart() *plugin.TValue[*time
 
 func (c *mqlDigitaloceanDroplet) GetNextBackupWindowEnd() *plugin.TValue[*time.Time] {
 	return &c.NextBackupWindowEnd
+}
+
+func (c *mqlDigitaloceanDroplet) GetBackupPlan() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.BackupPlan, func() (string, error) {
+		return c.backupPlan()
+	})
+}
+
+func (c *mqlDigitaloceanDroplet) GetBackupWeekday() *plugin.TValue[string] {
+	return plugin.GetOrCompute[string](&c.BackupWeekday, func() (string, error) {
+		return c.backupWeekday()
+	})
+}
+
+func (c *mqlDigitaloceanDroplet) GetBackupHour() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.BackupHour, func() (int64, error) {
+		return c.backupHour()
+	})
+}
+
+func (c *mqlDigitaloceanDroplet) GetBackupWindowLengthHours() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.BackupWindowLengthHours, func() (int64, error) {
+		return c.backupWindowLengthHours()
+	})
+}
+
+func (c *mqlDigitaloceanDroplet) GetBackupRetentionPeriodDays() *plugin.TValue[int64] {
+	return plugin.GetOrCompute[int64](&c.BackupRetentionPeriodDays, func() (int64, error) {
+		return c.backupRetentionPeriodDays()
+	})
 }
 
 func (c *mqlDigitaloceanDroplet) GetBackups() *plugin.TValue[[]any] {

--- a/providers/digitalocean/resources/digitalocean.lr.versions
+++ b/providers/digitalocean/resources/digitalocean.lr.versions
@@ -217,6 +217,11 @@ digitalocean.domain.ttl 13.0.1
 digitalocean.domain.zoneFile 13.0.1
 digitalocean.domains 13.0.1
 digitalocean.droplet 13.0.1
+digitalocean.droplet.backupHour 13.14.5
+digitalocean.droplet.backupPlan 13.14.5
+digitalocean.droplet.backupRetentionPeriodDays 13.14.5
+digitalocean.droplet.backupWeekday 13.14.5
+digitalocean.droplet.backupWindowLengthHours 13.14.5
 digitalocean.droplet.backups 13.6.2
 digitalocean.droplet.backupsEnabled 13.0.1
 digitalocean.droplet.baseImage 13.1.7

--- a/providers/digitalocean/resources/digitalocean_droplet_backup.go
+++ b/providers/digitalocean/resources/digitalocean_droplet_backup.go
@@ -1,0 +1,160 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+	"go.mondoo.com/mql/v13/providers-sdk/v1/plugin"
+	"go.mondoo.com/mql/v13/providers/digitalocean/connection"
+)
+
+// dropletBackupPolicy is the normalized automated-backup schedule for one
+// droplet. weekday is empty on the daily plan, where DigitalOcean returns no
+// day of the week.
+type dropletBackupPolicy struct {
+	plan                string
+	weekday             string
+	hour                int64
+	windowLengthHours   int64
+	retentionPeriodDays int64
+}
+
+// indexBackupPolicies normalizes one page of the account-wide backup-policy
+// response and adds it to the given index.
+//
+// Droplets whose backups are disabled come back with no schedule attached.
+// They are left out of the index entirely rather than stored as a zero value,
+// so their fields resolve to null. Storing zeros instead would report a
+// never-configured droplet as having a zero-day retention policy.
+func indexBackupPolicies(policies map[int]*godo.DropletBackupPolicy, into map[int64]dropletBackupPolicy) {
+	for id, p := range policies {
+		if p == nil || p.BackupPolicy == nil {
+			continue
+		}
+		into[int64(id)] = dropletBackupPolicy{
+			plan:                p.BackupPolicy.Plan,
+			weekday:             p.BackupPolicy.Weekday,
+			hour:                int64(p.BackupPolicy.Hour),
+			windowLengthHours:   int64(p.BackupPolicy.WindowLengthHours),
+			retentionPeriodDays: int64(p.BackupPolicy.RetentionPeriodDays),
+		}
+	}
+}
+
+// backupPolicyByDropletID resolves a droplet's backup schedule from an
+// account-wide index, returning nil when the droplet has no policy.
+//
+// DigitalOcean exposes both a per-droplet policy endpoint and an account-wide
+// one. Reading the account-wide list once and indexing it keeps a query over
+// every droplet at a single (paginated) call instead of one call per droplet.
+func (r *mqlDigitalocean) backupPolicyByDropletID(dropletID int64) (*dropletBackupPolicy, error) {
+	r.backupPolicyIndexOnce.Do(func() {
+		conn := r.MqlRuntime.Connection.(*connection.DigitaloceanConnection)
+		client := conn.Client()
+
+		idx := map[int64]dropletBackupPolicy{}
+		opt := &godo.ListOptions{PerPage: 200}
+		for {
+			policies, resp, err := client.Droplets.ListBackupPolicies(context.Background(), opt)
+			if err != nil {
+				r.backupPolicyIndexErr = err
+				return
+			}
+			indexBackupPolicies(policies, idx)
+			if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+				break
+			}
+			page, err := resp.Links.CurrentPage()
+			if err != nil {
+				r.backupPolicyIndexErr = err
+				return
+			}
+			opt.Page = page + 1
+		}
+		r.backupPolicyIndex = idx
+	})
+	if r.backupPolicyIndexErr != nil {
+		return nil, r.backupPolicyIndexErr
+	}
+	policy, ok := r.backupPolicyIndex[dropletID]
+	if !ok {
+		return nil, nil
+	}
+	return &policy, nil
+}
+
+// backupPolicy fetches this droplet's schedule from the parent's index. All
+// five backup* accessors share it, so the account-wide list is read once no
+// matter how many of them a query touches.
+func (r *mqlDigitaloceanDroplet) backupPolicy() (*dropletBackupPolicy, error) {
+	parent, err := parentDigitalocean(r.MqlRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return parent.backupPolicyByDropletID(r.Id.Data)
+}
+
+func (r *mqlDigitaloceanDroplet) backupPlan() (string, error) {
+	policy, err := r.backupPolicy()
+	if err != nil {
+		return "", err
+	}
+	if policy == nil {
+		r.BackupPlan.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+	return policy.plan, nil
+}
+
+// backupWeekday resolves to null on the daily plan, which has no day of the
+// week, so `where(backupWeekday != null)` selects the weekly-plan droplets.
+func (r *mqlDigitaloceanDroplet) backupWeekday() (string, error) {
+	policy, err := r.backupPolicy()
+	if err != nil {
+		return "", err
+	}
+	if policy == nil || policy.weekday == "" {
+		r.BackupWeekday.State = plugin.StateIsSet | plugin.StateIsNull
+		return "", nil
+	}
+	return policy.weekday, nil
+}
+
+func (r *mqlDigitaloceanDroplet) backupHour() (int64, error) {
+	policy, err := r.backupPolicy()
+	if err != nil {
+		return 0, err
+	}
+	if policy == nil {
+		r.BackupHour.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return policy.hour, nil
+}
+
+func (r *mqlDigitaloceanDroplet) backupWindowLengthHours() (int64, error) {
+	policy, err := r.backupPolicy()
+	if err != nil {
+		return 0, err
+	}
+	if policy == nil {
+		r.BackupWindowLengthHours.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return policy.windowLengthHours, nil
+}
+
+func (r *mqlDigitaloceanDroplet) backupRetentionPeriodDays() (int64, error) {
+	policy, err := r.backupPolicy()
+	if err != nil {
+		return 0, err
+	}
+	if policy == nil {
+		r.BackupRetentionPeriodDays.State = plugin.StateIsSet | plugin.StateIsNull
+		return 0, nil
+	}
+	return policy.retentionPeriodDays, nil
+}

--- a/providers/digitalocean/resources/digitalocean_droplet_backup_test.go
+++ b/providers/digitalocean/resources/digitalocean_droplet_backup_test.go
@@ -1,0 +1,88 @@
+// Copyright Mondoo, Inc. 2024, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndexBackupPolicies(t *testing.T) {
+	t.Run("maps a weekly policy", func(t *testing.T) {
+		idx := map[int64]dropletBackupPolicy{}
+		indexBackupPolicies(map[int]*godo.DropletBackupPolicy{
+			7: {
+				DropletID:     7,
+				BackupEnabled: true,
+				BackupPolicy: &godo.DropletBackupPolicyConfig{
+					Plan:                "weekly",
+					Weekday:             "SUN",
+					Hour:                20,
+					WindowLengthHours:   4,
+					RetentionPeriodDays: 28,
+				},
+			},
+		}, idx)
+
+		policy, ok := idx[7]
+		require.True(t, ok)
+		assert.Equal(t, "weekly", policy.plan)
+		assert.Equal(t, "SUN", policy.weekday)
+		assert.Equal(t, int64(20), policy.hour)
+		assert.Equal(t, int64(4), policy.windowLengthHours)
+		assert.Equal(t, int64(28), policy.retentionPeriodDays)
+	})
+
+	t.Run("daily policy carries no weekday", func(t *testing.T) {
+		idx := map[int64]dropletBackupPolicy{}
+		indexBackupPolicies(map[int]*godo.DropletBackupPolicy{
+			8: {
+				DropletID:     8,
+				BackupEnabled: true,
+				BackupPolicy: &godo.DropletBackupPolicyConfig{
+					Plan:                "daily",
+					Hour:                4,
+					WindowLengthHours:   4,
+					RetentionPeriodDays: 7,
+				},
+			},
+		}, idx)
+
+		policy, ok := idx[8]
+		require.True(t, ok)
+		assert.Equal(t, "daily", policy.plan)
+		assert.Empty(t, policy.weekday)
+		assert.Equal(t, int64(7), policy.retentionPeriodDays)
+	})
+
+	// A droplet with backups disabled must stay out of the index so its
+	// fields resolve to null. Indexing it as a zero value would report a
+	// never-configured droplet as having zero-day backup retention.
+	t.Run("skips droplets with no schedule", func(t *testing.T) {
+		idx := map[int64]dropletBackupPolicy{}
+		indexBackupPolicies(map[int]*godo.DropletBackupPolicy{
+			9:  {DropletID: 9, BackupEnabled: false},
+			10: nil,
+		}, idx)
+
+		assert.Empty(t, idx)
+	})
+
+	t.Run("accumulates across pages", func(t *testing.T) {
+		idx := map[int64]dropletBackupPolicy{}
+		indexBackupPolicies(map[int]*godo.DropletBackupPolicy{
+			1: {BackupPolicy: &godo.DropletBackupPolicyConfig{Plan: "daily"}},
+		}, idx)
+		indexBackupPolicies(map[int]*godo.DropletBackupPolicy{
+			2: {BackupPolicy: &godo.DropletBackupPolicyConfig{Plan: "weekly"}},
+		}, idx)
+
+		assert.Len(t, idx, 2)
+		assert.Equal(t, "daily", idx[1].plan)
+		assert.Equal(t, "weekly", idx[2].plan)
+	})
+}

--- a/providers/digitalocean/resources/digitalocean_security.go
+++ b/providers/digitalocean/resources/digitalocean_security.go
@@ -74,6 +74,14 @@ type mqlDigitaloceanInternal struct {
 	sizeIndexOnce sync.Once
 	sizeIndex     map[string]*mqlDigitaloceanSize
 	sizeIndexErr  error
+
+	// backupPolicyIndex maps droplet id to its automated-backup schedule.
+	// Droplets without a policy are absent from the map rather than
+	// present with a zero value, so callers can tell "no policy" from
+	// "policy with zero retention". See digitalocean_droplet_backup.go.
+	backupPolicyIndexOnce sync.Once
+	backupPolicyIndex     map[int64]dropletBackupPolicy
+	backupPolicyIndexErr  error
 }
 
 // partnerAttachmentByID resolves a partner attachment by its ID from the


### PR DESCRIPTION
## What

`digitalocean.droplet` reported whether backups were enabled and when the next window opened, but nothing about the schedule itself. A droplet with backups on and 7-day retention looked identical to one with 28-day retention, so `backupsEnabled == true` was as far as an audit could get.

This wires up `Droplets.ListBackupPolicies` — previously unused — and adds five computed fields:

| Field | Meaning |
|---|---|
| `backupPlan()` | `daily` or `weekly` |
| `backupWeekday()` | day the weekly window opens (SUN…SAT) |
| `backupHour()` | hour the window opens, UTC |
| `backupWindowLengthHours()` | length of the window |
| `backupRetentionPeriodDays()` | how long a backup image is kept |

Retention is the one that carries real weight: it caps how far back a restore can reach after data loss or a compromise that goes undetected.

```
digitalocean.droplets.where(backupsEnabled) {
  name
  backupPlan
  backupRetentionPeriodDays
}

// droplets whose backups won't survive a slow-burn incident
digitalocean.droplets.where(backupRetentionPeriodDays < 14)
```

## Shape

The five values are flat scalars with no ID of their own and no references to other modeled resources, so per the sub-resource bar they're flattened onto the droplet with a `backup*` prefix rather than given a sub-resource.

Resolution goes through an account-wide index cached on the parent `digitalocean` resource with `sync.Once`, matching the existing firewall / droplet / VPC indexes. DigitalOcean also exposes a per-droplet policy endpoint, but listing once keeps a query across every droplet at a single paginated call instead of one call per droplet, and all five accessors share the one fetch. Fields stay computed, so accounts that never query them pay nothing.

## Null semantics

Droplets with backups disabled are **left out of the index** rather than stored as a zero value, so their fields resolve to null.

This is the load-bearing decision in the change. Indexing them as zeros would report a never-configured droplet as having zero-day backup retention — a finding that reads as severe and is entirely fabricated. `backupWeekday` resolves to null on the daily plan for the same reason, which has the useful side effect that `where(backupWeekday != null)` selects exactly the weekly-plan droplets.

The normalization is extracted into a pure `indexBackupPolicies` function so that behavior is unit-tested directly, including the skip path and accumulation across pages.

## Verification

- `mqlr generate` clean; new `.lr.versions` entries at `13.14.5` (provider is at `13.14.4`)
- `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- `go test ./...` passes, including 4 new subtests
- `make providers/build/digitalocean` succeeds
- `go mod tidy` produces no diff

**Not verified against live infrastructure** — there's no DigitalOcean token in this environment. The field mapping follows godo's `DropletBackupPolicyConfig` struct directly, but the daily-plan weekday behavior (assumed empty) is inferred from the API docs rather than observed, and is worth confirming on a real account before this is relied on for policy.
