### PR TITLE
✨ hetzner: expose egress restriction, vSwitch bridging, TSIG auth, and typed parent refs

### DIFF
--- a/providers/hetzner/resources/hetzner.lr
+++ b/providers/hetzner/resources/hetzner.lr
@@ -149,10 +149,16 @@ private hetzner.server @defaults("id name status") {
 
 // Hetzner Cloud server private network attachment
 private hetzner.server.privateNet @defaults("ip macAddress") {
-  // Parent server ID (composite key with networkId)
-  serverId int
-  // Attached network ID (composite key)
-  networkId int
+  // Parent server ID
+  //
+  // Deprecated in favor of server.
+  serverId @maturity("deprecated") int
+  // Attached network ID
+  //
+  // Deprecated in favor of network.
+  networkId @maturity("deprecated") int
+  // Server the network is attached to
+  server() hetzner.server
   // Hetzner Cloud network attached to the server
   network() hetzner.network
   // IP address on the network
@@ -165,10 +171,16 @@ private hetzner.server.privateNet @defaults("ip macAddress") {
 
 // Hetzner Cloud server firewall binding
 private hetzner.server.firewallBinding @defaults("status") {
-  // Parent server ID (composite key with firewallId)
-  serverId int
-  // Bound firewall ID (composite key)
-  firewallId int
+  // Parent server ID
+  //
+  // Deprecated in favor of server.
+  serverId @maturity("deprecated") int
+  // Bound firewall ID
+  //
+  // Deprecated in favor of firewall.
+  firewallId @maturity("deprecated") int
+  // Server the firewall is bound to
+  server() hetzner.server
   // Hetzner Cloud firewall bound to the server
   firewall() hetzner.firewall
   // Application status (applied, pending)
@@ -189,9 +201,11 @@ private hetzner.network.exposure @defaults("internetReachable hasPublicIp") {
   hasPublicIp bool
   // Whether inbound traffic from any address is admitted
   //
-  // For a server, a firewall inbound rule open to the internet or no firewall
-  // attached at all; for a load balancer, an enabled public network with at
-  // least one forwarding service.
+  // For a server, a firewall inbound rule open to the internet, or no firewall
+  // enforcing rules at all. Only bindings whose status is applied count as
+  // enforcing, so a server whose firewalls are all still pending admits
+  // ingress. For a load balancer, an enabled public network with at least one
+  // forwarding service.
   firewallAllowsIngress bool
   // Ingress rules or services that admit traffic from any address
   //
@@ -238,10 +252,16 @@ private hetzner.serverType @defaults("id name cores memory") {
 
 // Hetzner Cloud server type availability in a single location
 private hetzner.serverType.location @defaults("available recommended") {
-  // Parent server type ID (composite key with locationId)
-  serverTypeId int
-  // Location ID (composite key)
-  locationId int
+  // Parent server type ID
+  //
+  // Deprecated in favor of serverType.
+  serverTypeId @maturity("deprecated") int
+  // Location ID
+  //
+  // Deprecated in favor of location.
+  locationId @maturity("deprecated") int
+  // Server type offered in this location
+  serverType() hetzner.serverType
   // Hetzner location where the server type is offered
   location() hetzner.location
   // Whether new servers of this type can be created in this location
@@ -401,7 +421,12 @@ private hetzner.network @defaults("id name ipRange") {
   ipRange string
   // Creation timestamp
   created time
-  // Subnets [{type, ipRange, networkZone, gateway}]
+  // Subnets carved out of the network's IP range
+  //
+  // Each subnet is a dict with `type` (cloud, server, or vswitch), `ipRange`,
+  // `networkZone`, `gateway`, and `vswitchId`. A `vswitchId` other than 0
+  // attaches the subnet to a Hetzner vSwitch, extending the network to
+  // dedicated servers and other networks outside this project.
   subnets []dict
   // Routes [{destination, gateway}]
   routes []dict
@@ -559,10 +584,16 @@ hetzner.loadBalancer @defaults("id name") {
 
 // Hetzner Cloud load balancer private network attachment
 private hetzner.loadBalancer.privateNet @defaults("ip") {
-  // Parent load balancer ID (composite key with networkId)
-  loadBalancerId int
-  // Attached network ID (composite key)
-  networkId int
+  // Parent load balancer ID
+  //
+  // Deprecated in favor of loadBalancer.
+  loadBalancerId @maturity("deprecated") int
+  // Attached network ID
+  //
+  // Deprecated in favor of network.
+  networkId @maturity("deprecated") int
+  // Load balancer the network is attached to
+  loadBalancer() hetzner.loadBalancer
   // Hetzner Cloud network attached to the load balancer
   network() hetzner.network
   // IP address on the network
@@ -572,7 +603,11 @@ private hetzner.loadBalancer.privateNet @defaults("ip") {
 // Load balancer service definition
 private hetzner.loadBalancer.service @defaults("protocol listenPort") {
   // Parent load balancer ID
-  loadBalancerId int
+  //
+  // Deprecated in favor of loadBalancer.
+  loadBalancerId @maturity("deprecated") int
+  // Load balancer the service forwards for
+  loadBalancer() hetzner.loadBalancer
   // Protocol (tcp, http, https)
   protocol string
   // Listen port
@@ -590,8 +625,10 @@ private hetzner.loadBalancer.service @defaults("protocol listenPort") {
   // Session persistence and HTTP redirect options
   //
   // Dict with keys cookieName, cookieLifetime (seconds), redirectHttp
-  // (whether plain HTTP is redirected to HTTPS), and stickySessions. TLS
-  // certificates are exposed separately through certificates.
+  // (whether plain HTTP is redirected to HTTPS), stickySessions, and
+  // timeoutIdle (seconds an idle connection is held open before the load
+  // balancer closes it). TLS certificates are exposed separately through
+  // certificates.
   http dict
   // TLS certificates attached to this service
   certificates() []hetzner.certificate
@@ -600,7 +637,11 @@ private hetzner.loadBalancer.service @defaults("protocol listenPort") {
 // Load balancer target
 private hetzner.loadBalancer.target @defaults("type") {
   // Parent load balancer ID
-  loadBalancerId int
+  //
+  // Deprecated in favor of loadBalancer.
+  loadBalancerId @maturity("deprecated") int
+  // Load balancer the target sits behind
+  loadBalancer() hetzner.loadBalancer
   // Target type (server, label_selector, ip)
   type string
   // Health status of the target [{listenPort, status}]
@@ -685,6 +726,13 @@ hetzner.firewall @defaults("id name") {
   // An inbound rule whose `sourceIps` contains 0.0.0.0/0 or ::/0 opens the
   // port to the entire internet.
   rules []dict
+  // Whether the rule set restricts outbound traffic
+  //
+  // Hetzner firewalls permit all outbound traffic unless the rule set holds
+  // at least one rule with direction `out`, in which case only traffic
+  // matching those rules is allowed. False therefore means the firewall
+  // places no restriction on connections the server opens itself.
+  egressRestricted() bool
   // Servers the firewall is directly applied to (type=server entries)
   servers() []hetzner.server
   // Label selectors the firewall is applied to (type=label_selector entries)
@@ -993,7 +1041,11 @@ private hetzner.storageBox.subaccount @defaults("id username") {
   // Subaccount ID
   id int
   // Parent Storage Box ID
-  storageBoxId int
+  //
+  // Deprecated in favor of storageBox.
+  storageBoxId @maturity("deprecated") int
+  // Storage Box the subaccount grants access to
+  storageBox() hetzner.storageBox
   // Subaccount name
   name string
   // Login username
@@ -1031,7 +1083,11 @@ private hetzner.storageBox.snapshot @defaults("id name created") {
   // Snapshot ID
   id int
   // Parent Storage Box ID
-  storageBoxId int
+  //
+  // Deprecated in favor of storageBox.
+  storageBoxId @maturity("deprecated") int
+  // Storage Box the snapshot was taken from
+  storageBox() hetzner.storageBox
   // Snapshot name
   name string
   // Description
@@ -1075,7 +1131,13 @@ private hetzner.zone @defaults("id name mode status") {
   recordCount int
   // Registrar managing the domain (hetzner, other, unknown)
   registrar string
-  // Primary nameservers for secondary zones [{address, port, tsigAlgorithm}]
+  // Primary nameservers a secondary zone transfers from
+  //
+  // Each entry is a dict with `address`, `port`, `tsigAlgorithm`, and
+  // `tsigConfigured`. When `tsigConfigured` is false, the zone transfer from
+  // that primary is not authenticated with a TSIG key. The key itself is a
+  // shared secret and is never exposed as queryable data. Empty for primary
+  // zones, which serve their own data rather than transferring it.
   primaryNameservers []dict
   // Nameservers assigned by Hetzner for this zone
   assignedNameservers []string
@@ -1106,7 +1168,9 @@ private hetzner.zone.rrset @defaults("name type") {
   // Record set ID (name/type)
   id string
   // Parent zone ID
-  zoneId int
+  //
+  // Deprecated in favor of zone.
+  zoneId @maturity("deprecated") int
   // Zone the record set belongs to
   zone() hetzner.zone
   // Record name relative to the zone (e.g., "@", "www")

--- a/providers/hetzner/resources/hetzner.lr.go
+++ b/providers/hetzner/resources/hetzner.lr.go
@@ -411,6 +411,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.server.privateNet.networkId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerPrivateNet).GetNetworkId()).ToDataRes(types.Int)
 	},
+	"hetzner.server.privateNet.server": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerPrivateNet).GetServer()).ToDataRes(types.Resource("hetzner.server"))
+	},
 	"hetzner.server.privateNet.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerPrivateNet).GetNetwork()).ToDataRes(types.Resource("hetzner.network"))
 	},
@@ -428,6 +431,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.server.firewallBinding.firewallId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerFirewallBinding).GetFirewallId()).ToDataRes(types.Int)
+	},
+	"hetzner.server.firewallBinding.server": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerFirewallBinding).GetServer()).ToDataRes(types.Resource("hetzner.server"))
 	},
 	"hetzner.server.firewallBinding.firewall": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerFirewallBinding).GetFirewall()).ToDataRes(types.Resource("hetzner.firewall"))
@@ -485,6 +491,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.serverType.location.locationId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerTypeLocation).GetLocationId()).ToDataRes(types.Int)
+	},
+	"hetzner.serverType.location.serverType": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerServerTypeLocation).GetServerType()).ToDataRes(types.Resource("hetzner.serverType"))
 	},
 	"hetzner.serverType.location.location": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerServerTypeLocation).GetLocation()).ToDataRes(types.Resource("hetzner.location"))
@@ -780,6 +789,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.loadBalancer.privateNet.networkId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerPrivateNet).GetNetworkId()).ToDataRes(types.Int)
 	},
+	"hetzner.loadBalancer.privateNet.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancerPrivateNet).GetLoadBalancer()).ToDataRes(types.Resource("hetzner.loadBalancer"))
+	},
 	"hetzner.loadBalancer.privateNet.network": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerPrivateNet).GetNetwork()).ToDataRes(types.Resource("hetzner.network"))
 	},
@@ -788,6 +800,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.loadBalancer.service.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerService).GetLoadBalancerId()).ToDataRes(types.Int)
+	},
+	"hetzner.loadBalancer.service.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancerService).GetLoadBalancer()).ToDataRes(types.Resource("hetzner.loadBalancer"))
 	},
 	"hetzner.loadBalancer.service.protocol": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerService).GetProtocol()).ToDataRes(types.String)
@@ -812,6 +827,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.loadBalancer.target.loadBalancerId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerTarget).GetLoadBalancerId()).ToDataRes(types.Int)
+	},
+	"hetzner.loadBalancer.target.loadBalancer": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerLoadBalancerTarget).GetLoadBalancer()).ToDataRes(types.Resource("hetzner.loadBalancer"))
 	},
 	"hetzner.loadBalancer.target.type": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerLoadBalancerTarget).GetType()).ToDataRes(types.String)
@@ -872,6 +890,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.firewall.rules": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerFirewall).GetRules()).ToDataRes(types.Array(types.Dict))
+	},
+	"hetzner.firewall.egressRestricted": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerFirewall).GetEgressRestricted()).ToDataRes(types.Bool)
 	},
 	"hetzner.firewall.servers": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerFirewall).GetServers()).ToDataRes(types.Array(types.Resource("hetzner.server")))
@@ -1131,6 +1152,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	"hetzner.storageBox.subaccount.storageBoxId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBoxSubaccount).GetStorageBoxId()).ToDataRes(types.Int)
 	},
+	"hetzner.storageBox.subaccount.storageBox": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerStorageBoxSubaccount).GetStorageBox()).ToDataRes(types.Resource("hetzner.storageBox"))
+	},
 	"hetzner.storageBox.subaccount.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBoxSubaccount).GetName()).ToDataRes(types.String)
 	},
@@ -1172,6 +1196,9 @@ var getDataFields = map[string]func(r plugin.Resource) *plugin.DataRes{
 	},
 	"hetzner.storageBox.snapshot.storageBoxId": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBoxSnapshot).GetStorageBoxId()).ToDataRes(types.Int)
+	},
+	"hetzner.storageBox.snapshot.storageBox": func(r plugin.Resource) *plugin.DataRes {
+		return (r.(*mqlHetznerStorageBoxSnapshot).GetStorageBox()).ToDataRes(types.Resource("hetzner.storageBox"))
 	},
 	"hetzner.storageBox.snapshot.name": func(r plugin.Resource) *plugin.DataRes {
 		return (r.(*mqlHetznerStorageBoxSnapshot).GetName()).ToDataRes(types.String)
@@ -1517,6 +1544,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerServerPrivateNet).NetworkId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"hetzner.server.privateNet.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerPrivateNet).Server, ok = plugin.RawToTValue[*mqlHetznerServer](v.Value, v.Error)
+		return
+	},
 	"hetzner.server.privateNet.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServerPrivateNet).Network, ok = plugin.RawToTValue[*mqlHetznerNetwork](v.Value, v.Error)
 		return
@@ -1543,6 +1574,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.server.firewallBinding.firewallId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServerFirewallBinding).FirewallId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.server.firewallBinding.server": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerFirewallBinding).Server, ok = plugin.RawToTValue[*mqlHetznerServer](v.Value, v.Error)
 		return
 	},
 	"hetzner.server.firewallBinding.firewall": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -1631,6 +1666,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.serverType.location.locationId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerServerTypeLocation).LocationId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.serverType.location.serverType": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerServerTypeLocation).ServerType, ok = plugin.RawToTValue[*mqlHetznerServerType](v.Value, v.Error)
 		return
 	},
 	"hetzner.serverType.location.location": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2057,6 +2096,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerLoadBalancerPrivateNet).NetworkId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"hetzner.loadBalancer.privateNet.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancerPrivateNet).LoadBalancer, ok = plugin.RawToTValue[*mqlHetznerLoadBalancer](v.Value, v.Error)
+		return
+	},
 	"hetzner.loadBalancer.privateNet.network": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancerPrivateNet).Network, ok = plugin.RawToTValue[*mqlHetznerNetwork](v.Value, v.Error)
 		return
@@ -2071,6 +2114,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.loadBalancer.service.loadBalancerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancerService).LoadBalancerId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.loadBalancer.service.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancerService).LoadBalancer, ok = plugin.RawToTValue[*mqlHetznerLoadBalancer](v.Value, v.Error)
 		return
 	},
 	"hetzner.loadBalancer.service.protocol": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2107,6 +2154,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.loadBalancer.target.loadBalancerId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerLoadBalancerTarget).LoadBalancerId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.loadBalancer.target.loadBalancer": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerLoadBalancerTarget).LoadBalancer, ok = plugin.RawToTValue[*mqlHetznerLoadBalancer](v.Value, v.Error)
 		return
 	},
 	"hetzner.loadBalancer.target.type": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2195,6 +2246,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.firewall.rules": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerFirewall).Rules, ok = plugin.RawToTValue[[]any](v.Value, v.Error)
+		return
+	},
+	"hetzner.firewall.egressRestricted": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerFirewall).EgressRestricted, ok = plugin.RawToTValue[bool](v.Value, v.Error)
 		return
 	},
 	"hetzner.firewall.servers": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -2573,6 +2628,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 		r.(*mqlHetznerStorageBoxSubaccount).StorageBoxId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
 		return
 	},
+	"hetzner.storageBox.subaccount.storageBox": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerStorageBoxSubaccount).StorageBox, ok = plugin.RawToTValue[*mqlHetznerStorageBox](v.Value, v.Error)
+		return
+	},
 	"hetzner.storageBox.subaccount.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerStorageBoxSubaccount).Name, ok = plugin.RawToTValue[string](v.Value, v.Error)
 		return
@@ -2631,6 +2690,10 @@ var setDataFields = map[string]func(r plugin.Resource, v *llx.RawData) bool{
 	},
 	"hetzner.storageBox.snapshot.storageBoxId": func(r plugin.Resource, v *llx.RawData) (ok bool) {
 		r.(*mqlHetznerStorageBoxSnapshot).StorageBoxId, ok = plugin.RawToTValue[int64](v.Value, v.Error)
+		return
+	},
+	"hetzner.storageBox.snapshot.storageBox": func(r plugin.Resource, v *llx.RawData) (ok bool) {
+		r.(*mqlHetznerStorageBoxSnapshot).StorageBox, ok = plugin.RawToTValue[*mqlHetznerStorageBox](v.Value, v.Error)
 		return
 	},
 	"hetzner.storageBox.snapshot.name": func(r plugin.Resource, v *llx.RawData) (ok bool) {
@@ -3566,6 +3629,7 @@ type mqlHetznerServerPrivateNet struct {
 	// optional: if you define mqlHetznerServerPrivateNetInternal it will be used here
 	ServerId   plugin.TValue[int64]
 	NetworkId  plugin.TValue[int64]
+	Server     plugin.TValue[*mqlHetznerServer]
 	Network    plugin.TValue[*mqlHetznerNetwork]
 	Ip         plugin.TValue[string]
 	AliasIps   plugin.TValue[[]any]
@@ -3617,6 +3681,22 @@ func (c *mqlHetznerServerPrivateNet) GetNetworkId() *plugin.TValue[int64] {
 	return &c.NetworkId
 }
 
+func (c *mqlHetznerServerPrivateNet) GetServer() *plugin.TValue[*mqlHetznerServer] {
+	return plugin.GetOrCompute[*mqlHetznerServer](&c.Server, func() (*mqlHetznerServer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server.privateNet", c.__id, "server")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerServer), nil
+			}
+		}
+
+		return c.server()
+	})
+}
+
 func (c *mqlHetznerServerPrivateNet) GetNetwork() *plugin.TValue[*mqlHetznerNetwork] {
 	return plugin.GetOrCompute[*mqlHetznerNetwork](&c.Network, func() (*mqlHetznerNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -3652,6 +3732,7 @@ type mqlHetznerServerFirewallBinding struct {
 	// optional: if you define mqlHetznerServerFirewallBindingInternal it will be used here
 	ServerId   plugin.TValue[int64]
 	FirewallId plugin.TValue[int64]
+	Server     plugin.TValue[*mqlHetznerServer]
 	Firewall   plugin.TValue[*mqlHetznerFirewall]
 	Status     plugin.TValue[string]
 }
@@ -3699,6 +3780,22 @@ func (c *mqlHetznerServerFirewallBinding) GetServerId() *plugin.TValue[int64] {
 
 func (c *mqlHetznerServerFirewallBinding) GetFirewallId() *plugin.TValue[int64] {
 	return &c.FirewallId
+}
+
+func (c *mqlHetznerServerFirewallBinding) GetServer() *plugin.TValue[*mqlHetznerServer] {
+	return plugin.GetOrCompute[*mqlHetznerServer](&c.Server, func() (*mqlHetznerServer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.server.firewallBinding", c.__id, "server")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerServer), nil
+			}
+		}
+
+		return c.server()
+	})
 }
 
 func (c *mqlHetznerServerFirewallBinding) GetFirewall() *plugin.TValue[*mqlHetznerFirewall] {
@@ -3898,6 +3995,7 @@ type mqlHetznerServerTypeLocation struct {
 	// optional: if you define mqlHetznerServerTypeLocationInternal it will be used here
 	ServerTypeId plugin.TValue[int64]
 	LocationId   plugin.TValue[int64]
+	ServerType   plugin.TValue[*mqlHetznerServerType]
 	Location     plugin.TValue[*mqlHetznerLocation]
 	Available    plugin.TValue[bool]
 	Recommended  plugin.TValue[bool]
@@ -3947,6 +4045,22 @@ func (c *mqlHetznerServerTypeLocation) GetServerTypeId() *plugin.TValue[int64] {
 
 func (c *mqlHetznerServerTypeLocation) GetLocationId() *plugin.TValue[int64] {
 	return &c.LocationId
+}
+
+func (c *mqlHetznerServerTypeLocation) GetServerType() *plugin.TValue[*mqlHetznerServerType] {
+	return plugin.GetOrCompute[*mqlHetznerServerType](&c.ServerType, func() (*mqlHetznerServerType, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.serverType.location", c.__id, "serverType")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerServerType), nil
+			}
+		}
+
+		return c.serverType()
+	})
 }
 
 func (c *mqlHetznerServerTypeLocation) GetLocation() *plugin.TValue[*mqlHetznerLocation] {
@@ -4968,6 +5082,7 @@ type mqlHetznerLoadBalancerPrivateNet struct {
 	// optional: if you define mqlHetznerLoadBalancerPrivateNetInternal it will be used here
 	LoadBalancerId plugin.TValue[int64]
 	NetworkId      plugin.TValue[int64]
+	LoadBalancer   plugin.TValue[*mqlHetznerLoadBalancer]
 	Network        plugin.TValue[*mqlHetznerNetwork]
 	Ip             plugin.TValue[string]
 }
@@ -5017,6 +5132,22 @@ func (c *mqlHetznerLoadBalancerPrivateNet) GetNetworkId() *plugin.TValue[int64] 
 	return &c.NetworkId
 }
 
+func (c *mqlHetznerLoadBalancerPrivateNet) GetLoadBalancer() *plugin.TValue[*mqlHetznerLoadBalancer] {
+	return plugin.GetOrCompute[*mqlHetznerLoadBalancer](&c.LoadBalancer, func() (*mqlHetznerLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer.privateNet", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
+}
+
 func (c *mqlHetznerLoadBalancerPrivateNet) GetNetwork() *plugin.TValue[*mqlHetznerNetwork] {
 	return plugin.GetOrCompute[*mqlHetznerNetwork](&c.Network, func() (*mqlHetznerNetwork, error) {
 		if c.MqlRuntime.HasRecording {
@@ -5043,6 +5174,7 @@ type mqlHetznerLoadBalancerService struct {
 	__id       string
 	mqlHetznerLoadBalancerServiceInternal
 	LoadBalancerId  plugin.TValue[int64]
+	LoadBalancer    plugin.TValue[*mqlHetznerLoadBalancer]
 	Protocol        plugin.TValue[string]
 	ListenPort      plugin.TValue[int64]
 	DestinationPort plugin.TValue[int64]
@@ -5093,6 +5225,22 @@ func (c *mqlHetznerLoadBalancerService) GetLoadBalancerId() *plugin.TValue[int64
 	return &c.LoadBalancerId
 }
 
+func (c *mqlHetznerLoadBalancerService) GetLoadBalancer() *plugin.TValue[*mqlHetznerLoadBalancer] {
+	return plugin.GetOrCompute[*mqlHetznerLoadBalancer](&c.LoadBalancer, func() (*mqlHetznerLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer.service", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
+}
+
 func (c *mqlHetznerLoadBalancerService) GetProtocol() *plugin.TValue[string] {
 	return &c.Protocol
 }
@@ -5139,6 +5287,7 @@ type mqlHetznerLoadBalancerTarget struct {
 	__id       string
 	mqlHetznerLoadBalancerTargetInternal
 	LoadBalancerId       plugin.TValue[int64]
+	LoadBalancer         plugin.TValue[*mqlHetznerLoadBalancer]
 	Type                 plugin.TValue[string]
 	HealthStatus         plugin.TValue[[]any]
 	UsePrivateIp         plugin.TValue[bool]
@@ -5187,6 +5336,22 @@ func (c *mqlHetznerLoadBalancerTarget) MqlID() string {
 
 func (c *mqlHetznerLoadBalancerTarget) GetLoadBalancerId() *plugin.TValue[int64] {
 	return &c.LoadBalancerId
+}
+
+func (c *mqlHetznerLoadBalancerTarget) GetLoadBalancer() *plugin.TValue[*mqlHetznerLoadBalancer] {
+	return plugin.GetOrCompute[*mqlHetznerLoadBalancer](&c.LoadBalancer, func() (*mqlHetznerLoadBalancer, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.loadBalancer.target", c.__id, "loadBalancer")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerLoadBalancer), nil
+			}
+		}
+
+		return c.loadBalancer()
+	})
 }
 
 func (c *mqlHetznerLoadBalancerTarget) GetType() *plugin.TValue[string] {
@@ -5339,6 +5504,7 @@ type mqlHetznerFirewall struct {
 	Name                 plugin.TValue[string]
 	Created              plugin.TValue[*time.Time]
 	Rules                plugin.TValue[[]any]
+	EgressRestricted     plugin.TValue[bool]
 	Servers              plugin.TValue[[]any]
 	LabelSelectors       plugin.TValue[[]any]
 	LabelSelectorTargets plugin.TValue[[]any]
@@ -5396,6 +5562,12 @@ func (c *mqlHetznerFirewall) GetCreated() *plugin.TValue[*time.Time] {
 
 func (c *mqlHetznerFirewall) GetRules() *plugin.TValue[[]any] {
 	return &c.Rules
+}
+
+func (c *mqlHetznerFirewall) GetEgressRestricted() *plugin.TValue[bool] {
+	return plugin.GetOrCompute[bool](&c.EgressRestricted, func() (bool, error) {
+		return c.egressRestricted()
+	})
 }
 
 func (c *mqlHetznerFirewall) GetServers() *plugin.TValue[[]any] {
@@ -6309,6 +6481,7 @@ type mqlHetznerStorageBoxSubaccount struct {
 	// optional: if you define mqlHetznerStorageBoxSubaccountInternal it will be used here
 	Id                  plugin.TValue[int64]
 	StorageBoxId        plugin.TValue[int64]
+	StorageBox          plugin.TValue[*mqlHetznerStorageBox]
 	Name                plugin.TValue[string]
 	Username            plugin.TValue[string]
 	HomeDirectory       plugin.TValue[string]
@@ -6368,6 +6541,22 @@ func (c *mqlHetznerStorageBoxSubaccount) GetStorageBoxId() *plugin.TValue[int64]
 	return &c.StorageBoxId
 }
 
+func (c *mqlHetznerStorageBoxSubaccount) GetStorageBox() *plugin.TValue[*mqlHetznerStorageBox] {
+	return plugin.GetOrCompute[*mqlHetznerStorageBox](&c.StorageBox, func() (*mqlHetznerStorageBox, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.storageBox.subaccount", c.__id, "storageBox")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerStorageBox), nil
+			}
+		}
+
+		return c.storageBox()
+	})
+}
+
 func (c *mqlHetznerStorageBoxSubaccount) GetName() *plugin.TValue[string] {
 	return &c.Name
 }
@@ -6423,6 +6612,7 @@ type mqlHetznerStorageBoxSnapshot struct {
 	// optional: if you define mqlHetznerStorageBoxSnapshotInternal it will be used here
 	Id             plugin.TValue[int64]
 	StorageBoxId   plugin.TValue[int64]
+	StorageBox     plugin.TValue[*mqlHetznerStorageBox]
 	Name           plugin.TValue[string]
 	Description    plugin.TValue[string]
 	IsAutomatic    plugin.TValue[bool]
@@ -6475,6 +6665,22 @@ func (c *mqlHetznerStorageBoxSnapshot) GetId() *plugin.TValue[int64] {
 
 func (c *mqlHetznerStorageBoxSnapshot) GetStorageBoxId() *plugin.TValue[int64] {
 	return &c.StorageBoxId
+}
+
+func (c *mqlHetznerStorageBoxSnapshot) GetStorageBox() *plugin.TValue[*mqlHetznerStorageBox] {
+	return plugin.GetOrCompute[*mqlHetznerStorageBox](&c.StorageBox, func() (*mqlHetznerStorageBox, error) {
+		if c.MqlRuntime.HasRecording {
+			d, err := c.MqlRuntime.FieldResourceFromRecording("hetzner.storageBox.snapshot", c.__id, "storageBox")
+			if err != nil {
+				return nil, err
+			}
+			if d != nil {
+				return d.Value.(*mqlHetznerStorageBox), nil
+			}
+		}
+
+		return c.storageBox()
+	})
 }
 
 func (c *mqlHetznerStorageBoxSnapshot) GetName() *plugin.TValue[string] {

--- a/providers/hetzner/resources/hetzner.lr.versions
+++ b/providers/hetzner/resources/hetzner.lr.versions
@@ -37,6 +37,7 @@ hetzner.datacenter.supportedServerTypes 13.0.1
 hetzner.datacenters 13.0.1
 hetzner.firewall 13.0.1
 hetzner.firewall.created 13.0.1
+hetzner.firewall.egressRestricted 13.7.6
 hetzner.firewall.id 13.0.1
 hetzner.firewall.labelSelectorTargets 13.4.2
 hetzner.firewall.labelSelectors 13.0.1
@@ -101,6 +102,7 @@ hetzner.loadBalancer.name 13.0.1
 hetzner.loadBalancer.outgoingTraffic 13.0.1
 hetzner.loadBalancer.privateNet 13.0.1
 hetzner.loadBalancer.privateNet.ip 13.0.1
+hetzner.loadBalancer.privateNet.loadBalancer 13.7.6
 hetzner.loadBalancer.privateNet.loadBalancerId 13.0.1
 hetzner.loadBalancer.privateNet.network 13.0.1
 hetzner.loadBalancer.privateNet.networkId 13.0.1
@@ -113,6 +115,7 @@ hetzner.loadBalancer.service.destinationPort 13.0.1
 hetzner.loadBalancer.service.healthCheck 13.0.1
 hetzner.loadBalancer.service.http 13.0.1
 hetzner.loadBalancer.service.listenPort 13.0.1
+hetzner.loadBalancer.service.loadBalancer 13.7.6
 hetzner.loadBalancer.service.loadBalancerId 13.0.1
 hetzner.loadBalancer.service.protocol 13.0.1
 hetzner.loadBalancer.service.proxyProtocol 13.0.1
@@ -122,6 +125,7 @@ hetzner.loadBalancer.target.healthStatus 13.0.1
 hetzner.loadBalancer.target.ip 13.0.1
 hetzner.loadBalancer.target.labelSelector 13.0.1
 hetzner.loadBalancer.target.labelSelectorTargets 13.5.2
+hetzner.loadBalancer.target.loadBalancer 13.7.6
 hetzner.loadBalancer.target.loadBalancerId 13.0.1
 hetzner.loadBalancer.target.server 13.0.1
 hetzner.loadBalancer.target.type 13.0.1
@@ -202,6 +206,7 @@ hetzner.server.exposure 13.3.1
 hetzner.server.firewallBinding 13.1.2
 hetzner.server.firewallBinding.firewall 13.1.2
 hetzner.server.firewallBinding.firewallId 13.1.2
+hetzner.server.firewallBinding.server 13.7.6
 hetzner.server.firewallBinding.serverId 13.1.2
 hetzner.server.firewallBinding.status 13.1.2
 hetzner.server.firewallBindings 13.1.2
@@ -228,6 +233,7 @@ hetzner.server.privateNet.ip 13.0.1
 hetzner.server.privateNet.macAddress 13.0.1
 hetzner.server.privateNet.network 13.0.1
 hetzner.server.privateNet.networkId 13.0.1
+hetzner.server.privateNet.server 13.7.6
 hetzner.server.privateNet.serverId 13.0.1
 hetzner.server.protection 13.0.1
 hetzner.server.publicIpv4 13.0.6
@@ -254,6 +260,7 @@ hetzner.serverType.location.deprecation 13.0.1
 hetzner.serverType.location.location 13.0.1
 hetzner.serverType.location.locationId 13.0.1
 hetzner.serverType.location.recommended 13.0.1
+hetzner.serverType.location.serverType 13.7.6
 hetzner.serverType.location.serverTypeId 13.0.1
 hetzner.serverType.locations 13.0.1
 hetzner.serverType.memory 13.0.1
@@ -293,6 +300,7 @@ hetzner.storageBox.snapshot.labels 13.4.2
 hetzner.storageBox.snapshot.name 13.4.2
 hetzner.storageBox.snapshot.size 13.4.2
 hetzner.storageBox.snapshot.sizeFilesystem 13.4.2
+hetzner.storageBox.snapshot.storageBox 13.7.6
 hetzner.storageBox.snapshot.storageBoxId 13.4.2
 hetzner.storageBox.snapshotPlan 13.4.2
 hetzner.storageBox.snapshots 13.4.2
@@ -311,6 +319,7 @@ hetzner.storageBox.subaccount.readonly 13.4.2
 hetzner.storageBox.subaccount.sambaEnabled 13.4.2
 hetzner.storageBox.subaccount.server 13.4.2
 hetzner.storageBox.subaccount.sshEnabled 13.4.2
+hetzner.storageBox.subaccount.storageBox 13.7.6
 hetzner.storageBox.subaccount.storageBoxId 13.4.2
 hetzner.storageBox.subaccount.username 13.4.2
 hetzner.storageBox.subaccount.webdavEnabled 13.4.2

--- a/providers/hetzner/resources/hetzner_dict_serialization_test.go
+++ b/providers/hetzner/resources/hetzner_dict_serialization_test.go
@@ -60,6 +60,30 @@ func TestDeprecationDict(t *testing.T) {
 	})
 }
 
+func TestZonePrimaryNameserverDicts(t *testing.T) {
+	got := zonePrimaryNameserverDicts([]hcloud.ZonePrimaryNameserver{
+		{Address: "203.0.113.53", Port: 53, TSIGAlgorithm: hcloud.ZoneTSIGAlgorithmHMACSHA256, TSIGKey: "c2VjcmV0"},
+		{Address: "198.51.100.53", Port: 5353},
+	})
+	require.Len(t, got, 2)
+
+	authenticated := got[0].(map[string]any)
+	assert.Equal(t, "203.0.113.53", authenticated["address"])
+	assert.Equal(t, int64(53), authenticated["port"])
+	assert.Equal(t, true, authenticated["tsigConfigured"])
+	// The shared secret itself must never reach queryable data, under any key.
+	for k, v := range authenticated {
+		assert.NotEqual(t, "c2VjcmV0", v, "TSIG key leaked via key %q", k)
+	}
+
+	unauthenticated := got[1].(map[string]any)
+	assert.Equal(t, false, unauthenticated["tsigConfigured"])
+	assert.Equal(t, "", unauthenticated["tsigAlgorithm"])
+
+	requireDictArraySerializes(t, got)
+	assert.Empty(t, zonePrimaryNameserverDicts(nil))
+}
+
 func TestLoadBalancerHealthCheckDict(t *testing.T) {
 	t.Run("tcp check widens int ports and serializes", func(t *testing.T) {
 		d := loadBalancerHealthCheckDict(hcloud.LoadBalancerServiceHealthCheck{

--- a/providers/hetzner/resources/hetzner_exposure.go
+++ b/providers/hetzner/resources/hetzner_exposure.go
@@ -29,10 +29,41 @@ func firewallRuleOpenToInternet(rule map[string]any) bool {
 	return false
 }
 
+// firewallBindingRules pairs a firewall binding's application status with the
+// rule dicts of the firewall it binds, the two inputs the ingress decision
+// needs.
+type firewallBindingRules struct {
+	status string
+	rules  []any
+}
+
+// serverFirewallIngress reports whether a server's firewall bindings admit
+// traffic from any address, along with the inbound rules that do so.
+//
+// Only a binding whose status is applied enforces its rules; a pending binding
+// has not taken effect yet. A server with no enforcing binding therefore admits
+// ingress, which covers both the no-firewall case and the case where every
+// attached firewall is still pending.
+func serverFirewallIngress(bindings []firewallBindingRules) (bool, []any) {
+	openRules := []any{}
+	enforcing := 0
+	for _, b := range bindings {
+		if b.status != string(hcloud.FirewallStatusApplied) {
+			continue
+		}
+		enforcing++
+		for _, r := range b.rules {
+			rule, ok := r.(map[string]any)
+			if ok && firewallRuleOpenToInternet(rule) {
+				openRules = append(openRules, rule)
+			}
+		}
+	}
+	return enforcing == 0 || len(openRules) > 0, openRules
+}
+
 // exposure breaks down whether the server is reachable from the internet: a
-// public IP combined with firewall ingress that admits any address. A server
-// with no firewall attached is open, so an empty firewall set counts as
-// admitting ingress.
+// public IP combined with firewall ingress that admits any address.
 func (s *mqlHetznerServer) exposure() (*mqlHetznerNetworkExposure, error) {
 	id := s.GetId()
 	if id.Error != nil {
@@ -49,29 +80,37 @@ func (s *mqlHetznerServer) exposure() (*mqlHetznerNetworkExposure, error) {
 	}
 	hasPublicIp := ipv4.Data != "" || ipv6.Data != ""
 
-	firewalls := s.GetFirewalls()
-	if firewalls.Error != nil {
-		return nil, firewalls.Error
+	bindings := s.GetFirewallBindings()
+	if bindings.Error != nil {
+		return nil, bindings.Error
 	}
-	openRules := []any{}
-	for _, f := range firewalls.Data {
-		fw, ok := f.(*mqlHetznerFirewall)
+	collected := make([]firewallBindingRules, 0, len(bindings.Data))
+	for _, b := range bindings.Data {
+		binding, ok := b.(*mqlHetznerServerFirewallBinding)
 		if !ok {
 			continue
 		}
-		rules := fw.GetRules()
-		if rules.Error != nil {
-			return nil, rules.Error
+		status := binding.GetStatus()
+		if status.Error != nil {
+			return nil, status.Error
 		}
-		for _, r := range rules.Data {
-			rule, ok := r.(map[string]any)
-			if ok && firewallRuleOpenToInternet(rule) {
-				openRules = append(openRules, rule)
+		entry := firewallBindingRules{status: status.Data}
+
+		fw := binding.GetFirewall()
+		if fw.Error != nil {
+			return nil, fw.Error
+		}
+		if fw.Data != nil {
+			rules := fw.Data.GetRules()
+			if rules.Error != nil {
+				return nil, rules.Error
 			}
+			entry.rules = rules.Data
 		}
+		collected = append(collected, entry)
 	}
 
-	firewallAllowsIngress := len(firewalls.Data) == 0 || len(openRules) > 0
+	firewallAllowsIngress, openRules := serverFirewallIngress(collected)
 	internetReachable := hasPublicIp && firewallAllowsIngress
 
 	res, err := CreateResource(s.MqlRuntime, "hetzner.network.exposure", map[string]*llx.RawData{

--- a/providers/hetzner/resources/hetzner_exposure_test.go
+++ b/providers/hetzner/resources/hetzner_exposure_test.go
@@ -32,6 +32,95 @@ func TestFirewallRuleOpenToInternet(t *testing.T) {
 	}
 }
 
+func TestRulesRestrictEgress(t *testing.T) {
+	inbound := map[string]any{"direction": "in", "sourceIps": []any{"0.0.0.0/0"}}
+	outbound := map[string]any{"direction": "out", "destinationIps": []any{"10.0.0.0/8"}}
+	tests := []struct {
+		name  string
+		rules []any
+		want  bool
+	}{
+		{"no rules at all", nil, false},
+		{"inbound only", []any{inbound}, false},
+		{"outbound only", []any{outbound}, true},
+		{"mixed", []any{inbound, outbound}, true},
+		{"malformed entries ignored", []any{"not-a-rule", 42}, false},
+		{"malformed alongside outbound", []any{"not-a-rule", outbound}, true},
+		{"direction wrong type", []any{map[string]any{"direction": 7}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rulesRestrictEgress(tt.rules))
+		})
+	}
+}
+
+func TestServerFirewallIngress(t *testing.T) {
+	open := map[string]any{"direction": "in", "sourceIps": []any{"0.0.0.0/0"}}
+	scoped := map[string]any{"direction": "in", "sourceIps": []any{"203.0.113.0/24"}}
+	applied := string(hcloud.FirewallStatusApplied)
+	pending := string(hcloud.FirewallStatusPending)
+
+	tests := []struct {
+		name          string
+		bindings      []firewallBindingRules
+		wantIngress   bool
+		wantOpenRules int
+	}{
+		{"no bindings admits ingress", nil, true, 0},
+		{
+			"applied binding with scoped rule blocks ingress",
+			[]firewallBindingRules{{status: applied, rules: []any{scoped}}},
+			false, 0,
+		},
+		{
+			"applied binding with open rule admits ingress",
+			[]firewallBindingRules{{status: applied, rules: []any{open}}},
+			true, 1,
+		},
+		{
+			// The regression this guards: a pending binding is not enforcing, so
+			// the server is still open even though a firewall is attached.
+			"only pending binding admits ingress",
+			[]firewallBindingRules{{status: pending, rules: []any{scoped}}},
+			true, 0,
+		},
+		{
+			"pending binding's open rule is not reported",
+			[]firewallBindingRules{{status: pending, rules: []any{open}}},
+			true, 0,
+		},
+		{
+			"applied scoped alongside pending stays closed",
+			[]firewallBindingRules{
+				{status: applied, rules: []any{scoped}},
+				{status: pending, rules: []any{open}},
+			},
+			false, 0,
+		},
+		{
+			"open rules collected across applied bindings",
+			[]firewallBindingRules{
+				{status: applied, rules: []any{open}},
+				{status: applied, rules: []any{open, scoped}},
+			},
+			true, 2,
+		},
+		{
+			"applied binding with no rules blocks ingress",
+			[]firewallBindingRules{{status: applied}},
+			false, 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIngress, gotRules := serverFirewallIngress(tt.bindings)
+			assert.Equal(t, tt.wantIngress, gotIngress)
+			assert.Len(t, gotRules, tt.wantOpenRules)
+		})
+	}
+}
+
 func TestLoadBalancerHasPublicIp(t *testing.T) {
 	ipv4 := net.ParseIP("203.0.113.10")
 	ipv6 := net.ParseIP("2001:db8::1")

--- a/providers/hetzner/resources/hetzner_firewall.go
+++ b/providers/hetzner/resources/hetzner_firewall.go
@@ -135,6 +135,30 @@ func initHetznerFirewall(runtime *plugin.Runtime, args map[string]*llx.RawData) 
 	return args, res, err
 }
 
+// rulesRestrictEgress reports whether a rule set constrains outbound traffic.
+// Hetzner permits all egress unless at least one rule carries direction "out",
+// at which point only traffic matching those rules is allowed.
+func rulesRestrictEgress(rules []any) bool {
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if direction, _ := rule["direction"].(string); direction == "out" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *mqlHetznerFirewall) egressRestricted() (bool, error) {
+	rules := m.GetRules()
+	if rules.Error != nil {
+		return false, rules.Error
+	}
+	return rulesRestrictEgress(rules.Data), nil
+}
+
 func (m *mqlHetznerFirewall) servers() ([]any, error) {
 	return serverRefs(m.MqlRuntime, m.cacheServerIDs)
 }

--- a/providers/hetzner/resources/hetzner_loadbalancer.go
+++ b/providers/hetzner/resources/hetzner_loadbalancer.go
@@ -145,6 +145,26 @@ func newMqlHetznerLoadBalancerPrivateNet(runtime *plugin.Runtime, lbID int64, p 
 	return res.(*mqlHetznerLoadBalancerPrivateNet), nil
 }
 
+// loadBalancerRef builds a lazy hetzner.loadBalancer reference from its id,
+// used by the sub-resources that point back at their parent.
+func loadBalancerRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlHetznerLoadBalancer], id int64) (*mqlHetznerLoadBalancer, error) {
+	if id == 0 {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ref, err := NewResource(runtime, "hetzner.loadBalancer", map[string]*llx.RawData{
+		"id": llx.IntData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ref.(*mqlHetznerLoadBalancer), nil
+}
+
+func (m *mqlHetznerLoadBalancerPrivateNet) loadBalancer() (*mqlHetznerLoadBalancer, error) {
+	return loadBalancerRef(m.MqlRuntime, &m.LoadBalancer, m.LoadBalancerId.Data)
+}
+
 func (m *mqlHetznerLoadBalancerPrivateNet) network() (*mqlHetznerNetwork, error) {
 	if m.NetworkId.Data == 0 {
 		m.Network.State = plugin.StateIsSet | plugin.StateIsNull
@@ -225,6 +245,7 @@ func newMqlHetznerLoadBalancerService(runtime *plugin.Runtime, lbID int64, s hcl
 		"cookieLifetime": s.HTTP.CookieLifetime.Seconds(),
 		"redirectHttp":   s.HTTP.RedirectHTTP,
 		"stickySessions": s.HTTP.StickySessions,
+		"timeoutIdle":    s.HTTP.TimeoutIdle.Seconds(),
 	}
 
 	res, err := CreateResource(runtime, "hetzner.loadBalancer.service", map[string]*llx.RawData{
@@ -243,6 +264,10 @@ func newMqlHetznerLoadBalancerService(runtime *plugin.Runtime, lbID int64, s hcl
 	m := res.(*mqlHetznerLoadBalancerService)
 	m.cacheCertificates = s.HTTP.Certificates
 	return m, nil
+}
+
+func (m *mqlHetznerLoadBalancerService) loadBalancer() (*mqlHetznerLoadBalancer, error) {
+	return loadBalancerRef(m.MqlRuntime, &m.LoadBalancer, m.LoadBalancerId.Data)
 }
 
 func (m *mqlHetznerLoadBalancerService) certificates() ([]any, error) {
@@ -345,6 +370,10 @@ func newMqlHetznerLoadBalancerTarget(runtime *plugin.Runtime, lbID int64, idx in
 	m.cacheServerID = serverID
 	m.cacheLabelSelectorServerIDs = labelSelectorServerIDs
 	return m, nil
+}
+
+func (m *mqlHetznerLoadBalancerTarget) loadBalancer() (*mqlHetznerLoadBalancer, error) {
+	return loadBalancerRef(m.MqlRuntime, &m.LoadBalancer, m.LoadBalancerId.Data)
 }
 
 func (m *mqlHetznerLoadBalancerTarget) server() (*mqlHetznerServer, error) {

--- a/providers/hetzner/resources/hetzner_network.go
+++ b/providers/hetzner/resources/hetzner_network.go
@@ -47,6 +47,9 @@ func newMqlHetznerNetwork(runtime *plugin.Runtime, n *hcloud.Network) (*mqlHetzn
 			"ipRange":     ipNetString(s.IPRange),
 			"networkZone": string(s.NetworkZone),
 			"gateway":     ipString(s.Gateway),
+			// 0 when the subnet is not attached to a vSwitch. A non-zero value
+			// bridges the network to hardware outside this project.
+			"vswitchId": s.VSwitchID,
 		})
 	}
 	routes := make([]any, 0, len(n.Routes))

--- a/providers/hetzner/resources/hetzner_server.go
+++ b/providers/hetzner/resources/hetzner_server.go
@@ -344,6 +344,26 @@ func newMqlHetznerServerPrivateNet(runtime *plugin.Runtime, serverID int64, p hc
 	return res.(*mqlHetznerServerPrivateNet), nil
 }
 
+// serverRef builds a lazy hetzner.server reference from its id, used by the
+// sub-resources that point back at their parent server.
+func serverRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlHetznerServer], id int64) (*mqlHetznerServer, error) {
+	if id == 0 {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ref, err := NewResource(runtime, "hetzner.server", map[string]*llx.RawData{
+		"id": llx.IntData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ref.(*mqlHetznerServer), nil
+}
+
+func (m *mqlHetznerServerPrivateNet) server() (*mqlHetznerServer, error) {
+	return serverRef(m.MqlRuntime, &m.Server, m.ServerId.Data)
+}
+
 func (m *mqlHetznerServerPrivateNet) network() (*mqlHetznerNetwork, error) {
 	if m.NetworkId.Data == 0 {
 		m.Network.State = plugin.StateIsSet | plugin.StateIsNull
@@ -375,6 +395,10 @@ func newMqlHetznerServerFirewallBinding(runtime *plugin.Runtime, serverID int64,
 		return nil, err
 	}
 	return res.(*mqlHetznerServerFirewallBinding), nil
+}
+
+func (m *mqlHetznerServerFirewallBinding) server() (*mqlHetznerServer, error) {
+	return serverRef(m.MqlRuntime, &m.Server, m.ServerId.Data)
 }
 
 func (m *mqlHetznerServerFirewallBinding) firewall() (*mqlHetznerFirewall, error) {

--- a/providers/hetzner/resources/hetzner_servertype.go
+++ b/providers/hetzner/resources/hetzner_servertype.go
@@ -98,6 +98,20 @@ func newMqlHetznerServerTypeLocation(runtime *plugin.Runtime, serverTypeID int64
 	return res.(*mqlHetznerServerTypeLocation), nil
 }
 
+func (m *mqlHetznerServerTypeLocation) serverType() (*mqlHetznerServerType, error) {
+	if m.ServerTypeId.Data == 0 {
+		m.ServerType.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ref, err := NewResource(m.MqlRuntime, "hetzner.serverType", map[string]*llx.RawData{
+		"id": llx.IntData(m.ServerTypeId.Data),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ref.(*mqlHetznerServerType), nil
+}
+
 func (m *mqlHetznerServerTypeLocation) location() (*mqlHetznerLocation, error) {
 	if m.LocationId.Data == 0 {
 		m.Location.State = plugin.StateIsSet | plugin.StateIsNull

--- a/providers/hetzner/resources/hetzner_storagebox.go
+++ b/providers/hetzner/resources/hetzner_storagebox.go
@@ -161,6 +161,30 @@ func (m *mqlHetznerStorageBox) snapshots() ([]any, error) {
 	return out, nil
 }
 
+// storageBoxRef builds a lazy hetzner.storageBox reference from its id, used by
+// the sub-resources that point back at their parent box.
+func storageBoxRef(runtime *plugin.Runtime, field *plugin.TValue[*mqlHetznerStorageBox], id int64) (*mqlHetznerStorageBox, error) {
+	if id == 0 {
+		field.State = plugin.StateIsSet | plugin.StateIsNull
+		return nil, nil
+	}
+	ref, err := NewResource(runtime, "hetzner.storageBox", map[string]*llx.RawData{
+		"id": llx.IntData(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ref.(*mqlHetznerStorageBox), nil
+}
+
+func (m *mqlHetznerStorageBoxSubaccount) storageBox() (*mqlHetznerStorageBox, error) {
+	return storageBoxRef(m.MqlRuntime, &m.StorageBox, m.StorageBoxId.Data)
+}
+
+func (m *mqlHetznerStorageBoxSnapshot) storageBox() (*mqlHetznerStorageBox, error) {
+	return storageBoxRef(m.MqlRuntime, &m.StorageBox, m.StorageBoxId.Data)
+}
+
 func (r *mqlHetznerStorageBoxSubaccount) id() (string, error) {
 	return fmt.Sprintf("hetzner.storageBox.subaccount/%d/%d", r.StorageBoxId.Data, r.Id.Data), nil
 }

--- a/providers/hetzner/resources/hetzner_zone.go
+++ b/providers/hetzner/resources/hetzner_zone.go
@@ -34,17 +34,25 @@ func (h *mqlHetzner) zones() ([]any, error) {
 	return out, nil
 }
 
-func newMqlHetznerZone(runtime *plugin.Runtime, z *hcloud.Zone) (*mqlHetznerZone, error) {
-	primaryNS := make([]any, 0, len(z.PrimaryNameservers))
-	for _, ns := range z.PrimaryNameservers {
-		// Intentionally omit ns.TSIGKey — it is a shared secret used for
-		// zone transfers and must not be surfaced as queryable data.
-		primaryNS = append(primaryNS, map[string]any{
-			"address":       ns.Address,
-			"port":          int64(ns.Port),
-			"tsigAlgorithm": string(ns.TSIGAlgorithm),
+// zonePrimaryNameserverDicts renders the primaries a secondary zone transfers
+// from. The TSIG key is a shared secret and is never surfaced as queryable
+// data; only whether one is configured is reported, so an unauthenticated
+// transfer stays auditable.
+func zonePrimaryNameserverDicts(nameservers []hcloud.ZonePrimaryNameserver) []any {
+	out := make([]any, 0, len(nameservers))
+	for _, ns := range nameservers {
+		out = append(out, map[string]any{
+			"address":        ns.Address,
+			"port":           int64(ns.Port),
+			"tsigAlgorithm":  string(ns.TSIGAlgorithm),
+			"tsigConfigured": ns.TSIGKey != "",
 		})
 	}
+	return out
+}
+
+func newMqlHetznerZone(runtime *plugin.Runtime, z *hcloud.Zone) (*mqlHetznerZone, error) {
+	primaryNS := zonePrimaryNameserverDicts(z.PrimaryNameservers)
 
 	res, err := CreateResource(runtime, "hetzner.zone", map[string]*llx.RawData{
 		"__id":                 llx.StringData(fmt.Sprintf("hetzner.zone/%d", z.ID)),


### PR DESCRIPTION
## Summary

A gap audit of the hetzner provider against `hcloud-go v2.47.0` — both the typed structs and the generated wire schema in `hcloud/schema/` — turned up four fields the provider already had in memory but was dropping, one exposure false negative, and an incomplete typed-reference pattern. This fixes all of them.

## New fields

| Field | Why it's a finding |
|---|---|
| `hetzner.firewall.egressRestricted` | Hetzner permits **all** outbound traffic unless the rule set holds at least one `out` rule, at which point only matching traffic is allowed. That semantic isn't derivable by reading the raw rule list, so a firewall placing no restriction on outbound connections looked identical to a restricted one. |
| `vswitchId` on `hetzner.network.subnets` | `NetworkSubnet.VSwitchID` was dropped from the subnet dict. A `vswitch`-type subnet bridges the private network to dedicated servers outside the project; combined with the existing `exposeRoutesToVswitch`, this makes that bridge visible. `0` means no vSwitch. |
| `tsigConfigured` on `hetzner.zone.primaryNameservers` | Reports whether a secondary zone's transfer from each primary is authenticated with a TSIG key. The key itself stays deliberately unexposed (it's a shared secret) — only its presence is reported, so an unauthenticated AXFR becomes auditable. |
| `timeoutIdle` on `hetzner.loadBalancer.service.http` | Already fetched from the API, never mapped into the dict. |

## Exposure fix

`hetzner.server.exposure()` read `firewalls()`, which lists every binding regardless of its application status. A server whose only firewall binding was still `pending` therefore reported `firewallAllowsIngress: false` / `internetReachable: false` while its rules were not yet enforced.

That's a false negative on an exposure check — the worst direction. Only bindings whose status is `applied` now count as enforcing, so a server with no applied binding admits ingress. This covers both the no-firewall case and the all-pending case.

`firewalls()` is unchanged — it's documented as the full binding list and consumers may rely on that. Only the enforcement decision moved.

## Typed parent references

`zone.rrset` had `zone()`, `server.privateNet` had `network()`, and `server.firewallBinding` had `firewall()` — but five sub-resources carried a bare parent ID with no accessor at all. Added, with the raw `*Id` fields deprecated where a ref now carries the same value:

| Sub-resource | Added | Deprecated |
|---|---|---|
| `server.privateNet` | `server()` | `serverId`, `networkId` |
| `server.firewallBinding` | `server()` | `serverId`, `firewallId` |
| `loadBalancer.privateNet` | `loadBalancer()` | `loadBalancerId`, `networkId` |
| `loadBalancer.service` | `loadBalancer()` | `loadBalancerId` |
| `loadBalancer.target` | `loadBalancer()` | `loadBalancerId` |
| `storageBox.subaccount` | `storageBox()` | `storageBoxId` |
| `storageBox.snapshot` | `storageBox()` | `storageBoxId` |
| `serverType.location` | `serverType()` | `serverTypeId`, `locationId` |

`@maturity("deprecated")` is a marker only — the fields keep working, keep their original `.lr.versions` entries, and still feed both the `id()` methods and the new accessors. Every accessor passes `"id"`, which all four target inits accept via `idArg`.

`primaryIp.assigneeId` is intentionally **not** deprecated: it's a discriminated reference (`assigneeType`), and `server()` returns null for any non-server assignee, so the ref doesn't round-trip the raw value.

## Not available

Recorded so it isn't re-derived: which SSH keys a server actually has (the Cloud API doesn't return them post-create), zone DNSSEC state (absent from the wire schema, not just the typed structs), volume encryption, and API tokens / project members / MFA (console-only). Dedicated servers and vSwitch details live in the Robot API, which needs a separate auth path.

## Testing

The ingress and egress decisions are extracted into free functions (`serverFirewallIngress`, `rulesRestrictEgress`, `zonePrimaryNameserverDicts`) so the security-critical logic is unit tested rather than reachable only through a live runtime — matching the existing `firewallRuleOpenToInternet` pattern.

- 15 new table-driven cases, including a regression guard for the pending-binding false negative (it inverts under the old logic) and an assertion that the TSIG key does not leak under any dict key.
- `zonePrimaryNameserverDicts` runs through `requireDictArraySerializes`, the existing guard for the llx dict converter that only accepts JSON-native values.
- `go build ./...`, `go test ./resources/...`, `golangci-lint run ./resources/...` (0 issues), `gofmt` all clean. Codegen is idempotent; `go.mod` unchanged.

Not yet verified against a live Hetzner project — no token available in this environment.
